### PR TITLE
Add .desktop file and bump version to 0.0.4

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include Pipfile.lock
 include files/alembic.ini
 include files/client.ini
 include files/securedrop-client
+include files/securedrop-client.desktop
 
 recursive-include alembic *
 recursive-include securedrop_client *

--- a/files/securedrop-client.desktop
+++ b/files/securedrop-client.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=SecureDrop Client
+Exec=securedrop-client
+Icon=utilities-terminal
+Type=Application

--- a/securedrop_client/__init__.py
+++ b/securedrop_client/__init__.py
@@ -19,4 +19,4 @@ gettext.translation('securedrop_client', localedir=localedir,
                     languages=[language_code], fallback=True).install()
 
 
-__version__ = '0.0.3'
+__version__ = '0.0.4'

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ for name in os.listdir('./securedrop_client/resources/images/'):
 
 setuptools.setup(
     name="securedrop-client",
-    version="0.0.3",
+    version="0.0.4",
     author="Freedom of the Press Foundation",
     author_email="securedrop@freedom.press",
     description="SecureDrop Workstation client application",


### PR DESCRIPTION
Towards https://github.com/freedomofpress/securedrop-workstation/issues/198

Build logic will also need to be updated to copy this file when the .deb is installed.

Test plan:

- [ ] `python3 setup.py sdist` completes without error
- [ ] The contents of the tarball generate by the above command has version 0.0.4 in its name and contains the `securedrop-client.desktop` within the `files/` folder.