### PR TITLE
Clean up threading

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -96,7 +96,6 @@ class Client(QObject):
         self.api = None  # Reference to the API for secure drop proxy.
         self.session = session  # Reference to the SqlAlchemy session.
         self.api_thread = None  # Currently active API call thread.
-        self.home = home # used for finding DB in sync thread
         self.sync_flag = os.path.join(home, 'sync_flag')
         self.home = home  # The "home" directory for client files.
         self.data_dir = os.path.join(self.home, 'data')  # File data.

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -275,8 +275,6 @@ class Client(QObject):
             self.call_api(storage.get_remote_data, self.on_synced,
                           self.on_sync_timeout, self.api)
             logger.info("In sync_api, after call to call_api, I'm in thread {}".format(self.thread().currentThreadId()))
-        else:
-            logger.info("It looks like you are not authenticated. Weird, isn't it.")
 
     def last_sync(self):
         """

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -25,7 +25,6 @@ from securedrop_client import storage
 from securedrop_client import models
 from securedrop_client.utils import check_dir_permissions
 from PyQt5.QtCore import QObject, QThread, pyqtSignal, QTimer
-from securedrop_client.message_sync import MessageSync
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +96,6 @@ class Client(QObject):
         self.api = None  # Reference to the API for secure drop proxy.
         self.session = session  # Reference to the SqlAlchemy session.
         self.api_thread = None  # Currently active API call thread.
-        self.message_thread = None # A thread responsible for fetching messages
         self.home = home # used for finding DB in sync thread
         self.sync_flag = os.path.join(home, 'sync_flag')
         self.home = home  # The "home" directory for client files.
@@ -161,18 +159,6 @@ class Client(QObject):
         else:
             logger.info("There's already an API request running, so I'm not going to ignore this one (XXX this may not be the coolest thing to do...)")
 
-    def start_message_thread(self):
-        """
-        Starts the message-fetching thread in the background.
-        """
-        return True
-        if not self.message_thread:
-            self.message_thread = QThread()
-            self.message_sync = MessageSync(self.api, self.home)
-            self.message_sync.moveToThread(self.message_thread)
-            self.message_thread.started.connect(self.message_sync.run)
-            self.message_thread.start()
-
     def call_reset(self):
         """
         Clean up this object's state after an API call.
@@ -210,7 +196,6 @@ class Client(QObject):
             self.gui.hide_login()
             self.sync_api()
             self.gui.set_logged_in_as(self.api.username)
-            self.start_message_thread()
             # Clear the sidebar error status bar if a message was shown
             # to the user indicating they should log in.
             self.gui.update_error_status("")

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -20,11 +20,12 @@ import os
 import logging
 import sdclientapi
 import arrow
+import copy
 from securedrop_client import storage
 from securedrop_client import models
 from securedrop_client.utils import check_dir_permissions
 from PyQt5.QtCore import QObject, QThread, pyqtSignal, QTimer
-
+from securedrop_client.message_sync import MessageSync
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +37,6 @@ class APICallRunner(QObject):
     """
 
     call_finished = pyqtSignal(bool)  # Indicates there is a result.
-    timeout = pyqtSignal()  # Indicates there was a timeout.
 
     def __init__(self, api_call, *args, **kwargs):
         """
@@ -48,33 +48,29 @@ class APICallRunner(QObject):
         self.args = args
         self.kwargs = kwargs
         self.result = None
+        self.i_timed_out = False
 
     def call_api(self):
         """
         Call the API. Emit a boolean signal to indicate the outcome of the
-        call. Timeout signal emitted after 5 seconds. Any return value or
-        exception raised is stored in self.result.
+        call. Any return value or exception raised is stored in self.result.
         """
-        self.timer = QTimer()
-        self.timer.timeout.connect(lambda: self.timeout.emit())
-        self.timer.setSingleShot(True)
-        self.timer.start(5000)
+
+        # this blocks
         try:
-            logger.info('Calling API with "{}" method'.format(
-                        self.api_call.__name__))
             self.result = self.api_call(*self.args, **self.kwargs)
             result_flag = bool(self.result)
         except Exception as ex:
             logger.error(ex)
             self.result = ex
             result_flag = False
-        self.call_finished.emit(result_flag)
 
-    def on_cancel_timeout(self):
-        """
-        Handles a signal to indicate the timer should stop.
-        """
-        self.timer.stop()
+        # by the time we end up here, who knows how long it's taken
+        # we may not want to emit this, if there's nothing to catch it
+        if self.i_timed_out is False:
+            self.call_finished.emit(result_flag)
+        else:
+            logger.info("Huh, I am back from a remote API call and it seems like I timed out. Bye!")
 
 
 class Client(QObject):
@@ -83,7 +79,8 @@ class Client(QObject):
     application, this is the controller.
     """
 
-    finish_api_call = pyqtSignal()  # Acknowledges reciept of an API call.
+    # finish_api_call = pyqtSignal()  # Acknowledges reciept of an API call.
+    timeout_api_call = pyqtSignal()  # Indicates there was a timeout.
 
     def __init__(self, hostname, gui, session, home: str) -> None:
         """
@@ -100,9 +97,12 @@ class Client(QObject):
         self.api = None  # Reference to the API for secure drop proxy.
         self.session = session  # Reference to the SqlAlchemy session.
         self.api_thread = None  # Currently active API call thread.
+        self.message_thread = None # A thread responsible for fetching messages
+        self.home = home # used for finding DB in sync thread
         self.sync_flag = os.path.join(home, 'sync_flag')
         self.home = home  # The "home" directory for client files.
         self.data_dir = os.path.join(self.home, 'data')  # File data.
+        self.timer = None # call timeout timer
 
     def setup(self):
         """
@@ -133,46 +133,84 @@ class Client(QObject):
         timeout signal. Any further arguments are passed to the function to be
         called.
         """
+
         if not self.api_thread:
+            self.timer = QTimer()
+            self.timer.timeout.connect(lambda: self.timeout_api_call.emit())
+            self.timer.setSingleShot(True)
+            self.timer.start(20000)
+
             self.api_thread = QThread(self.gui)
             self.api_runner = APICallRunner(function, *args, **kwargs)
             self.api_runner.moveToThread(self.api_thread)
-            self.api_runner.current_object = current_object
-            self.api_runner.call_finished.connect(callback)
-            self.api_runner.timeout.connect(timeout)
-            self.finish_api_call.connect(self.api_runner.on_cancel_timeout)
+
+            # handle successful call: copy response data, reset the
+            # client, give the user-provided callback the response
+            # data
+            self.api_runner.call_finished.connect(lambda r: self.successful_api_call(r, callback))
+
+            # we've started a timer. when that hits zero, call our
+            # timeout function
+            self.timeout_api_call.connect(lambda: self.timeout_cleanup(timeout))
+
+            # when the thread starts, we want to run `call_api` on `api_runner`
             self.api_thread.started.connect(self.api_runner.call_api)
-            self.api_thread.finished.connect(self.call_reset)
+
             self.api_thread.start()
+
+        else:
+            logger.info("There's already an API request running, so I'm not going to ignore this one (XXX this may not be the coolest thing to do...)")
+
+    def start_message_thread(self):
+        """
+        Starts the message-fetching thread in the background.
+        """
+        return True
+        if not self.message_thread:
+            self.message_thread = QThread()
+            self.message_sync = MessageSync(self.api, self.home)
+            self.message_sync.moveToThread(self.message_thread)
+            self.message_thread.started.connect(self.message_sync.run)
+            self.message_thread.start()
 
     def call_reset(self):
         """
         Clean up this object's state after an API call.
         """
         if self.api_thread:
-            self.finish_api_call.emit()
+            self.timeout_api_call.disconnect()
             self.api_runner = None
             self.api_thread = None
+            self.timer = None
 
     def login(self, username, password, totp):
         """
         Given a username, password and time based one-time-passcode (TOTP),
         create a new instance representing the SecureDrop api and authenticate.
         """
-        self.api = sdclientapi.API(self.hostname, username, password, totp)
+
+        self.api = sdclientapi.API(self.hostname, username, password, totp, proxy=True)
+
         self.call_api(self.api.authenticate, self.on_authenticate,
                       self.on_login_timeout)
 
-    def on_authenticate(self, result):
+    def on_cancel_timeout(self):
+        """
+        Handles a signal to indicate the timer should stop.
+        """
+        self.timer.stop()
+
+    def on_authenticate(self, result, result_data):
         """
         Handles the result of an authentication call against the API.
         """
-        self.call_reset()
+
         if result:
             # It worked! Sync with the API and update the UI.
             self.gui.hide_login()
             self.sync_api()
             self.gui.set_logged_in_as(self.api.username)
+            self.start_message_thread()
             # Clear the sidebar error status bar if a message was shown
             # to the user indicating they should log in.
             self.gui.update_error_status("")
@@ -182,14 +220,42 @@ class Client(QObject):
             error = _('There was a problem logging in. Please try again.')
             self.gui.show_login_error(error=error)
 
+    def successful_api_call(self, r, user_callback):
+        logger.info("Hooray, successful API call. Cleaning up, then calling user function.")
+
+        self.timer.stop()
+        result_data = self.api_runner.result
+        self.call_reset()
+
+        user_callback(r, result_data)
+
+
+    def timeout_cleanup(self, user_callback):
+        logger.info("API call timed out. Doing a cleanup, then calling user function.")
+
+        if self.api_thread:
+            self.api_runner.i_timed_out = True
+            self.call_reset()
+
+        user_callback()
+
     def on_login_timeout(self):
         """
         Reset the form and indicate the error.
         """
-        self.call_reset()
+
         self.api = None
         error = _('The connection to SecureDrop timed out. Please try again.')
         self.gui.show_login_error(error=error)
+
+    def on_sync_timeout(self):
+        """
+        Reset the form and indicate the error.
+        """
+
+        error = _('The connection to SecureDrop timed out. Please try again.')
+        self.gui.show_login_error(error=error)
+
 
     def on_action_requiring_login(self):
         """
@@ -217,9 +283,15 @@ class Client(QObject):
         """
         Grab data from the remote SecureDrop API in a non-blocking manner.
         """
+        logger.info("In sync_api on thread {}".format(self.thread().currentThreadId()))
+
         if self.authenticated():
+            logger.info("You are authenticated, going to make your call")
             self.call_api(storage.get_remote_data, self.on_synced,
-                          self.on_login_timeout, self.api)
+                          self.on_sync_timeout, self.api)
+            logger.info("In sync_api, after call to call_api, I'm in thread {}".format(self.thread().currentThreadId()))
+        else:
+            logger.info("It looks like you are not authenticated. Weird, isn't it.")
 
     def last_sync(self):
         """
@@ -231,17 +303,19 @@ class Client(QObject):
         except Exception:
             return None
 
-    def on_synced(self, result):
+    def on_synced(self, result, result_data):
         """
         Called when syncronisation of data via the API is complete.
         """
-        if result and isinstance(self.api_runner.result, tuple):
+
+        if result and isinstance(result_data, tuple):
             remote_sources, remote_submissions, remote_replies = \
-                self.api_runner.result
-            self.call_reset()
+                result_data
+
             storage.update_local_storage(self.session, remote_sources,
                                          remote_submissions,
                                          remote_replies)
+
             # Set last sync flag.
             with open(self.sync_flag, 'w') as f:
                 f.write(arrow.now().format())
@@ -251,6 +325,7 @@ class Client(QObject):
             # How to handle a failure? Exceptions are already logged. Perhaps
             # a message in the UI?
             pass
+
         self.update_sources()
 
     def update_sync(self):
@@ -267,14 +342,14 @@ class Client(QObject):
         self.gui.show_sources(sources)
         self.update_sync()
 
-    def on_update_star_complete(self, result):
+    def on_update_star_complete(self, result, result_data):
         """
         After we star or unstar a source, we should sync the API
         such that the local database is updated.
 
         TODO: Improve the push to server sync logic.
         """
-        self.call_reset()
+
         if result:
             self.sync_api()  # Syncing the API also updates the source list UI
             self.gui.update_error_status("")
@@ -310,6 +385,7 @@ class Client(QObject):
         state.
         """
         self.api = None
+        self.stop_message_thread()
         self.gui.logout()
 
     def set_status(self, message, duration=5000):

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -31,9 +31,7 @@ def test_APICallRunner_call_api():
     mock_api_call.__name__ = 'my_function'
     cr = APICallRunner(mock_api_call, 'foo', bar='baz')
     cr.call_finished = mock.MagicMock()
-    with mock.patch('securedrop_client.logic.QTimer') as mock_timer:
-        cr.call_api()
-    assert cr.timer == mock_timer()
+    cr.call_api()
     assert cr.result == 'foo'
     cr.call_finished.emit.assert_called_once_with(True)
 
@@ -53,15 +51,16 @@ def test_APICallRunner_with_exception():
     cr.call_finished.emit.assert_called_once_with(False)
 
 
-def test_APICallRunner_on_cancel_timeout():
+def test_Client_on_cancel_timeout(safe_tmpdir):
     """
     Ensure the timer's stop method is called.
     """
-    mock_api_call = mock.MagicMock()
-    cr = APICallRunner(mock_api_call, 'foo', bar='baz')
-    cr.timer = mock.MagicMock()
-    cr.on_cancel_timeout()
-    cr.timer.stop.assert_called_once_with()
+    mock_gui = mock.MagicMock()
+    mock_session = mock.MagicMock()
+    cl = Client('http://localhost/', mock_gui, mock_session, str(safe_tmpdir))
+    cl.timer = mock.MagicMock()
+    cl.on_cancel_timeout()
+    cl.timer.stop.assert_called_once_with()
 
 
 def test_Client_init(safe_tmpdir):
@@ -114,7 +113,9 @@ def test_Client_call_api(safe_tmpdir):
     cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
     cl.finish_api_call = mock.MagicMock()
     with mock.patch('securedrop_client.logic.QThread') as mock_qthread, \
-            mock.patch('securedrop_client.logic.APICallRunner') as mock_runner:
+            mock.patch(
+                'securedrop_client.logic.APICallRunner') as mock_runner, \
+            mock.patch('securedrop_client.logic.QTimer') as mock_timer:
         mock_api_call = mock.MagicMock()
         mock_callback = mock.MagicMock()
         mock_timeout = mock.MagicMock()
@@ -122,13 +123,10 @@ def test_Client_call_api(safe_tmpdir):
                     bar='baz')
         cl.api_thread.started.connect.\
             assert_called_once_with(cl.api_runner.call_api)
-        cl.api_thread.finished.connect.\
-            assert_called_once_with(cl.call_reset)
         cl.api_thread.start.assert_called_once_with()
         cl.api_runner.moveToThread.assert_called_once_with(cl.api_thread)
-        cl.api_runner.call_finished.connect.\
-            assert_called_once_with(mock_callback)
-        cl.api_runner.timeout.connect.assert_called_once_with(mock_timeout)
+        cl.timer.timeout.connect.call_count == 1
+        cl.api_runner.call_finished.connect.call_count == 1
         cl.finish_api_call.connect(cl.api_runner.on_cancel_timeout)
 
 
@@ -154,12 +152,13 @@ def test_Client_call_reset(safe_tmpdir):
     mock_gui = mock.MagicMock()
     mock_session = mock.MagicMock()
     cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
-    cl.finish_api_call = mock.MagicMock()
+    cl.timeout_api_call = mock.MagicMock()
     cl.api_thread = True
     cl.call_reset()
-    assert cl.finish_api_call.emit.call_count == 1
+    assert cl.timeout_api_call.disconnect.call_count == 1
     assert cl.api_runner is None
     assert cl.api_thread is None
+    assert cl.timer is None
 
 
 def test_Client_login(safe_tmpdir):
@@ -186,7 +185,8 @@ def test_Client_on_authenticate_failed(safe_tmpdir):
     mock_gui = mock.MagicMock()
     mock_session = mock.MagicMock()
     cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
-    cl.on_authenticate(False)
+    result_data = 'false'
+    cl.on_authenticate(False, result_data)
     mock_gui.show_login_error.\
         assert_called_once_with(error='There was a problem logging in. Please '
                                 'try again.')
@@ -202,11 +202,113 @@ def test_Client_on_authenticate_ok(safe_tmpdir):
     cl.sync_api = mock.MagicMock()
     cl.api = mock.MagicMock()
     cl.api.username = 'test'
-    cl.on_authenticate(True)
+    result_data = 'true'
+    cl.on_authenticate(True, result_data)
     cl.sync_api.assert_called_once_with()
     cl.gui.set_logged_in_as.assert_called_once_with('test')
     # Error status bar should be cleared
     cl.gui.update_error_status.assert_called_once_with("")
+
+
+def test_Client_successful_api_call_without_current_object(safe_tmpdir):
+    """
+    Ensure that cleanup is performed if an API call returns in the expected
+    time.
+    """
+    mock_gui = mock.MagicMock()
+    mock_session = mock.MagicMock()
+    cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
+    cl.timer = mock.MagicMock()
+    cl.api_thread = mock.MagicMock()
+    cl.api_runner = mock.MagicMock()
+    cl.api_runner.current_object = None
+    cl.call_reset = mock.MagicMock()
+    mock_user_callback = mock.MagicMock()
+    res = mock.MagicMock()
+
+    cl.successful_api_call(res, mock_user_callback)
+
+    cl.call_reset.assert_called_once_with()
+    mock_user_callback.call_count == 1
+    cl.timer.stop.assert_called_once_with()
+
+
+def test_Client_successful_api_call_with_current_object(safe_tmpdir):
+    """
+    Ensure that cleanup is performed if an API call returns in the expected
+    time.
+    """
+    mock_gui = mock.MagicMock()
+    mock_session = mock.MagicMock()
+    cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
+    cl.timer = mock.MagicMock()
+    cl.api_thread = mock.MagicMock()
+    cl.api_runner = mock.MagicMock()
+    cl.api_runner.current_object = mock.MagicMock()
+    cl.call_reset = mock.MagicMock()
+    mock_user_callback = mock.MagicMock()
+    res = mock.MagicMock()
+
+    cl.successful_api_call(res, mock_user_callback)
+
+    cl.call_reset.assert_called_once_with()
+    mock_user_callback.call_count == 1
+    cl.timer.stop.assert_called_once_with()
+
+
+def test_Client_timeout_cleanup_without_current_object(safe_tmpdir):
+    """
+    Ensure that cleanup is performed if an API call times out.
+    """
+    mock_gui = mock.MagicMock()
+    mock_session = mock.MagicMock()
+    cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
+    cl.api_thread = mock.MagicMock()
+    cl.api_runner = mock.MagicMock()
+    cl.api_runner.current_object = None
+    cl.call_reset = mock.MagicMock()
+    mock_user_callback = mock.MagicMock()
+
+    cl.timeout_cleanup(mock_user_callback)
+
+    assert cl.api_runner.i_timed_out is True
+    cl.call_reset.assert_called_once_with()
+    mock_user_callback.call_count == 1
+
+
+def test_Client_timeout_cleanup_with_current_object(safe_tmpdir):
+    """
+    Ensure that cleanup is performed if an API call times out.
+    """
+    mock_gui = mock.MagicMock()
+    mock_session = mock.MagicMock()
+    cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
+    cl.api_thread = mock.MagicMock()
+    cl.api_runner = mock.MagicMock()
+    cl.api_runner.current_object = mock.MagicMock()
+    cl.call_reset = mock.MagicMock()
+    mock_user_callback = mock.MagicMock()
+
+    cl.timeout_cleanup(mock_user_callback)
+
+    assert cl.api_runner.i_timed_out is True
+    cl.call_reset.assert_called_once_with()
+    mock_user_callback.call_count == 1
+
+
+def test_Client_on_sync_timeout(safe_tmpdir):
+    """
+    Display error message in status bar if sync times out.
+    """
+    mock_gui = mock.MagicMock()
+    mock_session = mock.MagicMock()
+    cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
+    cl.api = "this is populated"
+    cl.on_sync_timeout()
+    assert cl.api is not None
+    mock_gui.update_error_status.\
+        assert_called_once_with(error='The connection to SecureDrop timed '
+                                'out. Please try again.')
 
 
 def test_Client_on_login_timeout(safe_tmpdir):
@@ -218,7 +320,7 @@ def test_Client_on_login_timeout(safe_tmpdir):
     cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
     cl.call_reset = mock.MagicMock()
     cl.on_login_timeout()
-    cl.call_reset.assert_called_once_with()
+    assert cl.api is None
     mock_gui.show_login_error.\
         assert_called_once_with(error='The connection to SecureDrop timed '
                                 'out. Please try again.')
@@ -296,7 +398,7 @@ def test_Client_sync_api(safe_tmpdir):
     cl.call_api = mock.MagicMock()
     cl.sync_api()
     cl.call_api.assert_called_once_with(storage.get_remote_data, cl.on_synced,
-                                        cl.on_login_timeout, cl.api)
+                                        cl.on_sync_timeout, cl.api)
 
 
 def test_Client_last_sync_with_file(safe_tmpdir):
@@ -335,8 +437,9 @@ def test_Client_on_synced_no_result(safe_tmpdir):
     mock_session = mock.MagicMock()
     cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
     cl.update_sources = mock.MagicMock()
+    result_data = ('sources go here', 'submissions go here', 'replies go here')
     with mock.patch('securedrop_client.logic.storage') as mock_storage:
-        cl.on_synced(False)
+        cl.on_synced(False, result_data)
         assert mock_storage.update_local_storage.call_count == 0
     cl.update_sources.assert_called_once_with()
 
@@ -350,11 +453,10 @@ def test_Client_on_synced_with_result(safe_tmpdir):
     cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
     cl.update_sources = mock.MagicMock()
     cl.api_runner = mock.MagicMock()
-    cl.api_runner.result = (1, 2, 3, )
+    result_data = (1, 2, 3, )
     cl.call_reset = mock.MagicMock()
     with mock.patch('securedrop_client.logic.storage') as mock_storage:
-        cl.on_synced(True)
-        cl.call_reset.assert_called_once_with()
+        cl.on_synced(True, result_data)
         mock_storage.update_local_storage.assert_called_once_with(mock_session,
                                                                   1, 2, 3)
     cl.update_sources.assert_called_once_with()
@@ -476,8 +578,8 @@ def test_Client_on_update_star_success(safe_tmpdir):
     result = True
     cl.call_reset = mock.MagicMock()
     cl.sync_api = mock.MagicMock()
-    cl.on_update_star_complete(result)
-    cl.call_reset.assert_called_once_with()
+    result_data = "Star added"
+    cl.on_update_star_complete(result, result_data)
     cl.sync_api.assert_called_once_with()
     mock_gui.update_error_status.assert_called_once_with("")
 
@@ -493,8 +595,8 @@ def test_Client_on_update_star_failed(safe_tmpdir):
     result = False
     cl.call_reset = mock.MagicMock()
     cl.sync_api = mock.MagicMock()
-    cl.on_update_star_complete(result)
-    cl.call_reset.assert_called_once_with()
+    result_data = "error message"
+    cl.on_update_star_complete(result, result_data)
     cl.sync_api.assert_not_called()
     mock_gui.update_error_status.assert_called_once_with(
         'Failed to apply change.')
@@ -600,16 +702,17 @@ def test_Client_on_file_download_success(safe_tmpdir):
     cl.update_sources = mock.MagicMock()
     cl.api_runner = mock.MagicMock()
     test_filename = "my-file-location-msg.gpg"
-    cl.api_runner.result = ("", test_filename)
-    cl.api_runner.current_object = mock.MagicMock()
     test_object_uuid = 'uuid-of-downloaded-object'
-    cl.api_runner.current_object.uuid = test_object_uuid
     cl.call_reset = mock.MagicMock()
     result = True
+    result_data = ('this-is-a-sha256-sum', test_filename)
+    submission_db_object = mock.MagicMock()
+    submission_db_object.uuid = test_object_uuid
+    submission_db_object.filename = test_filename
     with mock.patch('securedrop_client.logic.storage') as mock_storage, \
             mock.patch('os.rename'):
-        cl.on_file_download(result)
-        cl.call_reset.assert_called_once_with()
+        cl.on_file_download(result, result_data,
+                            current_object=submission_db_object)
         mock_storage.mark_file_as_downloaded.assert_called_once_with(
             test_object_uuid, mock_session)
 
@@ -625,8 +728,12 @@ def test_Client_on_file_download_failure(safe_tmpdir):
     cl.call_reset = mock.MagicMock()
     cl.set_status = mock.MagicMock()
     result = False
-    cl.on_file_download(result)
-    cl.call_reset.assert_called_once_with()
+    result_data = 'error message'
+    submission_db_object = mock.MagicMock()
+    submission_db_object.uuid = 'myuuid'
+    submission_db_object.filename = 'filename'
+    cl.on_file_download(result, result_data,
+                        current_object=submission_db_object)
     cl.set_status.assert_called_once_with(
         "Failed to download file, please try again.")
 
@@ -637,11 +744,12 @@ def test_Client_on_download_timeout(safe_tmpdir):
     cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
     cl.update_sources = mock.MagicMock()
     cl.api_runner = mock.MagicMock()
+    current_object = mock.MagicMock()
     test_filename = "my-file-location-msg.gpg"
     cl.api_runner.result = ("", test_filename)
     cl.call_reset = mock.MagicMock()
     cl.set_status = mock.MagicMock()
-    cl.on_download_timeout()
+    cl.on_download_timeout(current_object)
     cl.set_status.assert_called_once_with(
         "Connection to server timed out, please try again.")
 


### PR DESCRIPTION
This fixes our API request timeout handling, and in the process tries to clean up how we handle our API thread in general.

As a quick overview: in order to retain application interactivity while we do remote API calls, we run those API calls in a separate thread (as provided by Qt's `QThread`) from our main UI thread. That's a common and recommended pattern.

Specifically, we have a `logic.Client` class, which is responsible for spawning and managing an API thread. `Client` holds a ref to an `client.APICallRunner` object, which represents the remote API request. When it's time to run the request, the `Client` spawns a new thread, "moves" its `APICallRunner` object to the new thread, and starts the new thread. The `APICallRunner`'s `call_api` method does the actual remote request, and its thread is blocked while that request runs.

The `Client` is responsible for managing that thread: it needs to have methods to handle successes and failures, including timing out.

The first issue this PR addresses was that we were started a `QTimer` in the `APICallRunner` thread, setting its timeout handler to a function in that thread. But since that thread is blocked while the remote request is running, it has no way of handling that callback until the remote request returns. This led to a bug where both the success and timeout handlers were being run: the request would take longer than 5 seconds and then eventually succeed. In the meantime, the timer would _arrange for the timeout handler to be run_ on the API thread. When the remote request returned and the thread became unblocked, the success handler would be run (since the request succeeded), and also the timeout handler would run (since the timer arranged for that to happen).

I moved the timer and its handler into the `Client` object and its thread. When the timer runs out, we abandon it and its `APICallRunner` object (from the perspective of `Client`), but _the thread is still running_ and will happily call its success callback when it eventually gets unblocked. So, we set a flag in the CallRunner object telling it that it's run out of time, and should silently do nothing when it eventually becomes unblocked.

Next, this tidies up our callbacks a bit, by handling `Client`-object state changes after request/failure in Client-wide functions, rather than in individual callbacks. After every request,  we want to reset the client to an "empty" state: no `APICallRunner` object, no API thread, no callbacks registered. There are slightly different ways to do this on success and on failure. Rather than duplicating that logic in every callback handler, this PR now wraps the user-specific callback in a small function which handles the cleanup on its own.

Note that this involves a small change to how callbacks get to any response data. Previously, they'd look at `self.api_runner.result`. In this PR, we reset `self.api_runner` _before_ the callback is run, so `self.api_runner.result` will never be defined while in the callback. Rather, the result is passed as an argument to the callback function directly, so callback signatures should be of the form

    def foo_callback(self, result, result_data):

where result is a boolean, and result_data is the actual data returned from the API (previously found at `self.api_runner.result`)

This change allows us to greatly simplify how the client is reset between requests, and reduces the responsibilities of the success/failure callbacks (or, if you've consumed the same koolaide as me, it [decomplects](https://www.infoq.com/presentations/Simple-Made-Easy) those responsibilities).

Multitheaded stuff is notoriously hard to test and to reason about. I only found these problems because I'm developing against a remote SD instance and was running in to timeout issues. I've manually tested various success and failure cases, but I suspect that there are still race conditions and cases that cause unexpected behavior... though I do think this puts us in a better state than before?

Also this work originated as part of my branch adding message loading. I manually pulled out this threading stuff, but there are some changes remaining here which have to do with message loading still... I'll to clean those up shortly. 