### PR TITLE
Fix for wrong files and messages number at delete source dialog

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -227,12 +227,17 @@ class DeleteSourceMessageBox:
             self.controller.delete_source(self.source)
 
     def _construct_message(self, source):
+        files = 0
+        messages = 0
+        for submission in source.submissions:
+            if submission.filename.endswith("msg.gpg"):
+                messages += 1
+            else:
+                files += 1
         message = (
             "<big>Deleting the Source account for",
-            "<b>%s</b> will also" % (source.journalist_designation,),
-            "delete %d files and %d messages.</big>" % (
-                len(source.submissions), len(source.replies)
-            ),
+            "<b>{}</b> will also".format(source.journalist_designation,),
+            "delete {} files and {} messages.</big>".format(files, messages),
             "<br>",
             "<small>This Source will no longer be able to correspond",
             "through the log-in tied to this account.</small>",

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -306,8 +306,16 @@ def test_SourceWidget_delete_source_when_user_chooses_cancel(mocker):
     mock_message_box_question.return_value = QMessageBox.Cancel
     mock_source = mocker.MagicMock()
     mock_source.journalist_designation = 'foo bar baz'
-    mock_source.submissions = ["submission_1", "submission_2"]
-    mock_source.replies = ["reply_1", "reply_2"]
+    mock_source.submissions = []
+    submission_files = (
+        "submission_1-msg.gpg",
+        "submission_2-msg.gpg",
+        "submission_3-doc.gpg",
+    )
+    for filename in submission_files:
+        submission = mocker.MagicMock()
+        submission.filename = filename
+        mock_source.submissions.append(submission)
     mock_controller = mocker.MagicMock()
     sw = SourceWidget(None, mock_source)
     sw.controller = mock_controller
@@ -728,8 +736,16 @@ def test_DeleteSourceMessage_launch_when_user_chooses_cancel(mocker):
     mock_message_box_question.return_value = QMessageBox.Cancel
     mock_source = mocker.MagicMock()
     mock_source.journalist_designation = 'foo bar baz'
-    mock_source.submissions = ["submission_1", "submission_2"]
-    mock_source.replies = ["reply_1", "reply_2"]
+    mock_source.submissions = []
+    submission_files = (
+        "submission_1-msg.gpg",
+        "submission_2-msg.gpg",
+        "submission_3-doc.gpg",
+    )
+    for filename in submission_files:
+        submission = mocker.MagicMock()
+        submission.filename = filename
+        mock_source.submissions.append(submission)
     mock_controller = mocker.MagicMock()
     delete_source_message_box = DeleteSourceMessageBox(
         None, mock_source, mock_controller
@@ -747,8 +763,16 @@ def test_DeleteSourceMssageBox_launch_when_user_chooses_yes(mocker):
     mock_message_box_question.return_value = QMessageBox.Yes
     mock_source = mocker.MagicMock()
     mock_source.journalist_designation = 'foo bar baz'
-    mock_source.submissions = ["submission_1", "submission_2"]
-    mock_source.replies = ["reply_1", "reply_2"]
+    mock_source.submissions = []
+    submission_files = (
+        "submission_1-msg.gpg",
+        "submission_2-msg.gpg",
+        "submission_3-doc.gpg",
+    )
+    for filename in submission_files:
+        submission = mocker.MagicMock()
+        submission.filename = filename
+        mock_source.submissions.append(submission)
     mock_controller = mocker.MagicMock()
     delete_source_message_box = DeleteSourceMessageBox(
         None, mock_source, mock_controller
@@ -762,7 +786,7 @@ def test_DeleteSourceMssageBox_launch_when_user_chooses_yes(mocker):
     message = (
         "<big>Deleting the Source account for "
         "<b>foo bar baz</b> will also "
-        "delete 2 files and 2 messages.</big> "
+        "delete 1 files and 2 messages.</big> "
         "<br> "
         "<small>This Source will no longer be able to correspond "
         "through the log-in tied to this account.</small>"
@@ -780,8 +804,16 @@ def test_DeleteSourceMessageBox_construct_message(mocker):
     mock_controller = mocker.MagicMock()
     mock_source = mocker.MagicMock()
     mock_source.journalist_designation = 'foo bar baz'
-    mock_source.submissions = ["submission_1", "submission_2"]
-    mock_source.replies = ["reply_1", "reply_2"]
+    mock_source.submissions = []
+    submission_files = (
+        "submission_1-msg.gpg",
+        "submission_2-msg.gpg",
+        "submission_3-doc.gpg",
+    )
+    for filename in submission_files:
+        submission = mocker.MagicMock()
+        submission.filename = filename
+        mock_source.submissions.append(submission)
     delete_source_message_box = DeleteSourceMessageBox(
         None, mock_source, mock_controller
     )
@@ -789,11 +821,12 @@ def test_DeleteSourceMessageBox_construct_message(mocker):
     expected_message = (
         "<big>Deleting the Source account for "
         "<b>foo bar baz</b> will also "
-        "delete 2 files and 2 messages.</big> "
+        "delete {files} files and {messages} messages.</big> "
         "<br> "
         "<small>This Source will no longer be able to correspond "
         "through the log-in tied to this account.</small>"
     )
+    expected_message = expected_message.format(files=1, messages=2)
     assert message == expected_message
 
 


### PR DESCRIPTION
This will display accurate count of messages and files at dialog box
giving warning at the time of deleting source.

Resolves: #194