### PR TITLE
delete submissions, replies on disk when source, submission, or reply is deleted

### DIFF
--- a/securedrop_client/data.py
+++ b/securedrop_client/data.py
@@ -12,7 +12,10 @@ class Data:
     def get(self, fn):
         full_path = os.path.join(self.data_dir, fn)
 
-        with open(full_path) as fh:
-            msg = fh.read()
+        try:
+            with open(full_path) as fh:
+                msg = fh.read()
+        except FileNotFoundError:
+            msg = "<Content deleted>"
 
         return msg

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -377,7 +377,7 @@ class Client(QObject):
 
             storage.update_local_storage(self.session, remote_sources,
                                          remote_submissions,
-                                         remote_replies)
+                                         remote_replies, self.data_dir)
 
             # Set last sync flag.
             with open(self.sync_flag, 'w') as f:

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -87,7 +87,7 @@ def update_local_storage(session, remote_sources, remote_submissions,
     local_replies = get_local_replies(session)
     update_sources(remote_sources, local_sources, session)
     update_submissions(remote_submissions, local_submissions, session, data_dir)
-    update_replies(remote_replies, local_replies, session)
+    update_replies(remote_replies, local_replies, session, data_dir)
 
 
 def update_sources(remote_sources, local_sources, session):
@@ -179,7 +179,7 @@ def update_submissions(remote_submissions, local_submissions, session, data_dir)
     session.commit()
 
 
-def update_replies(remote_replies, local_replies, session):
+def update_replies(remote_replies, local_replies, session, data_dir):
     """
     * Existing replies are updated in the local database.
     * New replies have an entry created in the local database.
@@ -213,6 +213,7 @@ def update_replies(remote_replies, local_replies, session):
     # The uuids remaining in local_uuids do not exist on the remote server, so
     # delete the related records.
     for deleted_reply in [r for r in local_replies if r.uuid in local_uuids]:
+        delete_single_submission_or_reply_on_disk(deleted_reply, data_dir)
         session.delete(deleted_reply)
         logger.info('Deleted reply {}'.format(deleted_reply.uuid))
     session.commit()

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -85,12 +85,12 @@ def update_local_storage(session, remote_sources, remote_submissions,
     local_sources = get_local_sources(session)
     local_submissions = get_local_submissions(session)
     local_replies = get_local_replies(session)
-    update_sources(remote_sources, local_sources, session)
+    update_sources(remote_sources, local_sources, session, data_dir)
     update_submissions(remote_submissions, local_submissions, session, data_dir)
     update_replies(remote_replies, local_replies, session, data_dir)
 
 
-def update_sources(remote_sources, local_sources, session):
+def update_sources(remote_sources, local_sources, session, data_dir):
     """
     Given collections of remote sources, the current local sources and a
     session to the local database, ensure the state of the local database
@@ -133,6 +133,8 @@ def update_sources(remote_sources, local_sources, session):
     # The uuids remaining in local_uuids do not exist on the remote server, so
     # delete the related records.
     for deleted_source in [s for s in local_sources if s.uuid in local_uuids]:
+        for document in deleted_source.collection:
+            delete_single_submission_or_reply_on_disk(document, data_dir)
         session.delete(deleted_source)
         logger.info('Deleted source {}'.format(deleted_source.uuid))
     session.commit()

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -21,6 +21,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import logging
 from dateutil.parser import parse
+import glob
+import os
 from securedrop_client.models import Source, Submission, Reply, User
 
 
@@ -74,7 +76,7 @@ def get_remote_data(api):
 
 
 def update_local_storage(session, remote_sources, remote_submissions,
-                         remote_replies):
+                         remote_replies, data_dir):
     """
     Given a database session and collections of remote sources, submissions and
     replies from the SecureDrop API, ensures the local database is updated
@@ -84,7 +86,7 @@ def update_local_storage(session, remote_sources, remote_submissions,
     local_submissions = get_local_submissions(session)
     local_replies = get_local_replies(session)
     update_sources(remote_sources, local_sources, session)
-    update_submissions(remote_submissions, local_submissions, session)
+    update_submissions(remote_submissions, local_submissions, session, data_dir)
     update_replies(remote_replies, local_replies, session)
 
 
@@ -136,7 +138,7 @@ def update_sources(remote_sources, local_sources, session):
     session.commit()
 
 
-def update_submissions(remote_submissions, local_submissions, session):
+def update_submissions(remote_submissions, local_submissions, session, data_dir):
     """
     * Existing submissions are updated in the local database.
     * New submissions have an entry created in the local database.
@@ -171,6 +173,7 @@ def update_submissions(remote_submissions, local_submissions, session):
     # delete the related records.
     for deleted_submission in [s for s in local_submissions
                                if s.uuid in local_uuids]:
+        delete_single_submission_or_reply_on_disk(deleted_submission, data_dir)
         session.delete(deleted_submission)
         logger.info('Deleted submission {}'.format(deleted_submission.uuid))
     session.commit()
@@ -277,3 +280,21 @@ def mark_reply_as_downloaded(uuid, session):
     reply_db_object.is_downloaded = True
     session.add(reply_db_object)
     session.commit()
+
+
+def delete_single_submission_or_reply_on_disk(obj_db, data_dir):
+    """
+    Delete on disk a single submission or reply.
+    """
+    filename_without_extensions = obj_db.filename.split('.')[0]
+    files_to_delete = os.path.join(
+        data_dir,
+        '{}*'.format(filename_without_extensions))
+    logging.info('Deleting all {} files'.format(filename_without_extensions))
+
+    try:
+        for file_to_delete in glob.glob(files_to_delete):
+            os.remove(file_to_delete)
+    except FileNotFoundError:
+        logging.info(
+            'File {} already deleted, skipping'.format(file_to_delete))

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2,13 +2,25 @@
 Make sure the Data object (which abstracts access to the `/data/`
 storage directory) works as expected.
 """
-
 from securedrop_client.data import Data
 
 
-def test_Data_init(tmpdir):
+def test_Data_init(safe_tmpdir):
     """
     Ensure the Data class instantiates as expected
     """
-    data = Data(tmpdir)
-    assert data.data_dir == tmpdir
+    data = Data(str(safe_tmpdir))
+    assert data.data_dir == safe_tmpdir
+
+
+def test_Data_file_not_found(safe_tmpdir):
+    """
+    Ensure the data class handles missing files gracefully
+    (e.g. if the file gets deleted)
+    """
+    data = Data(str(safe_tmpdir))
+    msg = data.get('my-file.gpg')
+
+    # No unhandled exceptions should occur, and a 'nice' msg
+    # should be shown.
+    assert msg == "<Content deleted>"

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -501,7 +501,8 @@ def test_Client_on_synced_with_result(safe_tmpdir):
         cl.on_synced(result_data)
         mock_storage.update_local_storage.\
             assert_called_once_with(mock_session, "sources", "submissions",
-                                    "replies")
+                                    "replies",
+                                    os.path.join(str(safe_tmpdir), 'data'))
     cl.update_sources.assert_called_once_with()
 
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -138,7 +138,7 @@ def test_update_local_storage(safe_tmpdir):
         src_fn.assert_called_once_with([source, ], [local_source, ],
                                        mock_session)
         rpl_fn.assert_called_once_with([reply, ], [local_replies, ],
-                                       mock_session)
+                                       mock_session, str(safe_tmpdir))
         sub_fn.assert_called_once_with([submission, ], [local_submission, ],
                                        mock_session, str(safe_tmpdir))
 
@@ -282,7 +282,7 @@ def test_update_replies_deletes_files_associated_with_the_reply(safe_tmpdir):
     local_source.uuid = 'test-source-uuid'
     local_source.id = 666
     mock_session.query().filter_by.return_value = [local_source, ]
-    update_replies(remote_replies, local_replies, mock_session)
+    update_replies(remote_replies, local_replies, mock_session, str(safe_tmpdir))
 
     # Ensure the files associated with the reply are deleted on disk.
     assert not os.path.exists(abs_server_filename)
@@ -348,7 +348,7 @@ def test_update_submissions(safe_tmpdir):
     assert mock_session.commit.call_count == 1
 
 
-def test_update_replies():
+def test_update_replies(safe_tmpdir):
     """
     Check that:
 
@@ -391,7 +391,8 @@ def test_update_replies():
     mock_focu = mock.MagicMock(return_value=local_user)
     with mock.patch('securedrop_client.storage.find_or_create_user',
                     mock_focu):
-        update_replies(remote_replies, local_replies, mock_session)
+        update_replies(remote_replies, local_replies, mock_session,
+                       str(safe_tmpdir))
     # Check the expected local reply object has been updated with values
     # from the API.
     assert local_reply1.journalist_id == local_user.id

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -139,14 +139,14 @@ def test_update_local_storage(safe_tmpdir):
         update_local_storage(mock_session, sources, submissions, replies,
                              str(safe_tmpdir))
         src_fn.assert_called_once_with([source, ], [local_source, ],
-                                       mock_session)
+                                       mock_session, str(safe_tmpdir))
         rpl_fn.assert_called_once_with([reply, ], [local_replies, ],
                                        mock_session, str(safe_tmpdir))
         sub_fn.assert_called_once_with([submission, ], [local_submission, ],
                                        mock_session, str(safe_tmpdir))
 
 
-def test_update_sources():
+def test_update_sources(safe_tmpdir):
     """
     Check that:
 
@@ -170,7 +170,7 @@ def test_update_sources():
     local_source2 = mock.MagicMock()
     local_source2.uuid = str(uuid.uuid4())
     local_sources = [local_source1, local_source2]
-    update_sources(remote_sources, local_sources, mock_session)
+    update_sources(remote_sources, local_sources, mock_session, str(safe_tmpdir))
     # Check the expected local source object has been updated with values from
     # the API.
     assert local_source1.journalist_designation == \
@@ -349,7 +349,7 @@ def test_update_sources_deletes_files_associated_with_the_source(safe_tmpdir):
         test_filename_absolute_paths.append(abs_server_filename)
 
     local_sources = [local_source]
-    update_sources(remote_sources, local_sources, mock_session)
+    update_sources(remote_sources, local_sources, mock_session, str(safe_tmpdir))
 
     # Ensure the files associated with the reply are deleted on disk.
     for test_filename in test_filename_absolute_paths:


### PR DESCRIPTION
Closes #153

### Case 1: Submission deleted

1. Start the dev container.
2. Log into the client.
3. Make sure that one downloads a file from a source. 
4. This files should now be in the data folder (inside the SecureDrop homedir).
5. Log into the journalist interface and delete the submission you downloaded (NOT a reply, we will run through that separately).
6. Back in the client, click Refresh.
7. Now look in the data directory: the file associated with the submission you deleted should be gone.

### Case 2: Reply deleted

1. Now using the journalist interface, submit a reply to a source.
2. Wait until that reply downloads and decrypts.
3. Verify the file is there in the data folder locally.
4. Now delete the reply from the journalist interface.
5. Back in the client, click Refresh.
6. Now look in the data directory: the file associated with the reply you deleted should be gone.

### Case 3: Source deleted

1. Now, make sure there is at least a reply and submission associated with a given source.
2. Refresh the client again, make sure the documents associated with the source are downloaded. 
3. Verify the files associated with that source’s submissions are in the data folder locally.
4. Now delete the source from the journalist interface.
5. Back in the client, click refresh.
6. Now look in the data directory: all files associated with all sources documents should be gone.