### PR TITLE
make alembic happy for josh

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -2,6 +2,8 @@ from __future__ import with_statement
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 from logging.config import fileConfig
+import sys
+import os
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -13,6 +15,7 @@ fileConfig(config.config_file_name)
 
 # add your model's MetaData object here
 # for 'autogenerate' support
+sys.path.append(os.getcwd())
 from securedrop_client.models import Base  # noqa
 target_metadata = Base.metadata
 

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -3,7 +3,7 @@ from alembic import context
 from sqlalchemy import engine_from_config, pool
 from logging.config import fileConfig
 import sys
-import os
+from os import path
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -15,7 +15,7 @@ fileConfig(config.config_file_name)
 
 # add your model's MetaData object here
 # for 'autogenerate' support
-sys.path.append(os.getcwd())
+sys.path.insert(0, path.realpath(path.join(path.dirname(__file__), '..')))
 from securedrop_client.models import Base  # noqa
 target_metadata = Base.metadata
 

--- a/securedrop_client/models.py
+++ b/securedrop_client/models.py
@@ -1,6 +1,4 @@
 import os
-import sqlite3
-import subprocess
 
 from sqlalchemy import (Boolean, Column, create_engine, DateTime, ForeignKey,
                         Integer, String)

--- a/securedrop_client/models.py
+++ b/securedrop_client/models.py
@@ -11,10 +11,6 @@ from sqlalchemy.orm import relationship, backref
 # TODO: Store this in config file, see issue #2
 DB_PATH = os.path.abspath('svs.sqlite')
 
-if not os.path.exists(DB_PATH):
-    sqlite3.connect(DB_PATH)
-    subprocess.check_output('alembic upgrade head'.split())
-
 engine = create_engine('sqlite:///{}'.format(DB_PATH))
 Base = declarative_base()
 


### PR DESCRIPTION
For some reason in my environment running `alembic` lead to errors where `securedrop_client/models` was not able to be found. This looks like https://stackoverflow.com/questions/15648284/alembic-alembic-revision-says-import-error/15734665#15734665, and is solved here in a similar way (explicitly adding the path to the project root to `sys.path`. It's not clear why alembic works for others without this hack.

This PR also removes logic from `models.py` whereby the DB would be created automatically if it didn't already exist. A new DB is made (even if the .sqlite file doesn't exist) from running `alembic upgrade head` in a freshly-checked-out repo.