### PR TITLE
Split submissions table into files/messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ rm -f svs.sqlite
 sqlite3 svs.sqlite .databases > /dev/null
 alembic upgrade head
 alembic revision --autogenerate -m "describe your revision here"
-make test-alembic
 ```
 
 ### Merging Migrations

--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -2,7 +2,7 @@ import os
 
 from sqlalchemy import Boolean, Column, create_engine, DateTime, ForeignKey, Integer, String, \
     Text, MetaData, CheckConstraint
-from sqlalchemy.ext.declarative import declarative_base, AbstractConcreteBase
+from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, backref
 
 
@@ -65,17 +65,9 @@ class Source(Base):
         return collection
 
 
-class Submission(AbstractConcreteBase, Base):
-    pass
-
-
-class Message(Submission):
+class Message(Base):
 
     __tablename__ = 'messages'
-    __mapper_args__ = {
-        'polymorphic_identity': 'message',
-        'concrete': True,
-    }
 
     id = Column(Integer, primary_key=True)
     uuid = Column(String(36), unique=True, nullable=False)
@@ -105,13 +97,9 @@ class Message(Submission):
         return '<Message {}>'.format(self.filename)
 
 
-class File(Submission):
+class File(Base):
 
     __tablename__ = 'files'
-    __mapper_args__ = {
-        'polymorphic_identity': 'file',
-        'concrete': True,
-    }
 
     id = Column(Integer, primary_key=True)
     uuid = Column(String(36), unique=True, nullable=False)

--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -32,13 +32,11 @@ class Source(Base):
     uuid = Column(String(36), unique=True, nullable=False)
     journalist_designation = Column(String(255), nullable=False)
     document_count = Column(Integer, server_default="0", nullable=False)
-    is_flagged = Column(Boolean(name='is_flagged'),
-                        server_default="false")
+    is_flagged = Column(Boolean(name='is_flagged'), server_default="0")
     public_key = Column(Text, nullable=True)
     fingerprint = Column(String(64))
     interaction_count = Column(Integer, server_default="0", nullable=False)
-    is_starred = Column(Boolean(name='is_starred'),
-                        server_default="false")
+    is_starred = Column(Boolean(name='is_starred'), server_default="0")
     last_updated = Column(DateTime)
 
     def __init__(self, uuid, journalist_designation, is_flagged, public_key,
@@ -86,10 +84,10 @@ class Message(Submission):
     download_url = Column(String(255), nullable=False)
 
     # This is whether the submission has been downloaded in the local database.
-    is_downloaded = Column(Boolean(name='is_downloaded'), nullable=False, server_default='false')
+    is_downloaded = Column(Boolean(name='is_downloaded'), nullable=False, server_default="0")
 
     # This reflects read status stored on the server.
-    is_read = Column(Boolean(name='is_read'), nullable=False, server_default='false')
+    is_read = Column(Boolean(name='is_read'), nullable=False, server_default="0")
 
     content = Column(
         Text,
@@ -122,10 +120,10 @@ class File(Submission):
     download_url = Column(String(255), nullable=False)
 
     # This is whether the submission has been downloaded in the local database.
-    is_downloaded = Column(Boolean(name='is_downloaded'), nullable=False, server_default='false')
+    is_downloaded = Column(Boolean(name='is_downloaded'), nullable=False, server_default="0")
 
     # This reflects read status stored on the server.
-    is_read = Column(Boolean(name='is_read'), nullable=False, server_default='false')
+    is_read = Column(Boolean(name='is_read'), nullable=False, server_default="0")
 
     source_id = Column(Integer, ForeignKey('sources.id'))
     source = relationship("Source",

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -526,16 +526,14 @@ class Client(QObject):
         """
         self.gui.set_status(message, duration)
 
-    def on_file_open(self, submission_db_object):
+    def on_file_open(self, file_db_object):
         """
-        Open the already downloaded file associated with the message (which
-        is a Submission).
+        Open the already downloaded file associated with the message (which is a `File`).
         """
-
         # Once downloaded, submissions are stored in the data directory
         # with the same filename as the server, except with the .gz.gpg
         # stripped off.
-        server_filename = submission_db_object.filename
+        server_filename = file_db_object.filename
         fn_no_ext, _ = os.path.splitext(os.path.splitext(server_filename)[0])
         submission_filepath = os.path.join(self.data_dir, fn_no_ext)
 
@@ -561,7 +559,7 @@ class Client(QObject):
             self.on_action_requiring_login()
             return
 
-        if isinstance(message, db.Submission):
+        if isinstance(message, db.File) or isinstance(message, db.Message):
             # Handle submissions.
             func = self.api.download_submission
             sdk_object = sdclientapi.Submission(uuid=message.uuid)

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -4,7 +4,7 @@ Check the core Window UI class works as expected.
 from PyQt5.QtWidgets import QApplication, QVBoxLayout
 from securedrop_client.gui.main import Window
 from securedrop_client.resources import load_icon
-from securedrop_client.db import Submission
+from securedrop_client.db import Message
 from uuid import uuid4
 
 
@@ -245,13 +245,10 @@ def test_conversation_pending_message(mocker):
     mock_source.journalistic_designation = 'Testy McTestface'
 
     msg_uuid = str(uuid4())
-    submission = Submission(source=mock_source, uuid=msg_uuid, size=123,
-                            filename="test.msg.gpg",
-                            download_url='http://test/test')
+    message = Message(source=mock_source, uuid=msg_uuid, size=123, filename="test.msg.gpg",
+                      download_url='http://test/test', is_downloaded=False)
 
-    submission.is_downloaded = False
-
-    mock_source.collection = [submission]
+    mock_source.collection = [message]
 
     mocked_add_message = mocker.patch('securedrop_client.gui.widgets.ConversationView.add_message')
     mocker.patch('securedrop_client.gui.main.QVBoxLayout')

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -682,12 +682,10 @@ def test_FileWidget_init_left(mocker):
     """
     mock_controller = mocker.MagicMock()
     source = factory.Source()
-    submission = db.Submission(source, 'submission-uuid', 123,
-                               'mah-reply.gpg',
-                               'http://mah-server/mah-reply-url')
-    submission.is_downloaded = True
+    message = db.Message(source=source, uuid='uuid', size=123, filename='mah-reply.gpg',
+                         download_url='http://mah-server/mah-reply-url', is_downloaded=True)
 
-    fw = FileWidget(source, submission, mock_controller, align='left')
+    fw = FileWidget(source, message, mock_controller, align='left')
 
     layout = fw.layout()
     assert isinstance(layout.takeAt(0), QWidgetItem)
@@ -702,12 +700,10 @@ def test_FileWidget_init_right(mocker):
     """
     mock_controller = mocker.MagicMock()
     source = factory.Source()
-    submission = db.Submission(source, 'submission-uuid', 123,
-                               'mah-reply.gpg',
-                               'http://mah-server/mah-reply-url')
-    submission.is_downloaded = True
+    message = db.Message(source=source, uuid='uuid', size=123, filename='mah-reply.gpg',
+                         download_url='http://mah-server/mah-reply-url', is_downloaded=True)
 
-    fw = FileWidget(source, submission, mock_controller, align='right')
+    fw = FileWidget(source, message, mock_controller, align='right')
     layout = fw.layout()
     assert isinstance(layout.takeAt(0), QSpacerItem)
     assert isinstance(layout.takeAt(0), QWidgetItem)
@@ -721,14 +717,12 @@ def test_FileWidget_mousePressEvent_download(mocker):
     """
     mock_controller = mocker.MagicMock()
     source = factory.Source()
-    submission = db.Submission(source, 'submission-uuid', 123,
-                               'mah-reply.gpg',
-                               'http://mah-server/mah-reply-url')
-    submission.is_downloaded = False
+    file_ = db.File(source=source, uuid='uuid', size=123, filename='mah-reply.gpg',
+                    download_url='http://mah-server/mah-reply-url', is_downloaded=False)
 
-    fw = FileWidget(source, submission, mock_controller)
+    fw = FileWidget(source, file_, mock_controller)
     fw.mouseReleaseEvent(None)
-    fw.controller.on_file_download.assert_called_once_with(source, submission)
+    fw.controller.on_file_download.assert_called_once_with(source, file_)
 
 
 def test_FileWidget_mousePressEvent_open(mocker):
@@ -737,14 +731,12 @@ def test_FileWidget_mousePressEvent_open(mocker):
     """
     mock_controller = mocker.MagicMock()
     source = factory.Source()
-    submission = db.Submission(source, 'submission-uuid', 123,
-                               'mah-reply.gpg',
-                               'http://mah-server/mah-reply-url')
-    submission.is_downloaded = True
+    file_ = db.File(source=source, uuid='uuid', size=123, filename='mah-reply.gpg',
+                    download_url='http://mah-server/mah-reply-url', is_downloaded=True)
 
-    fw = FileWidget(source, submission, mock_controller)
+    fw = FileWidget(source, file_, mock_controller)
     fw.mouseReleaseEvent(None)
-    fw.controller.on_file_open.assert_called_once_with(submission)
+    fw.controller.on_file_open.assert_called_once_with(file_)
 
 
 def test_ConversationView_init(mocker, homedir):

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -951,18 +951,18 @@ def test_Client_on_file_download_Submission(homedir, config, mocker):
     mock_session = mocker.MagicMock()
     cl = Client('http://localhost', mock_gui, mock_session, homedir)
     source = factory.Source()
-    submission = db.Submission(source, 'submission-uuid', 1234,
-                               'myfile.doc.gpg', 'http://myserver/myfile')
+    file_ = db.File(source=source, uuid='uuid', size=1234, filename='myfile.doc.gpg',
+                    download_url='http://myserver/myfile', is_downloaded=False)
     cl.call_api = mocker.MagicMock()
     cl.api = mocker.MagicMock()
     submission_sdk_object = mocker.MagicMock()
     mock_submission = mocker.patch('sdclientapi.Submission')
     mock_submission.return_value = submission_sdk_object
-    cl.on_file_download(source, submission)
+    cl.on_file_download(source, file_)
     cl.call_api.assert_called_once_with(
         cl.api.download_submission, cl.on_file_downloaded,
         cl.on_download_timeout, submission_sdk_object,
-        cl.data_dir, current_object=submission)
+        cl.data_dir, current_object=file_)
 
 
 def test_Client_on_file_downloaded_success(homedir, config, mocker):
@@ -1048,14 +1048,14 @@ def test_Client_on_file_download_user_not_signed_in(homedir, config, mocker):
     mock_session = mocker.MagicMock()
     cl = Client('http://localhost', mock_gui, mock_session, homedir)
     source = factory.Source()
-    submission = db.Submission(source, 'submission-uuid', 1234,
-                               'myfile.doc.gpg', 'http://myserver/myfile')
+    file_ = db.File(source=source, uuid='uuid', size=1234, filename='myfile.doc.gpg',
+                    download_url='http://myserver/myfile', is_downloaded=False)
     cl.on_action_requiring_login = mocker.MagicMock()
     cl.api = None
     submission_sdk_object = mocker.MagicMock()
     mock_submission = mocker.patch('sdclientapi.Submission')
     mock_submission.return_value = submission_sdk_object
-    cl.on_file_download(source, submission)
+    cl.on_file_download(source, file_)
     cl.on_action_requiring_login.assert_called_once_with()
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,5 @@
 from tests import factory
-from securedrop_client.db import Reply, Submission, User
+from securedrop_client.db import Reply, File, Message, User
 
 
 def test_string_representation_of_user():
@@ -12,12 +12,18 @@ def test_string_representation_of_source():
     source.__repr__()
 
 
-def test_string_representation_of_submission():
+def test_string_representation_of_message():
     source = factory.Source()
-    submission = Submission(source=source, uuid="test", size=123,
-                            filename="test.docx",
-                            download_url='http://test/test')
-    submission.__repr__()
+    msg = Message(source=source, uuid="test", size=123, filename="test.docx",
+                  download_url='http://test/test')
+    msg.__repr__()
+
+
+def test_string_representation_of_file():
+    source = factory.Source()
+    file_ = File(source=source, uuid="test", size=123, filename="test.docx",
+                 download_url='http://test/test')
+    file_.__repr__()
 
 
 def test_string_representation_of_reply():
@@ -31,15 +37,18 @@ def test_string_representation_of_reply():
 def test_source_collection():
     # Create some test submissions and replies
     source = factory.Source()
-    submission = Submission(source=source, uuid="test", size=123,
-                            filename="2-test.doc.gpg",
-                            download_url='http://test/test')
+    file_ = File(source=source, uuid="test", size=123, filename="2-test.doc.gpg",
+                 download_url='http://test/test')
+    message = Message(source=source, uuid="test", size=123, filename="3-test.doc.gpg",
+                      download_url='http://test/test')
     user = User('hehe')
     reply = Reply(source=source, journalist=user, filename="1-reply.gpg",
                   size=1234, uuid='test')
-    source.submissions = [submission]
+    source.files = [file_]
+    source.messages = [message]
     source.replies = [reply]
 
     # Now these items should be in the source collection in the proper order
     assert source.collection[0] == reply
-    assert source.collection[1] == submission
+    assert source.collection[1] == file_
+    assert source.collection[2] == message


### PR DESCRIPTION
Update:

Fixes #229

Ready for review

--------------------
Toward #229

I considered using an [abstract concrete base](https://docs.sqlalchemy.org/en/latest/orm/inheritance.html#abstract-concrete-classes) pattern as described in the SqlAlchemy docs, but didn't actually see much benefit in it at first since we mainly use these as separate entities and do a lot of the manipulations like ordering in the code anyway. Adding back the `Submission` class as an `AbstractConcreteBase` is trivial should we want to do that.

This is a draft PR that establishes the models that we'd use for the rest of the ticket. Since the DB tends to be a subject that warrants debate and is something a lot of us have opinions on, I opened this as a draft for discussion on just this aspect before I put the rest of the work in.