### PR TITLE
Disable refresh button while API call is in progress

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -109,8 +109,7 @@ class ToolBar(QWidget):
         """
         Called when the refresh call completes
         """
-        self.refresh.setEnabled(data!='syncing')
-
+        self.refresh.setEnabled(data != 'syncing')
 
 
 class MainView(QWidget):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -67,6 +67,8 @@ class ToolBar(QWidget):
         self.window = window
         self.controller = controller
 
+        self.controller.sync_events.connect(self._on_sync_event)
+
     def set_logged_in_as(self, username):
         """
         Update the UI to reflect that the user is logged in as "username".
@@ -102,6 +104,13 @@ class ToolBar(QWidget):
         Called when the refresh button is clicked.
         """
         self.controller.sync_api()
+
+    def _on_sync_event(self, data):
+        """
+        Called when the refresh call completes
+        """
+        self.refresh.setEnabled(data!='syncing')
+
 
 
 class MainView(QWidget):

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -89,6 +89,8 @@ class Client(QObject):
     application, this is the controller.
     """
 
+    sync_events = pyqtSignal(str)
+
     def __init__(self, hostname, gui, session,
                  home: str, proxy: bool = True) -> None:
         """
@@ -345,6 +347,7 @@ class Client(QObject):
         """
         logger.debug("In sync_api on thread {}".format(
             self.thread().currentThreadId()))
+        self.sync_events.emit('syncing')
 
         if self.authenticated():
             logger.debug("You are authenticated, going to make your call")
@@ -367,6 +370,7 @@ class Client(QObject):
         """
         Called when syncronisation of data via the API is complete.
         """
+        self.sync_events.emit('synced')
         if isinstance(result, tuple):
             remote_sources, remote_submissions, remote_replies = \
                 result

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -96,6 +96,17 @@ def test_ToolBar_on_refresh_clicked():
     tb.controller.sync_api.assert_called_once_with()
 
 
+def test_ToolBar_sync_event():
+    """Toggles refresh button when syncing
+    """
+    tb = ToolBar(None)
+    tb._on_sync_event('syncing')
+    assert not tb.refresh.isEnabled()
+
+    tb._on_sync_event('synced')
+    assert tb.refresh.isEnabled()
+
+
 def test_MainView_init():
     """
     Ensure the MainView instance is correctly set up.


### PR DESCRIPTION
Quick POC of doing this without any significant changes to the code. It'd be good to get comments on some thoughts I had about how the API call is handled in the model and view (below)

![refresh disable](https://user-images.githubusercontent.com/249800/48307341-a7ee3600-e4ff-11e8-9b39-c0444ae099a9.gif)

The current API code makes this tricky to do particularly well:

- auto refresh and manual refresh could be simultaneously called
- the callbacks will be fired whether it's auto or manual

It'd be nice to create a `Promise` object or similar to return from API calls, which the caller could connect to, e.g:

```python
promise = self.controller.sync_api()
self.refresh.setEnabled(False)
promise.on_settled(lambda: self.refresh.setEnabled(True))
```
