### PR TITLE
segfault when clicking on Source

### DIFF
--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -30,7 +30,7 @@ from logging.handlers import TimedRotatingFileHandler
 from securedrop_client import __version__
 from securedrop_client.logic import Client
 from securedrop_client.gui.main import Window
-from securedrop_client.resources import load_icon, load_css
+from securedrop_client.resources import load_icon
 from securedrop_client.db import make_engine
 from securedrop_client.utils import safe_mkdir
 
@@ -162,7 +162,9 @@ def start_app(args, qt_args) -> None:
 
     gui = Window(args.sdc_home)
     app.setWindowIcon(load_icon(gui.icon))
-    app.setStyleSheet(load_css('sdclient.css'))
+    # Revert once https://bugreports.qt.io/browse/QTBUG-69204 is fixed
+    # See https://github.com/freedomofpress/securedrop-client/issues/273
+    # app.setStyleSheet(load_css('sdclient.css'))
 
     engine = make_engine(args.sdc_home)
     Session = sessionmaker(bind=engine)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -172,10 +172,10 @@ class MainView(QWidget):
         old_widget = self.view_layout.takeAt(0)
 
         if old_widget:
-            old_widget.widget().setVisible(False)
+            old_widget.widget().hide()
 
         self.view_layout.addWidget(widget)
-        widget.setVisible(True)
+        widget.show()
 
 
 class SourceList(QListWidget):
@@ -407,6 +407,7 @@ class LoginDialog(QDialog):
 
         self.error_label = QLabel('')
         self.error_label.setObjectName('error_label')
+        self.error_label.setStyleSheet('color: red')
 
         layout.addStretch()
         layout.addWidget(self.title)
@@ -695,7 +696,6 @@ class ConversationView(QWidget):
         main_layout = QVBoxLayout()
         main_layout.addWidget(self.scroll)
         self.setLayout(main_layout)
-
         self.update_conversation(self.source.collection)
 
     def clear_conversation(self):
@@ -771,7 +771,7 @@ class ConversationView(QWidget):
 class SourceConversationWrapper(QWidget):
     """
     Wrapper for a source's conversation including the chat window, profile tab, and other
-    per-soruce resources.
+    per-source resources.
     """
 
     def __init__(


### PR DESCRIPTION
Fixes https://github.com/freedomofpress/securedrop-client/issues/248 where the client crashes when a user clicks on a source from the sources list.

When debugging the client I could see that crash happened when adding the widget to the `view_layout`:

```
(Pdb) w
  /usr/lib/python3.5/runpy.py(193)_run_module_as_main()
-> "__main__", mod_spec)
  /usr/lib/python3.5/runpy.py(85)_run_code()
-> exec(code, run_globals)
  /home/creviera/workspace/freedomofpress/securedrop-client/securedrop_client/__main__.py(3)<module>()
-> run()
  /home/creviera/workspace/freedomofpress/securedrop-client/securedrop_client/app.py(187)run()
-> start_app(args, qt_args)
  /home/creviera/workspace/freedomofpress/securedrop-client/securedrop_client/app.py(180)start_app()
-> sys.exit(app.exec_())
  /home/creviera/workspace/freedomofpress/securedrop-client/securedrop_client/gui/main.py(167)on_source_changed()
-> self.show_conversation_for(self.current_source)
  /home/creviera/workspace/freedomofpress/securedrop-client/securedrop_client/gui/main.py(182)show_conversation_for()
-> self.main_view.set_conversation(conversation_container)
> /home/creviera/workspace/freedomofpress/securedrop-client/securedrop_client/gui/widgets.py(177)set_conversation()
-> self.view_layout.addWidget(widget)
```

**TODO:** Still more research needs to be done as to why Qt crashes when a widget isn't set to visible.