### PR TITLE
Prevent user from sending replies when client is not authenticated

### DIFF
--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -21,7 +21,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import logging
 from PyQt5.QtWidgets import QMainWindow, QWidget, QVBoxLayout, QDesktopWidget, QStatusBar
+from typing import List
+
 from securedrop_client import __version__
+from securedrop_client.db import Source
 from securedrop_client.gui.widgets import (ToolBar, MainView, LoginDialog,
                                            SourceConversationWrapper)
 from securedrop_client.resources import load_icon
@@ -49,6 +52,8 @@ class Window(QMainWindow):
         """
         super().__init__()
         self.sdc_home = sdc_home
+        self.controller = None
+
         self.setWindowTitle(_("SecureDrop Client {}").format(__version__))
         self.setWindowIcon(load_icon(self.icon))
 
@@ -127,7 +132,7 @@ class Window(QMainWindow):
         """
         self.main_view.update_error_status(error)
 
-    def show_sources(self, sources):
+    def show_sources(self, sources: List[Source]):
         """
         Update the left hand sources list in the UI with the passed in list of
         sources.

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -169,9 +169,9 @@ class Window(QMainWindow):
         source_widget = self.main_view.source_list.itemWidget(source_item)
         if source_widget:
             self.current_source = source_widget.source
-            self.show_conversation_for(self.current_source)
+            self.show_conversation_for(self.current_source, self.controller.is_authenticated)
 
-    def show_conversation_for(self, source):
+    def show_conversation_for(self, source: Source, is_authenticated: bool):
         """
         Show conversation of messages and replies between a source and
         journalists.
@@ -182,7 +182,8 @@ class Window(QMainWindow):
         if conversation_container is None:
             conversation_container = SourceConversationWrapper(source,
                                                                self.sdc_home,
-                                                               self.controller)
+                                                               self.controller,
+                                                               is_authenticated)
             self.conversations[source.uuid] = conversation_container
 
         self.main_view.set_conversation(conversation_container)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -797,16 +797,16 @@ class SourceConversationWrapper(QWidget):
         self.layout.addWidget(self.source_profile)
         self.layout.addWidget(self.conversation)
 
-        self.controller.authentication_state.connect(self._on_authentication_update)
-        self._on_authentication_update(is_authenticated)
+        self.controller.authentication_state.connect(self._show_or_hide_replybox)
+        self._show_or_hide_replybox(is_authenticated)
 
     def send_reply(self, message: str) -> None:
         msg_uuid = str(uuid4())
         self.conversation.add_reply(msg_uuid, message)
         self.controller.send_reply(self.source.uuid, msg_uuid, message)
 
-    def _on_authentication_update(self, is_authenticated: bool) -> None:
-        if is_authenticated:
+    def _show_or_hide_replybox(self, show: bool) -> None:
+        if show:
             new_widget = ReplyBoxWidget(self)
         else:
             new_widget = QLabel(_('You need to log in to send replies.'))

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -24,6 +24,7 @@ from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QListWidget, QLabel, QWidget, QListWidgetItem, QHBoxLayout, \
     QPushButton, QVBoxLayout, QLineEdit, QScrollArea, QDialog, QAction, QMenu, \
     QMessageBox, QToolButton, QSizePolicy, QTextEdit
+from typing import List
 from uuid import uuid4
 
 from securedrop_client.db import Source
@@ -40,7 +41,7 @@ class ToolBar(QWidget):
     Represents the tool bar across the top of the user interface.
     """
 
-    def __init__(self, parent):
+    def __init__(self, parent: QWidget):
         super().__init__(parent)
         layout = QHBoxLayout(self)
         self.logo = QLabel()
@@ -191,7 +192,7 @@ class SourceList(QListWidget):
         """
         self.controller = controller
 
-    def update(self, sources):
+    def update(self, sources: List[Source]):
         """
         Reset and update the list with the passed in list of sources.
         """
@@ -271,7 +272,7 @@ class SourceWidget(QWidget):
     Used to display summary information about a source in the list view.
     """
 
-    def __init__(self, parent, source):
+    def __init__(self, parent: QWidget, source: Source):
         """
         Set up the child widgets.
         """

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -175,8 +175,11 @@ def test_on_source_changed(mocker):
     w.main_view.source_list.currentItem()
     mock_sw = w.main_view.source_list.itemWidget()
     w.show_conversation_for = mocker.MagicMock()
+    mock_controller = mocker.MagicMock(is_authenticated=True)
+    w.controller = mock_controller
     w.on_source_changed()
-    w.show_conversation_for.assert_called_once_with(mock_sw.source)
+    w.show_conversation_for.assert_called_once_with(mock_sw.source,
+                                                    mock_controller.is_authenticated)
 
 
 def test_conversation_for(mocker):
@@ -203,7 +206,7 @@ def test_conversation_for(mocker):
     mocked_add_file = mocker.patch('securedrop_client.gui.widgets.ConversationView.add_file',
                                    new=mocker.Mock())
 
-    w.show_conversation_for(mock_source)
+    w.show_conversation_for(mock_source, is_authenticated=True)
 
     assert mocked_add_message.call_count > 0
     assert mocked_add_reply.call_count > 0
@@ -224,7 +227,8 @@ def test_conversation_for(mocker):
     mocked_add_file = mocker.patch('securedrop_client.gui.widgets.ConversationView.add_file',
                                    new=mocker.Mock())
 
-    w.show_conversation_for(mock_source)
+    # checking with is_authenticated=False just to ensure this doesn't break either
+    w.show_conversation_for(mock_source, is_authenticated=False)
 
     # because the conversation was cached, we don't call these functions again
     assert mocked_add_message.call_count == 0
@@ -257,7 +261,7 @@ def test_conversation_pending_message(mocker):
     mocker.patch('securedrop_client.gui.main.QVBoxLayout')
     mocker.patch('securedrop_client.gui.main.QWidget')
 
-    w.show_conversation_for(mock_source)
+    w.show_conversation_for(mock_source, True)
 
     assert mocked_add_message.call_count == 1
     assert mocked_add_message.call_args == mocker.call(msg_uuid, "<Message not yet downloaded>")

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1218,11 +1218,11 @@ def test_SourceConversationWrapper_auth_signals(mocker, homedir):
     mock_controller = mocker.MagicMock(authentication_state=mock_signal)
     mock_is_auth = mocker.MagicMock()
 
-    mock_on_auth = mocker.patch.object(SourceConversationWrapper, '_on_authentication_update')
+    mock_sh = mocker.patch.object(SourceConversationWrapper, '_show_or_hide_replybox')
     SourceConversationWrapper(mock_source, 'mock home', mock_controller, mock_is_auth)
 
-    mock_connect.assert_called_once_with(mock_on_auth)
-    mock_on_auth.assert_called_with(mock_is_auth)
+    mock_connect.assert_called_once_with(mock_sh)
+    mock_sh.assert_called_with(mock_is_auth)
 
 
 def test_SourceConversationWrapper_set_widgets_via_auth_value(mocker, homedir):
@@ -1239,12 +1239,12 @@ def test_SourceConversationWrapper_set_widgets_via_auth_value(mocker, homedir):
                                   return_value=QWidget())
     mock_label = mocker.patch('securedrop_client.gui.widgets.QLabel', return_value=QWidget())
 
-    cw._on_authentication_update(True)
+    cw._show_or_hide_replybox(True)
     mock_reply_box.assert_called_once_with(cw)
     assert not mock_label.called
 
     mock_reply_box.reset_mock()
 
-    cw._on_authentication_update(False)
+    cw._show_or_hide_replybox(False)
     assert not mock_reply_box.called
     assert mock_label.called

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1077,7 +1077,7 @@ def test_SourceConversationWrapper_send_reply(mocker):
     mocker.patch('securedrop_client.gui.widgets.uuid4', return_value=mock_uuid)
     mock_controller = mocker.MagicMock()
 
-    cw = SourceConversationWrapper(mock_source, 'mock home', mock_controller)
+    cw = SourceConversationWrapper(mock_source, 'mock home', mock_controller, True)
     mock_add_reply = mocker.Mock()
     cw.conversation.add_reply = mock_add_reply
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1326,3 +1326,40 @@ def test_Client_on_reply_timeout(homedir, mocker):
     cl._on_reply_timeout(current_object)
     mock_reply_failed.emit.assert_called_once_with(msg_uuid)
     assert not mock_reply_succeeded.emit.called
+
+
+def test_Client_is_authenticated_property(homedir, mocker):
+    '''
+    Check that the @property `is_authenticated`:
+      - Cannot be deleted
+      - Emits the correct signals when updated
+      - Sets internal state to ensure signals are only set when the state changes
+    '''
+    mock_gui = mocker.MagicMock()
+    mock_session = mocker.MagicMock()
+
+    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    mock_signal = mocker.patch.object(cl, 'authentication_state')
+
+    # default state is unauthenticated
+    assert cl.is_authenticated is False
+
+    # the property cannot be deleted
+    with pytest.raises(AttributeError):
+        del cl.is_authenticated
+
+    # setting the signal to its current value does not fire the signal
+    cl.is_authenticated = False
+    assert not mock_signal.emit.called
+    assert cl.is_authenticated is False
+
+    # setting the property to True sends a signal
+    cl.is_authenticated = True
+    mock_signal.emit.assert_called_once_with(True)
+    assert cl.is_authenticated is True
+
+    mock_signal.reset_mock()
+
+    cl.is_authenticated = False
+    mock_signal.emit.assert_called_once_with(False)
+    assert cl.is_authenticated is False


### PR DESCRIPTION
Fixes #243

Testing:

- Start client
- Skip login
- See warning instead of reply box
- Sign in
- See reply box
- Sign out
- See warning again

Also:

- Check that the type annotations I added are correct