### PR TITLE
Rename files

### DIFF
--- a/securedrop_client/message_sync.py
+++ b/securedrop_client/message_sync.py
@@ -70,7 +70,6 @@ class MessageSync(APISyncObject):
 
     def run(self, loop=True):
         while True:
-            logger.debug('Syncing messages.')
             submissions = storage.find_new_submissions(self.session)
 
             for db_submission in submissions:
@@ -93,7 +92,7 @@ class MessageSync(APISyncObject):
                     tb = traceback.format_exc()
                     logger.critical("Exception while downloading submission!\n{}".format(tb))
 
-            logger.debug('Completed message sync.')
+            logger.debug('Submissions synced')
 
             if not loop:
                 break
@@ -117,7 +116,6 @@ class ReplySync(APISyncObject):
 
     def run(self, loop=True):
         while True:
-            logger.debug('Syncing replies.')
             replies = storage.find_new_replies(self.session)
 
             for db_reply in replies:
@@ -143,7 +141,7 @@ class ReplySync(APISyncObject):
                     tb = traceback.format_exc()
                     logger.critical("Exception while downloading reply!\n{}".format(tb))
 
-            logger.debug('Completed reply sync.')
+            logger.debug('Replies synced')
 
             if not loop:
                 break


### PR DESCRIPTION
## Description
Fixes https://github.com/freedomofpress/securedrop-client/issues/238

## What changed?

#### securedrop_client/message_sync.py
 - I think we log too often here. Since it is a debug log, I left 2 of the 4 logs inside the 5-second loop
#### securedrop_client/storage.py
 - I made some opinions about log levels here
 - New `rename_file` function
 - `update_submissions` and `update_replies` now update data files to match new filenames in the db. 
#### ~tests/conftest.py~
  ~- I added a `data_dir` pytest function.~ I plan to make a follow-up PR for a couple renaming refactors that would have made this PR harder to follow had I added them here. But basically I think we need to pass `data_dir` where we pass `homedir` in many test instances. Not a huge deal but it would be more correct to mimic what we do in production. 
#### tests/test_storage.py
 - Added some unit tests for the new `rename_file` function
 - Updated existing tests: `test_update_submissions` and `test_update_replies` to check that `rename_file` is called if the local storage filenames need to be updated

---

#### *Update:*
>  - `update_submissions` and `update_replies` now update data files to match new filenames in the db. 

The reply and submission files are renamed in these functions when we have both the local filename and server filename. This makes it easy to ensure local matches what's on the server. 

Another option would be to rename the files in `update_sources` when the `journalist_designation` has changed. This would show the connection between a new `journalist_designation` and filename updates, but the code would be a bit more complicated because the filenames would need to be rebuilt, hard-coding the file naming structure so that we can find and replace the `journalist_designation` in the middle of the filename. 

I went with the first option because it would require less maintenance if in the future we decide to change the way files are named or there ends up being more reasons that file names can become out of sync. This logic says "regardless of reason the names have changed, local should always match the server."