### PR TITLE
LoginDialog going solo

### DIFF
--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -21,7 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import logging
 from typing import List
-import sys
 
 from PyQt5.QtWidgets import QMainWindow, QWidget, QHBoxLayout, QVBoxLayout, QDesktopWidget, QApplication
 

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import logging
 from typing import List
+import sys
 
 from PyQt5.QtWidgets import QMainWindow, QWidget, QHBoxLayout, QVBoxLayout, QDesktopWidget, QApplication
 
@@ -63,7 +64,7 @@ class Window(QMainWindow):
         self.controller = controller  # Reference the Client logic instance.
         self.show_login()
 
-    def show_main_window(self, username: str) -> None:
+    def show_main_window(self, username: str=None) -> None:
         self.setWindowTitle(_("SecureDrop Client {}").format(__version__))
         self.setWindowIcon(load_icon(self.icon))
 
@@ -103,7 +104,8 @@ class Window(QMainWindow):
         self.top_pane.setup(self.controller)
         self.main_view.source_list.setup(self.controller)
 
-        self.set_logged_in_as(username)
+        if username:
+            self.set_logged_in_as(username)
 
     def autosize_window(self):
         """
@@ -118,7 +120,8 @@ class Window(QMainWindow):
         Show the login form.
         """
         self.login_dialog = LoginDialog(self)
-        self.login_dialog.move(QApplication.desktop().screen().rect().center() - self.rect().center())
+        self.login_dialog.move(
+            QApplication.desktop().screen().rect().center() - self.rect().center())
         self.login_dialog.setup(self.controller)
         self.login_dialog.reset()
         self.login_dialog.exec()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -899,7 +899,6 @@ class LoginDialog(QDialog):
         self.submit = QPushButton(_('Sign in'))
         self.submit.clicked.connect(self.validate)
 
-
         self.offline_mode = QPushButton(_('Offline mode'))
         self.offline_mode.clicked.connect(self.controller.login_offline_mode)
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -19,13 +19,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import logging
 import arrow
 import html
+import sys
+from typing import List
+from uuid import uuid4
+
 from PyQt5.QtCore import Qt, pyqtSlot, QTimer, QSize
 from PyQt5.QtGui import QIcon, QPalette, QBrush, QColor, QFont, QLinearGradient
 from PyQt5.QtWidgets import QListWidget, QLabel, QWidget, QListWidgetItem, QHBoxLayout, \
     QPushButton, QVBoxLayout, QLineEdit, QScrollArea, QDialog, QAction, QMenu, QMessageBox, \
     QToolButton, QSizePolicy, QTextEdit, QStatusBar, QGraphicsDropShadowEffect
-from typing import List
-from uuid import uuid4
 
 from securedrop_client.db import Source, Message, File, Reply
 from securedrop_client.gui import SvgLabel, SvgPushButton
@@ -856,7 +858,15 @@ class LoginDialog(QDialog):
     MIN_JOURNALIST_USERNAME = 3  # Journalist.MIN_USERNAME_LEN on server
 
     def __init__(self, parent):
-        super().__init__(parent)
+        self.parent = parent
+        super().__init__(self.parent)
+
+    def closeEvent(self, event):
+        """
+        Only exit the application when the main window is not visible.
+        """
+        if not self.parent.isVisible():
+            sys.exit(0)
 
     def setup(self, controller):
         self.controller = controller

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -899,6 +899,10 @@ class LoginDialog(QDialog):
         self.submit = QPushButton(_('Sign in'))
         self.submit.clicked.connect(self.validate)
 
+
+        self.offline_mode = QPushButton(_('Offline mode'))
+        self.offline_mode.clicked.connect(self.controller.login_offline_mode)
+
         self.error_label = QLabel('')
         self.error_label.setObjectName('error_label')  # Set css id
         self.error_label.setStyleSheet(self.CSS)  # Set styles
@@ -913,6 +917,7 @@ class LoginDialog(QDialog):
         layout.addWidget(self.tfa_label)
         layout.addWidget(self.tfa_field)
         layout.addWidget(self.submit)
+        layout.addWidget(self.offline_mode)
         layout.addWidget(self.error_label)
         layout.addStretch()
 

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -192,9 +192,6 @@ class Client(QObject):
         # triggered by UI events.
         self.gui.setup(self)
 
-        # If possible, update the UI with available sources.
-        self.update_sources()
-
         # Create a timer to check for sync status every 30 seconds.
         self.sync_timer = QTimer()
         self.sync_timer.timeout.connect(self.update_sync)

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -195,9 +195,6 @@ class Client(QObject):
         # If possible, update the UI with available sources.
         self.update_sources()
 
-        # Show the login dialog.
-        self.gui.show_login()
-
         # Create a timer to check for sync status every 30 seconds.
         self.sync_timer = QTimer()
         self.sync_timer.timeout.connect(self.update_sync)
@@ -351,7 +348,7 @@ class Client(QObject):
             # It worked! Sync with the API and update the UI.
             self.gui.hide_login()
             self.sync_api()
-            self.gui.set_logged_in_as(self.api.username)
+            self.gui.show_main_window(self.api.username)
             self.start_message_thread()
             self.start_reply_thread()
 

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -366,7 +366,6 @@ class Client(QObject):
         Allow user to view in offline mode without authentication.
         """
         self.gui.hide_login()
-        self.sync_api()
         self.gui.show_main_window()
         self.start_message_thread()
         self.start_reply_thread()

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -362,6 +362,9 @@ class Client(QObject):
             self.gui.show_login_error(error=error)
 
     def login_offline_mode(self):
+        """
+        Allow user to view in offline mode without authentication.
+        """
         self.gui.hide_login()
         self.sync_api()
         self.gui.show_main_window()

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -361,6 +361,15 @@ class Client(QObject):
                       'Please verify your credentials and try again.')
             self.gui.show_login_error(error=error)
 
+    def login_offline_mode(self):
+        # It worked! Sync with the API and update the UI.
+        self.gui.hide_login()
+        self.sync_api()
+        self.gui.show_main_window()
+        self.start_message_thread()
+        self.start_reply_thread()
+        self.is_authenticated = False
+
     def on_login_timeout(self):
         """
         Reset the form and indicate the error.

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -362,13 +362,13 @@ class Client(QObject):
             self.gui.show_login_error(error=error)
 
     def login_offline_mode(self):
-        # It worked! Sync with the API and update the UI.
         self.gui.hide_login()
         self.sync_api()
         self.gui.show_main_window()
         self.start_message_thread()
         self.start_reply_thread()
         self.is_authenticated = False
+        self.update_sources()
 
     def on_login_timeout(self):
         """

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -379,6 +379,17 @@ def test_MainView_init():
     assert isinstance(mv.view_holder, QWidget)
 
 
+def test_MainView_setup(mocker):
+    mv = MainView(None)
+    mv.source_list = mocker.MagicMock()
+    controller = mocker.MagicMock()
+
+    mv.setup(controller)
+
+    assert mv.controller == controller
+    mv.source_list.setup.assert_called_once_with(controller)
+
+
 def test_MainView_show_conversation(mocker):
     """
     Ensure the passed-in widget is added to the layout of the main view holder

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -2,7 +2,7 @@
 Make sure the UI widgets are configured correctly and work as expected.
 """
 from PyQt5.QtWidgets import QWidget, QApplication, QWidgetItem, QSpacerItem, QVBoxLayout, \
-    QMessageBox, QLabel
+    QMessageBox, QLabel, QMainWindow
 from tests import factory
 from securedrop_client import db, logic
 from securedrop_client.gui.widgets import MainView, SourceList, SourceWidget, LoginDialog, \
@@ -788,6 +788,36 @@ def test_LoginDialog_validate_input_ok(mocker):
     assert ld.setDisabled.call_count == 1
     assert ld.error.call_count == 0
     mock_controller.login.assert_called_once_with('foo', 'nicelongpassword', '123456')
+
+
+def test_LoginDialog_closeEvent_exits(mocker):
+    """
+    If the main window is not visible, then exit the application when the LoginDialog receives a
+    close event.
+    """
+    mw = QMainWindow()
+    ld = LoginDialog(mw)
+    sys_exit_fn = mocker.patch('securedrop_client.gui.widgets.sys.exit')
+    mw.hide()
+
+    ld.closeEvent(event='mock')
+
+    sys_exit_fn.assert_called_once_with(0)
+
+
+def test_LoginDialog_closeEvent_does_not_exit_when_main_window_is_visible(mocker):
+    """
+    If the main window is visible, then to not exit the application when the LoginDialog receives a
+    close event.
+    """
+    mw = QMainWindow()
+    ld = LoginDialog(mw)
+    sys_exit_fn = mocker.patch('securedrop_client.gui.widgets.sys.exit')
+    mw.show()
+
+    ld.closeEvent(event='mock')
+
+    assert sys_exit_fn.called is False
 
 
 def test_SpeechBubble_init(mocker):

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -79,14 +79,12 @@ def test_Client_setup(homedir, config, mocker):
     Ensure the application is set up with the following default state:
     Using the `config` fixture to ensure the config is written to disk.
     """
-    mock_gui = mocker.MagicMock()
-    mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    cl = Client('http://localhost', mocker.MagicMock(), mocker.MagicMock(), homedir)
     cl.update_sources = mocker.MagicMock()
+
     cl.setup()
+
     cl.gui.setup.assert_called_once_with(cl)
-    cl.update_sources.assert_called_once_with()
-    cl.gui.show_login.assert_called_once_with()
 
 
 def test_Client_start_message_thread(homedir, config, mocker):
@@ -242,6 +240,32 @@ def test_Client_login(homedir, config, mocker):
                                         cl.on_login_timeout)
 
 
+def test_Client_login_offline_mode(homedir, config, mocker):
+    """
+    Ensures user is not authenticated when logging in in offline mode and that the correct windows
+    are displayed.
+    """
+    cl = Client('http://localhost', mocker.MagicMock(), mocker.MagicMock(), homedir)
+    cl.call_api = mocker.MagicMock()
+    cl.gui = mocker.MagicMock()
+    cl.gui.show_main_window = mocker.MagicMock()
+    cl.gui.hide_login = mocker.MagicMock()
+    cl.sync_api = mocker.MagicMock()
+    cl.start_message_thread = mocker.MagicMock()
+    cl.start_reply_thread = mocker.MagicMock()
+    cl.update_sources = mocker.MagicMock()
+
+    cl.login_offline_mode()
+
+    assert cl.call_api.called is False
+    assert cl.is_authenticated is False
+    cl.gui.show_main_window.assert_called_once_with()
+    cl.gui.hide_login.assert_called_once_with()
+    cl.sync_api.assert_called_once_with()
+    cl.start_message_thread.assert_called_once_with()
+    cl.update_sources.assert_called_once_with()
+
+
 def test_Client_on_authenticate_failed(homedir, config, mocker):
     """
     If the server responds with a negative to the request to authenticate, make
@@ -271,11 +295,12 @@ def test_Client_on_authenticate_ok(homedir, config, mocker):
     cl.start_message_thread = mocker.MagicMock()
     cl.start_reply_thread = mocker.MagicMock()
     cl.api.username = 'test'
+
     cl.on_authenticate(True)
+
     cl.sync_api.assert_called_once_with()
     cl.start_message_thread.assert_called_once_with()
-    cl.gui.set_logged_in_as.assert_called_once_with('test')
-    # Error status bar should be cleared
+    cl.gui.show_main_window.assert_called_once_with('test')
     cl.gui.clear_error_status.assert_called_once_with()
 
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -250,7 +250,6 @@ def test_Client_login_offline_mode(homedir, config, mocker):
     cl.gui = mocker.MagicMock()
     cl.gui.show_main_window = mocker.MagicMock()
     cl.gui.hide_login = mocker.MagicMock()
-    cl.sync_api = mocker.MagicMock()
     cl.start_message_thread = mocker.MagicMock()
     cl.start_reply_thread = mocker.MagicMock()
     cl.update_sources = mocker.MagicMock()
@@ -261,7 +260,6 @@ def test_Client_login_offline_mode(homedir, config, mocker):
     assert cl.is_authenticated is False
     cl.gui.show_main_window.assert_called_once_with()
     cl.gui.hide_login.assert_called_once_with()
-    cl.sync_api.assert_called_once_with()
     cl.start_message_thread.assert_called_once_with()
     cl.update_sources.assert_called_once_with()
 


### PR DESCRIPTION
## Description

Resolves #286 
Note: This does not include any styling

## Summary of changes

* When you start the client, instead of showing both the main window and login dialog, we now only show the login dialog
* There's now an option to click on "offline mode" which shows the main window without allowing behavior that requires authentication
* When you log in via the main window 'SIGN IN' button, the login dialog still pops up without hiding the main window
* Exiting the login dialog when it's the only window that shows closes the application

## Test

1. Start the client and see login dialog appears without main window
2. Click "offline mode" and main window appears in offline mode
3. Log in using the 'SIGN IN' button and see login dialog popup. Here you can click offline mode again or login.
4. Start the client again and log in with credentials this time.
5. Start the client again and before opening the main window by clicking on sign in or offline mode, close the login dialog and verify that it closes the application.
6. Start the client again and when the main window is open (by either clicking on sign in or offline mode), reopen and exit the login dialog window, and verify that the application continues to run.