### PR TITLE
no longer try to show conversation for deleted src

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -23,12 +23,14 @@ import sdclientapi
 import shutil
 import traceback
 import uuid
+
+from PyQt5.QtCore import QObject, QThread, pyqtSignal, QTimer, QProcess
+
 from securedrop_client import storage
 from securedrop_client import db
 from securedrop_client.utils import check_dir_permissions
 from securedrop_client.crypto import GpgHelper, CryptoError
 from securedrop_client.message_sync import MessageSync, ReplySync
-from PyQt5.QtCore import QObject, QThread, pyqtSignal, QTimer, QProcess
 
 logger = logging.getLogger(__name__)
 

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -20,10 +20,14 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import logging
-from dateutil.parser import parse
 import glob
-from sqlalchemy import or_
 import os
+from dateutil.parser import parse
+
+from sqlalchemy import or_
+from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.orm.session import Session
+
 from securedrop_client.db import Source, Message, File, Reply, User
 
 
@@ -396,3 +400,11 @@ def rename_file(data_dir: str, filename: str, new_filename: str):
                   os.path.join(data_dir, new_filename))
     except OSError as e:
         logger.debug('File could not be renamed: {}'.format(e))
+
+
+def source_exists(session: Session, source_uuid: str) -> bool:
+    try:
+        session.query(Source).filter_by(uuid=source_uuid).one()
+        return True
+    except NoResultFound:
+        return False

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -1,11 +1,14 @@
 """
 Check the core Window UI class works as expected.
 """
+from uuid import uuid4
+
 from PyQt5.QtWidgets import QApplication, QHBoxLayout
+
 from securedrop_client.db import Message
 from securedrop_client.gui.main import Window
 from securedrop_client.resources import load_icon
-from uuid import uuid4
+
 
 app = QApplication([])
 
@@ -220,14 +223,27 @@ def test_on_source_changed(mocker):
     """
     w = Window('mock')
     w.main_view = mocker.MagicMock()
-    w.main_view.source_list.currentItem()
-    mock_sw = w.main_view.source_list.itemWidget()
     w.show_conversation_for = mocker.MagicMock()
-    mock_controller = mocker.MagicMock(is_authenticated=True)
-    w.controller = mock_controller
+    w.controller = mocker.MagicMock(is_authenticated=True)
+
     w.on_source_changed()
-    w.show_conversation_for.assert_called_once_with(mock_sw.source,
-                                                    mock_controller.is_authenticated)
+
+    source = w.main_view.source_list.itemWidget().source
+    w.show_conversation_for.assert_called_once_with(source, True)
+
+
+def test_on_source_changed_when_source_no_longer_exists(mocker):
+    """
+    Test that conversation for a source is cleared when the source no longer exists.
+    """
+    w = Window('mock')
+    w.main_view = mocker.MagicMock()
+    w.controller = mocker.MagicMock(is_authenticated=True)
+    mocker.patch('securedrop_client.gui.main.source_exists', return_value=False)
+
+    w.on_source_changed()
+
+    w.main_view.clear_conversation.assert_called_once_with()
 
 
 def test_conversation_for(mocker):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -394,6 +394,21 @@ def test_MainView_show_conversation(mocker):
     mv.view_layout.addWidget.assert_called_once_with(mock_widget)
 
 
+def test_MainView_clear_conversation(mocker, homedir):
+    """
+    Calling clear_conversation deletes items from layout
+    """
+    mv = MainView(None)
+    mv.view_layout = QVBoxLayout()
+    mv.view_layout.addWidget(QWidget())
+
+    assert mv.view_layout.count() == 1
+
+    mv.clear_conversation()
+
+    assert mv.view_layout.count() == 0
+
+
 def test_SourceList_update(mocker):
     """
     Check the items in the source list are cleared and a new SourceWidget for
@@ -1307,6 +1322,8 @@ def test_DeleteSourceMssageBox_launch_when_user_chooses_yes(mocker, source, sess
     session.add(message)
     message = factory.Message(source=source)
     session.add(message)
+    reply = factory.Reply(source=source)
+    session.add(reply)
     session.commit()
 
     mock_message_box_question = mocker.MagicMock(QMessageBox.question)
@@ -1326,11 +1343,11 @@ def test_DeleteSourceMssageBox_launch_when_user_chooses_yes(mocker, source, sess
     message = (
         "<big>Deleting the Source account for "
         "<b>{designation}</b> will also "
-        "delete {files} files and {messages} messages.</big> "
-        "<br> "
+        "delete {files} files, {replies} replies, and {messages} messages.</big>"
+        " <br> "
         "<small>This Source will no longer be able to correspond "
         "through the log-in tied to this account.</small>"
-    ).format(designation=source.journalist_designation, files=1, messages=2)
+    ).format(designation=source.journalist_designation, files=1, replies=1, messages=2)
     mock_message_box_question.assert_called_once_with(
         None,
         "",
@@ -1348,6 +1365,8 @@ def test_DeleteSourceMessageBox_construct_message(mocker, source, session):
     session.add(message)
     message = factory.Message(source=source)
     session.add(message)
+    reply = factory.Reply(source=source)
+    session.add(reply)
     session.commit()
 
     mock_controller = mocker.MagicMock()
@@ -1359,11 +1378,11 @@ def test_DeleteSourceMessageBox_construct_message(mocker, source, session):
     expected_message = (
         "<big>Deleting the Source account for "
         "<b>{designation}</b> will also "
-        "delete {files} files and {messages} messages.</big> "
-        "<br> "
+        "delete {files} files, {replies} replies, and {messages} messages.</big>"
+        " <br> "
         "<small>This Source will no longer be able to correspond "
         "through the log-in tied to this account.</small>"
-    ).format(designation=source.journalist_designation, files=1, messages=2)
+    ).format(designation=source.journalist_designation, files=1, replies=1, messages=2)
     assert message == expected_message
 
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -5,6 +5,7 @@ expected.
 import arrow
 import os
 import pytest
+
 from sdclientapi import sdlocalobjects
 from tests import factory
 from securedrop_client import storage, db


### PR DESCRIPTION
## Description

Fixes #302 
Fixes #297 
Fixes #195 

## Summary of Changes

* `on_source_changed` now checks if the current source exists before trying to set the conversation
* `on_source_changed` clears the conversation from the conversation view if the source does not exist
* Removed calls to `self.controller.session.refresh` since it isn't necessary (might have been a fix for some bug that no longer exists)
* We now show the number of replies being deleted in the popup that checks if the user wants to delete a source. Before we showed only counts for messages and files.

## Test

1. Log into the client
2. Delete the first source by selecting 'x' next to the source in the source list and see conversation view cleared (app no longer crashes) after source and conversation are deleted
3. Delete the second source using the source menu in the far upper-right corner and see conversation view cleared (app no longer crashes) after source and conversation are deleted
4. See how conversation view is empty when the last source has been deleted