### PR TITLE
Opens downloaded files when double-clicked as per Qubes recipe. 

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -468,7 +468,7 @@ class FileWidget(QWidget):
     def mouseDoubleClickEvent(self, e):
         """
         Handle a double-click via the program logic. The download state of the
-        file distinguishes which function in the logic layet to call.
+        file distinguishes which function in the logic layer to call.
         """
         if self.submission.is_downloaded:
             # Open the already downloaded file.

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -467,9 +467,15 @@ class FileWidget(QWidget):
 
     def mouseDoubleClickEvent(self, e):
         """
-        Handle a double-click via the program logic.
+        Handle a double-click via the program logic. The download state of the
+        file distinguishes which function in the logic layet to call.
         """
-        self.controller.on_file_click(self.source, self.submission)
+        if self.submission.is_downloaded:
+            # Open the already downloaded file.
+            self.controller.on_file_open(self.submission)
+        else:
+            # Download the file.
+            self.controller.on_file_download(self.source, self.submission)
 
 
 class ConversationView(QWidget):

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -411,8 +411,8 @@ class Client(QObject):
 
     def on_file_open(self, source_db_object):
         """
-        Open the already doanloaded file associated with the message (which
-        may be a Submission or a Repl).
+        Open the already downloaded file associated with the message (which
+        may be a Submission or a Reply).
         """
         if self.proxy:
             # Running on Qubes.

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -411,9 +411,26 @@ def test_FileWidget_init_right():
     assert fw.controller == mock_controller
 
 
-def test_FileWidget_mouseDoubleClickEvent():
+def test_FileWidget_mouseDoubleClickEvent_download():
     """
-    Should fire the expected event handler in the logic layer.
+    Should fire the expected download event handler in the logic layer.
+    """
+    mock_message = mock.MagicMock()
+    mock_controller = mock.MagicMock()
+    source = models.Source('source-uuid', 'testy-mctestface', False,
+                           'mah pub key', 1, False, datetime.now())
+    submission = models.Submission(source, 'submission-uuid', 123,
+                                   'mah-reply.gpg')
+    submission.is_downloaded = False
+
+    fw = FileWidget(source, submission, mock_controller)
+    fw.mouseDoubleClickEvent(None)
+    fw.controller.on_file_download.assert_called_once_with(source, submission)
+
+
+def test_FileWidget_mouseDoubleClickEvent_open():
+    """
+    Should fire the expected open event handler in the logic layer.
     """
     mock_message = mock.MagicMock()
     mock_controller = mock.MagicMock()
@@ -425,7 +442,7 @@ def test_FileWidget_mouseDoubleClickEvent():
 
     fw = FileWidget(source, submission, mock_controller)
     fw.mouseDoubleClickEvent(None)
-    fw.controller.on_file_click.assert_called_once_with(source, submission)
+    fw.controller.on_file_open.assert_called_once_with(submission)
 
 
 def test_ConversationView_init():

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -677,7 +677,7 @@ def test_create_client_dir_permissions(tmpdir):
                 func()
 
 
-def test_Client_on_file_click_Submission(safe_tmpdir):
+def test_Client_on_file_download_Submission(safe_tmpdir):
     """
     If the handler is passed a submission, check the download_submission
     function is the one called against the API.
@@ -694,14 +694,14 @@ def test_Client_on_file_click_Submission(safe_tmpdir):
     submission_sdk_object = mock.MagicMock()
     with mock.patch('sdclientapi.Submission') as mock_submission:
         mock_submission.return_value = submission_sdk_object
-        cl.on_file_click(source, submission)
+        cl.on_file_download(source, submission)
     cl.call_api.assert_called_once_with(
-        cl.api.download_submission, cl.on_file_download,
+        cl.api.download_submission, cl.on_file_downloaded,
         cl.on_download_timeout, submission_sdk_object,
         cl.data_dir, current_object=submission)
 
 
-def test_Client_on_file_download_success(safe_tmpdir):
+def test_Client_on_file_downloaded_success(safe_tmpdir):
     mock_gui = mock.MagicMock()
     mock_session = mock.MagicMock()
     cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
@@ -716,12 +716,12 @@ def test_Client_on_file_download_success(safe_tmpdir):
     submission_db_object.filename = test_filename
     with mock.patch('securedrop_client.logic.storage') as mock_storage, \
             mock.patch('shutil.move'):
-        cl.on_file_download(result_data, current_object=submission_db_object)
+        cl.on_file_downloaded(result_data, current_object=submission_db_object)
         mock_storage.mark_file_as_downloaded.assert_called_once_with(
             test_object_uuid, mock_session)
 
 
-def test_Client_on_file_download_failure(safe_tmpdir):
+def test_Client_on_file_downloaded_failure(safe_tmpdir):
     mock_gui = mock.MagicMock()
     mock_session = mock.MagicMock()
     cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
@@ -735,7 +735,7 @@ def test_Client_on_file_download_failure(safe_tmpdir):
     submission_db_object = mock.MagicMock()
     submission_db_object.uuid = 'myuuid'
     submission_db_object.filename = 'filename'
-    cl.on_file_download(result_data, current_object=submission_db_object)
+    cl.on_file_downloaded(result_data, current_object=submission_db_object)
     cl.set_status.assert_called_once_with(
         "The file download failed. Please try again.")
 
@@ -756,7 +756,7 @@ def test_Client_on_download_timeout(safe_tmpdir):
         "The connection to the SecureDrop server timed out. Please try again.")
 
 
-def test_Client_on_file_click_Reply(safe_tmpdir):
+def test_Client_on_file_download_Reply(safe_tmpdir):
     """
     If the handler is passed a reply, check the download_reply
     function is the one called against the API.
@@ -774,9 +774,30 @@ def test_Client_on_file_click_Reply(safe_tmpdir):
     reply_sdk_object = mock.MagicMock()
     with mock.patch('sdclientapi.Reply') as mock_reply:
         mock_reply.return_value = reply_sdk_object
-        cl.on_file_click(source, reply)
+        cl.on_file_download(source, reply)
     cl.call_api.assert_called_once_with(cl.api.download_reply,
-                                        cl.on_file_download,
+                                        cl.on_file_downloaded,
                                         cl.on_download_timeout,
                                         reply_sdk_object,
                                         cl.data_dir, current_object=reply)
+
+
+def test_Client_on_file_open(safe_tmpdir):
+    """
+    If running on Qubes, a new QProcess with the expected command and args
+    should be started.
+    """
+    mock_gui = mock.MagicMock()
+    mock_session = mock.MagicMock()
+    cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
+    cl.proxy = True
+    mock_submission = mock.MagicMock()
+    mock_submission.filename = 'test.pdf'
+    mock_subprocess = mock.MagicMock()
+    mock_process = mock.MagicMock(return_value=mock_subprocess)
+    with mock.patch('securedrop_client.logic.QProcess', mock_process):
+        cl.on_file_open(mock_submission)
+        mock_process.assert_called_once_with(cl)
+        mock_subprocess.start.assert_called_once_with("qvm-open-in-vm",
+                                                      ["'$dispvm:sd-svs-disp'",
+                                                       'test.pdf', ])


### PR DESCRIPTION
This PR fixes #20.

* I've added tests as per the requirements for opening files on Qubes. PLEASE CHECK THIS ACTUALLY WORKS ON QUBES!
* Since we're writing a Qt application, I've used the `QProcess` class to kick off the new process since it's only marginally simpler than the built-in Python equivalent.
* If not running on Qubes, as requested, we just log the file was clicked to be opened.
* Question: once opened, should we update the `is_read` attribute via the API? It should be trivial to add this action to this PR, just let me know.