### PR TITLE
Improve scrolling logic in conversation view

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -689,7 +689,7 @@ class ConversationView(QWidget):
         # Completely unintuitive way to ensure the view remains scrolled to the
         # bottom.
         sb = self.scroll.verticalScrollBar()
-        sb.rangeChanged.connect(self.move_to_bottom)
+        sb.rangeChanged.connect(self.update_conversation_position)
 
         main_layout = QVBoxLayout()
         main_layout.addWidget(self.scroll)
@@ -736,12 +736,16 @@ class ConversationView(QWidget):
             FileWidget(source_db_object, submission_db_object,
                        self.controller))
 
-    def move_to_bottom(self, min_val, max_val):
+    def update_conversation_position(self, min_val, max_val):
         """
         Handler called when a new item is added to the conversation. Ensures
         it's scrolled to the bottom and thus visible.
         """
-        self.scroll.verticalScrollBar().setValue(max_val)
+        current_val = self.scroll.verticalScrollBar().value()
+        viewport_height = self.scroll.viewport().height()
+
+        if current_val + viewport_height > max_val:
+            self.scroll.verticalScrollBar().setValue(max_val)
 
     def add_message(self, message_id: str, message: str) -> None:
         """

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -756,21 +756,43 @@ def test_ConversationView_init(mocker, homedir):
     cv = ConversationView(mocked_source, homedir, mocked_controller)
     assert isinstance(cv.conversation_layout, QVBoxLayout)
 
-
-def test_ConversationView_move_to_bottom(mocker, homedir):
+def test_ConversationView_update_conversation_position_follow(mocker, homedir):
     """
     Check the signal handler sets the correct value for the scrollbar to be
-    the maximum possible value.
+    the maximum possible value, when the scrollbar is near the bottom, meaning
+    it is following the conversation.
     """
     mocked_source = mocker.MagicMock()
     mocked_controller = mocker.MagicMock()
 
     cv = ConversationView(mocked_source, homedir, mocked_controller)
 
-    cv.scroll = mocker.MagicMock()
-    cv.move_to_bottom(0, 6789)
-    cv.scroll.verticalScrollBar().setValue.assert_called_once_with(6789)
+    cv.scroll.verticalScrollBar().value = mocker.MagicMock(return_value=5900)
+    cv.scroll.viewport().height = mocker.MagicMock(return_value=500)
+    cv.scroll.verticalScrollBar().setValue = mocker.MagicMock()
 
+    cv.update_conversation_position(0, 6000)
+
+    cv.scroll.verticalScrollBar().setValue.assert_called_once_with(6000)
+
+def test_ConversationView_update_conversation_position_stay_fixed(mocker, homedir):
+    """
+    Check the signal handler does not change the conversation position when
+    journalist is reading older messages
+    """
+
+    mocked_source = mocker.MagicMock()
+    mocked_controller = mocker.MagicMock()
+
+    cv = ConversationView(mocked_source, homedir, mocked_controller)
+
+    cv.scroll.verticalScrollBar().value = mocker.MagicMock(return_value=5500)
+    cv.scroll.viewport().height = mocker.MagicMock(return_value=500)
+    cv.scroll.verticalScrollBar().setValue = mocker.MagicMock()
+
+    cv.update_conversation_position(0, 6000)
+
+    cv.scroll.verticalScrollBar().setValue.assert_not_called()
 
 def test_ConversationView_add_message(mocker, homedir):
     """

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -756,6 +756,7 @@ def test_ConversationView_init(mocker, homedir):
     cv = ConversationView(mocked_source, homedir, mocked_controller)
     assert isinstance(cv.conversation_layout, QVBoxLayout)
 
+
 def test_ConversationView_update_conversation_position_follow(mocker, homedir):
     """
     Check the signal handler sets the correct value for the scrollbar to be
@@ -775,12 +776,12 @@ def test_ConversationView_update_conversation_position_follow(mocker, homedir):
 
     cv.scroll.verticalScrollBar().setValue.assert_called_once_with(6000)
 
+
 def test_ConversationView_update_conversation_position_stay_fixed(mocker, homedir):
     """
     Check the signal handler does not change the conversation position when
     journalist is reading older messages
     """
-
     mocked_source = mocker.MagicMock()
     mocked_controller = mocker.MagicMock()
 
@@ -793,6 +794,7 @@ def test_ConversationView_update_conversation_position_stay_fixed(mocker, homedi
     cv.update_conversation_position(0, 6000)
 
     cv.scroll.verticalScrollBar().setValue.assert_not_called()
+
 
 def test_ConversationView_add_message(mocker, homedir):
     """


### PR DESCRIPTION
## Status
Work in progress (tests missing)

## Description of Changes

Fixes #144 is a way that is simple enough. Structural changes are still needed for #187 but for the time being this solves the issue.

renamed `move_to_bottom` function in `widgets.py` to `update_conversation_position` as it does not always go to the bottom. Added checks to see what parts of the conversation are currently visible. The way it works currently is it detects whether or not it is within a view-port distance of the last message (since it is hard to detect exactly the length of the last message)

## Testing
Open conversation with source. Type enough text such that it covers more than the window. Pull to the top and receive a msg from the source. It should stay in the same place. move to the bottom and do the same and see that it scrolls with the new content.

Type any message as a journalist and it should scroll to the bottom too

## Deployment
No deployment issues

## TODO
Testing needs to be redone for the function `move_to_bottom` as it was renamed and behavior change. I will do the test soon, but I will still have to learn how to do them. If someone with more experience would like to make a test, please feel free to. Otherwise it should take me a couple of days.