### PR TITLE
bugfix: resolve application crash due to existing gpg homedir

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -20,7 +20,7 @@ SDC_HOME=${SDC_HOME:-$(mktemp -d)}
 export SDC_HOME
 
 GPG_HOME="$SDC_HOME/gpg"
-mkdir "$GPG_HOME"
+mkdir -p "$GPG_HOME"
 chmod 0700 "$SDC_HOME" "$GPG_HOME"
 
 echo "Running app with home directory: $SDC_HOME"


### PR DESCRIPTION
Fix #193

(Test by running `./run.sh --sdc-home path-to-my-homedir` twice and verifying the app does not crash)