### PR TITLE
Clear old items in conversation view on refresh

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -697,15 +697,15 @@ class ConversationView(QWidget):
 
         self.update_conversation(self.source.collection)
 
+    def clear_conversation(self):
+        while self.conversation_layout.count():
+            child = self.conversation_layout.takeAt(0)
+            if child.widget():
+                child.widget().deleteLater()
+
     def update_conversation(self, collection: list) -> None:
         # clear all old items
-        while True:
-            w = self.conversation_layout.takeAt(0)
-            if w:  # pragma: no cover
-                del w
-            else:
-                break
-
+        self.clear_conversation()
         # add new items
         for conversation_item in collection:
             if conversation_item.filename.endswith('msg.gpg'):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1116,3 +1116,69 @@ def test_ReplyWidget_success_failure_slots(mocker):
     assert not mock_logger.debug.called
     widget._on_reply_failure(msg_id)
     assert mock_logger.debug.called
+
+
+def test_update_conversation_maintains_old_items(mocker, homedir):
+    """
+    Calling update_conversation deletes and adds old items back to layout
+    """
+    mock_controller = mocker.MagicMock()
+    mock_source = mocker.MagicMock()
+    mock_source.collection = []
+    mock_file = mocker.MagicMock()
+    mock_file.filename = '1-source-doc.gpg'
+    mock_source.collection.append(mock_file)
+    mock_message = mocker.MagicMock()
+    mock_message.filename = '2-source-msg.gpg'
+    mock_source.collection.append(mock_message)
+    mock_reply = mocker.MagicMock()
+    mock_reply.filename = '3-source-reply.gpg'
+    mock_source.collection.append(mock_reply)
+    cv = ConversationView(mock_source, homedir, mock_controller)
+    assert cv.conversation_layout.count() == 3
+
+    cv.update_conversation(cv.source.collection)
+
+    assert cv.conversation_layout.count() == 3
+
+
+def test_update_conversation_adds_new_items(mocker, homedir):
+    """
+    Calling update_conversation adds new items to layout
+    """
+    mock_controller = mocker.MagicMock()
+    mock_source = mocker.MagicMock()
+    mock_source.collection = []
+    mock_file = mocker.MagicMock()
+    mock_file.filename = '1-source-doc.gpg'
+    mock_source.collection.append(mock_file)
+    mock_message = mocker.MagicMock()
+    mock_message.filename = '2-source-msg.gpg'
+    mock_source.collection.append(mock_message)
+    mock_reply = mocker.MagicMock()
+    mock_reply.filename = '3-source-reply.gpg'
+    mock_source.collection.append(mock_reply)
+    cv = ConversationView(mock_source, homedir, mock_controller)
+    mock_new_message = mocker.MagicMock()
+    mock_new_message.filename = '4-source-msg.gpg'
+    mock_source.collection.append(mock_new_message)
+    assert cv.conversation_layout.count() == 3
+
+    cv.update_conversation(cv.source.collection)
+
+    assert cv.conversation_layout.count() == 4
+
+
+def test_clear_conversation_deletes_items(mocker, homedir):
+    """
+    Calling clear_conversation deletes items from layout
+    """
+    mock_controller = mocker.MagicMock()
+    mock_source = mocker.MagicMock()
+    cv = ConversationView(mock_source, homedir, mock_controller)
+    cv.add_message('mock id', 'hello')
+    assert cv.conversation_layout.count() == 1
+
+    cv.clear_conversation()
+
+    assert cv.conversation_layout.count() == 0


### PR DESCRIPTION
Fixes https://github.com/freedomofpress/securedrop-client/issues/226 and `[Conversation Reordering]` issue noted in https://github.com/freedomofpress/securedrop-client/pull/240

**STR**
1. start client
2. refresh
3. resize window (should no longer see bubble layering issue)
4. send message from source
5. refresh, resize (should see no bubble layering issues)