### PR TITLE
Fix crash in offline mode

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -484,6 +484,10 @@ class Client(QObject):
         Download the file associated with the associated message (which may
         be a Submission or Reply).
         """
+        if not self.api:  # Then we should tell the user they need to login.
+            self.on_action_requiring_login()
+            return
+
         if isinstance(message, models.Submission):
             # Handle submissions.
             func = self.api.download_submission

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,6 +2,7 @@
 Tests for the app module, which sets things up and runs the application.
 """
 import os
+import platform
 import pytest
 import sys
 from PyQt5.QtWidgets import QApplication
@@ -46,6 +47,8 @@ def test_configure_logging(safe_tmpdir):
         assert sys.excepthook == excepthook
 
 
+@pytest.mark.skipif(platform.system() != 'Linux',
+                    reason="concurrent app prevention skipped on non Linux")
 @mock.patch('securedrop_client.app.sys.exit')
 @mock.patch('securedrop_client.app.QMessageBox')
 class TestSecondInstancePrevention(object):

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -800,6 +800,27 @@ def test_Client_on_file_downloaded_decrypt_failure(safe_tmpdir):
             "Failed to download and decrypt file, please try again.")
 
 
+def test_Client_on_file_download_user_not_signed_in(safe_tmpdir):
+    """
+    If a user clicks the download button but is not logged in,
+    an error should appear.
+    """
+    mock_gui = mock.MagicMock()
+    mock_session = mock.MagicMock()
+    cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
+    source = models.Source('source-uuid', 'testy-mctestface', False,
+                           'mah pub key', 1, False, datetime.now())
+    submission = models.Submission(source, 'submission-uuid', 1234,
+                                   'myfile.doc.gpg', 'http://myserver/myfile')
+    cl.on_action_requiring_login = mock.MagicMock()
+    cl.api = None
+    submission_sdk_object = mock.MagicMock()
+    with mock.patch('sdclientapi.Submission') as mock_submission:
+        mock_submission.return_value = submission_sdk_object
+        cl.on_file_download(source, submission)
+    cl.on_action_requiring_login.assert_called_once_with()
+
+
 def test_Client_on_download_timeout(safe_tmpdir):
     mock_gui = mock.MagicMock()
     mock_session = mock.MagicMock()


### PR DESCRIPTION
Fix defect #146 discovered by @zenmonkeykstop

Also adds a conditional test skip on macOS as followup from #148 

Test plan:

1. Submit a test document via the source interface
2. Sign in and sync
3. Sign out
4. Click the download
5. The application should not crash :wink: and you should see: 

<img width="713" alt="screen shot 2018-11-10 at 2 02 30 pm" src="https://user-images.githubusercontent.com/7832803/48306655-4921c000-e4f1-11e8-8a79-0a385a9047ec.png">
