### PR TITLE
Only show attachment icon when document count is > 0

### DIFF
--- a/alembic/versions/cd0fbb73bf8e_capture_document_count.py
+++ b/alembic/versions/cd0fbb73bf8e_capture_document_count.py
@@ -1,0 +1,25 @@
+"""Capture document count
+
+Revision ID: cd0fbb73bf8e
+Revises: 5344fc3a3d3f
+Create Date: 2018-11-10 18:10:23.847838
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'cd0fbb73bf8e'
+down_revision = '5344fc3a3d3f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('sources', sa.Column(
+        'document_count', sa.Integer(), nullable=False, server_default='0'))
+
+
+def downgrade():
+    op.drop_column('sources', 'document_count')

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -237,6 +237,9 @@ class SourceWidget(QWidget):
         self.name.setText("<strong>{}</strong>".format(
                           self.source.journalist_designation))
 
+        if self.source.document_count == 0:
+            self.attached.hide()
+
     def toggle_star(self, event):
         """
         Called when the star is clicked.

--- a/securedrop_client/models.py
+++ b/securedrop_client/models.py
@@ -37,9 +37,11 @@ class WithContent():
 
 class Source(Base):
     __tablename__ = 'sources'
+    # TODO - add number_of_docs
     id = Column(Integer, primary_key=True)
     uuid = Column(String(36), unique=True, nullable=False)
     journalist_designation = Column(String(255), nullable=False)
+    document_count = Column(Integer, server_default="0", nullable=False)
     is_flagged = Column(Boolean(name='ck_sources_is_flagged'),
                         server_default="false")
     public_key = Column(Text, nullable=True)
@@ -49,11 +51,12 @@ class Source(Base):
     last_updated = Column(DateTime)
 
     def __init__(self, uuid, journalist_designation, is_flagged, public_key,
-                 interaction_count, is_starred, last_updated):
+                 interaction_count, is_starred, last_updated, document_count):
         self.uuid = uuid
         self.journalist_designation = journalist_designation
         self.is_flagged = is_flagged
         self.public_key = public_key
+        self.document_count = document_count
         self.interaction_count = interaction_count
         self.is_starred = is_starred
         self.last_updated = last_updated

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -109,6 +109,7 @@ def update_sources(remote_sources, local_sources, session):
             local_source.is_flagged = source.is_flagged
             local_source.public_key = source.key['public']
             local_source.interaction_count = source.interaction_count
+            local_source.document_count = source.number_of_documents
             local_source.is_starred = source.is_starred
             local_source.last_updated = parse(source.last_updated)
             # Removing the UUID from local_uuids ensures this record won't be
@@ -123,7 +124,8 @@ def update_sources(remote_sources, local_sources, session):
                         public_key=source.key['public'],
                         interaction_count=source.interaction_count,
                         is_starred=source.is_starred,
-                        last_updated=parse(source.last_updated))
+                        last_updated=parse(source.last_updated),
+                        document_count=source.number_of_documents)
             session.add(ns)
             logger.info('Added new source {}'.format(source.uuid))
     # The uuids remaining in local_uuids do not exist on the remote server, so

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -1,0 +1,22 @@
+"""Create models with a set of default valid properties, to avoid
+changes forcing an update of all test code.
+"""
+from datetime import datetime
+from securedrop_client import models
+
+
+def Source(**attrs):
+    defaults = dict(
+        uuid='source-uuid',
+        journalist_designation='testy-mctestface',
+        is_flagged=False,
+        public_key='mah pub key',
+        interaction_count=0,
+        is_starred=False,
+        last_updated=datetime.now(),
+        document_count=0
+    )
+
+    defaults.update(attrs)
+
+    return models.Source(**defaults)

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1,8 +1,8 @@
 """
 Make sure the UI widgets are configured correctly and work as expected.
 """
-from datetime import datetime
 from PyQt5.QtWidgets import QWidget, QApplication, QWidgetItem, QSpacerItem, QVBoxLayout
+from tests import factory
 from securedrop_client import models
 from securedrop_client.gui.widgets import ToolBar, MainView, SourceList, SourceWidget, \
     LoginDialog, SpeechBubble, ConversationWidget, MessageWidget, ReplyWidget, FileWidget, \
@@ -208,6 +208,22 @@ def test_SourceWidget_update_unstarred():
     sw.name.setText.assert_called_once_with('<strong>foo bar baz</strong>')
 
 
+def test_SourceWidget_update_attachment_icon():
+    """
+    Attachment icon identicates document count
+    """
+    source = factory.Source(document_count=1)
+    sw = SourceWidget(None, source)
+
+    sw.update()
+    assert not sw.attached.isHidden()
+
+    source.document_count = 0
+
+    sw.update()
+    assert sw.attached.isHidden()
+
+
 def test_SourceWidget_toggle_star():
     """
     The toggle_star method should call self.controller.update_star
@@ -374,8 +390,7 @@ def test_FileWidget_init_left():
     Check the FileWidget is configured correctly for align-left.
     """
     mock_controller = mock.MagicMock()
-    source = models.Source('source-uuid', 'testy-mctestface', False,
-                           'mah pub key', 1, False, datetime.now())
+    source = factory.Source()
     submission = models.Submission(source, 'submission-uuid', 123,
                                    'mah-reply.gpg',
                                    'http://mah-server/mah-reply-url')
@@ -395,8 +410,7 @@ def test_FileWidget_init_right():
     Check the FileWidget is configured correctly for align-right.
     """
     mock_controller = mock.MagicMock()
-    source = models.Source('source-uuid', 'testy-mctestface', False,
-                           'mah pub key', 1, False, datetime.now())
+    source = factory.Source()
     submission = models.Submission(source, 'submission-uuid', 123,
                                    'mah-reply.gpg',
                                    'http://mah-server/mah-reply-url')
@@ -415,8 +429,7 @@ def test_FileWidget_mousePressEvent_download():
     Should fire the expected download event handler in the logic layer.
     """
     mock_controller = mock.MagicMock()
-    source = models.Source('source-uuid', 'testy-mctestface', False,
-                           'mah pub key', 1, False, datetime.now())
+    source = factory.Source()
     submission = models.Submission(source, 'submission-uuid', 123,
                                    'mah-reply.gpg',
                                    'http://mah-server/mah-reply-url')
@@ -432,8 +445,7 @@ def test_FileWidget_mousePressEvent_open():
     Should fire the expected open event handler in the logic layer.
     """
     mock_controller = mock.MagicMock()
-    source = models.Source('source-uuid', 'testy-mctestface', False,
-                           'mah pub key', 1, False, datetime.now())
+    source = factory.Source()
     submission = models.Submission(source, 'submission-uuid', 123,
                                    'mah-reply.gpg',
                                    'http://mah-server/mah-reply-url')

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -5,7 +5,7 @@ expected.
 import arrow
 import os
 import pytest
-from datetime import datetime
+from tests import factory
 from securedrop_client import storage, models
 from securedrop_client.logic import APICallRunner, Client
 from unittest import mock
@@ -720,8 +720,7 @@ def test_Client_on_file_download_Submission(safe_tmpdir):
     mock_gui = mock.MagicMock()
     mock_session = mock.MagicMock()
     cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
-    source = models.Source('source-uuid', 'testy-mctestface', False,
-                           'mah pub key', 1, False, datetime.now())
+    source = factory.Source()
     submission = models.Submission(source, 'submission-uuid', 1234,
                                    'myfile.doc.gpg', 'http://myserver/myfile')
     cl.call_api = mock.MagicMock()
@@ -824,8 +823,7 @@ def test_Client_on_file_download_Reply(safe_tmpdir):
     mock_gui = mock.MagicMock()
     mock_session = mock.MagicMock()
     cl = Client('http://localhost', mock_gui, mock_session, str(safe_tmpdir))
-    source = models.Source('source-uuid', 'testy-mctestface', False,
-                           'mah pub key', 1, False, datetime.now())
+    source = factory.Source()
     journalist = models.User('Testy mcTestface')
     reply = models.Reply('reply-uuid', journalist, source,
                          'my-reply.gpg', 123)  # Not a sdclientapi.Submission

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
-from securedrop_client.models import Reply, Source, Submission, User
+from tests import factory
+from securedrop_client.models import Reply, Submission, User
 from unittest import mock
 
 
@@ -8,16 +9,12 @@ def test_string_representation_of_user():
 
 
 def test_string_representation_of_source():
-    source = Source(journalist_designation="testy test", uuid="test",
-                    is_flagged=False, public_key='test', interaction_count=1,
-                    is_starred=False, last_updated='test')
+    source = factory.Source()
     source.__repr__()
 
 
 def test_string_representation_of_submission():
-    source = Source(journalist_designation="testy test", uuid="test",
-                    is_flagged=False, public_key='test', interaction_count=1,
-                    is_starred=False, last_updated='test')
+    source = factory.Source()
     submission = Submission(source=source, uuid="test", size=123,
                             filename="test.docx",
                             download_url='http://test/test')
@@ -25,9 +22,7 @@ def test_string_representation_of_submission():
 
 
 def test_submission_content_not_downloaded():
-    source = Source(journalist_designation="testy test", uuid="test",
-                    is_flagged=False, public_key='test', interaction_count=1,
-                    is_starred=False, last_updated='test')
+    source = factory.Source()
     submission = Submission(source=source, uuid="test", size=123,
                             filename="test.docx",
                             download_url='http://test/test')
@@ -35,9 +30,7 @@ def test_submission_content_not_downloaded():
 
 
 def test_submission_content_downloaded():
-    source = Source(journalist_designation="testy test", uuid="test",
-                    is_flagged=False, public_key='test', interaction_count=1,
-                    is_starred=False, last_updated='test')
+    source = factory.Source()
     submission = Submission(source=source, uuid="test", size=123,
                             filename="test.docx",
                             download_url='http://test/test')
@@ -47,9 +40,7 @@ def test_submission_content_downloaded():
 
 
 def test_reply_content_not_downloaded():
-    source = Source(journalist_designation="testy test", uuid="test",
-                    is_flagged=False, public_key='test', interaction_count=1,
-                    is_starred=False, last_updated='test')
+    source = factory.Source()
     journalist = User('Testy mcTestface')
     reply = Reply(source=source, uuid="test", size=123,
                   filename="test.docx", journalist=journalist)
@@ -57,9 +48,7 @@ def test_reply_content_not_downloaded():
 
 
 def test_reply_content_downloaded():
-    source = Source(journalist_designation="testy test", uuid="test",
-                    is_flagged=False, public_key='test', interaction_count=1,
-                    is_starred=False, last_updated='test')
+    source = factory.Source()
     journalist = User('Testy mcTestface')
     reply = Reply(source=source, uuid="test", size=123,
                   filename="test.docx", journalist=journalist)
@@ -70,9 +59,7 @@ def test_reply_content_downloaded():
 
 def test_string_representation_of_reply():
     user = User('hehe')
-    source = Source(journalist_designation="testy test", uuid="test",
-                    is_flagged=False, public_key='test', interaction_count=1,
-                    is_starred=False, last_updated='test')
+    source = factory.Source()
     reply = Reply(source=source, journalist=user, filename="reply.gpg",
                   size=1234, uuid='test')
     reply.__repr__()
@@ -82,9 +69,7 @@ def test_string_representation_of_reply():
 
 def test_source_collection():
     # Create some test submissions and replies
-    source = Source(journalist_designation="testy test", uuid="test",
-                    is_flagged=False, public_key='test', interaction_count=1,
-                    is_starred=False, last_updated='test')
+    source = factory.Source()
     submission = Submission(source=source, uuid="test", size=123,
                             filename="2-test.doc.gpg",
                             download_url='http://test/test')


### PR DESCRIPTION
Added a factory module to DRY up creating test objects. Stops a new attribute etc requiring a lot of updating. Also makes it clearer which attributes are important for a test.

I named the field `document_count` to keep it consistent with `interaction_count`. Might be a worse option than matching the server's field name `number_of_documents` however. 🤷‍♂️ 