### PR TITLE
Refresh conversation view

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -138,6 +138,13 @@ class Client(QObject):
         self.sync_update = QTimer()
         self.sync_update.timeout.connect(self.sync_api)
         self.sync_update.start(1000 * 60 * 5)  # every 5 minutes.
+        # Use a QTimer to update the current conversation view such
+        # that as downloads/decryption occur, the messages and replies
+        # populate the view.
+        self.conv_view_update = QTimer()
+        self.conv_view_update.timeout.connect(
+            self.update_conversation_view)
+        self.conv_view_update.start(1000 * 60 * 0.25)  # every 15 seconds
 
         event.listen(models.Submission, 'load', self.on_object_loaded)
         event.listen(models.Submission, 'init', self.on_object_instantiated)
@@ -401,6 +408,15 @@ class Client(QObject):
         sources = list(storage.get_local_sources(self.session))
         self.gui.show_sources(sources)
         self.update_sync()
+
+    def update_conversation_view(self):
+        """
+        Updates the conversation view every 15 seconds to reflect progress
+        of the download and decryption of messages and replies.
+        """
+        # Redraw the conversation view if we have clicked on a source.
+        if self.gui.current_source:
+            self.gui.show_conversation_for(self.gui.current_source)
 
     def on_update_star_complete(self, result):
         """

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -411,11 +411,12 @@ class Client(QObject):
 
     def update_conversation_view(self):
         """
-        Updates the conversation view every 15 seconds to reflect progress
+        Updates the conversation view to reflect progress
         of the download and decryption of messages and replies.
         """
         # Redraw the conversation view if we have clicked on a source.
         if self.gui.current_source:
+            self.session.refresh(self.gui.current_source)
             self.gui.show_conversation_for(self.gui.current_source)
 
     def on_update_star_complete(self, result):

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -144,7 +144,7 @@ class Client(QObject):
         self.conv_view_update = QTimer()
         self.conv_view_update.timeout.connect(
             self.update_conversation_view)
-        self.conv_view_update.start(1000 * 60 * 0.25)  # every 15 seconds
+        self.conv_view_update.start(1000 * 60 * 0.10)  # every 6 seconds
 
         event.listen(models.Submission, 'load', self.on_object_loaded)
         event.listen(models.Submission, 'init', self.on_object_instantiated)

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -535,6 +535,34 @@ def test_Client_update_sources(safe_tmpdir):
         mock_gui.show_sources.assert_called_once_with([1, 2, 3])
 
 
+def test_Client_update_conversation_view_current_source(safe_tmpdir):
+    """
+    Ensure the UI displays the latest version of the messages/replies that
+    have been downloaded/decrypted in the current conversation view.
+    """
+    mock_gui = mock.MagicMock()
+    mock_gui.current_source = 'teehee'
+    mock_gui.show_conversation_for = mock.MagicMock()
+    mock_session = mock.MagicMock()
+    cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
+    cl.update_conversation_view()
+    mock_gui.show_conversation_for.assert_called_once_with(
+        mock_gui.current_source)
+
+
+def test_Client_update_conversation_view_no_current_source(safe_tmpdir):
+    """
+    Ensure that if there is no current source (i.e. the user has not clicked
+    a source in the sidebar), the UI will not redraw the conversation view.
+    """
+    mock_gui = mock.MagicMock()
+    mock_gui.current_source = None
+    mock_session = mock.MagicMock()
+    cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
+    cl.update_conversation_view()
+    mock_gui.show_conversation_for.assert_not_called()
+
+
 def test_Client_unstars_a_source_if_starred(safe_tmpdir):
     """
     Ensure that the client unstars a source if it is starred.


### PR DESCRIPTION
Closes #107

# Test plan

1. Login to client
2. Click on source in sidebar
3. The messages and replies are downloading... wait six seconds
4. The messages and replies should appear decrypted in the conversation view. The user should not have to sync again or take any other manual action