### PR TITLE
securedrop-client 0.0.2

### DIFF
--- a/securedrop_client/__init__.py
+++ b/securedrop_client/__init__.py
@@ -19,4 +19,4 @@ gettext.translation('securedrop_client', localedir=localedir,
                     languages=[language_code], fallback=True).install()
 
 
-__version__ = '0.0.1-alpha.1'
+__version__ = '0.0.2'

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ for name in os.listdir('./securedrop_client/resources/images/'):
 
 setuptools.setup(
     name="securedrop-client",
-    version="0.0.1",
+    version="0.0.2",
     author="Freedom of the Press Foundation",
     author_email="securedrop@freedom.press",
     description="SecureDrop Workstation client application",


### PR DESCRIPTION
made a debian package based on the latest code, available here: https://apt-test-qubes.freedom.press/pool/main/s/securedrop-client/