### PR TITLE
Standardize dev env

### DIFF
--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -17,7 +17,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import logging
-import pathlib
 import os
 import signal
 import sys
@@ -34,7 +33,6 @@ from securedrop_client.gui.main import Window
 from securedrop_client.resources import load_icon, load_css
 from securedrop_client.models import make_engine
 from securedrop_client.utils import safe_mkdir
-from securedrop_client.data import Data
 
 DEFAULT_SDC_HOME = '~/.securedrop_client'
 ENCODING = 'utf-8'

--- a/securedrop_client/crypto.py
+++ b/securedrop_client/crypto.py
@@ -22,8 +22,6 @@ import shutil
 import subprocess
 import tempfile
 
-from securedrop_client.models import make_engine
-
 
 logger = logging.getLogger(__name__)
 

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -20,14 +20,10 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import logging
-from PyQt5.QtWidgets import (QMainWindow, QWidget, QVBoxLayout, QDesktopWidget,
-                             QStatusBar)
-from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QMainWindow, QWidget, QVBoxLayout, QDesktopWidget, QStatusBar
 from securedrop_client import __version__
-from securedrop_client.gui.widgets import (ToolBar, MainView, LoginDialog,
-                                           ConversationView)
+from securedrop_client.gui.widgets import ToolBar, MainView, LoginDialog, ConversationView
 from securedrop_client.resources import load_icon
-import os
 
 logger = logging.getLogger(__name__)
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -19,11 +19,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import logging
 import arrow
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QPainter
-from PyQt5.QtWidgets import (QListWidget, QTextEdit, QLabel, QToolBar, QAction,
-                             QWidget, QListWidgetItem, QHBoxLayout,
-                             QPushButton, QVBoxLayout, QLineEdit, QScrollArea,
-                             QPlainTextEdit, QSpacerItem, QSizePolicy, QDialog)
+from PyQt5.QtWidgets import QListWidget, QLabel, QWidget, QListWidgetItem, QHBoxLayout, \
+    QPushButton, QVBoxLayout, QLineEdit, QScrollArea, QDialog
 from securedrop_client.resources import load_svg, load_image
 from securedrop_client.utils import humanize_filesize
 

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -21,7 +21,6 @@ import logging
 import sdclientapi
 import shutil
 import arrow
-import copy
 import uuid
 from sqlalchemy import event
 from securedrop_client import crypto

--- a/securedrop_client/message_sync.py
+++ b/securedrop_client/message_sync.py
@@ -20,10 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
 import logging
-import os
-import shutil
-import subprocess
-import tempfile
 import sdclientapi.sdlocalobjects as sdkobjects
 
 from PyQt5.QtCore import QObject

--- a/securedrop_client/models.py
+++ b/securedrop_client/models.py
@@ -1,11 +1,10 @@
 import os
 
-from sqlalchemy import (Boolean, Column, create_engine, DateTime, ForeignKey,
-                        Integer, String, Text, MetaData)
+from sqlalchemy import Boolean, Column, create_engine, DateTime, ForeignKey, Integer, String, \
+    Text, MetaData
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, backref
 
-from securedrop_client.data import Data
 
 convention = {
     "ix": 'ix_%(column_0_label)s',

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,9 @@
+[flake8]
+exclude =
+    .git,
+    __pycache__,
+
+max-line-length = 100
+
+builtins = 
+    _,

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -2,11 +2,9 @@
 Check the core Window UI class works as expected.
 """
 from PyQt5.QtWidgets import QApplication, QVBoxLayout
-from PyQt5.QtCore import QTimer
 from securedrop_client.gui.main import Window
-from securedrop_client.gui.widgets import LoginDialog
 from securedrop_client.resources import load_icon
-from securedrop_client.models import Submission, Source
+from securedrop_client.models import Submission
 from unittest import mock
 
 
@@ -24,7 +22,7 @@ def test_init():
             mock.patch('securedrop_client.gui.main.ToolBar') as mock_tb, \
             mock.patch('securedrop_client.gui.main.MainView') as mock_mv, \
             mock.patch('securedrop_client.gui.main.QVBoxLayout', mock_lo), \
-            mock.patch('securedrop_client.gui.main.QMainWindow') as mock_qmw:
+            mock.patch('securedrop_client.gui.main.QMainWindow'):
         w = Window()
         mock_li.assert_called_once_with(w.icon)
         mock_tb.assert_called_once_with(w.widget)
@@ -172,7 +170,7 @@ def test_on_source_changed():
     """
     w = Window()
     w.main_view = mock.MagicMock()
-    mock_si = w.main_view.source_list.currentItem()
+    w.main_view.source_list.currentItem()
     mock_sw = w.main_view.source_list.itemWidget()
     w.show_conversation_for = mock.MagicMock()
     w.on_source_changed()

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -2,14 +2,11 @@
 Make sure the UI widgets are configured correctly and work as expected.
 """
 from datetime import datetime
-from PyQt5.QtWidgets import (QLineEdit, QWidget, QApplication, QWidgetItem,
-                             QSpacerItem, QVBoxLayout)
+from PyQt5.QtWidgets import QWidget, QApplication, QWidgetItem, QSpacerItem, QVBoxLayout
 from securedrop_client import models
-from securedrop_client.gui.widgets import (ToolBar, MainView, SourceList,
-                                           SourceWidget, LoginDialog,
-                                           SpeechBubble, ConversationWidget,
-                                           MessageWidget, ReplyWidget,
-                                           FileWidget, ConversationView)
+from securedrop_client.gui.widgets import ToolBar, MainView, SourceList, SourceWidget, \
+    LoginDialog, SpeechBubble, ConversationWidget, MessageWidget, ReplyWidget, FileWidget, \
+    ConversationView
 from unittest import mock
 
 
@@ -330,7 +327,7 @@ def test_SpeechBubble_init():
     with mock.patch('securedrop_client.gui.widgets.QLabel') as mock_label, \
             mock.patch('securedrop_client.gui.widgets.QVBoxLayout'), \
             mock.patch('securedrop_client.gui.widgets.SpeechBubble.setLayout'):
-        sb = SpeechBubble('hello')
+        SpeechBubble('hello')
         mock_label.assert_called_once_with('hello')
 
 
@@ -417,7 +414,6 @@ def test_FileWidget_mousePressEvent_download():
     """
     Should fire the expected download event handler in the logic layer.
     """
-    mock_message = mock.MagicMock()
     mock_controller = mock.MagicMock()
     source = models.Source('source-uuid', 'testy-mctestface', False,
                            'mah pub key', 1, False, datetime.now())
@@ -435,7 +431,6 @@ def test_FileWidget_mousePressEvent_open():
     """
     Should fire the expected open event handler in the logic layer.
     """
-    mock_message = mock.MagicMock()
     mock_controller = mock.MagicMock()
     source = models.Source('source-uuid', 'testy-mctestface', False,
                            'mah pub key', 1, False, datetime.now())

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -105,12 +105,12 @@ def test_start_app(safe_tmpdir):
     mock_args.sdc_home = sdc_home
     mock_args.proxy = False
 
-    with mock.patch('securedrop_client.app.configure_logging') as conf_log, \
+    with mock.patch('securedrop_client.app.configure_logging'), \
             mock.patch('securedrop_client.app.QApplication') as mock_app, \
             mock.patch('securedrop_client.app.Window') as mock_win, \
             mock.patch('securedrop_client.app.Client') as mock_client, \
             mock.patch('securedrop_client.app.prevent_second_instance'), \
-            mock.patch('securedrop_client.app.sys') as mock_sys, \
+            mock.patch('securedrop_client.app.sys'), \
             mock.patch('securedrop_client.app.sessionmaker',
                        return_value=mock_session_class):
         start_app(mock_args, mock_qt_args)
@@ -174,10 +174,10 @@ def test_create_app_dir_permissions(tmpdir):
             os.makedirs(full_path, perms)
 
         with mock.patch('logging.getLogger'), \
-                mock.patch('securedrop_client.app.QApplication') as mock_app, \
-                mock.patch('securedrop_client.app.Window') as mock_win, \
-                mock.patch('securedrop_client.app.Client') as mock_client, \
-                mock.patch('securedrop_client.app.sys') as mock_sys, \
+                mock.patch('securedrop_client.app.QApplication'), \
+                mock.patch('securedrop_client.app.Window'), \
+                mock.patch('securedrop_client.app.Client'), \
+                mock.patch('securedrop_client.app.sys'), \
                 mock.patch('securedrop_client.app.prevent_second_instance'), \
                 mock.patch('securedrop_client.app.sessionmaker',
                            return_value=mock_session_class):
@@ -222,7 +222,7 @@ def test_run():
 
     with mock.patch('securedrop_client.app.start_app') as mock_start_app, \
             mock.patch('argparse.ArgumentParser.parse_known_args',
-                       side_effect=fake_known_args) as wat:
+                       side_effect=fake_known_args):
         run()
 
         mock_start_app.assert_called_once_with(mock_args, mock_qt_args)

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,4 +1,3 @@
-import pytest
 import os
 from unittest import mock
 
@@ -19,7 +18,7 @@ def test_gunzip_logic(safe_tmpdir):
 
     with mock.patch('subprocess.call',
                     return_value=0) as mock_gpg, \
-            mock.patch('os.unlink') as mock_unlink:
+            mock.patch('os.unlink'):
         res, dest = decrypt_submission_or_reply(
             test_gzip, expected_output_filename,
             str(safe_tmpdir), is_qubes=False,

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -3,11 +3,9 @@ Make sure the Client object, containing the application logic, behaves as
 expected.
 """
 import arrow
-from datetime import datetime
 import os
 import pytest
-import sdclientapi
-import shutil
+from datetime import datetime
 from securedrop_client import storage, models
 from securedrop_client.logic import APICallRunner, Client
 from unittest import mock
@@ -50,7 +48,7 @@ def test_APICallRunner_with_exception():
     mock_current_object = mock.MagicMock()
     cr = APICallRunner(mock_api_call, mock_current_object, 'foo', bar='baz')
     cr.call_finished = mock.MagicMock()
-    with mock.patch('securedrop_client.logic.QTimer') as mock_timer:
+    with mock.patch('securedrop_client.logic.QTimer'):
         cr.call_api()
     assert cr.result == ex
     cr.call_finished.emit.assert_called_once_with()
@@ -92,7 +90,7 @@ def test_Client_start_message_thread(safe_tmpdir):
     mock_session = mock.MagicMock()
     cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
     with mock.patch('securedrop_client.logic.QThread') as mock_qthread, \
-            mock.patch('securedrop_client.logic.MessageSync') as mock_msync:
+            mock.patch('securedrop_client.logic.MessageSync'):
         cl.message_sync = mock.MagicMock()
         cl.start_message_thread()
         cl.message_sync.moveToThread.assert_called_once_with(mock_qthread())
@@ -109,7 +107,7 @@ def test_Client_start_reply_thread(safe_tmpdir):
     mock_session = mock.MagicMock()
     cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
     with mock.patch('securedrop_client.logic.QThread') as mock_qthread, \
-            mock.patch('securedrop_client.logic.ReplySync') as mock_msync:
+            mock.patch('securedrop_client.logic.ReplySync'):
         cl.reply_sync = mock.MagicMock()
         cl.start_reply_thread()
         cl.reply_sync.moveToThread.assert_called_once_with(mock_qthread())
@@ -126,10 +124,10 @@ def test_Client_call_api(safe_tmpdir):
     mock_session = mock.MagicMock()
     cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
     cl.finish_api_call = mock.MagicMock()
-    with mock.patch('securedrop_client.logic.QThread') as mock_qthread, \
+    with mock.patch('securedrop_client.logic.QThread'), \
             mock.patch(
-                'securedrop_client.logic.APICallRunner') as mock_runner, \
-            mock.patch('securedrop_client.logic.QTimer') as mock_timer:
+                'securedrop_client.logic.APICallRunner'), \
+            mock.patch('securedrop_client.logic.QTimer'):
         mock_api_call = mock.MagicMock()
         mock_callback = mock.MagicMock()
         mock_timeout = mock.MagicMock()

--- a/tests/test_message_sync.py
+++ b/tests/test_message_sync.py
@@ -1,7 +1,6 @@
 """
 Make sure the message sync object behaves as expected.
 """
-import pytest
 from unittest import mock
 from securedrop_client.message_sync import MessageSync, ReplySync
 
@@ -40,14 +39,14 @@ def test_MessageSync_run_success():
                     ]),\
             mock.patch('subprocess.call',
                        return_value=0), \
-            mock.patch('shutil.move') as mock_move, \
-            mock.patch('shutil.copy') as mock_copy, \
-            mock.patch('os.unlink') as mock_unlink, \
+            mock.patch('shutil.move'), \
+            mock.patch('shutil.copy'), \
+            mock.patch('os.unlink'), \
             mock.patch('securedrop_client.message_sync.storage'
-                       '.mark_file_as_downloaded') as mock_mark_as_dl, \
+                       '.mark_file_as_downloaded'), \
             mock.patch(
                 'tempfile.NamedTemporaryFile',
-                return_value=fh) as mock_temp_file, \
+                return_value=fh), \
             mock.patch('builtins.open', mock.mock_open(read_data="blah")):
 
         api = mock.MagicMock()
@@ -97,14 +96,14 @@ def test_MessageSync_run_failure():
                     ]),\
             mock.patch('subprocess.call',
                        return_value=1), \
-            mock.patch('shutil.move') as mock_move, \
-            mock.patch('shutil.copy') as mock_copy, \
-            mock.patch('os.unlink') as mock_unlink, \
+            mock.patch('shutil.move'), \
+            mock.patch('shutil.copy'), \
+            mock.patch('os.unlink'), \
             mock.patch('securedrop_client.message_sync.storage'
-                       '.mark_file_as_downloaded') as mock_mark_as_dl, \
+                       '.mark_file_as_downloaded'), \
             mock.patch(
                 'tempfile.NamedTemporaryFile',
-                return_value=fh) as mock_temp_file, \
+                return_value=fh), \
             mock.patch('builtins.open', mock.mock_open(read_data="blah")):
 
         api = mock.MagicMock()
@@ -133,14 +132,14 @@ def test_ReplySync_run_success():
                     ]),\
             mock.patch('subprocess.call',
                        return_value=0), \
-            mock.patch('shutil.move') as mock_move, \
-            mock.patch('shutil.copy') as mock_copy, \
-            mock.patch('os.unlink') as mock_unlink, \
+            mock.patch('shutil.move'), \
+            mock.patch('shutil.copy'), \
+            mock.patch('os.unlink'), \
             mock.patch('securedrop_client.message_sync.storage'
-                       '.mark_file_as_downloaded') as mock_mark_as_dl, \
+                       '.mark_file_as_downloaded'), \
             mock.patch(
                 'tempfile.NamedTemporaryFile',
-                return_value=fh) as mock_temp_file, \
+                return_value=fh), \
             mock.patch('builtins.open', mock.mock_open(read_data="blah")):
 
         api = mock.MagicMock()
@@ -190,14 +189,14 @@ def test_ReplySync_run_failure():
                     ]),\
             mock.patch('subprocess.call',
                        return_value=1), \
-            mock.patch('shutil.move') as mock_move, \
-            mock.patch('shutil.copy') as mock_copy, \
-            mock.patch('os.unlink') as mock_unlink, \
+            mock.patch('shutil.move'), \
+            mock.patch('shutil.copy'), \
+            mock.patch('os.unlink'), \
             mock.patch('securedrop_client.message_sync.storage'
-                       '.mark_reply_as_downloaded') as mock_mark_as_dl, \
+                       '.mark_reply_as_downloaded'), \
             mock.patch(
                 'tempfile.NamedTemporaryFile',
-                return_value=fh) as mock_temp_file, \
+                return_value=fh), \
             mock.patch('builtins.open', mock.mock_open(read_data="blah")):
 
         api = mock.MagicMock()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -6,17 +6,10 @@ import uuid
 import securedrop_client.models
 from dateutil.parser import parse
 from unittest import mock
-from securedrop_client.storage import (get_local_sources,
-                                       get_local_submissions,
-                                       get_local_replies,
-                                       get_remote_data, update_local_storage,
-                                       update_sources,
-                                       update_submissions, update_replies,
-                                       find_or_create_user,
-                                       find_new_submissions,
-                                       find_new_replies,
-                                       mark_file_as_downloaded,
-                                       mark_reply_as_downloaded)
+from securedrop_client.storage import get_local_sources, get_local_submissions, get_local_replies, \
+    get_remote_data, update_local_storage, update_sources, update_submissions, update_replies, \
+    find_or_create_user, find_new_submissions, find_new_replies, mark_file_as_downloaded, \
+    mark_reply_as_downloaded
 from sdclientapi import Source, Submission, Reply
 
 
@@ -95,7 +88,6 @@ def test_get_remote_data_handles_api_error():
     """
     mock_api = mock.MagicMock()
     mock_api.get_sources.side_effect = Exception('BANG!')
-    mock_session = mock.MagicMock()
     with pytest.raises(Exception):
         get_remote_data(mock_api)
 


### PR DESCRIPTION
- Uses the standard SD `Makefile`
- Splits `check` into `lint` and `test` (because it's nice to run one but not the other)
- Moves to `flake8` for linting
- Fixes lint errors
- **HIGHLY CONTROVERSIALLY** sets the max line length to 100
  - I am very prepared to squabble over why this change is A Good Thing™
- Only runs tests with `xvfb-run` if it's present

fixes #139 
fixes #111
fixes #57 