### PR TITLE
FileWidget responds to completed *single* clicks.

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -465,9 +465,9 @@ class FileWidget(QWidget):
             layout.addStretch(5)
         self.setLayout(layout)
 
-    def mouseDoubleClickEvent(self, e):
+    def mouseReleaseEvent(self, e):
         """
-        Handle a double-click via the program logic.
+        Handle a completed click via the program logic.
         """
         self.controller.on_file_click(self.source, self.submission)
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -411,7 +411,7 @@ def test_FileWidget_init_right():
     assert fw.controller == mock_controller
 
 
-def test_FileWidget_mouseDoubleClickEvent():
+def test_FileWidget_mousePressEvent():
     """
     Should fire the expected event handler in the logic layer.
     """
@@ -424,7 +424,7 @@ def test_FileWidget_mouseDoubleClickEvent():
     submission.is_downloaded = True
 
     fw = FileWidget(source, submission, mock_controller)
-    fw.mouseDoubleClickEvent(None)
+    fw.mouseReleaseEvent(None)
     fw.controller.on_file_click.assert_called_once_with(source, submission)
 
 


### PR DESCRIPTION
Fixes #98.

Simply overrides a different default event handler (`mouseReleaseEvent` - http://doc.qt.io/qt-5/qwidget.html#mouseReleaseEvent) to catch a completed single click.