### PR TITLE
Starring/unstarring

### DIFF
--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -149,7 +149,8 @@ class Window(QMainWindow):
         """
         source_item = self.main_view.source_list.currentItem()
         source_widget = self.main_view.source_list.itemWidget(source_item)
-        self.show_conversation_for(source_widget.source)
+        if source_widget:
+            self.show_conversation_for(source_widget.source)
 
     def show_conversation_for(self, source):
         """

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -74,6 +74,8 @@ class Window(QMainWindow):
         self.status_bar = QStatusBar(self)
         self.setStatusBar(self.status_bar)
         self.set_status('Started SecureDrop Client. Please sign in.', 20000)
+        self.login_dialog = LoginDialog(self)
+        self.main_view.setup(self.controller)
 
     def autosize_window(self):
         """
@@ -105,6 +107,12 @@ class Window(QMainWindow):
         """
         self.login_dialog.accept()
         self.login_dialog = None
+
+    def update_error_status(self, error=None):
+        """
+        Show an error message on the sidebar.
+        """
+        self.main_view.update_error_status(error)
 
     def show_sources(self, sources):
         """

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -108,7 +108,10 @@ class MainView(QWidget):
         left_layout = QVBoxLayout()
         left_column.setLayout(left_layout)
         self.status = QLabel(_('Waiting to Synchronize'))
+        self.error_status = QLabel('')
+        self.error_status.setObjectName('error_label')
         left_layout.addWidget(self.status)
+        left_layout.addWidget(self.error_status)
         filter_widget = QWidget()
         filter_layout = QHBoxLayout()
         filter_widget.setLayout(filter_layout)
@@ -124,6 +127,16 @@ class MainView(QWidget):
         self.view_layout = QVBoxLayout()
         self.view_holder.setLayout(self.view_layout)
         self.layout.addWidget(self.view_holder, 6)
+
+    def setup(self, controller):
+        """
+        Pass through the controller object to this widget.
+        """
+        self.controller = controller
+        self.source_list.setup(controller)
+
+    def update_error_status(self, error=None):
+        self.error_status.setText(error)
 
     def update_view(self, widget):
         """
@@ -141,6 +154,15 @@ class SourceList(QListWidget):
     Displays the list of sources.
     """
 
+    def __init__(self, parent):
+        super().__init__(parent)
+
+    def setup(self, controller):
+        """
+        Pass through the controller object to this widget.
+        """
+        self.controller = controller
+
     def update(self, sources):
         """
         Reset and update the list with the passed in list of sources.
@@ -148,6 +170,7 @@ class SourceList(QListWidget):
         self.clear()
         for source in sources:
             new_source = SourceWidget(self, source)
+            new_source.setup(self.controller)
             list_item = QListWidgetItem(self)
             list_item.setSizeHint(new_source.sizeHint())
             self.addItem(list_item)
@@ -165,8 +188,8 @@ class SourceWidget(QWidget):
         """
         super().__init__(parent)
         self.source = source
-        self.layout = QVBoxLayout()
-        self.setLayout(self.layout)
+        layout = QVBoxLayout()
+        self.setLayout(layout)
         self.summary = QWidget(self)
         self.summary_layout = QHBoxLayout()
         self.summary.setLayout(self.summary_layout)
@@ -176,13 +199,19 @@ class SourceWidget(QWidget):
         self.summary_layout.addWidget(self.name)
         self.summary_layout.addStretch()
         self.summary_layout.addWidget(self.attached)
-        self.layout.addWidget(self.summary)
+        layout.addWidget(self.summary)
         self.updated = QLabel()
-        self.layout.addWidget(self.updated)
+        layout.addWidget(self.updated)
         self.details = QLabel()
         self.details.setWordWrap(True)
-        self.layout.addWidget(self.details)
+        layout.addWidget(self.details)
         self.update()
+
+    def setup(self, controller):
+        """
+        Pass through the controller object to this widget.
+        """
+        self.controller = controller
 
     def display_star_icon(self):
         """
@@ -217,7 +246,8 @@ class SourceWidget(QWidget):
         """
         Called when the star is clicked.
         """
-        logging.info('click')
+        self.controller.update_star(self.source)
+
 
 class LoginDialog(QDialog):
     """

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -165,27 +165,40 @@ class SourceWidget(QWidget):
         """
         super().__init__(parent)
         self.source = source
-        layout = QVBoxLayout()
-        self.setLayout(layout)
+        self.layout = QVBoxLayout()
+        self.setLayout(self.layout)
         self.summary = QWidget(self)
-        summary_layout = QHBoxLayout()
-        self.summary.setLayout(summary_layout)
+        self.summary_layout = QHBoxLayout()
+        self.summary.setLayout(self.summary_layout)
         self.attached = load_svg('paperclip.svg')
         self.attached.setMaximumSize(16, 16)
-        self.starred = load_svg('star_on.svg')
-        self.starred.setMaximumSize(16, 16)
         self.name = QLabel()
-        summary_layout.addWidget(self.name)
-        summary_layout.addStretch()
-        summary_layout.addWidget(self.attached)
-        summary_layout.addWidget(self.starred)
-        layout.addWidget(self.summary)
+        self.summary_layout.addWidget(self.name)
+        self.summary_layout.addStretch()
+        self.summary_layout.addWidget(self.attached)
+        self.layout.addWidget(self.summary)
         self.updated = QLabel()
-        layout.addWidget(self.updated)
+        self.layout.addWidget(self.updated)
         self.details = QLabel()
         self.details.setWordWrap(True)
-        layout.addWidget(self.details)
+        self.layout.addWidget(self.details)
         self.update()
+
+    def display_star_icon(self):
+        """
+        Show the correct star icon
+        """
+        if getattr(self, 'starred', None):  # Delete icon if it exists.
+            self.summary_layout.removeWidget(self.starred)
+
+        if self.source.is_starred:
+            self.starred = load_svg('star_on.svg')
+        else:
+            self.starred = load_svg('star_off.svg')
+
+        self.summary_layout.addWidget(self.starred)
+        self.starred.setMaximumSize(16, 16)
+        self.starred.mousePressEvent = self.toggle_star
 
     def update(self):
         """
@@ -195,14 +208,16 @@ class SourceWidget(QWidget):
         self.details label.
         """
         self.updated.setText(arrow.get(self.source.last_updated).humanize())
-        if self.source.is_starred:
-            self.starred = load_svg('star_on.svg')
-        else:
-            self.starred = load_svg('star_off.svg')
+        self.display_star_icon()
         self.name.setText("<strong>{}</strong>".format(
                           self.source.journalist_designation))
         self.details.setText("Lorum ipsum dolor sit amet thingy dodah...")
 
+    def toggle_star(self, event):
+        """
+        Called when the star is clicked.
+        """
+        logging.info('click')
 
 class LoginDialog(QDialog):
     """

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -109,6 +109,18 @@ def test_show_sources():
     w.main_view.source_list.update.assert_called_once_with([1, 2, 3])
 
 
+def test_update_error_status():
+    """
+    Ensure that the error to be shown in the error status sidebar will
+    be passed to the left sidebar for display.
+    """
+    error_message = "this is a bad thing!"
+    w = Window()
+    w.main_view = mock.MagicMock()
+    w.update_error_status(error=error_message)
+    w.main_view.update_error_status.assert_called_once_with(error_message)
+
+
 def test_show_sync():
     """
     If there's a value display the result of its "humanize" method.

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -107,15 +107,29 @@ def test_MainView_update_view():
     mv.view_layout.addWidget.assert_called_once_with(mock_widget)
 
 
+def test_MainView_update_error_status():
+    """
+    Ensure when the update_error_status method is called on the MainView that
+    the error status text is set as expected.
+    """
+    mv = MainView(None)
+    expected_message = "this is the message to be displayed"
+    mv.error_status = mock.MagicMock()
+    mv.error_status.setText = mock.MagicMock()
+    mv.update_error_status(error=expected_message)
+    mv.error_status.setText.assert_called_once_with(expected_message)
+
+
 def test_SourceList_update():
     """
     Check the items in the source list are cleared and a new SourceWidget for
     each passed-in source is created along with an associated QListWidgetItem.
     """
-    sl = SourceList()
+    sl = SourceList(None)
     sl.clear = mock.MagicMock()
     sl.addItem = mock.MagicMock()
     sl.setItemWidget = mock.MagicMock()
+    sl.controller = mock.MagicMock()
     mock_sw = mock.MagicMock()
     mock_lwi = mock.MagicMock()
     with mock.patch('securedrop_client.gui.widgets.SourceWidget', mock_sw), \
@@ -140,6 +154,17 @@ def test_SourceWidget_init():
     assert sw.source == mock_source
 
 
+def test_SourceWidget_setup():
+    """
+    The setup method adds the controller as an attribute on the SourceWidget.
+    """
+    mock_controller = mock.MagicMock()
+    mock_source = mock.MagicMock()
+    sw = SourceWidget(None, mock_source)
+    sw.setup(mock_controller)
+    assert sw.controller == mock_controller
+
+
 def test_SourceWidget_update_starred():
     """
     Ensure the widget displays the expected details from the source.
@@ -149,6 +174,7 @@ def test_SourceWidget_update_starred():
     mock_source.is_starred = True
     sw = SourceWidget(None, mock_source)
     sw.name = mock.MagicMock()
+    sw.summary_layout = mock.MagicMock()
     with mock.patch('securedrop_client.gui.widgets.load_svg') as mock_load:
         sw.update()
         mock_load.assert_called_once_with('star_on.svg')
@@ -164,10 +190,25 @@ def test_SourceWidget_update_unstarred():
     mock_source.is_starred = False
     sw = SourceWidget(None, mock_source)
     sw.name = mock.MagicMock()
+    sw.summary_layout = mock.MagicMock()
     with mock.patch('securedrop_client.gui.widgets.load_svg') as mock_load:
         sw.update()
         mock_load.assert_called_once_with('star_off.svg')
     sw.name.setText.assert_called_once_with('<strong>foo bar baz</strong>')
+
+
+def test_SourceWidget_toggle_star():
+    """
+    The toggle_star method should call self.controller.update_star
+    """
+    mock_controller = mock.MagicMock()
+    mock_source = mock.MagicMock()
+    event = mock.MagicMock()
+    sw = SourceWidget(None, mock_source)
+    sw.controller = mock_controller
+    sw.controller.update_star = mock.MagicMock()
+    sw.toggle_star(event)
+    sw.controller.update_star.assert_called_once_with(mock_source)
 
 
 def test_LoginDialog_setup():

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -13,7 +13,7 @@ from securedrop_client.app import ENCODING, excepthook, configure_logging, \
 app = QApplication([])
 
 
-def test_excpethook():
+def test_excepthook():
     """
     Ensure the custom excepthook logs the error and calls sys.exit.
     """


### PR DESCRIPTION
fix #17 

needs merge of https://github.com/freedomofpress/securedrop-sdk/pull/26 (discovered while working on this)

### trying to star/unstar while not logged in

![starring-not-logged-in](https://user-images.githubusercontent.com/7832803/47201366-69b18c80-d32e-11e8-902b-7d62975b23df.gif)

### successful starring or unstarring

![starring](https://user-images.githubusercontent.com/7832803/47201376-70d89a80-d32e-11e8-9bd5-dc1801dc183b.gif)

 (the first iteration as described in the ticket being not changing the ordering of sources in the list upon starring)

two things:
 1. I feel like the logic in 8a8e2ba should not be necessary, but otherwise the QSvgWidget did not seem to be repainting when the star icon changed 🤔(i'm missing something here)
 2. we need more robust logic for _pushing_ changes to the server. i'm going to open a followup for this because this is a generic problem across a few issues that we should have a consistent strategy for