### PR TITLE
Fix for SD client crash

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -313,8 +313,12 @@ class SourceWidget(QWidget):
         self.controller.update_star(self.source)
 
     def delete_source(self, event):
-        messagebox = DeleteSourceMessageBox(self, self.source, self.controller)
-        messagebox.launch()
+        if self.controller.api is None:
+            self.controller.on_action_requiring_login()
+            return
+        else:
+            messagebox = DeleteSourceMessageBox(self, self.source, self.controller)
+            messagebox.launch()
 
 
 class LoginDialog(QDialog):
@@ -619,7 +623,14 @@ class DeleteSourceAction(QAction):
         self.messagebox = DeleteSourceMessageBox(
             parent, self.source, self.controller
         )
-        self.triggered.connect(self.messagebox.launch)
+        self.triggered.connect(self.trigger)
+
+    def trigger(self):
+        if self.controller.api is None:
+            self.controller.on_action_requiring_login()
+            return
+        else:
+            self.messagebox.launch()
 
 
 class SourceMenu(QMenu):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -5,9 +5,10 @@ from PyQt5.QtWidgets import QWidget, QApplication, QWidgetItem, QSpacerItem, QVB
     QMessageBox
 from tests import factory
 from securedrop_client import models
+from securedrop_client import logic
 from securedrop_client.gui.widgets import ToolBar, MainView, SourceList, SourceWidget, \
     LoginDialog, SpeechBubble, ConversationWidget, MessageWidget, ReplyWidget, FileWidget, \
-    ConversationView, DeleteSourceMessageBox, DeleteSourceAction
+    ConversationView, DeleteSourceMessageBox, DeleteSourceAction, SourceMenu
 
 
 app = QApplication([])
@@ -804,3 +805,62 @@ def test_DeleteSourceAction_init(mocker):
         None,
         mock_controller
     )
+
+
+def test_DeleteSourceAction_trigger(mocker):
+    mock_controller = mocker.MagicMock()
+    mock_source = mocker.MagicMock()
+    mock_delete_source_message_box_obj = mocker.MagicMock()
+    mock_delete_source_message_box = mocker.MagicMock()
+    mock_delete_source_message_box.return_value = (
+        mock_delete_source_message_box_obj
+    )
+    with mocker.patch(
+        'securedrop_client.gui.widgets.DeleteSourceMessageBox',
+        mock_delete_source_message_box
+    ):
+        delete_source_action = DeleteSourceAction(
+            mock_source,
+            None,
+            mock_controller
+        )
+        delete_source_action.trigger()
+        mock_delete_source_message_box_obj.launch.assert_called_once_with()
+
+
+def test_DeleteSource_from_source_menu_when_user_is_loggedout(mocker):
+    mock_source = mocker.MagicMock()
+    mock_controller = mocker.MagicMock(logic.Client)
+    mock_controller.api = None
+    mock_delete_source_message_box_obj = mocker.MagicMock()
+    mock_delete_source_message_box = mocker.MagicMock()
+    mock_delete_source_message_box.return_value = (
+        mock_delete_source_message_box_obj
+    )
+    with mocker.patch(
+        'securedrop_client.gui.widgets.DeleteSourceMessageBox',
+        mock_delete_source_message_box
+    ):
+        source_menu = SourceMenu(mock_source, mock_controller)
+        source_menu.actions()[0].trigger()
+        mock_delete_source_message_box_obj.launch.assert_not_called()
+
+
+def test_DeleteSource_from_source_widget_when_user_is_loggedout(mocker):
+    mock_source = mocker.MagicMock()
+    mock_controller = mocker.MagicMock(logic.Client)
+    mock_controller.api = None
+    mock_event = mocker.MagicMock()
+    mock_delete_source_message_box_obj = mocker.MagicMock()
+    mock_delete_source_message_box = mocker.MagicMock()
+    mock_delete_source_message_box.return_value = (
+        mock_delete_source_message_box_obj
+    )
+    with mocker.patch(
+        'securedrop_client.gui.widgets.DeleteSourceMessageBox',
+        mock_delete_source_message_box
+    ):
+        source_widget = SourceWidget(None, mock_source)
+        source_widget.setup(mock_controller)
+        source_widget.delete_source(mock_event)
+        mock_delete_source_message_box_obj.launch.assert_not_called()


### PR DESCRIPTION
When Journalist is signed-out (offline mode) and tries to delete the
source either from source menu or from the widget button, SD client
crashes. This commit will prevent crashing SD client and notify User to
logged in.

Resolves: #198