### PR TITLE
Adds a refresh button to client UI

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -49,11 +49,15 @@ class ToolBar(QWidget):
         self.logout = QPushButton(_('Log Out'))
         self.logout.clicked.connect(self.on_logout_clicked)
         self.logout.setVisible(False)
+        self.refresh = QPushButton(_('Refresh'))
+        self.refresh.clicked.connect(self.on_refresh_clicked)
+        self.refresh.setVisible(False)
         layout.addWidget(self.logo)
         layout.addStretch()
         layout.addWidget(self.user_state)
         layout.addWidget(self.login)
         layout.addWidget(self.logout)
+        layout.addWidget(self.refresh)
 
     def setup(self, window, controller):
         """
@@ -73,6 +77,7 @@ class ToolBar(QWidget):
         self.user_state.setText(_('Logged in as: ' + username))
         self.login.setVisible(False)
         self.logout.setVisible(True)
+        self.refresh.setVisible(True)
 
     def set_logged_out(self):
         """
@@ -81,6 +86,8 @@ class ToolBar(QWidget):
         self.user_state.setText(_('Logged out.'))
         self.login.setVisible(True)
         self.logout.setVisible(False)
+        self.refresh.setVisible(False)
+
 
     def on_login_clicked(self):
         """
@@ -93,6 +100,12 @@ class ToolBar(QWidget):
         Called when the logout button is clicked.
         """
         self.controller.logout()
+
+    def on_refresh_clicked(self):
+        """
+        Called when the refresh button is clicked.
+        """
+        self.controller.sync_api()
 
 
 class MainView(QWidget):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -88,7 +88,6 @@ class ToolBar(QWidget):
         self.logout.setVisible(False)
         self.refresh.setVisible(False)
 
-
     def on_login_clicked(self):
         """
         Called when the login button is clicked.

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -38,19 +38,19 @@ def test_ToolBar_setup():
 
 
 def test_ToolBar_set_logged_in_as():
-    """
-    Given a username, the user_state is updated and login/logout buttons are
-    in the correct state.
+    """Given a username, the user_state is updated and login/logout
+    buttons, and refresh buttons, are in the correct state.
     """
     tb = ToolBar(None)
     tb.user_state = mock.MagicMock()
     tb.login = mock.MagicMock()
     tb.logout = mock.MagicMock()
+    tb.refresh = mock.MagicMock()
     tb.set_logged_in_as('test')
     tb.user_state.setText.assert_called_once_with('Logged in as: test')
     tb.login.setVisible.assert_called_once_with(False)
     tb.logout.setVisible.assert_called_once_with(True)
-
+    tb.refresh.setVisible.assert_called_once_with(True)
 
 def test_ToolBar_set_logged_out():
     """
@@ -60,10 +60,12 @@ def test_ToolBar_set_logged_out():
     tb.user_state = mock.MagicMock()
     tb.login = mock.MagicMock()
     tb.logout = mock.MagicMock()
+    tb.refresh = mock.MagicMock()
     tb.set_logged_out()
     tb.user_state.setText.assert_called_once_with('Logged out.')
     tb.login.setVisible.assert_called_once_with(True)
     tb.logout.setVisible.assert_called_once_with(False)
+    tb.refresh.setVisible.assert_called_once_with(False)
 
 
 def test_ToolBar_on_login_clicked():
@@ -85,6 +87,14 @@ def test_ToolBar_on_logout_clicked():
     tb.on_logout_clicked()
     tb.controller.logout.assert_called_once_with()
 
+def test_ToolBar_on_refresh_clicked():
+    """
+    When refresh is clicked, the refresh logic from the controller is stated.
+    """
+    tb = ToolBar(None)
+    tb.controller = mock.MagicMock()
+    tb.on_refresh_clicked()
+    tb.controller.sync_api.assert_called_once_with()
 
 def test_MainView_init():
     """

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -52,6 +52,7 @@ def test_ToolBar_set_logged_in_as():
     tb.logout.setVisible.assert_called_once_with(True)
     tb.refresh.setVisible.assert_called_once_with(True)
 
+
 def test_ToolBar_set_logged_out():
     """
     Ensure the UI reverts to the logged out state.
@@ -87,6 +88,7 @@ def test_ToolBar_on_logout_clicked():
     tb.on_logout_clicked()
     tb.controller.logout.assert_called_once_with()
 
+
 def test_ToolBar_on_refresh_clicked():
     """
     When refresh is clicked, the refresh logic from the controller is stated.
@@ -95,6 +97,7 @@ def test_ToolBar_on_refresh_clicked():
     tb.controller = mock.MagicMock()
     tb.on_refresh_clicked()
     tb.controller.sync_api.assert_called_once_with()
+
 
 def test_MainView_init():
     """


### PR DESCRIPTION
Adds a refresh button next to the logout button, which manually triggers a call to `sync_api`. 

Resolves #75 (remainder)