### PR TITLE
[Qubes] fix file download moving

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
 import logging
 import sdclientapi
+import shutil
 import arrow
 from securedrop_client import storage
 from securedrop_client import models
@@ -449,7 +450,7 @@ class Client(QObject):
             # On Qubes OS, this will a ~/QubesIncoming directory. In case
             # we are on Qubes, we should move the file to the data directory
             # and name it the same as the server (e.g. spotless-tater-msg.gpg).
-            os.rename(filename, os.path.join(self.data_dir, server_filename))
+            shutil.move(filename, os.path.join(self.data_dir, server_filename))
             storage.mark_file_as_downloaded(file_uuid, self.session)
 
             # Refresh the current source conversation, bearing in mind

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import os
 import pytest
 import sdclientapi
+import shutil
 from securedrop_client import storage, models
 from securedrop_client.logic import APICallRunner, Client
 from unittest import mock
@@ -711,7 +712,7 @@ def test_Client_on_file_download_success(safe_tmpdir):
     submission_db_object.uuid = test_object_uuid
     submission_db_object.filename = test_filename
     with mock.patch('securedrop_client.logic.storage') as mock_storage, \
-            mock.patch('os.rename'):
+            mock.patch('shutil.move'):
         cl.on_file_download(result_data, current_object=submission_db_object)
         mock_storage.mark_file_as_downloaded.assert_called_once_with(
             test_object_uuid, mock_session)


### PR DESCRIPTION
Fixes #83

Test plan:

1. Set up client in Qubes workstation, using the proxy
2. Submit a test file to the source interface of your test instance
3. Run client via `./run.sh` and login
4. Ensure you can download the test file (you download by double clicking on the file)

I was encountering a strange issue while testing this where I tried to download files, but they were not getting moved to the `sd-svs` VM (instead `qvm-move-to-vm` was just hanging). Please let me know if you spot that. 