### PR TITLE
Handle messages and files that fail to decrypt

### DIFF
--- a/securedrop_client/crypto.py
+++ b/securedrop_client/crypto.py
@@ -61,8 +61,6 @@ class GpgHelper:
             cmd.extend(["--decrypt", filepath])
             res = subprocess.call(cmd, stdout=out, stderr=err)
 
-            os.unlink(filepath)  # original file
-
             if res != 0:
                 # The err tempfile was created with delete=False, so needs to
                 # be explicitly cleaned up. We will do that after we've read the file.
@@ -79,6 +77,8 @@ class GpgHelper:
                 # Cleanup err file
                 err.close()
                 os.unlink(err.name)
+
+                os.unlink(filepath)  # success so remove original (encrypted) file
 
                 if is_doc:
                     # Need to split twice as filename is e.g.

--- a/securedrop_client/message_sync.py
+++ b/securedrop_client/message_sync.py
@@ -93,23 +93,28 @@ class MessageSync(APISyncObject):
                     # Need to set filename on non-Qubes platforms
                     sdk_submission.filename = db_submission.filename
 
-                    if self.api:
+                    if not db_submission.is_downloaded and self.api:
+                        # Download and decrypt
                         self.fetch_the_thing(sdk_submission,
                                              db_submission,
                                              self.api.download_submission,
                                              storage.mark_message_as_downloaded)
+                    elif db_submission.is_downloaded:
+                        # Just decrypt file that is already on disk
+                        self.decrypt_the_thing(db_submission.filename,
+                                               db_submission)
 
-                        if db_submission.content is not None:
-                            content = db_submission.content
-                        else:
-                            content = '<Message not yet available>'
+                    if db_submission.content is not None:
+                        content = db_submission.content
+                    else:
+                        content = '<Message not yet available>'
 
-                        self.message_ready.emit(db_submission.uuid, content)
+                    self.message_ready.emit(db_submission.uuid, content)
                 except Exception:
                     tb = traceback.format_exc()
-                    logger.critical("Exception while downloading submission!\n{}".format(tb))
+                    logger.critical("Exception while processing message!\n{}".format(tb))
 
-            logger.debug('Submissions synced')
+            logger.debug('Messages synced')
 
             if not loop:
                 break
@@ -147,21 +152,26 @@ class ReplySync(APISyncObject):
                     sdk_reply.source_uuid = db_reply.source.uuid
                     # Need to set filename on non-Qubes platforms
 
-                    if self.api:
+                    if not db_reply.is_downloaded and self.api:
+                        # Download and decrypt
                         self.fetch_the_thing(sdk_reply,
                                              db_reply,
                                              self.api.download_reply,
                                              storage.mark_reply_as_downloaded)
+                    elif db_reply.is_downloaded:
+                        # Just decrypt file that is already on disk
+                        self.decrypt_the_thing(db_reply.filename,
+                                               db_reply)
 
-                        if db_reply.content is not None:
-                            content = db_reply.content
-                        else:
-                            content = '<Reply not yet available>'
+                    if db_reply.content is not None:
+                        content = db_reply.content
+                    else:
+                        content = '<Reply not yet available>'
 
-                        self.reply_ready.emit(db_reply.uuid, content)
+                    self.reply_ready.emit(db_reply.uuid, content)
                 except Exception:
                     tb = traceback.format_exc()
-                    logger.critical("Exception while downloading reply!\n{}".format(tb))
+                    logger.critical("Exception while processing reply!\n{}".format(tb))
 
             logger.debug('Replies synced')
 

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -306,7 +306,7 @@ def find_new_messages(session):
     return session.query(Message).filter(
         or_(Message.is_downloaded == False,
             Message.is_decrypted == False,
-            Message.is_decrypted == None)).all()  # noqa E711
+            Message.is_decrypted == None)).all()  # noqa: E711
 
 
 def find_new_files(session):
@@ -325,7 +325,7 @@ def find_new_replies(session):
     return session.query(Reply).filter(
         or_(Reply.is_downloaded == False,
             Reply.is_decrypted == False,
-            Reply.is_decrypted == None)).all()  # noqa E711
+            Reply.is_decrypted == None)).all()  # noqa: E711
 
 
 def mark_file_as_downloaded(uuid, session):

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import logging
 from dateutil.parser import parse
 import glob
+from sqlalchemy import or_
 import os
 from securedrop_client.db import Source, Message, File, Reply, User
 
@@ -294,7 +295,18 @@ def find_or_create_user(uuid, username, session):
 
 
 def find_new_messages(session):
-    return session.query(Message).filter_by(is_downloaded=False).all()
+    """
+    Find messages to process. Those messages are those where one of the following
+    conditions is true:
+
+    * The message has not yet been downloaded.
+    * The message has not yet had decryption attempted.
+    * Decryption previously failed on a message.
+    """
+    return session.query(Message).filter(
+        or_(Message.is_downloaded == False,
+            Message.is_decrypted == False,
+            Message.is_decrypted == None)).all()  # noqa E711
 
 
 def find_new_files(session):
@@ -302,7 +314,18 @@ def find_new_files(session):
 
 
 def find_new_replies(session):
-    return session.query(Reply).filter_by(is_downloaded=False).all()
+    """
+    Find replies to process. Those replies are those where one of the following
+    conditions is true:
+
+    * The reply has not yet been downloaded.
+    * The reply has not yet had decryption attempted.
+    * Decryption previously failed on a reply.
+    """
+    return session.query(Reply).filter(
+        or_(Reply.is_downloaded == False,
+            Reply.is_decrypted == False,
+            Reply.is_decrypted == None)).all()  # noqa E711
 
 
 def mark_file_as_downloaded(uuid, session):

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -34,7 +34,7 @@ def Message(**attrs):
     MESSAGE_COUNT += 1
     defaults = dict(
         uuid='source-uuid-{}'.format(MESSAGE_COUNT),
-        filename='{}-reply.gpg'.format(MESSAGE_COUNT),
+        filename='{}-msg.gpg'.format(MESSAGE_COUNT),
         size=123,
         download_url='http://wat.onion/abc',
         is_decrypted=True,

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -43,11 +43,13 @@ def test_gunzip_logic(homedir, config, mocker):
     expected_output_filename = 'test-doc'
 
     mock_gpg = mocker.patch('subprocess.call', return_value=0)
-    mocker.patch('os.unlink')
+    mock_unlink = mocker.patch('os.unlink')
     dest = gpg.decrypt_submission_or_reply(test_gzip, expected_output_filename, is_doc=True)
 
     assert mock_gpg.call_count == 1
     assert dest == os.path.join(homedir, 'data', expected_output_filename)
+    # We should remove two files in the success scenario: err, filepath
+    assert mock_unlink.call_count == 2
 
 
 def test_subprocess_raises_exception(homedir, config, mocker):
@@ -61,12 +63,14 @@ def test_subprocess_raises_exception(homedir, config, mocker):
     output_filename = 'test-doc'
 
     mock_gpg = mocker.patch('subprocess.call', return_value=1)
-    mocker.patch('os.unlink')
+    mock_unlink = mocker.patch('os.unlink')
 
     with pytest.raises(CryptoError):
         gpg.decrypt_submission_or_reply(test_gzip, output_filename, is_doc=True)
 
     assert mock_gpg.call_count == 1
+    # We should only remove one file in the failure scenario: err
+    assert mock_unlink.call_count == 1
 
 
 def test_import_key(homedir, config, source):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -634,17 +634,42 @@ def test_find_or_create_user_new(mocker):
     mock_session.commit.assert_called_once_with()
 
 
-def test_find_new_messages(mocker):
-    mock_session = mocker.MagicMock()
-    mock_submission = mocker.MagicMock()
-    mock_submission.is_downloaded = False
-    mock_submissions = [mock_submission]
-    mock_session.query().filter_by().all.return_value = mock_submissions
-    submissions = find_new_messages(mock_session)
-    assert submissions[0].is_downloaded is False
+def test_find_new_messages(mocker, session):
+    source = factory.Source()
+    message_not_downloaded = factory.Message(
+        source=source,
+        is_downloaded=False,
+        is_decrypted=None,
+        content=None)
+    message_decrypt_not_attempted = factory.Message(
+        source=source,
+        is_downloaded=True,
+        is_decrypted=None,
+        content=None)
+    message_decrypt_failed = factory.Message(
+        source=source,
+        is_downloaded=True,
+        is_decrypted=False,
+        content=None)
+    message_decrypt_success = factory.Message(
+        source=source,
+        is_downloaded=True,
+        is_decrypted=True,
+        content='teehee')
+    session.add(source)
+    session.add(message_decrypt_not_attempted)
+    session.add(message_not_downloaded)
+    session.add(message_decrypt_failed)
+    session.add(message_decrypt_success)
+
+    messages = find_new_messages(session)
+    assert len(messages) == 3
+
+    for message in messages:
+        assert message.is_downloaded is False or message.is_decrypted is not True
 
 
-def test_find_new_files(mocker):
+def test_find_new_files(mocker, session):
     mock_session = mocker.MagicMock()
     mock_submission = mocker.MagicMock()
     mock_submission.is_downloaded = False
@@ -654,15 +679,39 @@ def test_find_new_files(mocker):
     assert submissions[0].is_downloaded is False
 
 
-def test_find_new_replies(mocker):
-    mock_session = mocker.MagicMock()
-    mock_reply = mocker.MagicMock()
-    mock_reply.is_downloaded = False
-    mock_replies = [mock_reply]
-    mock_session.query().filter_by() \
-                        .all.return_value = mock_replies
-    replies = find_new_replies(mock_session)
-    assert replies[0].is_downloaded is False
+def test_find_new_replies(mocker, session):
+    source = factory.Source()
+    reply_not_downloaded = factory.Reply(
+        source=source,
+        is_downloaded=False,
+        is_decrypted=None,
+        content=None)
+    reply_decrypt_not_attempted = factory.Reply(
+        source=source,
+        is_downloaded=True,
+        is_decrypted=None,
+        content=None)
+    reply_decrypt_failed = factory.Reply(
+        source=source,
+        is_downloaded=True,
+        is_decrypted=False,
+        content=None)
+    reply_decrypt_success = factory.Reply(
+        source=source,
+        is_downloaded=True,
+        is_decrypted=True,
+        content='teehee')
+    session.add(source)
+    session.add(reply_decrypt_not_attempted)
+    session.add(reply_not_downloaded)
+    session.add(reply_decrypt_failed)
+    session.add(reply_decrypt_success)
+
+    replies = find_new_replies(session)
+    assert len(replies) == 3
+
+    for reply in replies:
+        assert reply.is_downloaded is False or reply.is_decrypted is not True
 
 
 def test_set_object_decryption_status_with_content_null_to_false(mocker, source):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -661,6 +661,7 @@ def test_find_new_messages(mocker, session):
     session.add(message_not_downloaded)
     session.add(message_decrypt_failed)
     session.add(message_decrypt_success)
+    session.commit()
 
     messages = find_new_messages(session)
     assert len(messages) == 3
@@ -706,6 +707,7 @@ def test_find_new_replies(mocker, session):
     session.add(reply_not_downloaded)
     session.add(reply_decrypt_failed)
     session.add(reply_decrypt_success)
+    session.commit()
 
     replies = find_new_replies(session)
     assert len(replies) == 3


### PR DESCRIPTION
Fix #276

Previously:
* Files that failed to decrypt would not get re-downloaded
* Once that was addressed, once decryption failed (which you can simulate using the STR in #276 after 287752c05bc2825811ae40db2c8c24f397c65ddc), every 5 seconds, the client would re-download the same message or reply and attempt to decrypt, meaning a lot of repeated/pointless network activity

Now:
* Files that fail to decrypt will get decrypted 5 seconds after a key becomes available
* If decryption is failing, the file will only be downloaded once and then saved on disk. The message sync / reply sync threads will resume and decrypt 

Test with STR in #276 and ensure that the `download` endpoints are only hit once per file