### PR TITLE
Fix for displaying quote based messages in conversation

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -388,7 +388,7 @@ class SpeechBubble(QWidget):
         super().__init__()
         layout = QVBoxLayout()
         self.setLayout(layout)
-        message = QLabel(html.escape(text))
+        message = QLabel(html.escape(text, quote=False))
         message.setWordWrap(True)
         layout.addWidget(message)
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -459,6 +459,16 @@ def test_SpeechBubble_html_init():
         mock_label.assert_called_once_with('&lt;b&gt;hello&lt;/b&gt;')
 
 
+def test_SpeechBubble_with_apostrophe_in_text():
+    """Check Speech Bubble is displaying text with apostrophe correctly."""
+    with mock.patch('securedrop_client.gui.widgets.QLabel') as mock_label, \
+            mock.patch('securedrop_client.gui.widgets.QVBoxLayout'), \
+            mock.patch('securedrop_client.gui.widgets.SpeechBubble.setLayout'):
+        message = "I'm sure, you are reading my message."
+        SpeechBubble(message)
+        mock_label.assert_called_once_with(message)
+
+
 def test_ConversationWidget_init_left():
     """
     Check the ConversationWidget is configured correctly for align-left.


### PR DESCRIPTION
**Description:** In conversation, messages with single quote **'** or double quote **"** quote
wasn't rendered correct. It was difficult for journalist to read those
messages. This commit is fixing that problem of parsing quote based
messages and improves readability of the text in the conversation.

**Resolves**: #175

[Video demonstration](https://youtu.be/8nXX1R3HnfY) of this feature.