### PR TITLE
Prevent UI flicker on conversation switch / update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ SHELL := /bin/bash
 
 .PHONY: clean
 clean:  ## Clean the workspace of generated resources
-	@rm -rf build dist *.egg-info .coverage .eggs docs/_build .pytest_cache lib htmlcov && \
+	@rm -rf build dist *.egg-info .coverage .eggs docs/_build .pytest_cache lib htmlcov .cache && \
 		find . \( -name '*.py[co]' -o -name dropin.cache \) -delete && \
 		find . \( -name '*.bak' -o -name dropin.cache \) -delete && \
 		find . \( -name '*.tgz' -o -name dropin.cache \) -delete && \
-		find . -name __pycache__ -print0 | xargs rm -rf
+		find . -name __pycache__ -print0 | xargs -0 rm -rf
 
 TESTS ?= tests
 TESTOPTS ?= -v
@@ -34,7 +34,7 @@ check: clean lint test ## Run the full CI test suite
 # 6. Format columns with colon as delimiter.
 .PHONY: help
 help: ## Print this message and exit.
-	@printf "Makefile for developing and testing SecureDrop.\n"
+	@printf "Makefile for developing and testing the SecureDrop client.\n"
 	@printf "Subcommands:\n\n"
 	@awk 'BEGIN {FS = ":.*?## "} /^[0-9a-zA-Z_-]+:.*?## / {printf "\033[36m%s\033[0m : %s\n", $$1, $$2}' $(MAKEFILE_LIST) \
 		| sort \

--- a/run.sh
+++ b/run.sh
@@ -26,9 +26,11 @@ chmod 0700 "$SDC_HOME" "$GPG_HOME"
 echo "Running app with home directory: $SDC_HOME"
 echo ""
 
-gpg --homedir "$GPG_HOME" --allow-secret-key-import --import tests/files/securedrop.gpg.asc
+gpg --homedir "$GPG_HOME" --allow-secret-key-import --import tests/files/securedrop.gpg.asc &
 
 # create the database and config for local testing
-./create_dev_data.py "$SDC_HOME"
+./create_dev_data.py "$SDC_HOME" &
+
+wait
 
 exec python -m securedrop_client --sdc-home "$SDC_HOME" --no-proxy $@

--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -65,16 +65,19 @@ def configure_logging(sdc_home: str) -> None:
     log_fmt = ('%(asctime)s - %(name)s:%(lineno)d(%(funcName)s) '
                '%(levelname)s: %(message)s')
     formatter = logging.Formatter(log_fmt)
+
     # define log handlers such as for rotating log files
     handler = TimedRotatingFileHandler(log_file, when='midnight',
                                        backupCount=5, delay=0,
                                        encoding=ENCODING)
     handler.setFormatter(formatter)
     handler.setLevel(logging.DEBUG)
+
     # set up primary log
     log = logging.getLogger()
     log.setLevel(logging.DEBUG)
     log.addHandler(handler)
+
     # override excepthook to capture a log of catastrophic failures.
     sys.excepthook = excepthook
 

--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -25,7 +25,9 @@ def make_engine(home: str):
 
 
 class Source(Base):
+
     __tablename__ = 'sources'
+
     # TODO - add number_of_docs
     id = Column(Integer, primary_key=True)
     uuid = Column(String(36), unique=True, nullable=False)
@@ -66,7 +68,9 @@ class Source(Base):
 
 
 class Submission(Base):
+
     __tablename__ = 'submissions'
+
     id = Column(Integer, primary_key=True)
     uuid = Column(String(36), unique=True, nullable=False)
     filename = Column(String(255), nullable=False)
@@ -101,7 +105,9 @@ class Submission(Base):
 
 
 class Reply(Base):
+
     __tablename__ = 'replies'
+
     id = Column(Integer, primary_key=True)
     uuid = Column(String(36), unique=True, nullable=False)
     source_id = Column(Integer, ForeignKey('sources.id'))
@@ -133,7 +139,9 @@ class Reply(Base):
 
 
 class User(Base):
+
     __tablename__ = 'users'
+
     id = Column(Integer, primary_key=True)
     uuid = Column(String(36), unique=True, nullable=False)
     username = Column(String(255), nullable=False, unique=True)

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -53,19 +53,29 @@ class Window(QMainWindow):
         self.sdc_home = sdc_home
         self.setWindowTitle(_("SecureDrop Client {}").format(__version__))
         self.setWindowIcon(load_icon(self.icon))
+
         self.widget = QWidget()
         widget_layout = QVBoxLayout()
         self.widget.setLayout(widget_layout)
+        self.setCentralWidget(self.widget)
+
         self.tool_bar = ToolBar(self.widget)
+
         self.main_view = MainView(self.widget)
         self.main_view.source_list.itemSelectionChanged.connect(self.on_source_changed)
+
         widget_layout.addWidget(self.tool_bar, 1)
         widget_layout.addWidget(self.main_view, 6)
-        self.setCentralWidget(self.widget)
-        self.current_source = None  # Tracks which source is shown
+
+        # Cache a dict of source.uuid -> ConversationView
+        # We do this to not create/destroy widgets constantly (because it causes UI "flicker")
         self.conversations = {}
-        self.show()
+
+        # Tracks which source is shown
+        self.current_source = None
+
         self.autosize_window()
+        self.show()
 
     def setup(self, controller):
         """
@@ -74,9 +84,11 @@ class Window(QMainWindow):
         """
         self.controller = controller  # Reference the Client logic instance.
         self.tool_bar.setup(self, controller)
+
         self.status_bar = QStatusBar(self)
         self.setStatusBar(self.status_bar)
         self.set_status('Started SecureDrop Client. Please sign in.', 20000)
+
         self.login_dialog = LoginDialog(self)
         self.main_view.setup(self.controller)
 
@@ -190,10 +202,12 @@ class Window(QMainWindow):
         container = QWidget()
         layout = QVBoxLayout()
         container.setLayout(layout)
+
         source_profile = SourceProfileShortWidget(source, self.controller)
 
         layout.addWidget(source_profile)
         layout.addWidget(conversation)
+
         self.main_view.update_view(container)
 
     def set_status(self, message, duration=5000):

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -26,7 +26,6 @@ from securedrop_client.gui.widgets import (ToolBar, MainView, LoginDialog,
                                            ConversationView,
                                            SourceProfileShortWidget)
 from securedrop_client.resources import load_icon
-from securedrop_client.storage import get_data
 
 logger = logging.getLogger(__name__)
 
@@ -177,8 +176,7 @@ class Window(QMainWindow):
         conversation_container = self.conversations.get(source.uuid, None)
 
         if conversation_container is None:
-            conversation = ConversationView(source, parent=self)
-            conversation.setup(self.controller)
+            conversation = ConversationView(source, self.sdc_home, self.controller, parent=self)
 
             conversation_container = QWidget()
             layout = QVBoxLayout()

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -172,8 +172,6 @@ class Window(QMainWindow):
         """
         conversation = ConversationView(self)
         conversation.setup(self.controller)
-        conversation.add_message('Source name: {}'.format(
-                                 source.journalist_designation))
 
         # Display each conversation item in the source collection.
         for conversation_item in source.collection:

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -168,15 +168,6 @@ class Window(QMainWindow):
             self.current_source = source_widget.source
             self.show_conversation_for(self.current_source)
 
-    def add_item_content_or(self, adder, item, default):
-        """
-        Private helper function to add correct message to conversation widgets
-        """
-        if item.is_downloaded is False:
-            adder(default)
-        else:
-            adder(get_data(self.sdc_home, item.filename))
-
     def show_conversation_for(self, source):
         """
         Show conversation of messages and replies between a source and
@@ -186,22 +177,8 @@ class Window(QMainWindow):
         conversation_container = self.conversations.get(source.uuid, None)
 
         if conversation_container is None:
-            conversation = ConversationView(self)
+            conversation = ConversationView(source, parent=self)
             conversation.setup(self.controller)
-
-            # Display each conversation item in the source collection.
-            for conversation_item in source.collection:
-
-                if conversation_item.filename.endswith('msg.gpg'):
-                    self.add_item_content_or(conversation.add_message,
-                                             conversation_item,
-                                             "<Message not yet downloaded>")
-                elif conversation_item.filename.endswith('reply.gpg'):
-                    self.add_item_content_or(conversation.add_reply,
-                                             conversation_item,
-                                             "<Reply not yet downloaded>")
-                else:
-                    conversation.add_file(source, conversation_item)
 
             conversation_container = QWidget()
             layout = QVBoxLayout()

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -23,8 +23,7 @@ import logging
 from PyQt5.QtWidgets import QMainWindow, QWidget, QVBoxLayout, QDesktopWidget, QStatusBar
 from securedrop_client import __version__
 from securedrop_client.gui.widgets import (ToolBar, MainView, LoginDialog,
-                                           ConversationView,
-                                           SourceProfileShortWidget)
+                                           SourceConversationWrapper)
 from securedrop_client.resources import load_icon
 
 logger = logging.getLogger(__name__)
@@ -66,7 +65,7 @@ class Window(QMainWindow):
         widget_layout.addWidget(self.tool_bar, 1)
         widget_layout.addWidget(self.main_view, 6)
 
-        # Cache a dict of source.uuid -> ConversationView
+        # Cache a dict of source.uuid -> SourceConversationWrapper
         # We do this to not create/destroy widgets constantly (because it causes UI "flicker")
         self.conversations = {}
 
@@ -176,16 +175,10 @@ class Window(QMainWindow):
         conversation_container = self.conversations.get(source.uuid, None)
 
         if conversation_container is None:
-            conversation = ConversationView(source, self.sdc_home, self.controller, parent=self)
-
-            conversation_container = QWidget()
-            layout = QVBoxLayout()
-            conversation_container.setLayout(layout)
-
-            source_profile = SourceProfileShortWidget(source, self.controller)
-
-            layout.addWidget(source_profile)
-            layout.addWidget(conversation)
+            conversation_container = SourceConversationWrapper(source,
+                                                               self.sdc_home,
+                                                               self.controller)
+            self.conversations[source.uuid] = conversation_container
 
         self.main_view.set_conversation(conversation_container)
 

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -182,33 +182,37 @@ class Window(QMainWindow):
         Show conversation of messages and replies between a source and
         journalists.
         """
-        conversation = ConversationView(self)
-        conversation.setup(self.controller)
 
-        # Display each conversation item in the source collection.
-        for conversation_item in source.collection:
+        conversation_container = self.conversations.get(source.uuid, None)
 
-            if conversation_item.filename.endswith('msg.gpg'):
-                self.add_item_content_or(conversation.add_message,
-                                         conversation_item,
-                                         "<Message not yet downloaded>")
-            elif conversation_item.filename.endswith('reply.gpg'):
-                self.add_item_content_or(conversation.add_reply,
-                                         conversation_item,
-                                         "<Reply not yet downloaded>")
-            else:
-                conversation.add_file(source, conversation_item)
+        if conversation_container is None:
+            conversation = ConversationView(self)
+            conversation.setup(self.controller)
 
-        container = QWidget()
-        layout = QVBoxLayout()
-        container.setLayout(layout)
+            # Display each conversation item in the source collection.
+            for conversation_item in source.collection:
 
-        source_profile = SourceProfileShortWidget(source, self.controller)
+                if conversation_item.filename.endswith('msg.gpg'):
+                    self.add_item_content_or(conversation.add_message,
+                                             conversation_item,
+                                             "<Message not yet downloaded>")
+                elif conversation_item.filename.endswith('reply.gpg'):
+                    self.add_item_content_or(conversation.add_reply,
+                                             conversation_item,
+                                             "<Reply not yet downloaded>")
+                else:
+                    conversation.add_file(source, conversation_item)
 
-        layout.addWidget(source_profile)
-        layout.addWidget(conversation)
+            conversation_container = QWidget()
+            layout = QVBoxLayout()
+            conversation_container.setLayout(layout)
 
-        self.main_view.update_view(container)
+            source_profile = SourceProfileShortWidget(source, self.controller)
+
+            layout.addWidget(source_profile)
+            layout.addWidget(conversation)
+
+        self.main_view.set_conversation(conversation_container)
 
     def set_status(self, message, duration=5000):
         """

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -162,15 +162,17 @@ class MainView(QWidget):
     def update_error_status(self, error=None):
         self.error_status.setText(html.escape(error))
 
-    def update_view(self, widget):
+    def set_conversation(self, widget):
         """
         Update the view holder to contain the referenced widget.
         """
         old_widget = self.view_layout.takeAt(0)
+
         if old_widget:
             old_widget.widget().setVisible(False)
-        widget.setVisible(True)
+
         self.view_layout.addWidget(widget)
+        widget.setVisible(True)
 
 
 class SourceList(QListWidget):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -43,15 +43,20 @@ class ToolBar(QWidget):
         layout = QHBoxLayout(self)
         self.logo = QLabel()
         self.logo.setPixmap(load_image('header_logo.png'))
+
         self.user_state = QLabel(_("Signed out."))
+
         self.login = QPushButton(_('Sign in'))
         self.login.clicked.connect(self.on_login_clicked)
+
         self.logout = QPushButton(_('Sign out'))
         self.logout.clicked.connect(self.on_logout_clicked)
         self.logout.setVisible(False)
+
         self.refresh = QPushButton(_('Refresh'))
         self.refresh.clicked.connect(self.on_refresh_clicked)
         self.refresh.setVisible(False)
+
         layout.addWidget(self.logo)
         layout.addStretch()
         layout.addWidget(self.user_state)
@@ -125,17 +130,23 @@ class MainView(QWidget):
         super().__init__(parent)
         self.layout = QHBoxLayout(self)
         self.setLayout(self.layout)
+
         left_column = QWidget(parent=self)
         left_layout = QVBoxLayout()
         left_column.setLayout(left_layout)
+
         self.status = QLabel(_('Waiting to refresh...'))
         self.error_status = QLabel('')
         self.error_status.setObjectName('error_label')
+
         left_layout.addWidget(self.status)
         left_layout.addWidget(self.error_status)
+
         self.source_list = SourceList(left_column)
         left_layout.addWidget(self.source_list)
+
         self.layout.addWidget(left_column, 2)
+
         self.view_holder = QWidget()
         self.view_layout = QVBoxLayout()
         self.view_holder.setLayout(self.view_layout)
@@ -187,10 +198,13 @@ class SourceList(QListWidget):
         for source in sources:
             new_source = SourceWidget(self, source)
             new_source.setup(self.controller)
+
             list_item = QListWidgetItem(self)
             list_item.setSizeHint(new_source.sizeHint())
+
             self.addItem(list_item)
             self.setItemWidget(list_item, new_source)
+
             if current_maybe and (source.id == current_maybe.source.id):
                 new_current_maybe = list_item
 
@@ -222,6 +236,7 @@ class DeleteSourceMessageBox:
             QMessageBox.Cancel | QMessageBox.Yes,
             QMessageBox.Cancel
         )
+
         if reply == QMessageBox.Yes:
             logger.debug("Deleting source %s" % (self.source.uuid,))
             self.controller.delete_source(self.source)
@@ -234,6 +249,7 @@ class DeleteSourceMessageBox:
                 messages += 1
             else:
                 files += 1
+
         message = (
             "<big>Deleting the Source account for",
             "<b>{}</b> will also".format(source.journalist_designation,),
@@ -257,23 +273,30 @@ class SourceWidget(QWidget):
         """
         super().__init__(parent)
         self.source = source
+        self.name = QLabel()
+        self.updated = QLabel()
+
         layout = QVBoxLayout()
         self.setLayout(layout)
+
         self.summary = QWidget(self)
         self.summary_layout = QHBoxLayout()
         self.summary.setLayout(self.summary_layout)
+
         self.attached = load_svg('paperclip.svg')
         self.attached.setMaximumSize(16, 16)
-        self.name = QLabel()
+
         self.summary_layout.addWidget(self.name)
         self.summary_layout.addStretch()
         self.summary_layout.addWidget(self.attached)
+
         layout.addWidget(self.summary)
-        self.updated = QLabel()
         layout.addWidget(self.updated)
+
         self.delete = load_svg('cross.svg')
         self.delete.setMaximumSize(16, 16)
         self.delete.mouseReleaseEvent = self.delete_source
+
         self.summary_layout.addWidget(self.delete)
         self.update()
 
@@ -342,33 +365,44 @@ class LoginDialog(QDialog):
         self.controller = controller
         self.setMinimumSize(600, 400)
         self.setWindowTitle(_('Sign in to SecureDrop'))
+
         main_layout = QHBoxLayout()
         main_layout.addStretch()
         self.setLayout(main_layout)
+
         form = QWidget()
         layout = QVBoxLayout()
         form.setLayout(layout)
+
         main_layout.addWidget(form)
         main_layout.addStretch()
+
         self.title = QLabel(_('<h1>Sign in</h1>'))
         self.title.setTextFormat(Qt.RichText)
+
         self.instructions = QLabel(_('You may read all documents and messages '
                                      'shown here, without signing in. To '
                                      'correspond with a Source or to check '
                                      'the server for updates, you must sign '
                                      'in.'))
         self.instructions.setWordWrap(True)
+
         self.username_label = QLabel(_('Username'))
         self.username_field = QLineEdit()
+
         self.password_label = QLabel(_('Password'))
         self.password_field = QLineEdit()
         self.password_field.setEchoMode(QLineEdit.Password)
+
         self.tfa_label = QLabel(_('Two-Factor Number'))
         self.tfa_field = QLineEdit()
+
         self.submit = QPushButton(_('Sign in'))
         self.submit.clicked.connect(self.validate)
+
         self.error_label = QLabel('')
         self.error_label.setObjectName('error_label')
+
         layout.addStretch()
         layout.addWidget(self.title)
         layout.addWidget(self.instructions)
@@ -432,6 +466,7 @@ class LoginDialog(QDialog):
                 self.setDisabled(False)
                 self.error(_('Please use only numerals for the two factor number.'))
                 return
+
             self.controller.login(username, password, tfa_token)
         else:
             self.setDisabled(False)
@@ -451,8 +486,10 @@ class SpeechBubble(QWidget):
         super().__init__()
         layout = QVBoxLayout()
         self.setLayout(layout)
+
         message = QLabel(html.escape(text, quote=False))
         message.setWordWrap(True)
+
         layout.addWidget(message)
 
 
@@ -470,16 +507,21 @@ class ConversationWidget(QWidget):
         super().__init__()
         layout = QHBoxLayout()
         label = SpeechBubble(message)
+
         if align is not "left":
             # Float right...
             layout.addStretch(5)
             label.setStyleSheet(label.css + 'border-bottom-right-radius: 0px;')
+
         layout.addWidget(label, 6)
+
         if align is "left":
             # Add space on right hand side...
             layout.addStretch(5)
             label.setStyleSheet(label.css + 'border-bottom-left-radius: 0px;')
+
         layout.setContentsMargins(0, 0, 0, 0)
+
         self.setLayout(layout)
         self.setContentsMargins(0, 0, 0, 0)
 
@@ -526,22 +568,28 @@ class FileWidget(QWidget):
         self.controller = controller
         self.source = source_db_object
         self.submission = submission_db_object
+
         layout = QHBoxLayout()
         icon = QLabel()
         icon.setPixmap(load_image('file.png'))
+
         if submission_db_object.is_downloaded:
             description = QLabel("Open")
         else:
             human_filesize = humanize_filesize(self.submission.size)
             description = QLabel("Download ({})".format(human_filesize))
+
         if align is not "left":
             # Float right...
             layout.addStretch(5)
+
         layout.addWidget(icon)
         layout.addWidget(description, 5)
+
         if align is "left":
             # Add space on right hand side...
             layout.addStretch(5)
+
         self.setLayout(layout)
 
     def mouseReleaseEvent(self, e):
@@ -574,6 +622,7 @@ class ConversationView(QWidget):
         self.scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.scroll.setWidget(self.container)
         self.scroll.setWidgetResizable(True)
+
         # Completely unintuitive way to ensure the view remains scrolled to the
         # bottom.
         sb = self.scroll.verticalScrollBar()
@@ -624,7 +673,9 @@ class DeleteSourceAction(QAction):
         self.source = source
         self.controller = controller
         self.text = _("Delete source account")
+
         super().__init__(self.text, parent)
+
         self.messagebox = DeleteSourceMessageBox(
             parent, self.source, self.controller
         )
@@ -673,10 +724,13 @@ class SourceMenuButton(QToolButton):
         super().__init__()
         self.controller = controller
         self.source = source
+
         ellipsis_icon = load_image("ellipsis.svg")
         self.setIcon(QIcon(ellipsis_icon))
+
         self.menu = SourceMenu(self.source, self.controller)
         self.setMenu(self.menu)
+
         self.setPopupMode(QToolButton.InstantPopup)
 
 
@@ -701,11 +755,14 @@ class SourceProfileShortWidget(QWidget):
         super().__init__()
         self.source = source
         self.controller = controller
+
         self.layout = QHBoxLayout()
         self.setLayout(self.layout)
+
         widgets = (
             TitleLabel(self.source.journalist_designation),
-            SourceMenuButton(self.source, self.controller)
+            SourceMenuButton(self.source, self.controller),
         )
+
         for widget in widgets:
             self.layout.addWidget(widget)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -25,6 +25,7 @@ from PyQt5.QtWidgets import QListWidget, QLabel, QWidget, QListWidgetItem, QHBox
     QPushButton, QVBoxLayout, QLineEdit, QScrollArea, QDialog, QAction, QMenu, \
     QMessageBox, QToolButton
 
+from securedrop_client.db import Source
 from securedrop_client.logic import Client
 from securedrop_client.resources import load_svg, load_image
 from securedrop_client.storage import get_data
@@ -637,7 +638,7 @@ class ConversationView(QWidget):
     Renders a conversation.
     """
 
-    def __init__(self, source_db_object, sdc_home: str, controller: Client, parent=None):
+    def __init__(self, source_db_object: Source, sdc_home: str, controller: Client, parent=None):
         super().__init__(parent)
         self.source = source_db_object
         self.sdc_home = sdc_home
@@ -724,6 +725,24 @@ class ConversationView(QWidget):
         """
         self.conversation_layout.addWidget(
             ReplyWidget(message_id, reply, self.controller.reply_sync.reply_downloaded))
+
+
+class SourceConversationWrapper(QWidget):
+    """
+    Wrapper for a source's conversation including the chat window, profile tab, and other
+    per-soruce resources.
+    """
+
+    def __init__(self, source: Source, sdc_home: str, controller: Client, parent=None) -> None:
+        super().__init__(parent)
+        self.layout = QVBoxLayout()
+        self.setLayout(self.layout)
+
+        self.conversation = ConversationView(source, sdc_home, controller, parent=self)
+        self.source_profile = SourceProfileShortWidget(source, controller)
+
+        self.layout.addWidget(self.source_profile)
+        self.layout.addWidget(self.conversation)
 
 
 class DeleteSourceAction(QAction):

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -96,22 +96,42 @@ class Client(QObject):
         various other layers of the application: the location of the SecureDrop
         proxy, the user interface and SqlAlchemy local storage respectively.
         """
-
         check_dir_permissions(home)
-
         super().__init__()
-        self.hostname = hostname  # Location of the SecureDrop server.
-        self.gui = gui  # Reference to the UI window.
-        self.api = None  # Reference to the API for secure drop proxy.
-        self.session = session  # Reference to the SqlAlchemy session.
-        self.message_thread = None  # thread responsible for fetching messages
-        self.reply_thread = None  # thread responsible for fetching replies
-        self.home = home  # used for finding DB in sync thread
-        self.api_threads = {}  # Contains active threads calling the API.
-        self.sync_flag = os.path.join(home, 'sync_flag')
-        self.data_dir = os.path.join(self.home, 'data')  # File data.
-        self.timer = None  # call timeout timer
+
+        # used for finding DB in sync thread
+        self.home = home
+
+        # boolean flag for whether or not the client is operating behind a proxy
         self.proxy = proxy
+
+        # Location of the SecureDrop server.
+        self.hostname = hostname
+
+        # Reference to the UI window.
+        self.gui = gui
+
+        # Reference to the API for secure drop proxy.
+        self.api = None
+        # Contains active threads calling the API.
+        self.api_threads = {}
+
+        # Reference to the SqlAlchemy session.
+        self.session = session
+
+        # thread responsible for fetching messages
+        self.message_thread = None
+        self.message_sync = MessageSync(self.api, self.home, self.proxy)
+
+        # thread responsible for fetching replies
+        self.reply_thread = None
+        self.reply_sync = ReplySync(self.api, self.home, self.proxy)
+
+        self.sync_flag = os.path.join(home, 'sync_flag')
+
+        # File data.
+        self.data_dir = os.path.join(self.home, 'data')
+
         self.gpg = GpgHelper(home, proxy)
 
     def setup(self):
@@ -142,13 +162,6 @@ class Client(QObject):
         self.sync_update = QTimer()
         self.sync_update.timeout.connect(self.sync_api)
         self.sync_update.start(1000 * 60 * 5)  # every 5 minutes.
-
-        # Use a QTimer to update the current conversation view such
-        # that as downloads/decryption occur, the messages and replies
-        # populate the view.
-        self.conv_view_update = QTimer()
-        self.conv_view_update.timeout.connect(self.update_conversation_view)
-        self.conv_view_update.start(1000 * 60 * 0.10)  # every 6 seconds
 
     def call_api(self, function, callback, timeout, *args, current_object=None,
                  **kwargs):
@@ -232,8 +245,8 @@ class Client(QObject):
         Starts the message-fetching thread in the background.
         """
         if not self.message_thread:
+            self.message_sync.api = self.api
             self.message_thread = QThread()
-            self.message_sync = MessageSync(self.api, self.home, self.proxy)
             self.message_sync.moveToThread(self.message_thread)
             self.message_thread.started.connect(self.message_sync.run)
             self.message_thread.start()
@@ -245,8 +258,8 @@ class Client(QObject):
         Starts the reply-fetching thread in the background.
         """
         if not self.reply_thread:
+            self.reply_sync.api = self.api
             self.reply_thread = QThread()
-            self.reply_sync = ReplySync(self.api, self.home, self.proxy)
             self.reply_sync.moveToThread(self.reply_thread)
             self.reply_thread.started.connect(self.reply_sync.run)
             self.reply_thread.start()
@@ -406,8 +419,7 @@ class Client(QObject):
                     except CryptoError:
                         logger.warning('Failed to import key for source {}'.format(source.uuid))
 
-            # TODO: show something in the conversation view?
-            # self.gui.show_conversation_for()
+            self.update_conversation_views()
         else:
             # How to handle a failure? Exceptions are already logged. Perhaps
             # a message in the UI?
@@ -431,16 +443,14 @@ class Client(QObject):
         self.gui.show_sources(sources)
         self.update_sync()
 
-    def update_conversation_view(self):
+    def update_conversation_views(self):
         """
         Updates the conversation view to reflect progress
         of the download and decryption of messages and replies.
         """
-        # Redraw the conversation view if we have clicked on a source
-        # and the source has not been deleted.
-        if self.gui.current_source and self.gui.current_source in self.session:
-            self.session.refresh(self.gui.current_source)
-            self.gui.show_conversation_for(self.gui.current_source)
+        for conversation in self.gui.conversations.values():
+            self.session.refresh(conversation.source)
+            conversation.update_conversation(conversation.source.collection)
 
     def on_update_star_complete(self, result):
         """
@@ -569,7 +579,9 @@ class Client(QObject):
                 # Attempt to decrypt the file.
                 self.gpg.decrypt_submission_or_reply(
                     filepath_in_datadir, server_filename, is_doc=True)
-            except CryptoError:
+            except CryptoError as e:
+                logger.debug('Failed to decrypt file {}: {}'.format(server_filename, e))
+
                 self.set_status("Failed to download and decrypt file, "
                                 "please try again.")
                 # TODO: We should save the downloaded content, and just
@@ -579,12 +591,9 @@ class Client(QObject):
             # Now that download and decrypt are done, mark the file as such.
             storage.mark_file_as_downloaded(file_uuid, self.session)
 
-            # Refresh the current source conversation, bearing in mind
-            # that the user may have navigated to another source.
-            self.gui.show_conversation_for(self.gui.current_source)
-            self.set_status(
-                'Finished downloading {}'.format(current_object.filename))
+            self.set_status('Finished downloading {}'.format(current_object.filename))
         else:  # The file did not download properly.
+            logger.debug('Failed to download file {}'.format(server_filename))
             # Update the UI in some way to indicate a failure state.
             self.set_status("The file download failed. Please try again.")
 

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -404,6 +404,13 @@ class Client(QObject):
                                          remote_submissions,
                                          remote_replies, self.data_dir)
 
+            # clean up locally cached conversation views
+            remote_source_uuids = [s.uuid for s in remote_sources]
+            cached_sources = list(self.gui.conversations.keys())
+            for cached_source in cached_sources:
+                if cached_source not in remote_source_uuids:
+                    self.gui.conversations.pop(cached_source, None)
+
             # Set last sync flag.
             with open(self.sync_flag, 'w') as f:
                 f.write(arrow.now().format())
@@ -448,9 +455,10 @@ class Client(QObject):
         Updates the conversation view to reflect progress
         of the download and decryption of messages and replies.
         """
-        for conversation in self.gui.conversations.values():
-            self.session.refresh(conversation.source)
-            conversation.update_conversation(conversation.source.collection)
+        for conversation_wrapper in self.gui.conversations.values():
+            conv = conversation_wrapper.conversation
+            self.session.refresh(conv.source)
+            conv.update_conversation(conv.source.collection)
 
     def on_update_star_complete(self, result):
         """

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -68,10 +68,12 @@ def get_remote_data(api):
         # Log any errors but allow the caller to handle the exception.
         logger.error(ex)
         raise(ex)
+
     logger.info('Fetched {} remote sources.'.format(len(remote_sources)))
     logger.info('Fetched {} remote submissions.'.format(
         len(remote_submissions)))
     logger.info('Fetched {} remote replies.'.format(len(remote_replies)))
+
     return (remote_sources, remote_submissions, remote_replies)
 
 
@@ -85,6 +87,7 @@ def update_local_storage(session, remote_sources, remote_submissions,
     local_sources = get_local_sources(session)
     local_submissions = get_local_submissions(session)
     local_replies = get_local_replies(session)
+
     update_sources(remote_sources, local_sources, session, data_dir)
     update_submissions(remote_submissions, local_submissions, session, data_dir)
     update_replies(remote_replies, local_replies, session, data_dir)
@@ -114,6 +117,7 @@ def update_sources(remote_sources, local_sources, session, data_dir):
             local_source.document_count = source.number_of_documents
             local_source.is_starred = source.is_starred
             local_source.last_updated = parse(source.last_updated)
+
             # Removing the UUID from local_uuids ensures this record won't be
             # deleted at the end of this function.
             local_uuids.remove(source.uuid)
@@ -130,13 +134,16 @@ def update_sources(remote_sources, local_sources, session, data_dir):
                         document_count=source.number_of_documents)
             session.add(ns)
             logger.info('Added new source {}'.format(source.uuid))
+
     # The uuids remaining in local_uuids do not exist on the remote server, so
     # delete the related records.
     for deleted_source in [s for s in local_sources if s.uuid in local_uuids]:
         for document in deleted_source.collection:
             delete_single_submission_or_reply_on_disk(document, data_dir)
+
         session.delete(deleted_source)
         logger.info('Deleted source {}'.format(deleted_source.uuid))
+
     session.commit()
 
 
@@ -157,6 +164,7 @@ def update_submissions(remote_submissions, local_submissions, session, data_dir)
             local_submission.size = submission.size
             local_submission.is_read = submission.is_read
             local_submission.download_url = submission.download_url
+
             # Removing the UUID from local_uuids ensures this record won't be
             # deleted at the end of this function.
             local_uuids.remove(submission.uuid)
@@ -171,6 +179,7 @@ def update_submissions(remote_submissions, local_submissions, session, data_dir)
                             download_url=submission.download_url)
             session.add(ns)
             logger.info('Added new submission {}'.format(submission.uuid))
+
     # The uuids remaining in local_uuids do not exist on the remote server, so
     # delete the related records.
     for deleted_submission in [s for s in local_submissions
@@ -178,6 +187,7 @@ def update_submissions(remote_submissions, local_submissions, session, data_dir)
         delete_single_submission_or_reply_on_disk(deleted_submission, data_dir)
         session.delete(deleted_submission)
         logger.info('Deleted submission {}'.format(deleted_submission.uuid))
+
     session.commit()
 
 
@@ -201,6 +211,7 @@ def update_replies(remote_replies, local_replies, session, data_dir):
             local_reply.journalist_id = user.id
             local_reply.filename = reply.filename
             local_reply.size = reply.size
+
             local_uuids.remove(reply.uuid)
             logger.info('Updated reply {}'.format(reply.uuid))
         else:
@@ -212,12 +223,14 @@ def update_replies(remote_replies, local_replies, session, data_dir):
             nr = Reply(reply.uuid, user, source, reply.filename, reply.size)
             session.add(nr)
             logger.info('Added new reply {}'.format(reply.uuid))
+
     # The uuids remaining in local_uuids do not exist on the remote server, so
     # delete the related records.
     for deleted_reply in [r for r in local_replies if r.uuid in local_uuids]:
         delete_single_submission_or_reply_on_disk(deleted_reply, data_dir)
         session.delete(deleted_reply)
         logger.info('Deleted reply {}'.format(deleted_reply.uuid))
+
     session.commit()
 
 

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -236,8 +236,7 @@ def test_conversation_pending_message(mocker):
     w.show_conversation_for(mock_source)
     conv = mock_conview()
 
-    # once for source name, once for message
-    assert conv.add_message.call_count == 2
+    assert conv.add_message.call_count == 1
     assert conv.add_message.call_args == mocker.call("<Message not yet downloaded>")
 
 

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -185,7 +185,6 @@ def test_conversation_for(mocker):
     w = Window('mock')
     w.controller = mocker.MagicMock()
     w.main_view = mocker.MagicMock()
-    mock_conview = mocker.MagicMock()
     mock_source = mocker.MagicMock()
     mock_source.journalistic_designation = 'Testy McTestface'
     mock_file = mocker.MagicMock()
@@ -196,16 +195,30 @@ def test_conversation_for(mocker):
     mock_reply.filename = '3-my-source-reply.gpg'
     mock_source.collection = [mock_file, mock_message, mock_reply]
 
-    mocker.patch('securedrop_client.gui.main.ConversationView', mock_conview)
+    mocked_add_message = mocker.patch('securedrop_client.gui.main.ConversationView.add_message')
+    mocked_add_reply = mocker.patch('securedrop_client.gui.main.ConversationView.add_reply')
+    mocked_add_file = mocker.patch('securedrop_client.gui.main.ConversationView.add_file')
     mocker.patch('securedrop_client.gui.main.QVBoxLayout')
     mocker.patch('securedrop_client.gui.main.QWidget')
 
     w.show_conversation_for(mock_source)
-    conv = mock_conview()
 
-    assert conv.add_message.call_count > 0
-    assert conv.add_reply.call_count > 0
-    assert conv.add_file.call_count > 0
+    assert mocked_add_message.call_count > 0
+    assert mocked_add_reply.call_count > 0
+    assert mocked_add_file.call_count > 0
+
+    # check that showing the conversation a second time doesn't break anything
+
+    # use new mocks to check the count again
+    mocked_add_message = mocker.patch('securedrop_client.gui.main.ConversationView.add_message')
+    mocked_add_reply = mocker.patch('securedrop_client.gui.main.ConversationView.add_reply')
+    mocked_add_file = mocker.patch('securedrop_client.gui.main.ConversationView.add_file')
+
+    w.show_conversation_for(mock_source)
+
+    assert mocked_add_message.call_count > 0
+    assert mocked_add_reply.call_count > 0
+    assert mocked_add_file.call_count > 0
 
 
 def test_conversation_pending_message(mocker):
@@ -217,7 +230,6 @@ def test_conversation_pending_message(mocker):
     w.controller = mocker.MagicMock()
     w.main_view = mocker.MagicMock()
     w._add_item_content_or = mocker.MagicMock()
-    mock_conview = mocker.MagicMock()
     mock_source = mocker.MagicMock()
     mock_source.journalistic_designation = 'Testy McTestface'
 
@@ -229,15 +241,14 @@ def test_conversation_pending_message(mocker):
 
     mock_source.collection = [submission]
 
-    mocker.patch('securedrop_client.gui.main.ConversationView', mock_conview)
+    mocked_add_message = mocker.patch('securedrop_client.gui.main.ConversationView.add_message')
     mocker.patch('securedrop_client.gui.main.QVBoxLayout')
     mocker.patch('securedrop_client.gui.main.QWidget')
 
     w.show_conversation_for(mock_source)
-    conv = mock_conview()
 
-    assert conv.add_message.call_count == 1
-    assert conv.add_message.call_args == mocker.call("<Message not yet downloaded>")
+    assert mocked_add_message.call_count == 1
+    assert mocked_add_message.call_args == mocker.call("<Message not yet downloaded>")
 
 
 def test_set_status(mocker):

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -196,11 +196,12 @@ def test_conversation_for(mocker):
     mock_reply.filename = '3-my-source-reply.gpg'
     mock_source.collection = [mock_file, mock_message, mock_reply]
 
-    mocked_add_message = mocker.patch('securedrop_client.gui.main.ConversationView.add_message')
-    mocked_add_reply = mocker.patch('securedrop_client.gui.main.ConversationView.add_reply')
-    mocked_add_file = mocker.patch('securedrop_client.gui.main.ConversationView.add_file')
-    mocker.patch('securedrop_client.gui.main.QVBoxLayout')
-    mocker.patch('securedrop_client.gui.main.QWidget')
+    mocked_add_message = mocker.patch('securedrop_client.gui.widgets.ConversationView.add_message',
+                                      new=mocker.Mock())
+    mocked_add_reply = mocker.patch('securedrop_client.gui.widgets.ConversationView.add_reply',
+                                    new=mocker.Mock())
+    mocked_add_file = mocker.patch('securedrop_client.gui.widgets.ConversationView.add_file',
+                                   new=mocker.Mock())
 
     w.show_conversation_for(mock_source)
 
@@ -210,16 +211,25 @@ def test_conversation_for(mocker):
 
     # check that showing the conversation a second time doesn't break anything
 
+    # stop the old mockers
+    mocked_add_message.stop()
+    mocked_add_reply.stop()
+    mocked_add_file.stop()
+
     # use new mocks to check the count again
-    mocked_add_message = mocker.patch('securedrop_client.gui.main.ConversationView.add_message')
-    mocked_add_reply = mocker.patch('securedrop_client.gui.main.ConversationView.add_reply')
-    mocked_add_file = mocker.patch('securedrop_client.gui.main.ConversationView.add_file')
+    mocked_add_message = mocker.patch('securedrop_client.gui.widgets.ConversationView.add_message',
+                                      new=mocker.Mock())
+    mocked_add_reply = mocker.patch('securedrop_client.gui.widgets.ConversationView.add_reply',
+                                    new=mocker.Mock())
+    mocked_add_file = mocker.patch('securedrop_client.gui.widgets.ConversationView.add_file',
+                                   new=mocker.Mock())
 
     w.show_conversation_for(mock_source)
 
-    assert mocked_add_message.call_count > 0
-    assert mocked_add_reply.call_count > 0
-    assert mocked_add_file.call_count > 0
+    # because the conversation was cached, we don't call these functions again
+    assert mocked_add_message.call_count == 0
+    assert mocked_add_reply.call_count == 0
+    assert mocked_add_file.call_count == 0
 
 
 def test_conversation_pending_message(mocker):
@@ -243,7 +253,7 @@ def test_conversation_pending_message(mocker):
 
     mock_source.collection = [submission]
 
-    mocked_add_message = mocker.patch('securedrop_client.gui.main.ConversationView.add_message')
+    mocked_add_message = mocker.patch('securedrop_client.gui.widgets.ConversationView.add_message')
     mocker.patch('securedrop_client.gui.main.QVBoxLayout')
     mocker.patch('securedrop_client.gui.main.QWidget')
 

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -5,6 +5,7 @@ from PyQt5.QtWidgets import QApplication, QVBoxLayout
 from securedrop_client.gui.main import Window
 from securedrop_client.resources import load_icon
 from securedrop_client.db import Submission
+from uuid import uuid4
 
 
 app = QApplication([])
@@ -233,7 +234,8 @@ def test_conversation_pending_message(mocker):
     mock_source = mocker.MagicMock()
     mock_source.journalistic_designation = 'Testy McTestface'
 
-    submission = Submission(source=mock_source, uuid="test", size=123,
+    msg_uuid = str(uuid4())
+    submission = Submission(source=mock_source, uuid=msg_uuid, size=123,
                             filename="test.msg.gpg",
                             download_url='http://test/test')
 
@@ -248,7 +250,7 @@ def test_conversation_pending_message(mocker):
     w.show_conversation_for(mock_source)
 
     assert mocked_add_message.call_count == 1
-    assert mocked_add_message.call_args == mocker.call("<Message not yet downloaded>")
+    assert mocked_add_message.call_args == mocker.call(msg_uuid, "<Message not yet downloaded>")
 
 
 def test_set_status(mocker):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -680,11 +680,12 @@ def test_FileWidget_mousePressEvent_open(mocker):
     fw.controller.on_file_open.assert_called_once_with(submission)
 
 
-def test_ConversationView_init():
+def test_ConversationView_init(mocker):
     """
     Ensure the conversation view has a layout to add widgets to.
     """
-    cv = ConversationView(None)
+    mocked_source = mocker.MagicMock()
+    cv = ConversationView(mocked_source)
     assert isinstance(cv.conversation_layout, QVBoxLayout)
 
 
@@ -692,7 +693,8 @@ def test_ConversationView_setup(mocker):
     """
     Ensure the controller is set
     """
-    cv = ConversationView(None)
+    mocked_source = mocker.MagicMock()
+    cv = ConversationView(mocked_source)
     mock_controller = mocker.MagicMock()
     cv.setup(mock_controller)
     assert cv.controller == mock_controller
@@ -703,7 +705,8 @@ def test_ConversationView_move_to_bottom(mocker):
     Check the signal handler sets the correct value for the scrollbar to be
     the maximum possible value.
     """
-    cv = ConversationView(None)
+    mocked_source = mocker.MagicMock()
+    cv = ConversationView(mocked_source)
     cv.scroll = mocker.MagicMock()
     cv.move_to_bottom(0, 6789)
     cv.scroll.verticalScrollBar().setValue.assert_called_once_with(6789)
@@ -713,7 +716,8 @@ def test_ConversationView_add_message(mocker):
     """
     Adding a message results in a new MessageWidget added to the layout.
     """
-    cv = ConversationView(None)
+    mocked_source = mocker.MagicMock()
+    cv = ConversationView(mocked_source)
     cv.controller = mocker.MagicMock()
     cv.conversation_layout = mocker.MagicMock()
 
@@ -728,7 +732,8 @@ def test_ConversationView_add_reply(mocker):
     """
     Adding a reply results in a new ReplyWidget added to the layout.
     """
-    cv = ConversationView(None)
+    mocked_source = mocker.MagicMock()
+    cv = ConversationView(mocked_source)
     cv.controller = mocker.MagicMock()
     cv.conversation_layout = mocker.MagicMock()
 
@@ -744,7 +749,8 @@ def test_ConversationView_add_downloaded_file(mocker):
     Adding a file results in a new FileWidget added to the layout with the
     proper QLabel.
     """
-    cv = ConversationView(None)
+    mocked_source = mocker.MagicMock()
+    cv = ConversationView(mocked_source)
     cv.controller = mocker.MagicMock()
     cv.conversation_layout = mocker.MagicMock()
 
@@ -768,7 +774,8 @@ def test_ConversationView_add_not_downloaded_file(mocker):
     Adding a file results in a new FileWidget added to the layout with the
     proper QLabel.
     """
-    cv = ConversationView(None)
+    mocked_source = mocker.MagicMock()
+    cv = ConversationView(mocked_source)
     cv.controller = mocker.MagicMock()
     cv.conversation_layout = mocker.MagicMock()
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -117,7 +117,7 @@ def test_MainView_init():
     assert isinstance(mv.view_holder, QWidget)
 
 
-def test_MainView_update_view(mocker):
+def test_MainView_show_conversation(mocker):
     """
     Ensure the passed-in widget is added to the layout of the main view holder
     (i.e. that area of the screen on the right hand side).
@@ -125,7 +125,7 @@ def test_MainView_update_view(mocker):
     mv = MainView(None)
     mv.view_layout = mocker.MagicMock()
     mock_widget = mocker.MagicMock()
-    mv.update_view(mock_widget)
+    mv.set_conversation(mock_widget)
     mv.view_layout.takeAt.assert_called_once_with(0)
     mv.view_layout.addWidget.assert_called_once_with(mock_widget)
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -28,9 +28,12 @@ def test_ToolBar_setup(mocker):
     them becoming attributes of self.
     """
     tb = ToolBar(None)
+
     mock_window = mocker.MagicMock()
     mock_controller = mocker.MagicMock()
+
     tb.setup(mock_window, mock_controller)
+
     assert tb.window == mock_window
     assert tb.controller == mock_controller
 
@@ -40,11 +43,14 @@ def test_ToolBar_set_logged_in_as(mocker):
     buttons, and refresh buttons, are in the correct state.
     """
     tb = ToolBar(None)
+
     tb.user_state = mocker.MagicMock()
     tb.login = mocker.MagicMock()
     tb.logout = mocker.MagicMock()
     tb.refresh = mocker.MagicMock()
+
     tb.set_logged_in_as('test')
+
     tb.user_state.setText.assert_called_once_with('Signed in as: test')
     tb.login.setVisible.assert_called_once_with(False)
     tb.logout.setVisible.assert_called_once_with(True)
@@ -56,11 +62,14 @@ def test_ToolBar_set_logged_out(mocker):
     Ensure the UI reverts to the logged out state.
     """
     tb = ToolBar(None)
+
     tb.user_state = mocker.MagicMock()
     tb.login = mocker.MagicMock()
     tb.logout = mocker.MagicMock()
     tb.refresh = mocker.MagicMock()
+
     tb.set_logged_out()
+
     tb.user_state.setText.assert_called_once_with('Signed out.')
     tb.login.setVisible.assert_called_once_with(True)
     tb.logout.setVisible.assert_called_once_with(False)
@@ -124,8 +133,10 @@ def test_MainView_show_conversation(mocker):
     """
     mv = MainView(None)
     mv.view_layout = mocker.MagicMock()
+
     mock_widget = mocker.MagicMock()
     mv.set_conversation(mock_widget)
+
     mv.view_layout.takeAt.assert_called_once_with(0)
     mv.view_layout.addWidget.assert_called_once_with(mock_widget)
 
@@ -137,8 +148,10 @@ def test_MainView_update_error_status(mocker):
     """
     mv = MainView(None)
     expected_message = "this is the message to be displayed"
+
     mv.error_status = mocker.MagicMock()
     mv.error_status.setText = mocker.MagicMock()
+
     mv.update_error_status(error=expected_message)
     mv.error_status.setText.assert_called_once_with(expected_message)
 
@@ -149,6 +162,7 @@ def test_SourceList_update(mocker):
     each passed-in source is created along with an associated QListWidgetItem.
     """
     sl = SourceList(None)
+
     sl.clear = mocker.MagicMock()
     sl.addItem = mocker.MagicMock()
     sl.setItemWidget = mocker.MagicMock()
@@ -161,6 +175,7 @@ def test_SourceList_update(mocker):
 
     sources = ['a', 'b', 'c', ]
     sl.update(sources)
+
     sl.clear.assert_called_once_with()
     assert mock_sw.call_count == len(sources)
     assert mock_lwi.call_count == len(sources)
@@ -200,8 +215,10 @@ def test_SourceWidget_setup(mocker):
     """
     mock_controller = mocker.MagicMock()
     mock_source = mocker.MagicMock()
+
     sw = SourceWidget(None, mock_source)
     sw.setup(mock_controller)
+
     assert sw.controller == mock_controller
 
 
@@ -212,11 +229,14 @@ def test_SourceWidget_html_init(mocker):
     """
     mock_source = mocker.MagicMock()
     mock_source.journalist_designation = 'foo <b>bar</b> baz'
+
     sw = SourceWidget(None, mock_source)
     sw.name = mocker.MagicMock()
     sw.summary_layout = mocker.MagicMock()
+
     mocker.patch('securedrop_client.gui.widgets.load_svg')
     sw.update()
+
     sw.name.setText.assert_called_once_with('<strong>foo &lt;b&gt;bar&lt;/b&gt; baz</strong>')
 
 
@@ -227,11 +247,14 @@ def test_SourceWidget_update_starred(mocker):
     mock_source = mocker.MagicMock()
     mock_source.journalist_designation = 'foo bar baz'
     mock_source.is_starred = True
+
     sw = SourceWidget(None, mock_source)
     sw.name = mocker.MagicMock()
     sw.summary_layout = mocker.MagicMock()
+
     mock_load = mocker.patch('securedrop_client.gui.widgets.load_svg')
     sw.update()
+
     mock_load.assert_called_once_with('star_on.svg')
     sw.name.setText.assert_called_once_with('<strong>foo bar baz</strong>')
 
@@ -243,11 +266,14 @@ def test_SourceWidget_update_unstarred(mocker):
     mock_source = mocker.MagicMock()
     mock_source.journalist_designation = 'foo bar baz'
     mock_source.is_starred = False
+
     sw = SourceWidget(None, mock_source)
     sw.name = mocker.MagicMock()
     sw.summary_layout = mocker.MagicMock()
+
     mock_load = mocker.patch('securedrop_client.gui.widgets.load_svg')
     sw.update()
+
     mock_load.assert_called_once_with('star_off.svg')
     sw.name.setText.assert_called_once_with('<strong>foo bar baz</strong>')
 
@@ -275,9 +301,11 @@ def test_SourceWidget_toggle_star(mocker):
     mock_controller = mocker.MagicMock()
     mock_source = mocker.MagicMock()
     event = mocker.MagicMock()
+
     sw = SourceWidget(None, mock_source)
     sw.controller = mock_controller
     sw.controller.update_star = mocker.MagicMock()
+
     sw.toggle_star(event)
     sw.controller.update_star.assert_called_once_with(mock_source)
 
@@ -304,9 +332,11 @@ def test_SourceWidget_delete_source(mocker):
 def test_SourceWidget_delete_source_when_user_chooses_cancel(mocker):
     mock_message_box_question = mocker.MagicMock(QMessageBox.question)
     mock_message_box_question.return_value = QMessageBox.Cancel
+
     mock_source = mocker.MagicMock()
     mock_source.journalist_designation = 'foo bar baz'
     mock_source.submissions = []
+
     submission_files = (
         "submission_1-msg.gpg",
         "submission_2-msg.gpg",
@@ -316,9 +346,11 @@ def test_SourceWidget_delete_source_when_user_chooses_cancel(mocker):
         submission = mocker.MagicMock()
         submission.filename = filename
         mock_source.submissions.append(submission)
+
     mock_controller = mocker.MagicMock()
     sw = SourceWidget(None, mock_source)
     sw.controller = mock_controller
+
     mocker.patch(
         "securedrop_client.gui.widgets.QMessageBox.question",
         mock_message_box_question,
@@ -343,6 +375,7 @@ def test_LoginDialog_reset(mocker):
     Ensure the state of the login view is returned to the correct state.
     """
     mock_controller = mocker.MagicMock()
+
     ld = LoginDialog(None)
     ld.setup(mock_controller)
     ld.username_field = mocker.MagicMock()
@@ -350,7 +383,9 @@ def test_LoginDialog_reset(mocker):
     ld.tfa_field = mocker.MagicMock()
     ld.setDisabled = mocker.MagicMock()
     ld.error_label = mocker.MagicMock()
+
     ld.reset()
+
     ld.username_field.setText.assert_called_once_with('')
     ld.password_field.setText.assert_called_once_with('')
     ld.tfa_field.setText.assert_called_once_with('')
@@ -375,6 +410,7 @@ def test_LoginDialog_validate_no_input(mocker):
     If the user doesn't provide input, tell them and give guidance.
     """
     mock_controller = mocker.MagicMock()
+
     ld = LoginDialog(None)
     ld.setup(mock_controller)
     ld.username_field.text = mocker.MagicMock(return_value='')
@@ -382,7 +418,9 @@ def test_LoginDialog_validate_no_input(mocker):
     ld.tfa_field.text = mocker.MagicMock(return_value='')
     ld.setDisabled = mocker.MagicMock()
     ld.error = mocker.MagicMock()
+
     ld.validate()
+
     assert ld.setDisabled.call_count == 2
     assert ld.error.call_count == 1
 
@@ -393,6 +431,7 @@ def test_LoginDialog_validate_input_non_numeric_2fa(mocker):
     guidance.
     """
     mock_controller = mocker.MagicMock()
+
     ld = LoginDialog(None)
     ld.setup(mock_controller)
     ld.username_field.text = mocker.MagicMock(return_value='foo')
@@ -400,7 +439,9 @@ def test_LoginDialog_validate_input_non_numeric_2fa(mocker):
     ld.tfa_field.text = mocker.MagicMock(return_value='baz')
     ld.setDisabled = mocker.MagicMock()
     ld.error = mocker.MagicMock()
+
     ld.validate()
+
     assert ld.setDisabled.call_count == 2
     assert ld.error.call_count == 1
     assert mock_controller.login.call_count == 0
@@ -411,6 +452,7 @@ def test_LoginDialog_validate_too_short_username(mocker):
     If the username is too small, we show an informative error message.
     """
     mock_controller = mocker.MagicMock()
+
     ld = LoginDialog(None)
     ld.setup(mock_controller)
     ld.username_field.text = mocker.MagicMock(return_value='he')
@@ -418,7 +460,9 @@ def test_LoginDialog_validate_too_short_username(mocker):
     ld.tfa_field.text = mocker.MagicMock(return_value='123456')
     ld.setDisabled = mocker.MagicMock()
     ld.error = mocker.MagicMock()
+
     ld.validate()
+
     assert ld.setDisabled.call_count == 2
     assert ld.error.call_count == 1
     assert mock_controller.login.call_count == 0
@@ -429,6 +473,7 @@ def test_LoginDialog_validate_too_short_password(mocker):
     If the password is too small, we show an informative error message.
     """
     mock_controller = mocker.MagicMock()
+
     ld = LoginDialog(None)
     ld.setup(mock_controller)
     ld.username_field.text = mocker.MagicMock(return_value='foo')
@@ -436,7 +481,9 @@ def test_LoginDialog_validate_too_short_password(mocker):
     ld.tfa_field.text = mocker.MagicMock(return_value='123456')
     ld.setDisabled = mocker.MagicMock()
     ld.error = mocker.MagicMock()
+
     ld.validate()
+
     assert ld.setDisabled.call_count == 2
     assert ld.error.call_count == 1
     assert mock_controller.login.call_count == 0
@@ -452,12 +499,15 @@ def test_LoginDialog_validate_too_long_password(mocker):
 
     max_password_len = 128
     too_long_password = 'a' * (max_password_len + 1)
+
     ld.username_field.text = mocker.MagicMock(return_value='foo')
     ld.password_field.text = mocker.MagicMock(return_value=too_long_password)
     ld.tfa_field.text = mocker.MagicMock(return_value='123456')
     ld.setDisabled = mocker.MagicMock()
     ld.error = mocker.MagicMock()
+
     ld.validate()
+
     assert ld.setDisabled.call_count == 2
     assert ld.error.call_count == 1
     assert mock_controller.login.call_count == 0
@@ -468,6 +518,7 @@ def test_LoginDialog_validate_input_ok(mocker):
     Valid input from the user causes a call to the controller's login method.
     """
     mock_controller = mocker.MagicMock()
+
     ld = LoginDialog(None)
     ld.setup(mock_controller)
     ld.username_field.text = mocker.MagicMock(return_value='foo')
@@ -475,7 +526,9 @@ def test_LoginDialog_validate_input_ok(mocker):
     ld.tfa_field.text = mocker.MagicMock(return_value='123456')
     ld.setDisabled = mocker.MagicMock()
     ld.error = mocker.MagicMock()
+
     ld.validate()
+
     assert ld.setDisabled.call_count == 1
     assert ld.error.call_count == 0
     mock_controller.login.assert_called_once_with('foo', 'nicelongpassword', '123456')
@@ -663,8 +716,10 @@ def test_ConversationView_add_message(mocker):
     cv = ConversationView(None)
     cv.controller = mocker.MagicMock()
     cv.conversation_layout = mocker.MagicMock()
+
     cv.add_message('hello')
     assert cv.conversation_layout.addWidget.call_count == 1
+
     cal = cv.conversation_layout.addWidget.call_args_list
     assert isinstance(cal[0][0][0], MessageWidget)
 
@@ -676,8 +731,10 @@ def test_ConversationView_add_reply(mocker):
     cv = ConversationView(None)
     cv.controller = mocker.MagicMock()
     cv.conversation_layout = mocker.MagicMock()
+
     cv.add_reply('hello')
     assert cv.conversation_layout.addWidget.call_count == 1
+
     cal = cv.conversation_layout.addWidget.call_args_list
     assert isinstance(cal[0][0][0], ReplyWidget)
 
@@ -690,15 +747,18 @@ def test_ConversationView_add_downloaded_file(mocker):
     cv = ConversationView(None)
     cv.controller = mocker.MagicMock()
     cv.conversation_layout = mocker.MagicMock()
+
     mock_source = mocker.MagicMock()
     mock_file = mocker.MagicMock()
     mock_file.is_downloaded = True
     mock_label = mocker.patch('securedrop_client.gui.widgets.QLabel')
     mocker.patch('securedrop_client.gui.widgets.QHBoxLayout.addWidget')
     mocker.patch('securedrop_client.gui.widgets.FileWidget.setLayout')
+
     cv.add_file(mock_source, mock_file)
     mock_label.assert_called_with("Open")
     assert cv.conversation_layout.addWidget.call_count == 1
+
     cal = cv.conversation_layout.addWidget.call_args_list
     assert isinstance(cal[0][0][0], FileWidget)
 
@@ -711,6 +771,7 @@ def test_ConversationView_add_not_downloaded_file(mocker):
     cv = ConversationView(None)
     cv.controller = mocker.MagicMock()
     cv.conversation_layout = mocker.MagicMock()
+
     mock_source = mocker.MagicMock()
     mock_file = mocker.MagicMock()
     mock_file.is_downloaded = False
@@ -718,9 +779,11 @@ def test_ConversationView_add_not_downloaded_file(mocker):
     mock_label = mocker.patch('securedrop_client.gui.widgets.QLabel')
     mocker.patch('securedrop_client.gui.widgets.QHBoxLayout.addWidget')
     mocker.patch('securedrop_client.gui.widgets.FileWidget.setLayout')
+
     cv.add_file(mock_source, mock_file)
     mock_label.assert_called_with("Download (123 bytes)")
     assert cv.conversation_layout.addWidget.call_count == 1
+
     cal = cv.conversation_layout.addWidget.call_args_list
     assert isinstance(cal[0][0][0], FileWidget)
 
@@ -737,6 +800,7 @@ def test_DeleteSourceMessage_launch_when_user_chooses_cancel(mocker):
     mock_source = mocker.MagicMock()
     mock_source.journalist_designation = 'foo bar baz'
     mock_source.submissions = []
+
     submission_files = (
         "submission_1-msg.gpg",
         "submission_2-msg.gpg",
@@ -746,6 +810,7 @@ def test_DeleteSourceMessage_launch_when_user_chooses_cancel(mocker):
         submission = mocker.MagicMock()
         submission.filename = filename
         mock_source.submissions.append(submission)
+
     mock_controller = mocker.MagicMock()
     delete_source_message_box = DeleteSourceMessageBox(
         None, mock_source, mock_controller
@@ -754,6 +819,7 @@ def test_DeleteSourceMessage_launch_when_user_chooses_cancel(mocker):
         "securedrop_client.gui.widgets.QMessageBox.question",
         mock_message_box_question,
     )
+
     delete_source_message_box.launch()
     mock_controller.delete_source.assert_not_called()
 
@@ -764,6 +830,7 @@ def test_DeleteSourceMssageBox_launch_when_user_chooses_yes(mocker):
     mock_source = mocker.MagicMock()
     mock_source.journalist_designation = 'foo bar baz'
     mock_source.submissions = []
+
     submission_files = (
         "submission_1-msg.gpg",
         "submission_2-msg.gpg",
@@ -773,6 +840,7 @@ def test_DeleteSourceMssageBox_launch_when_user_chooses_yes(mocker):
         submission = mocker.MagicMock()
         submission.filename = filename
         mock_source.submissions.append(submission)
+
     mock_controller = mocker.MagicMock()
     delete_source_message_box = DeleteSourceMessageBox(
         None, mock_source, mock_controller
@@ -781,8 +849,10 @@ def test_DeleteSourceMssageBox_launch_when_user_chooses_yes(mocker):
         "securedrop_client.gui.widgets.QMessageBox.question",
         mock_message_box_question,
     )
+
     delete_source_message_box.launch()
     mock_controller.delete_source.assert_called_once_with(mock_source)
+
     message = (
         "<big>Deleting the Source account for "
         "<b>foo bar baz</b> will also "
@@ -805,6 +875,7 @@ def test_DeleteSourceMessageBox_construct_message(mocker):
     mock_source = mocker.MagicMock()
     mock_source.journalist_designation = 'foo bar baz'
     mock_source.submissions = []
+
     submission_files = (
         "submission_1-msg.gpg",
         "submission_2-msg.gpg",
@@ -814,10 +885,12 @@ def test_DeleteSourceMessageBox_construct_message(mocker):
         submission = mocker.MagicMock()
         submission.filename = filename
         mock_source.submissions.append(submission)
+
     delete_source_message_box = DeleteSourceMessageBox(
         None, mock_source, mock_controller
     )
     message = delete_source_message_box._construct_message(mock_source)
+
     expected_message = (
         "<big>Deleting the Source account for "
         "<b>foo bar baz</b> will also "
@@ -825,8 +898,7 @@ def test_DeleteSourceMessageBox_construct_message(mocker):
         "<br> "
         "<small>This Source will no longer be able to correspond "
         "through the log-in tied to this account.</small>"
-    )
-    expected_message = expected_message.format(files=1, messages=2)
+    ).format(files=1, messages=2)
     assert message == expected_message
 
 
@@ -848,6 +920,7 @@ def test_DeleteSourceAction_trigger(mocker):
     mock_delete_source_message_box.return_value = (
         mock_delete_source_message_box_obj
     )
+
     with mocker.patch(
         'securedrop_client.gui.widgets.DeleteSourceMessageBox',
         mock_delete_source_message_box
@@ -870,6 +943,7 @@ def test_DeleteSource_from_source_menu_when_user_is_loggedout(mocker):
     mock_delete_source_message_box.return_value = (
         mock_delete_source_message_box_obj
     )
+
     with mocker.patch(
         'securedrop_client.gui.widgets.DeleteSourceMessageBox',
         mock_delete_source_message_box
@@ -889,6 +963,7 @@ def test_DeleteSource_from_source_widget_when_user_is_loggedout(mocker):
     mock_delete_source_message_box.return_value = (
         mock_delete_source_message_box_obj
     )
+
     with mocker.patch(
         'securedrop_client.gui.widgets.DeleteSourceMessageBox',
         mock_delete_source_message_box

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -234,7 +234,7 @@ def test_run(mocker):
     mock_start_app.assert_called_once_with(mock_args, mock_qt_args)
 
 
-def test_signal_interception(mocker):
+def test_signal_interception(mocker, homedir):
     # check that initializing an app calls configure_signal_handlers
     mocker.patch('securedrop_client.app.QApplication')
     mocker.patch('securedrop_client.app.prevent_second_instance')
@@ -245,8 +245,10 @@ def test_signal_interception(mocker):
     mocker.patch('securedrop_client.logic.GpgHelper')
     mocker.patch('securedrop_client.app.configure_logging')
     mock_signal_handlers = mocker.patch('securedrop_client.app.configure_signal_handlers')
+    mock_args = mocker.Mock()
+    mock_args.sdc_home = homedir
 
-    start_app(mocker.MagicMock(), [])
+    start_app(mock_args, [])
     assert mock_signal_handlers.called
 
     # check that a signal interception calls quit on the app

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -687,10 +687,12 @@ def test_Client_update_conversation_views(homedir, config, mocker):
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.Mock()
+    mock_conversation_wrapper = mocker.Mock()
     mock_conversation = mocker.MagicMock()
+    mock_conversation_wrapper.conversation = mock_conversation
     mock_update_conversation = mocker.MagicMock()
     mock_conversation.update_conversation = mock_update_conversation
-    mock_gui.conversations = {'foo': mock_conversation}
+    mock_gui.conversations = {'foo': mock_conversation_wrapper}
     mock_session = mocker.MagicMock()
 
     # Since we use the set-like behavior of self.session

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -503,6 +503,31 @@ def test_Client_sync_api(homedir, config, mocker):
                                         cl.on_sync_timeout, cl.api)
 
 
+def test_Client_on_synced_remove_stale_sources(homedir, config, mocker):
+    """
+    On an API sync, if a source no longer exists, remove it from the GUI.
+    Using the `config` fixture to ensure the config is written to disk.
+    """
+    mock_source_id = 'abc123'
+    mock_conv_wrapper = 'mock'
+
+    gui = mocker.Mock()
+    gui.conversations = {mock_source_id: mock_conv_wrapper}
+
+    mock_session = mocker.MagicMock()
+    cl = Client('http://localhost', gui, mock_session, homedir)
+
+    mock_source = mocker.Mock()
+    mock_source.uuid = mock_source_id
+
+    # not that the first item does *not* have the mock_source
+    api_res = ([], mocker.MagicMock(), mocker.MagicMock())
+    cl.on_synced(api_res)
+
+    # check that the uuid is not longer in the dict
+    assert mock_source_id not in gui.conversations
+
+
 def test_Client_last_sync_with_file(homedir, config, mocker):
     """
     The flag indicating the time of the last sync with the API is stored in a

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -680,59 +680,29 @@ def test_Client_update_sources(homedir, config, mocker):
     mock_gui.show_sources.assert_called_once_with(source_list)
 
 
-def test_Client_update_conversation_view_current_source(homedir, config, mocker):
+def test_Client_update_conversation_views(homedir, config, mocker):
     """
     Ensure the UI displays the latest version of the messages/replies that
     have been downloaded/decrypted in the current conversation view.
     Using the `config` fixture to ensure the config is written to disk.
     """
-    mock_gui = mocker.MagicMock()
-    mock_gui.current_source = 'teehee'
-    mock_gui.show_conversation_for = mocker.MagicMock()
+    mock_gui = mocker.Mock()
+    mock_conversation = mocker.MagicMock()
+    mock_update_conversation = mocker.MagicMock()
+    mock_conversation.update_conversation = mock_update_conversation
+    mock_gui.conversations = {'foo': mock_conversation}
     mock_session = mocker.MagicMock()
 
     # Since we use the set-like behavior of self.session
     # to check if the source is still persistent, let's mock that here
-    mock_session.__contains__ = mocker.MagicMock()
-    mock_session.__contains__.return_value = [mock_gui.current_source]
+    mock_session.__contains__ = mocker.Mock()
+    mock_session.__contains__.return_value = True
 
     mock_session.refresh = mocker.MagicMock()
     cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.update_conversation_view()
-    mock_session.refresh.assert_called_with(mock_gui.current_source)
-    mock_gui.show_conversation_for.assert_called_once_with(
-        mock_gui.current_source)
-
-
-def test_Client_update_conversation_deleted_source(homedir, config, mocker):
-    """
-    Ensure the UI does not attempt to refresh and display a deleted
-    source.
-    Using the `config` fixture to ensure the config is written to disk.
-    """
-    mock_gui = mocker.MagicMock()
-    mock_gui.current_source = 'teehee'
-    mock_gui.show_conversation_for = mocker.MagicMock()
-    mock_session = mocker.MagicMock()
-    mock_session.refresh = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.update_conversation_view()
-    mock_session.refresh.assert_not_called()
-    mock_gui.show_conversation_for.assert_not_called()
-
-
-def test_Client_update_conversation_view_no_current_source(homedir, config, mocker):
-    """
-    Ensure that if there is no current source (i.e. the user has not clicked
-    a source in the sidebar), the UI will not redraw the conversation view.
-    Using the `config` fixture to ensure the config is written to disk.
-    """
-    mock_gui = mocker.MagicMock()
-    mock_gui.current_source = None
-    mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.update_conversation_view()
-    mock_gui.show_conversation_for.assert_not_called()
+    cl.update_conversation_views()
+    assert mock_session.refresh.called
+    assert mock_update_conversation.called
 
 
 def test_Client_unstars_a_source_if_starred(homedir, config, mocker):
@@ -743,18 +713,22 @@ def test_Client_unstars_a_source_if_starred(homedir, config, mocker):
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
     cl = Client('http://localhost', mock_gui, mock_session, homedir)
+
     source_db_object = mocker.MagicMock()
     source_db_object.uuid = mocker.MagicMock()
     source_db_object.is_starred = True
+
     cl.call_api = mocker.MagicMock()
     cl.api = mocker.MagicMock()
     cl.api.remove_star = mocker.MagicMock()
     cl.on_update_star_complete = mocker.MagicMock()
     cl.on_sidebar_action_timeout = mocker.MagicMock()
+
     source_sdk_object = mocker.MagicMock()
     mock_source = mocker.patch('sdclientapi.Source')
     mock_source.return_value = source_sdk_object
     cl.update_star(source_db_object)
+
     cl.call_api.assert_called_once_with(
         cl.api.remove_star, cl.on_update_star_complete,
         cl.on_sidebar_action_timeout, source_sdk_object)


### PR DESCRIPTION
Fixes #185 

This fixes the problem of the UI flickering every time there is a API sync or message-download-decrypt sync. This is done by caching the conversation views and swapping between them instead of dropping and recreating them.

(Also I updated some of the code and tests to try to logically separate code blocks to avoid walls of text because I found it hard to read some times)
