### PR TITLE
Minor tweaks to UI messages

### DIFF
--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -127,10 +127,10 @@ class Window(QMainWindow):
         Display a message indicating the data-sync state.
         """
         if updated_on:
-            self.main_view.status.setText('Last Sync: ' +
+            self.main_view.status.setText('Last refresh: ' +
                                           updated_on.humanize())
         else:
-            self.main_view.status.setText(_('Waiting to Synchronize'))
+            self.main_view.status.setText(_('Waiting to refresh...'))
 
     def set_logged_in_as(self, username):
         """

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -43,10 +43,10 @@ class ToolBar(QWidget):
         layout = QHBoxLayout(self)
         self.logo = QLabel()
         self.logo.setPixmap(load_image('header_logo.png'))
-        self.user_state = QLabel(_("Logged out."))
-        self.login = QPushButton(_('Sign In'))
+        self.user_state = QLabel(_("Signed out."))
+        self.login = QPushButton(_('Sign in'))
         self.login.clicked.connect(self.on_login_clicked)
-        self.logout = QPushButton(_('Log Out'))
+        self.logout = QPushButton(_('Sign out'))
         self.logout.clicked.connect(self.on_logout_clicked)
         self.logout.setVisible(False)
         self.refresh = QPushButton(_('Refresh'))
@@ -74,7 +74,7 @@ class ToolBar(QWidget):
         """
         Update the UI to reflect that the user is logged in as "username".
         """
-        self.user_state.setText(_('Logged in as: ' + username))
+        self.user_state.setText(_('Signed in as: ' + username))
         self.login.setVisible(False)
         self.logout.setVisible(True)
         self.refresh.setVisible(True)
@@ -83,7 +83,7 @@ class ToolBar(QWidget):
         """
         Update the UI to a logged out state.
         """
-        self.user_state.setText(_('Logged out.'))
+        self.user_state.setText(_('Signed out.'))
         self.login.setVisible(True)
         self.logout.setVisible(False)
         self.refresh.setVisible(False)
@@ -120,7 +120,7 @@ class MainView(QWidget):
         left_column = QWidget(parent=self)
         left_layout = QVBoxLayout()
         left_column.setLayout(left_layout)
-        self.status = QLabel(_('Waiting to Synchronize'))
+        self.status = QLabel(_('Waiting to refresh...'))
         self.error_status = QLabel('')
         self.error_status.setObjectName('error_label')
         left_layout.addWidget(self.status)
@@ -273,7 +273,7 @@ class LoginDialog(QDialog):
     def setup(self, controller):
         self.controller = controller
         self.setMinimumSize(600, 400)
-        self.setWindowTitle(_('Login to SecureDrop'))
+        self.setWindowTitle(_('Sign in to SecureDrop'))
         main_layout = QHBoxLayout()
         main_layout.addStretch()
         self.setLayout(main_layout)
@@ -282,7 +282,7 @@ class LoginDialog(QDialog):
         form.setLayout(layout)
         main_layout.addWidget(form)
         main_layout.addStretch()
-        self.title = QLabel(_('<h1>Sign In</h1>'))
+        self.title = QLabel(_('<h1>Sign in</h1>'))
         self.title.setTextFormat(Qt.RichText)
         self.instructions = QLabel(_('You may read all documents and messages '
                                      'shown here, without signing in. To '
@@ -301,10 +301,10 @@ class LoginDialog(QDialog):
         gutter = QWidget(self)
         gutter_layout = QHBoxLayout()
         gutter.setLayout(gutter_layout)
-        self.help_url = QLabel(_('<a href="#">Trouble Signing In?</a>'))
+        self.help_url = QLabel(_('<a href="#">Trouble signing in?</a>'))
         self.help_url.setTextFormat(Qt.RichText)
         self.help_url.setOpenExternalLinks(True)
-        self.submit = QPushButton(_('Sign In'))
+        self.submit = QPushButton(_('Sign in'))
         self.submit.clicked.connect(self.validate)
         gutter_layout.addWidget(self.help_url)
         gutter_layout.addWidget(self.submit)

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -214,7 +214,8 @@ class Client(QObject):
         else:
             # Failed to authenticate. Reset state with failure message.
             self.api = None
-            error = _('There was a problem logging in. Please try again.')
+            error = _('There was a problem signing in. '
+                      'Please verify your credentials and try again.')
             self.gui.show_login_error(error=error)
 
     def completed_api_call(self, user_callback):
@@ -266,7 +267,8 @@ class Client(QObject):
         """
 
         self.api = None
-        error = _('The connection to SecureDrop timed out. Please try again.')
+        error = _('The connection to the SecureDrop server timed out. '
+                  'Please try again.')
         self.gui.show_login_error(error=error)
 
     def on_sync_timeout(self):
@@ -278,14 +280,15 @@ class Client(QObject):
         have been many timeouts in a row.
         """
 
-        error = _('The connection to SecureDrop timed out. Please try again.')
+        error = _('The connection to the SecureDrop server timed out. '
+                  'Please try again.')
         self.gui.update_error_status(error=error)
 
     def on_action_requiring_login(self):
         """
         Indicate that a user needs to login to perform the specified action.
         """
-        error = _('You must login to perform this action.')
+        error = _('You must sign in to perform this action.')
         self.gui.update_error_status(error)
 
     def on_sidebar_action_timeout(self):
@@ -293,7 +296,8 @@ class Client(QObject):
         Indicate that a timeout occurred for an action occuring in the left
         sidebar.
         """
-        error = _('The connection to SecureDrop timed out. Please try again.')
+        error = _('The connection to the SecureDrop server timed out. '
+                  'Please try again.')
         self.gui.update_error_status(error)
 
     def authenticated(self):
@@ -458,11 +462,12 @@ class Client(QObject):
             self.gui.show_conversation_for(self.gui.current_source)
         else:
             # Update the UI in some way to indicate a failure state.
-            self.set_status("Failed to download file, please try again.")
+            self.set_status("The file download failed. Please try again.")
 
     def on_download_timeout(self, current_object):
         """
         Called when downloading a file has timed out.
         """
         # Update the status bar to indicate a failure state.
-        self.set_status("Connection to server timed out, please try again.")
+        self.set_status("The connection to the SecureDrop server timed out. "
+                        "Please try again.")

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -129,7 +129,7 @@ def test_show_sync():
     w.main_view = mock.MagicMock()
     updated_on = mock.MagicMock()
     w.show_sync(updated_on)
-    w.main_view.status.setText.assert_called_once_with('Last Sync: ' +
+    w.main_view.status.setText.assert_called_once_with('Last refresh: ' +
                                                        updated_on.humanize())
 
 
@@ -141,7 +141,7 @@ def test_show_sync_no_sync():
     w.main_view = mock.MagicMock()
     w.show_sync(None)
     w.main_view.status.setText.\
-        assert_called_once_with('Waiting to Synchronize')
+        assert_called_once_with('Waiting to refresh...')
 
 
 def test_set_logged_in_as():

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -21,7 +21,7 @@ def test_ToolBar_init():
     Ensure the ToolBar instance is correctly set up.
     """
     tb = ToolBar(None)
-    assert "Logged out." in tb.user_state.text()
+    assert "Signed out." in tb.user_state.text()
 
 
 def test_ToolBar_setup():
@@ -47,7 +47,7 @@ def test_ToolBar_set_logged_in_as():
     tb.logout = mock.MagicMock()
     tb.refresh = mock.MagicMock()
     tb.set_logged_in_as('test')
-    tb.user_state.setText.assert_called_once_with('Logged in as: test')
+    tb.user_state.setText.assert_called_once_with('Signed in as: test')
     tb.login.setVisible.assert_called_once_with(False)
     tb.logout.setVisible.assert_called_once_with(True)
     tb.refresh.setVisible.assert_called_once_with(True)
@@ -63,7 +63,7 @@ def test_ToolBar_set_logged_out():
     tb.logout = mock.MagicMock()
     tb.refresh = mock.MagicMock()
     tb.set_logged_out()
-    tb.user_state.setText.assert_called_once_with('Logged out.')
+    tb.user_state.setText.assert_called_once_with('Signed out.')
     tb.login.setVisible.assert_called_once_with(True)
     tb.logout.setVisible.assert_called_once_with(False)
     tb.refresh.setVisible.assert_called_once_with(False)
@@ -234,7 +234,7 @@ def test_LoginDialog_setup():
     ld = LoginDialog(None)
     ld.setup(mock_controller)
     assert ld.controller == mock_controller
-    assert ld.title.text() == '<h1>Sign In</h1>'
+    assert ld.title.text() == '<h1>Sign in</h1>'
 
 
 def test_LoginDialog_reset():

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -193,8 +193,8 @@ def test_Client_on_authenticate_failed(safe_tmpdir):
     result_data = 'false'
     cl.on_authenticate(result_data)
     mock_gui.show_login_error.\
-        assert_called_once_with(error='There was a problem logging in. Please '
-                                'try again.')
+        assert_called_once_with(error='There was a problem signing in. Please '
+                                'verify your credentials and try again.')
 
 
 def test_Client_on_authenticate_ok(safe_tmpdir):
@@ -311,8 +311,8 @@ def test_Client_on_sync_timeout(safe_tmpdir):
     cl.on_sync_timeout()
     assert cl.api is not None
     mock_gui.update_error_status.\
-        assert_called_once_with(error='The connection to SecureDrop timed '
-                                'out. Please try again.')
+        assert_called_once_with(error='The connection to the SecureDrop '
+                                'server timed out. Please try again.')
 
 
 def test_Client_on_login_timeout(safe_tmpdir):
@@ -326,8 +326,8 @@ def test_Client_on_login_timeout(safe_tmpdir):
     cl.on_login_timeout()
     assert cl.api is None
     mock_gui.show_login_error.\
-        assert_called_once_with(error='The connection to SecureDrop timed '
-                                'out. Please try again.')
+        assert_called_once_with(error='The connection to the SecureDrop '
+                                'server timed out. Please try again.')
 
 
 def test_Client_on_action_requiring_login(safe_tmpdir):
@@ -340,7 +340,7 @@ def test_Client_on_action_requiring_login(safe_tmpdir):
     cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
     cl.on_action_requiring_login()
     mock_gui.update_error_status.assert_called_once_with(
-        'You must login to perform this action.')
+        'You must sign in to perform this action.')
 
 
 def test_Client_authenticated_yes(safe_tmpdir):
@@ -569,7 +569,7 @@ def test_Client_sidebar_action_timeout(safe_tmpdir):
     cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
     cl.on_sidebar_action_timeout()
     mock_gui.update_error_status.assert_called_once_with(
-        'The connection to SecureDrop timed out. Please try again.')
+        'The connection to the SecureDrop server timed out. Please try again.')
 
 
 def test_Client_on_update_star_success(safe_tmpdir):
@@ -734,7 +734,7 @@ def test_Client_on_file_download_failure(safe_tmpdir):
     submission_db_object.filename = 'filename'
     cl.on_file_download(result_data, current_object=submission_db_object)
     cl.set_status.assert_called_once_with(
-        "Failed to download file, please try again.")
+        "The file download failed. Please try again.")
 
 
 def test_Client_on_download_timeout(safe_tmpdir):
@@ -750,7 +750,7 @@ def test_Client_on_download_timeout(safe_tmpdir):
     cl.set_status = mock.MagicMock()
     cl.on_download_timeout(current_object)
     cl.set_status.assert_called_once_with(
-        "Connection to server timed out, please try again.")
+        "The connection to the SecureDrop server timed out. Please try again.")
 
 
 def test_Client_on_file_click_Reply(safe_tmpdir):


### PR DESCRIPTION
This is part of the messages audit in #53. Specifically, here we
are:

- consistently using "sign in" / "sign out"
- consistently using "refresh" instead of "sync"
- consistently using sentence case
- avoiding ambiguity between server/workstation errors by being
  explicit