### PR TITLE
renamed logic.Client to logic.Controller

### DIFF
--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -28,7 +28,7 @@ from PyQt5.QtWidgets import QApplication, QMessageBox
 from PyQt5.QtCore import Qt, QTimer
 from logging.handlers import TimedRotatingFileHandler
 from securedrop_client import __version__
-from securedrop_client.logic import Client
+from securedrop_client.logic import Controller
 from securedrop_client.gui.main import Window
 from securedrop_client.resources import load_icon, load_css
 from securedrop_client.db import make_engine
@@ -168,9 +168,9 @@ def start_app(args, qt_args) -> None:
     Session = sessionmaker(bind=engine)
     session = Session()
 
-    client = Client("http://localhost:8081/", gui, session,
-                    args.sdc_home, not args.no_proxy)
-    client.setup()
+    controller = Controller("http://localhost:8081/", gui, session,
+                            args.sdc_home, not args.no_proxy)
+    controller.setup()
 
     configure_signal_handlers(app)
     timer = QTimer()

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -59,7 +59,7 @@ class Window(QMainWindow):
         # We do this to not create/destroy widgets constantly (because it causes UI "flicker")
         self.conversations = {}
 
-        self.setWindowTitle(_("SecureDrop Client {}").format(__version__))
+        self.setWindowTitle(_("SecureDrop Controller {}").format(__version__))
         self.setWindowIcon(load_icon(self.icon))
 
         # Top Pane to display activity and error messages
@@ -92,7 +92,7 @@ class Window(QMainWindow):
         Create references to the controller logic and instantiate the various
         views used in the UI.
         """
-        self.controller = controller  # Reference the Client logic instance.
+        self.controller = controller  # Reference the Controller logic instance.
         self.top_pane.setup(self.controller)
         self.left_pane.setup(self, self.controller)
         self.main_view.source_list.setup(self.controller)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -31,7 +31,7 @@ from PyQt5.QtWidgets import QListWidget, QLabel, QWidget, QListWidgetItem, QHBox
 
 from securedrop_client.db import Source, Message, File, Reply
 from securedrop_client.gui import SvgLabel, SvgPushButton
-from securedrop_client.logic import Client
+from securedrop_client.logic import Controller
 from securedrop_client.resources import load_svg, load_icon, load_image
 from securedrop_client.utils import humanize_filesize
 
@@ -1235,7 +1235,13 @@ class ConversationView(QWidget):
     https://github.com/freedomofpress/securedrop-client/issues/273
     """
 
-    def __init__(self, source_db_object: Source, sdc_home: str, controller: Client, parent=None):
+    def __init__(
+        self,
+        source_db_object: Source,
+        sdc_home: str,
+        controller: Controller,
+        parent=None,
+    ):
         super().__init__(parent)
         self.source = source_db_object
         self.sdc_home = sdc_home
@@ -1342,7 +1348,7 @@ class SourceConversationWrapper(QWidget):
         self,
         source: Source,
         sdc_home: str,
-        controller: Client,
+        controller: Controller,
         is_authenticated: bool,
         parent=None
     ) -> None:

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -1,5 +1,5 @@
 """
-Contains the core logic for the application in the Client class.
+Contains the core logic for the application in the Controller class.
 
 Copyright (C) 2018  The Freedom of the Press Foundation.
 
@@ -42,7 +42,7 @@ class APICallRunner(QObject):
     the state of i_timed_out (a flag used to indicate the call to the API has
     timed out).
 
-    See the call_api method of the Client class for how this is
+    See the call_api method of the Controller class for how this is
     done (hint: you should be using the call_api method and not directly
     using this class).
     """
@@ -84,7 +84,7 @@ class APICallRunner(QObject):
                         "but it had timed out.")  # pragma: no cover
 
 
-class Client(QObject):
+class Controller(QObject):
     """
     Represents the logic for the secure drop client application. In an MVC
     application, this is the controller.
@@ -127,7 +127,7 @@ class Client(QObject):
         check_dir_permissions(home)
         super().__init__()
 
-        # Client is unauthenticated by default
+        # Controller is unauthenticated by default
         self.__is_authenticated = False
 
         # used for finding DB in sync thread

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1461,7 +1461,7 @@ def test_DeleteSourceAction_trigger(mocker):
 
 def test_DeleteSource_from_source_menu_when_user_is_loggedout(mocker):
     mock_source = mocker.MagicMock()
-    mock_controller = mocker.MagicMock(logic.Client)
+    mock_controller = mocker.MagicMock(logic.Controller)
     mock_controller.api = None
     mock_delete_source_message_box_obj = mocker.MagicMock()
     mock_delete_source_message_box = mocker.MagicMock()
@@ -1480,7 +1480,7 @@ def test_DeleteSource_from_source_menu_when_user_is_loggedout(mocker):
 
 def test_DeleteSource_from_source_widget_when_user_is_loggedout(mocker):
     mock_source = mocker.MagicMock()
-    mock_controller = mocker.MagicMock(logic.Client)
+    mock_controller = mocker.MagicMock(logic.Controller)
     mock_controller.api = None
     mock_event = mocker.MagicMock()
     mock_delete_source_message_box_obj = mocker.MagicMock()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -114,7 +114,7 @@ def test_start_app(homedir, mocker):
     mocker.patch('securedrop_client.app.configure_logging')
     mock_app = mocker.patch('securedrop_client.app.QApplication')
     mock_win = mocker.patch('securedrop_client.app.Window')
-    mock_client = mocker.patch('securedrop_client.app.Client')
+    mock_controller = mocker.patch('securedrop_client.app.Controller')
     mocker.patch('securedrop_client.app.prevent_second_instance')
     mocker.patch('securedrop_client.app.sys')
     mocker.patch('securedrop_client.app.sessionmaker', return_value=mock_session_class)
@@ -122,9 +122,9 @@ def test_start_app(homedir, mocker):
     start_app(mock_args, mock_qt_args)
     mock_app.assert_called_once_with(mock_qt_args)
     mock_win.assert_called_once_with(str(homedir))
-    mock_client.assert_called_once_with('http://localhost:8081/',
-                                        mock_win(), mock_session_class(),
-                                        homedir, False)
+    mock_controller.assert_called_once_with('http://localhost:8081/',
+                                            mock_win(), mock_session_class(),
+                                            homedir, False)
 
 
 PERMISSIONS_CASES = [
@@ -183,7 +183,7 @@ def test_create_app_dir_permissions(tmpdir, mocker):
         mocker.patch('logging.getLogger')
         mocker.patch('securedrop_client.app.QApplication')
         mocker.patch('securedrop_client.app.Window')
-        mocker.patch('securedrop_client.app.Client')
+        mocker.patch('securedrop_client.app.Controller')
         mocker.patch('securedrop_client.app.sys')
         mocker.patch('securedrop_client.app.prevent_second_instance')
         mocker.patch('securedrop_client.app.sessionmaker', return_value=mock_session_class)
@@ -241,7 +241,7 @@ def test_signal_interception(mocker, homedir):
     mocker.patch('sys.exit')
     mocker.patch('securedrop_client.db.make_engine')
     mocker.patch('securedrop_client.app.init')
-    mocker.patch('securedrop_client.logic.Client.setup')
+    mocker.patch('securedrop_client.logic.Controller.setup')
     mocker.patch('securedrop_client.logic.GpgHelper')
     mocker.patch('securedrop_client.app.configure_logging')
     mock_signal_handlers = mocker.patch('securedrop_client.app.configure_signal_handlers')

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,5 +1,5 @@
 """
-Make sure the Client object, containing the application logic, behaves as
+Make sure the Controller object, containing the application logic, behaves as
 expected.
 """
 import arrow
@@ -10,7 +10,7 @@ from sdclientapi import sdlocalobjects
 from tests import factory
 from securedrop_client import storage, db
 from securedrop_client.crypto import CryptoError
-from securedrop_client.logic import APICallRunner, Client
+from securedrop_client.logic import APICallRunner, Controller
 
 with open(os.path.join(os.path.dirname(__file__), 'files', 'test-key.gpg.pub.asc')) as f:
     PUB_KEY = f.read()
@@ -59,7 +59,7 @@ def test_APICallRunner_with_exception(mocker):
     cr.call_finished.emit.assert_called_once_with()
 
 
-def test_Client_init(homedir, config, mocker):
+def test_Controller_init(homedir, config, mocker):
     """
     The passed in gui, app and session instances are correctly referenced and,
     where appropriate, have a reference back to the client.
@@ -67,44 +67,44 @@ def test_Client_init(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost/', mock_gui, mock_session, homedir)
-    assert cl.hostname == 'http://localhost/'
-    assert cl.gui == mock_gui
-    assert cl.session == mock_session
-    assert cl.api_threads == {}
+    co = Controller('http://localhost/', mock_gui, mock_session, homedir)
+    assert co.hostname == 'http://localhost/'
+    assert co.gui == mock_gui
+    assert co.session == mock_session
+    assert co.api_threads == {}
 
 
-def test_Client_setup(homedir, config, mocker):
+def test_Controller_setup(homedir, config, mocker):
     """
     Ensure the application is set up with the following default state:
     Using the `config` fixture to ensure the config is written to disk.
     """
-    cl = Client('http://localhost', mocker.MagicMock(), mocker.MagicMock(), homedir)
-    cl.update_sources = mocker.MagicMock()
+    co = Controller('http://localhost', mocker.MagicMock(), mocker.MagicMock(), homedir)
+    co.update_sources = mocker.MagicMock()
 
-    cl.setup()
+    co.setup()
 
-    cl.gui.setup.assert_called_once_with(cl)
+    co.gui.setup.assert_called_once_with(co)
 
 
-def test_Client_start_message_thread(homedir, config, mocker):
+def test_Controller_start_message_thread(homedir, config, mocker):
     """
     When starting message-fetching thread, make sure we do a few things.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
     mock_qthread = mocker.patch('securedrop_client.logic.QThread')
     mocker.patch('securedrop_client.logic.MessageSync')
-    cl.message_sync = mocker.MagicMock()
-    cl.start_message_thread()
-    cl.message_sync.moveToThread.assert_called_once_with(mock_qthread())
-    cl.message_thread.started.connect.assert_called_once_with(cl.message_sync.run)
-    cl.message_thread.start.assert_called_once_with()
+    co.message_sync = mocker.MagicMock()
+    co.start_message_thread()
+    co.message_sync.moveToThread.assert_called_once_with(mock_qthread())
+    co.message_thread.started.connect.assert_called_once_with(co.message_sync.run)
+    co.message_thread.start.assert_called_once_with()
 
 
-def test_Client_start_message_thread_if_already_running(homedir, config, mocker):
+def test_Controller_start_message_thread_if_already_running(homedir, config, mocker):
     """
     Ensure that when starting the message thread, we don't start another thread
     if it's already running. Instead, we just authenticate the existing thread.
@@ -112,35 +112,35 @@ def test_Client_start_message_thread_if_already_running(homedir, config, mocker)
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.api = 'api object'
-    cl.message_sync = mocker.MagicMock()
-    cl.message_thread = mocker.MagicMock()
-    cl.message_thread.api = None
-    cl.start_message_thread()
-    cl.message_sync.api = cl.api
-    cl.message_thread.start.assert_not_called()
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.api = 'api object'
+    co.message_sync = mocker.MagicMock()
+    co.message_thread = mocker.MagicMock()
+    co.message_thread.api = None
+    co.start_message_thread()
+    co.message_sync.api = co.api
+    co.message_thread.start.assert_not_called()
 
 
-def test_Client_start_reply_thread(homedir, config, mocker):
+def test_Controller_start_reply_thread(homedir, config, mocker):
     """
     When starting reply-fetching thread, make sure we do a few things.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
     mock_qthread = mocker.patch('securedrop_client.logic.QThread')
     mocker.patch('securedrop_client.logic.ReplySync')
-    cl.reply_sync = mocker.MagicMock()
-    cl.start_reply_thread()
-    cl.reply_sync.moveToThread.assert_called_once_with(mock_qthread())
-    cl.reply_thread.started.connect.assert_called_once_with(
-        cl.reply_sync.run)
-    cl.reply_thread.start.assert_called_once_with()
+    co.reply_sync = mocker.MagicMock()
+    co.start_reply_thread()
+    co.reply_sync.moveToThread.assert_called_once_with(mock_qthread())
+    co.reply_thread.started.connect.assert_called_once_with(
+        co.reply_sync.run)
+    co.reply_thread.start.assert_called_once_with()
 
 
-def test_Client_start_reply_thread_if_already_running(homedir, config, mocker):
+def test_Controller_start_reply_thread_if_already_running(homedir, config, mocker):
     """
     Ensure that when starting the reply thread, we don't start another thread
     if it's already running. Instead, we just authenticate the existing thread.
@@ -148,25 +148,25 @@ def test_Client_start_reply_thread_if_already_running(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.api = 'api object'
-    cl.reply_sync = mocker.MagicMock()
-    cl.reply_thread = mocker.MagicMock()
-    cl.reply_thread.api = None
-    cl.start_reply_thread()
-    cl.reply_sync.api = cl.api
-    cl.reply_thread.start.assert_not_called()
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.api = 'api object'
+    co.reply_sync = mocker.MagicMock()
+    co.reply_thread = mocker.MagicMock()
+    co.reply_thread.api = None
+    co.start_reply_thread()
+    co.reply_sync.api = co.api
+    co.reply_thread.start.assert_not_called()
 
 
-def test_Client_call_api(homedir, config, mocker):
+def test_Controller_call_api(homedir, config, mocker):
     """
     A new thread and APICallRunner is created / setup.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.finish_api_call = mocker.MagicMock()
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.finish_api_call = mocker.MagicMock()
     mocker.patch('securedrop_client.logic.QThread')
     mocker.patch('securedrop_client.logic.APICallRunner')
     mocker.patch('securedrop_client.logic.QTimer')
@@ -174,10 +174,10 @@ def test_Client_call_api(homedir, config, mocker):
     mock_callback = mocker.MagicMock()
     mock_timeout = mocker.MagicMock()
 
-    cl.call_api(mock_api_call, mock_callback, mock_timeout, 'foo', bar='baz')
+    co.call_api(mock_api_call, mock_callback, mock_timeout, 'foo', bar='baz')
 
-    assert len(cl.api_threads) == 1
-    thread_info = cl.api_threads[list(cl.api_threads.keys())[0]]
+    assert len(co.api_threads) == 1
+    thread_info = co.api_threads[list(co.api_threads.keys())[0]]
     thread = thread_info['thread']
     runner = thread_info['runner']
     timer = thread_info['timer']
@@ -188,7 +188,7 @@ def test_Client_call_api(homedir, config, mocker):
     runner.call_finished.connect.call_count == 1
 
 
-def test_Client_clean_thread_no_thread(homedir, config, mocker):
+def test_Controller_clean_thread_no_thread(homedir, config, mocker):
     """
     The client will ignore an attempt to reset an API call if there's no such
     call "in flight".
@@ -196,14 +196,14 @@ def test_Client_clean_thread_no_thread(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.finish_api_call = mocker.MagicMock()
-    cl.api_threads = {'a': 'b'}
-    cl.clean_thread('foo')
-    assert len(cl.api_threads) == 1
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.finish_api_call = mocker.MagicMock()
+    co.api_threads = {'a': 'b'}
+    co.clean_thread('foo')
+    assert len(co.api_threads) == 1
 
 
-def test_Client_clean_thread(homedir, config, mocker):
+def test_Controller_clean_thread(homedir, config, mocker):
     """
     Cleaning up an existing thread disconnects the timer and removes it from
     the api_threads collection.
@@ -211,19 +211,19 @@ def test_Client_clean_thread(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
     mock_timer = mocker.MagicMock()
-    cl.api_threads = {
+    co.api_threads = {
         'foo': {
             'timer': mock_timer,
         }
     }
-    cl.clean_thread('foo')
+    co.clean_thread('foo')
     assert mock_timer.disconnect.call_count == 1
-    assert 'foo' not in cl.api_threads
+    assert 'foo' not in co.api_threads
 
 
-def test_Client_login(homedir, config, mocker):
+def test_Controller_login(homedir, config, mocker):
     """
     Ensures the API is called in the expected manner for logging in the user
     given the username, password and 2fa token.
@@ -231,40 +231,40 @@ def test_Client_login(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.call_api = mocker.MagicMock()
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.call_api = mocker.MagicMock()
     mock_api = mocker.patch('securedrop_client.logic.sdclientapi.API')
-    cl.login('username', 'password', '123456')
-    cl.call_api.assert_called_once_with(mock_api().authenticate,
-                                        cl.on_authenticate,
-                                        cl.on_login_timeout)
+    co.login('username', 'password', '123456')
+    co.call_api.assert_called_once_with(mock_api().authenticate,
+                                        co.on_authenticate,
+                                        co.on_login_timeout)
 
 
-def test_Client_login_offline_mode(homedir, config, mocker):
+def test_Controller_login_offline_mode(homedir, config, mocker):
     """
     Ensures user is not authenticated when logging in in offline mode and that the correct windows
     are displayed.
     """
-    cl = Client('http://localhost', mocker.MagicMock(), mocker.MagicMock(), homedir)
-    cl.call_api = mocker.MagicMock()
-    cl.gui = mocker.MagicMock()
-    cl.gui.show_main_window = mocker.MagicMock()
-    cl.gui.hide_login = mocker.MagicMock()
-    cl.start_message_thread = mocker.MagicMock()
-    cl.start_reply_thread = mocker.MagicMock()
-    cl.update_sources = mocker.MagicMock()
+    co = Controller('http://localhost', mocker.MagicMock(), mocker.MagicMock(), homedir)
+    co.call_api = mocker.MagicMock()
+    co.gui = mocker.MagicMock()
+    co.gui.show_main_window = mocker.MagicMock()
+    co.gui.hide_login = mocker.MagicMock()
+    co.start_message_thread = mocker.MagicMock()
+    co.start_reply_thread = mocker.MagicMock()
+    co.update_sources = mocker.MagicMock()
 
-    cl.login_offline_mode()
+    co.login_offline_mode()
 
-    assert cl.call_api.called is False
-    assert cl.is_authenticated is False
-    cl.gui.show_main_window.assert_called_once_with()
-    cl.gui.hide_login.assert_called_once_with()
-    cl.start_message_thread.assert_called_once_with()
-    cl.update_sources.assert_called_once_with()
+    assert co.call_api.called is False
+    assert co.is_authenticated is False
+    co.gui.show_main_window.assert_called_once_with()
+    co.gui.hide_login.assert_called_once_with()
+    co.start_message_thread.assert_called_once_with()
+    co.update_sources.assert_called_once_with()
 
 
-def test_Client_on_authenticate_failed(homedir, config, mocker):
+def test_Controller_on_authenticate_failed(homedir, config, mocker):
     """
     If the server responds with a negative to the request to authenticate, make
     sure the user knows.
@@ -272,37 +272,37 @@ def test_Client_on_authenticate_failed(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
     result_data = 'false'
-    cl.on_authenticate(result_data)
+    co.on_authenticate(result_data)
     mock_gui.show_login_error.\
         assert_called_once_with(error='There was a problem signing in. Please '
                                 'verify your credentials and try again.')
 
 
-def test_Client_on_authenticate_ok(homedir, config, mocker):
+def test_Controller_on_authenticate_ok(homedir, config, mocker):
     """
     Ensure the client syncs when the user successfully logs in.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.sync_api = mocker.MagicMock()
-    cl.api = mocker.MagicMock()
-    cl.start_message_thread = mocker.MagicMock()
-    cl.start_reply_thread = mocker.MagicMock()
-    cl.api.username = 'test'
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.sync_api = mocker.MagicMock()
+    co.api = mocker.MagicMock()
+    co.start_message_thread = mocker.MagicMock()
+    co.start_reply_thread = mocker.MagicMock()
+    co.api.username = 'test'
 
-    cl.on_authenticate(True)
+    co.on_authenticate(True)
 
-    cl.sync_api.assert_called_once_with()
-    cl.start_message_thread.assert_called_once_with()
-    cl.gui.show_main_window.assert_called_once_with('test')
-    cl.gui.clear_error_status.assert_called_once_with()
+    co.sync_api.assert_called_once_with()
+    co.start_message_thread.assert_called_once_with()
+    co.gui.show_main_window.assert_called_once_with('test')
+    co.gui.clear_error_status.assert_called_once_with()
 
 
-def test_Client_completed_api_call_without_current_object(homedir, config, mocker):
+def test_Controller_completed_api_call_without_current_object(homedir, config, mocker):
     """
     Ensure that cleanup is performed if an API call returns in the expected
     time.
@@ -310,28 +310,28 @@ def test_Client_completed_api_call_without_current_object(homedir, config, mocke
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
     mock_thread = mocker.MagicMock()
     mock_runner = mocker.MagicMock()
     mock_runner.result = 'result'
     mock_runner.current_object = None
     mock_timer = mocker.MagicMock()
-    cl.api_threads = {
+    co.api_threads = {
         'thread_uuid': {
             'thread': mock_thread,
             'runner': mock_runner,
             'timer': mock_timer,
         }
     }
-    cl.clean_thread = mocker.MagicMock()
+    co.clean_thread = mocker.MagicMock()
     mock_user_callback = mocker.MagicMock()
-    cl.completed_api_call('thread_uuid', mock_user_callback)
-    cl.clean_thread.assert_called_once_with('thread_uuid')
+    co.completed_api_call('thread_uuid', mock_user_callback)
+    co.clean_thread.assert_called_once_with('thread_uuid')
     mock_user_callback.assert_called_once_with('result')
     mock_timer.stop.assert_called_once_with()
 
 
-def test_Client_completed_api_call_with_current_object(homedir, config, mocker):
+def test_Controller_completed_api_call_with_current_object(homedir, config, mocker):
     """
     Ensure that cleanup is performed if an API call returns in the expected
     time.
@@ -339,115 +339,115 @@ def test_Client_completed_api_call_with_current_object(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
     mock_thread = mocker.MagicMock()
     mock_runner = mocker.MagicMock()
     mock_runner.result = 'result'
     mock_runner.current_object = 'current_object'
     mock_timer = mocker.MagicMock()
-    cl.api_threads = {
+    co.api_threads = {
         'thread_uuid': {
             'thread': mock_thread,
             'runner': mock_runner,
             'timer': mock_timer,
         }
     }
-    cl.clean_thread = mocker.MagicMock()
+    co.clean_thread = mocker.MagicMock()
     mock_user_callback = mocker.MagicMock()
-    cl.completed_api_call('thread_uuid', mock_user_callback)
-    cl.clean_thread.assert_called_once_with('thread_uuid')
+    co.completed_api_call('thread_uuid', mock_user_callback)
+    co.clean_thread.assert_called_once_with('thread_uuid')
     mock_user_callback.assert_called_once_with('result',
                                                current_object='current_object')
     mock_timer.stop.assert_called_once_with()
 
 
-def test_Client_timeout_cleanup_without_current_object(homedir, config, mocker):
+def test_Controller_timeout_cleanup_without_current_object(homedir, config, mocker):
     """
     Ensure that cleanup is performed if an API call times out.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
     mock_thread = mocker.MagicMock()
     mock_runner = mocker.MagicMock()
     mock_runner.current_object = None
     mock_timer = mocker.MagicMock()
-    cl.api_threads = {
+    co.api_threads = {
         'thread_uuid': {
             'thread': mock_thread,
             'runner': mock_runner,
             'timer': mock_timer,
         }
     }
-    cl.clean_thread = mocker.MagicMock()
+    co.clean_thread = mocker.MagicMock()
     mock_user_callback = mocker.MagicMock()
-    cl.timeout_cleanup('thread_uuid', mock_user_callback)
+    co.timeout_cleanup('thread_uuid', mock_user_callback)
     assert mock_runner.i_timed_out is True
-    cl.clean_thread.assert_called_once_with('thread_uuid')
+    co.clean_thread.assert_called_once_with('thread_uuid')
     mock_user_callback.assert_called_once_with()
 
 
-def test_Client_timeout_cleanup_with_current_object(homedir, config, mocker):
+def test_Controller_timeout_cleanup_with_current_object(homedir, config, mocker):
     """
     Ensure that cleanup is performed if an API call times out.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
     mock_thread = mocker.MagicMock()
     mock_runner = mocker.MagicMock()
     mock_runner.current_object = 'current_object'
     mock_timer = mocker.MagicMock()
-    cl.api_threads = {
+    co.api_threads = {
         'thread_uuid': {
             'thread': mock_thread,
             'runner': mock_runner,
             'timer': mock_timer,
         }
     }
-    cl.clean_thread = mocker.MagicMock()
+    co.clean_thread = mocker.MagicMock()
     mock_user_callback = mocker.MagicMock()
-    cl.timeout_cleanup('thread_uuid', mock_user_callback)
+    co.timeout_cleanup('thread_uuid', mock_user_callback)
     assert mock_runner.i_timed_out is True
-    cl.clean_thread.assert_called_once_with('thread_uuid')
+    co.clean_thread.assert_called_once_with('thread_uuid')
     mock_user_callback.assert_called_once_with(current_object='current_object')
 
 
-def test_Client_on_sync_timeout(homedir, config, mocker):
+def test_Controller_on_sync_timeout(homedir, config, mocker):
     """
     Display error message in status bar if sync times out.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.api = "this is populated"
-    cl.on_sync_timeout()
-    assert cl.api is not None
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.api = "this is populated"
+    co.on_sync_timeout()
+    assert co.api is not None
     mock_gui.update_error_status.\
         assert_called_once_with(error='The connection to the SecureDrop '
                                 'server timed out. Please try again.')
 
 
-def test_Client_on_login_timeout(homedir, config, mocker):
+def test_Controller_on_login_timeout(homedir, config, mocker):
     """
     Reset the form if the API call times out.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.call_reset = mocker.MagicMock()
-    cl.on_login_timeout()
-    assert cl.api is None
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.call_reset = mocker.MagicMock()
+    co.on_login_timeout()
+    assert co.api is None
     mock_gui.show_login_error.\
         assert_called_once_with(error='The connection to the SecureDrop '
                                 'server timed out. Please try again.')
 
 
-def test_Client_on_action_requiring_login(homedir, config, mocker):
+def test_Controller_on_action_requiring_login(homedir, config, mocker):
     """
     Ensure that when on_action_requiring_login is called, an error
     is shown in the GUI status area.
@@ -455,80 +455,80 @@ def test_Client_on_action_requiring_login(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.on_action_requiring_login()
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.on_action_requiring_login()
     mock_gui.update_error_status.assert_called_once_with(
         'You must sign in to perform this action.')
 
 
-def test_Client_authenticated_yes(homedir, config, mocker):
+def test_Controller_authenticated_yes(homedir, config, mocker):
     """
     If the API is authenticated return True.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.api = mocker.MagicMock()
-    cl.api.token = {'token': 'foo'}
-    assert cl.authenticated() is True
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.api = mocker.MagicMock()
+    co.api.token = {'token': 'foo'}
+    assert co.authenticated() is True
 
 
-def test_Client_authenticated_no(homedir, config, mocker):
+def test_Controller_authenticated_no(homedir, config, mocker):
     """
     If the API is authenticated return True.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.api = mocker.MagicMock()
-    cl.api.token = {'token': ''}
-    assert cl.authenticated() is False
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.api = mocker.MagicMock()
+    co.api.token = {'token': ''}
+    assert co.authenticated() is False
 
 
-def test_Client_authenticated_no_api(homedir, config, mocker):
+def test_Controller_authenticated_no_api(homedir, config, mocker):
     """
     If the API is authenticated return True.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.api = None
-    assert cl.authenticated() is False
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.api = None
+    assert co.authenticated() is False
 
 
-def test_Client_sync_api_not_authenticated(homedir, config, mocker):
+def test_Controller_sync_api_not_authenticated(homedir, config, mocker):
     """
     If the API isn't authenticated, don't sync.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.authenticated = mocker.MagicMock(return_value=False)
-    cl.call_api = mocker.MagicMock()
-    cl.sync_api()
-    assert cl.call_api.call_count == 0
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.authenticated = mocker.MagicMock(return_value=False)
+    co.call_api = mocker.MagicMock()
+    co.sync_api()
+    assert co.call_api.call_count == 0
 
 
-def test_Client_sync_api(homedir, config, mocker):
+def test_Controller_sync_api(homedir, config, mocker):
     """
     Sync the API is authenticated.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.authenticated = mocker.MagicMock(return_value=True)
-    cl.call_api = mocker.MagicMock()
-    cl.sync_api()
-    cl.call_api.assert_called_once_with(storage.get_remote_data, cl.on_synced,
-                                        cl.on_sync_timeout, cl.api)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.authenticated = mocker.MagicMock(return_value=True)
+    co.call_api = mocker.MagicMock()
+    co.sync_api()
+    co.call_api.assert_called_once_with(storage.get_remote_data, co.on_synced,
+                                        co.on_sync_timeout, co.api)
 
 
-def test_Client_on_synced_remove_stale_sources(homedir, config, mocker):
+def test_Controller_on_synced_remove_stale_sources(homedir, config, mocker):
     """
     On an API sync, if a source no longer exists, remove it from the GUI.
     Using the `config` fixture to ensure the config is written to disk.
@@ -540,20 +540,20 @@ def test_Client_on_synced_remove_stale_sources(homedir, config, mocker):
     gui.conversations = {mock_source_id: mock_conv_wrapper}
 
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', gui, mock_session, homedir)
+    co = Controller('http://localhost', gui, mock_session, homedir)
 
     mock_source = mocker.Mock()
     mock_source.uuid = mock_source_id
 
     # not that the first item does *not* have the mock_source
     api_res = ([], mocker.MagicMock(), mocker.MagicMock())
-    cl.on_synced(api_res)
+    co.on_synced(api_res)
 
     # check that the uuid is not longer in the dict
     assert mock_source_id not in gui.conversations
 
 
-def test_Client_last_sync_with_file(homedir, config, mocker):
+def test_Controller_last_sync_with_file(homedir, config, mocker):
     """
     The flag indicating the time of the last sync with the API is stored in a
     dotfile in the user's home directory. If such a file exists, ensure an
@@ -562,27 +562,27 @@ def test_Client_last_sync_with_file(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
     timestamp = '2018-10-10 18:17:13+01:00'
     mocker.patch("builtins.open", mocker.mock_open(read_data=timestamp))
-    result = cl.last_sync()
+    result = co.last_sync()
     assert isinstance(result, arrow.Arrow)
     assert result.format() == timestamp
 
 
-def test_Client_last_sync_no_file(homedir, config, mocker):
+def test_Controller_last_sync_no_file(homedir, config, mocker):
     """
     If there's no sync file, then just return None.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
     mocker.patch("builtins.open", mocker.MagicMock(side_effect=Exception()))
-    assert cl.last_sync() is None
+    assert co.last_sync() is None
 
 
-def test_Client_on_synced_no_result(homedir, config, mocker):
+def test_Controller_on_synced_no_result(homedir, config, mocker):
     """
     If there's no result to syncing, then don't attempt to update local storage
     and perhaps implement some as-yet-undefined UI update.
@@ -590,31 +590,31 @@ def test_Client_on_synced_no_result(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.update_sources = mocker.MagicMock()
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.update_sources = mocker.MagicMock()
     result_data = Exception('Boom')  # Not the expected tuple.
     mock_storage = mocker.patch('securedrop_client.logic.storage')
-    cl.on_synced(result_data)
+    co.on_synced(result_data)
     assert mock_storage.update_local_storage.call_count == 0
-    cl.update_sources.assert_called_once_with()
+    co.update_sources.assert_called_once_with()
 
 
-def test_Client_on_synced_with_result(homedir, config, mocker):
+def test_Controller_on_synced_with_result(homedir, config, mocker):
     """
     If there's a result to syncing, then update local storage.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.update_sources = mocker.MagicMock()
-    cl.api_runner = mocker.MagicMock()
-    cl.gpg = mocker.MagicMock()
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.update_sources = mocker.MagicMock()
+    co.api_runner = mocker.MagicMock()
+    co.gpg = mocker.MagicMock()
 
     result_data = ('sources', 'submissions', 'replies')
 
-    cl.update_sources = mocker.MagicMock()
-    cl.api_runner = mocker.MagicMock()
+    co.update_sources = mocker.MagicMock()
+    co.api_runner = mocker.MagicMock()
 
     mock_source = mocker.MagicMock()
     mock_source.key = {
@@ -626,18 +626,18 @@ def test_Client_on_synced_with_result(homedir, config, mocker):
 
     result_data = (mock_sources, 'submissions', 'replies')
 
-    cl.call_reset = mocker.MagicMock()
+    co.call_reset = mocker.MagicMock()
     mock_storage = mocker.patch('securedrop_client.logic.storage')
-    cl.on_synced(result_data)
+    co.on_synced(result_data)
     mock_storage.update_local_storage. \
         assert_called_once_with(mock_session, mock_sources, "submissions",
                                 "replies",
                                 os.path.join(homedir, 'data'))
 
-    cl.update_sources.assert_called_once_with()
+    co.update_sources.assert_called_once_with()
 
 
-def test_Client_on_synced_with_non_pgp_key(homedir, config, mocker):
+def test_Controller_on_synced_with_non_pgp_key(homedir, config, mocker):
     """
     If there's a result to syncing, then update local storage.
     This is it to check that we can gracefully handle missing keys.
@@ -645,9 +645,9 @@ def test_Client_on_synced_with_non_pgp_key(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.update_sources = mocker.MagicMock()
-    cl.api_runner = mocker.MagicMock()
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.update_sources = mocker.MagicMock()
+    co.api_runner = mocker.MagicMock()
 
     mock_source = mocker.MagicMock()
     mock_source.key = {
@@ -657,17 +657,17 @@ def test_Client_on_synced_with_non_pgp_key(homedir, config, mocker):
     mock_sources = [mock_source]
     result_data = (mock_sources, 'submissions', 'replies')
 
-    cl.call_reset = mocker.MagicMock()
+    co.call_reset = mocker.MagicMock()
     mock_storage = mocker.patch('securedrop_client.logic.storage')
-    cl.on_synced(result_data)
+    co.on_synced(result_data)
     mock_storage.update_local_storage. \
         assert_called_once_with(mock_session, mock_sources, "submissions",
                                 "replies",
                                 os.path.join(homedir, 'data'))
-    cl.update_sources.assert_called_once_with()
+    co.update_sources.assert_called_once_with()
 
 
-def test_Client_on_synced_with_key_import_fail(homedir, config, mocker):
+def test_Controller_on_synced_with_key_import_fail(homedir, config, mocker):
     """
     If there's a result to syncing, then update local storage.
     This is it to check that we can gracefully handle an import failure.
@@ -675,9 +675,9 @@ def test_Client_on_synced_with_key_import_fail(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.update_sources = mocker.MagicMock()
-    cl.api_runner = mocker.MagicMock()
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.update_sources = mocker.MagicMock()
+    co.api_runner = mocker.MagicMock()
 
     mock_source = mocker.MagicMock()
     mock_source.key = {
@@ -688,32 +688,32 @@ def test_Client_on_synced_with_key_import_fail(homedir, config, mocker):
     mock_sources = [mock_source]
     result_data = (mock_sources, 'submissions', 'replies')
 
-    cl.call_reset = mocker.MagicMock()
+    co.call_reset = mocker.MagicMock()
     mock_storage = mocker.patch('securedrop_client.logic.storage')
-    mocker.patch.object(cl.gpg, 'import_key', side_effect=CryptoError)
-    cl.on_synced(result_data)
+    mocker.patch.object(co.gpg, 'import_key', side_effect=CryptoError)
+    co.on_synced(result_data)
     mock_storage.update_local_storage. \
         assert_called_once_with(mock_session, mock_sources, "submissions",
                                 "replies",
                                 os.path.join(homedir, 'data'))
-    cl.update_sources.assert_called_once_with()
+    co.update_sources.assert_called_once_with()
 
 
-def test_Client_update_sync(homedir, config, mocker):
+def test_Controller_update_sync(homedir, config, mocker):
     """
     Cause the UI to update with the result of self.last_sync().
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.last_sync = mocker.MagicMock()
-    cl.update_sync()
-    assert cl.last_sync.call_count == 1
-    cl.gui.show_sync.assert_called_once_with(cl.last_sync())
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.last_sync = mocker.MagicMock()
+    co.update_sync()
+    assert co.last_sync.call_count == 1
+    co.gui.show_sync.assert_called_once_with(co.last_sync())
 
 
-def test_Client_update_sources(homedir, config, mocker):
+def test_Controller_update_sources(homedir, config, mocker):
     """
     Ensure the UI displays a list of the available sources from local data
     store.
@@ -721,16 +721,16 @@ def test_Client_update_sources(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
     mock_storage = mocker.patch('securedrop_client.logic.storage')
     source_list = [factory.Source(last_updated=2), factory.Source(last_updated=1)]
     mock_storage.get_local_sources.return_value = source_list
-    cl.update_sources()
+    co.update_sources()
     mock_storage.get_local_sources.assert_called_once_with(mock_session)
     mock_gui.show_sources.assert_called_once_with(source_list)
 
 
-def test_Client_update_conversation_views(homedir, config, mocker):
+def test_Controller_update_conversation_views(homedir, config, mocker):
     """
     Ensure the UI displays the latest version of the messages/replies that
     have been downloaded/decrypted in the current conversation view.
@@ -751,69 +751,69 @@ def test_Client_update_conversation_views(homedir, config, mocker):
     mock_session.__contains__.return_value = True
 
     mock_session.refresh = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.update_conversation_views()
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.update_conversation_views()
     assert mock_session.refresh.called
     assert mock_update_conversation.called
 
 
-def test_Client_unstars_a_source_if_starred(homedir, config, mocker):
+def test_Controller_unstars_a_source_if_starred(homedir, config, mocker):
     """
     Ensure that the client unstars a source if it is starred.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
 
     source_db_object = mocker.MagicMock()
     source_db_object.uuid = mocker.MagicMock()
     source_db_object.is_starred = True
 
-    cl.call_api = mocker.MagicMock()
-    cl.api = mocker.MagicMock()
-    cl.api.remove_star = mocker.MagicMock()
-    cl.on_update_star_complete = mocker.MagicMock()
-    cl.on_sidebar_action_timeout = mocker.MagicMock()
+    co.call_api = mocker.MagicMock()
+    co.api = mocker.MagicMock()
+    co.api.remove_star = mocker.MagicMock()
+    co.on_update_star_complete = mocker.MagicMock()
+    co.on_sidebar_action_timeout = mocker.MagicMock()
 
     source_sdk_object = mocker.MagicMock()
     mock_source = mocker.patch('sdclientapi.Source')
     mock_source.return_value = source_sdk_object
-    cl.update_star(source_db_object)
+    co.update_star(source_db_object)
 
-    cl.call_api.assert_called_once_with(
-        cl.api.remove_star, cl.on_update_star_complete,
-        cl.on_sidebar_action_timeout, source_sdk_object)
+    co.call_api.assert_called_once_with(
+        co.api.remove_star, co.on_update_star_complete,
+        co.on_sidebar_action_timeout, source_sdk_object)
     mock_gui.clear_error_status.assert_called_once_with()
 
 
-def test_Client_unstars_a_source_if_unstarred(homedir, config, mocker):
+def test_Controller_unstars_a_source_if_unstarred(homedir, config, mocker):
     """
     Ensure that the client stars a source if it is unstarred.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
     source_db_object = mocker.MagicMock()
     source_db_object.uuid = mocker.MagicMock()
     source_db_object.is_starred = False
-    cl.call_api = mocker.MagicMock()
-    cl.api = mocker.MagicMock()
-    cl.api.add_star = mocker.MagicMock()
-    cl.on_update_star_complete = mocker.MagicMock()
-    cl.on_sidebar_action_timeout = mocker.MagicMock()
+    co.call_api = mocker.MagicMock()
+    co.api = mocker.MagicMock()
+    co.api.add_star = mocker.MagicMock()
+    co.on_update_star_complete = mocker.MagicMock()
+    co.on_sidebar_action_timeout = mocker.MagicMock()
     source_sdk_object = mocker.MagicMock()
     mock_source = mocker.patch('sdclientapi.Source')
     mock_source.return_value = source_sdk_object
-    cl.update_star(source_db_object)
-    cl.call_api.assert_called_once_with(
-        cl.api.add_star, cl.on_update_star_complete,
-        cl.on_sidebar_action_timeout, source_sdk_object)
+    co.update_star(source_db_object)
+    co.call_api.assert_called_once_with(
+        co.api.add_star, co.on_update_star_complete,
+        co.on_sidebar_action_timeout, source_sdk_object)
     mock_gui.clear_error_status.assert_called_once_with()
 
 
-def test_Client_update_star_not_logged_in(homedir, config, mocker):
+def test_Controller_update_star_not_logged_in(homedir, config, mocker):
     """
     Ensure that starring/unstarring a source when not logged in calls
     the method that displays an error status in the left sidebar.
@@ -821,28 +821,28 @@ def test_Client_update_star_not_logged_in(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
     source_db_object = mocker.MagicMock()
-    cl.on_action_requiring_login = mocker.MagicMock()
-    cl.api = None
-    cl.update_star(source_db_object)
-    cl.on_action_requiring_login.assert_called_with()
+    co.on_action_requiring_login = mocker.MagicMock()
+    co.api = None
+    co.update_star(source_db_object)
+    co.on_action_requiring_login.assert_called_with()
 
 
-def test_Client_sidebar_action_timeout(homedir, config, mocker):
+def test_Controller_sidebar_action_timeout(homedir, config, mocker):
     """
     Show on error status sidebar that a timeout occurred.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.on_sidebar_action_timeout()
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.on_sidebar_action_timeout()
     mock_gui.update_error_status.assert_called_once_with(
         'The connection to the SecureDrop server timed out. Please try again.')
 
 
-def test_Client_on_update_star_success(homedir, config, mocker):
+def test_Controller_on_update_star_success(homedir, config, mocker):
     """
     If the starring occurs successfully, then a sync should occur to update
     locally.
@@ -850,16 +850,16 @@ def test_Client_on_update_star_success(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
     result = True
-    cl.call_reset = mocker.MagicMock()
-    cl.sync_api = mocker.MagicMock()
-    cl.on_update_star_complete(result)
-    cl.sync_api.assert_called_once_with()
+    co.call_reset = mocker.MagicMock()
+    co.sync_api = mocker.MagicMock()
+    co.on_update_star_complete(result)
+    co.sync_api.assert_called_once_with()
     mock_gui.clear_error_status.assert_called_once_with()
 
 
-def test_Client_on_update_star_failed(homedir, config, mocker):
+def test_Controller_on_update_star_failed(homedir, config, mocker):
     """
     If the starring does not occur properly, then an error should appear
     on the error status sidebar, and a sync will not occur.
@@ -867,17 +867,17 @@ def test_Client_on_update_star_failed(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
     result = Exception('boom')
-    cl.call_reset = mocker.MagicMock()
-    cl.sync_api = mocker.MagicMock()
-    cl.on_update_star_complete(result)
-    cl.sync_api.assert_not_called()
+    co.call_reset = mocker.MagicMock()
+    co.sync_api = mocker.MagicMock()
+    co.on_update_star_complete(result)
+    co.sync_api.assert_not_called()
     mock_gui.update_error_status.assert_called_once_with(
         'Failed to apply change.')
 
 
-def test_Client_logout(homedir, config, mocker):
+def test_Controller_logout(homedir, config, mocker):
     """
     The API is reset to None and the UI is set to logged out state.
     The message and reply threads should also have the
@@ -885,28 +885,28 @@ def test_Client_logout(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.api = mocker.MagicMock()
-    cl.message_sync = mocker.MagicMock()
-    cl.reply_sync = mocker.MagicMock()
-    cl.message_sync.api = mocker.MagicMock()
-    cl.reply_sync.api = mocker.MagicMock()
-    cl.logout()
-    assert cl.api is None
-    assert cl.message_sync.api is None
-    assert cl.reply_sync.api is None
-    cl.gui.logout.assert_called_once_with()
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.api = mocker.MagicMock()
+    co.message_sync = mocker.MagicMock()
+    co.reply_sync = mocker.MagicMock()
+    co.message_sync.api = mocker.MagicMock()
+    co.reply_sync.api = mocker.MagicMock()
+    co.logout()
+    assert co.api is None
+    assert co.message_sync.api is None
+    assert co.reply_sync.api is None
+    co.gui.logout.assert_called_once_with()
 
 
-def test_Client_set_activity_status(homedir, config, mocker):
+def test_Controller_set_activity_status(homedir, config, mocker):
     """
     Ensure the GUI set_status API is called.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.set_status("Hello, World!", 1000)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.set_status("Hello, World!", 1000)
     mock_gui.update_activity_status.assert_called_once_with("Hello, World!", 1000)
 
 
@@ -952,7 +952,7 @@ def test_create_client_dir_permissions(tmpdir, mocker):
             os.mkdir(sdc_home, case['home_perms'])
 
         def func() -> None:
-            Client('http://localhost', mock_gui, mock_session, sdc_home)
+            Controller('http://localhost', mock_gui, mock_session, sdc_home)
 
         if case['should_pass']:
             func()
@@ -965,7 +965,7 @@ def test_create_client_dir_permissions(tmpdir, mocker):
     assert mock_json.called
 
 
-def test_Client_on_file_download_Submission(homedir, config, mocker):
+def test_Controller_on_file_download_Submission(homedir, config, mocker):
     """
     If the handler is passed a submission, check the download_submission
     function is the one called against the API.
@@ -973,43 +973,43 @@ def test_Client_on_file_download_Submission(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
     source = factory.Source()
     file_ = db.File(source=source, uuid='uuid', size=1234, filename='1-myfile.doc.gpg',
                     download_url='http://myserver/myfile', is_downloaded=False)
-    cl.call_api = mocker.MagicMock()
-    cl.api = mocker.MagicMock()
+    co.call_api = mocker.MagicMock()
+    co.api = mocker.MagicMock()
     submission_sdk_object = mocker.MagicMock()
     mock_submission = mocker.patch('sdclientapi.Submission')
     mock_submission.return_value = submission_sdk_object
-    cl.on_file_download(source, file_)
-    cl.call_api.assert_called_once_with(
-        cl.api.download_submission, cl.on_file_downloaded,
-        cl.on_download_timeout, submission_sdk_object,
-        cl.data_dir, current_object=file_)
+    co.on_file_download(source, file_)
+    co.call_api.assert_called_once_with(
+        co.api.download_submission, co.on_file_downloaded,
+        co.on_download_timeout, submission_sdk_object,
+        co.data_dir, current_object=file_)
 
 
-def test_Client_on_file_downloaded_success(homedir, config, mocker):
+def test_Controller_on_file_downloaded_success(homedir, config, mocker):
     '''
     Using the `config` fixture to ensure the config is written to disk.
     '''
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.update_sources = mocker.MagicMock()
-    cl.api_runner = mocker.MagicMock()
-    cl.file_ready = mocker.MagicMock()  # signal when file is downloaded
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.update_sources = mocker.MagicMock()
+    co.api_runner = mocker.MagicMock()
+    co.file_ready = mocker.MagicMock()  # signal when file is downloaded
     test_filename = "1-my-file-location-msg.gpg"
     test_object_uuid = 'uuid-of-downloaded-object'
-    cl.call_reset = mocker.MagicMock()
+    co.call_reset = mocker.MagicMock()
     result_data = ('this-is-a-sha256-sum', test_filename)
     submission_db_object = mocker.MagicMock()
     submission_db_object.uuid = test_object_uuid
     submission_db_object.filename = test_filename
     mock_storage = mocker.patch('securedrop_client.logic.storage')
-    mock_gpg = mocker.patch.object(cl.gpg, 'decrypt_submission_or_reply', return_value='filepath')
+    mock_gpg = mocker.patch.object(co.gpg, 'decrypt_submission_or_reply', return_value='filepath')
     mocker.patch('shutil.move')
-    cl.on_file_downloaded(result_data, current_object=submission_db_object)
+    co.on_file_downloaded(result_data, current_object=submission_db_object)
     mock_gpg.call_count == 1
     mock_storage.mark_file_as_downloaded.assert_called_once_with(
         test_object_uuid, mock_session)
@@ -1017,65 +1017,65 @@ def test_Client_on_file_downloaded_success(homedir, config, mocker):
         submission_db_object, mock_session, True)
 
     # Signal should be emitted with UUID of the successfully downloaded object
-    cl.file_ready.emit.assert_called_once_with(test_object_uuid)
+    co.file_ready.emit.assert_called_once_with(test_object_uuid)
 
 
-def test_Client_on_file_downloaded_api_failure(homedir, config, mocker):
+def test_Controller_on_file_downloaded_api_failure(homedir, config, mocker):
     '''
     Using the `config` fixture to ensure the config is written to disk.
     '''
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.file_ready = mocker.MagicMock()  # signal when file is downloaded
-    cl.update_sources = mocker.MagicMock()
-    cl.api_runner = mocker.MagicMock()
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.file_ready = mocker.MagicMock()  # signal when file is downloaded
+    co.update_sources = mocker.MagicMock()
+    co.api_runner = mocker.MagicMock()
     test_filename = "1-my-file-location-msg.gpg"
-    cl.api_runner.result = ("", test_filename)
-    cl.call_reset = mocker.MagicMock()
-    cl.set_status = mocker.MagicMock()
+    co.api_runner.result = ("", test_filename)
+    co.call_reset = mocker.MagicMock()
+    co.set_status = mocker.MagicMock()
     result_data = Exception('error message')
     submission_db_object = mocker.MagicMock()
     submission_db_object.uuid = 'myuuid'
     submission_db_object.filename = 'filename'
-    cl.on_file_downloaded(result_data, current_object=submission_db_object)
-    cl.set_status.assert_called_once_with(
+    co.on_file_downloaded(result_data, current_object=submission_db_object)
+    co.set_status.assert_called_once_with(
         "The file download failed. Please try again.")
-    cl.file_ready.emit.assert_not_called()
+    co.file_ready.emit.assert_not_called()
 
 
-def test_Client_on_file_downloaded_decrypt_failure(homedir, config, mocker):
+def test_Controller_on_file_downloaded_decrypt_failure(homedir, config, mocker):
     '''
     Using the `config` fixture to ensure the config is written to disk.
     '''
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.update_sources = mocker.MagicMock()
-    cl.api_runner = mocker.MagicMock()
-    cl.file_ready = mocker.MagicMock()  # signal when file is downloaded
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.update_sources = mocker.MagicMock()
+    co.api_runner = mocker.MagicMock()
+    co.file_ready = mocker.MagicMock()  # signal when file is downloaded
     test_filename = "1-my-file-location-msg.gpg"
-    cl.api_runner.result = ("", test_filename)
-    cl.set_status = mocker.MagicMock()
+    co.api_runner.result = ("", test_filename)
+    co.set_status = mocker.MagicMock()
     result_data = ('this-is-a-sha256-sum', test_filename)
     submission_db_object = mocker.MagicMock()
     submission_db_object.uuid = 'myuuid'
     submission_db_object.filename = 'filename'
-    mock_gpg = mocker.patch.object(cl.gpg, 'decrypt_submission_or_reply',
+    mock_gpg = mocker.patch.object(co.gpg, 'decrypt_submission_or_reply',
                                    side_effect=CryptoError())
     mock_storage = mocker.patch('securedrop_client.logic.storage')
     mocker.patch('shutil.move')
 
-    cl.on_file_downloaded(result_data, current_object=submission_db_object)
+    co.on_file_downloaded(result_data, current_object=submission_db_object)
     mock_gpg.call_count == 1
-    cl.set_status.assert_called_once_with(
+    co.set_status.assert_called_once_with(
         "Failed to decrypt file, please try again or talk to your administrator.")
     mock_storage.set_object_decryption_status_with_content.assert_called_once_with(
         submission_db_object, mock_session, False)
-    cl.file_ready.emit.assert_not_called()
+    co.file_ready.emit.assert_not_called()
 
 
-def test_Client_on_file_download_user_not_signed_in(homedir, config, mocker):
+def test_Controller_on_file_download_user_not_signed_in(homedir, config, mocker):
     """
     If a user clicks the download button but is not logged in,
     an error should appear.
@@ -1083,39 +1083,39 @@ def test_Client_on_file_download_user_not_signed_in(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
     source = factory.Source()
     file_ = db.File(source=source, uuid='uuid', size=1234, filename='1-myfile.doc.gpg',
                     download_url='http://myserver/myfile', is_downloaded=False)
-    cl.on_action_requiring_login = mocker.MagicMock()
-    cl.api = None
+    co.on_action_requiring_login = mocker.MagicMock()
+    co.api = None
     submission_sdk_object = mocker.MagicMock()
     mock_submission = mocker.patch('sdclientapi.Submission')
     mock_submission.return_value = submission_sdk_object
-    cl.on_file_download(source, file_)
-    cl.on_action_requiring_login.assert_called_once_with()
+    co.on_file_download(source, file_)
+    co.on_action_requiring_login.assert_called_once_with()
 
 
-def test_Client_on_download_timeout(homedir, config, mocker):
+def test_Controller_on_download_timeout(homedir, config, mocker):
     '''
     Using the `config` fixture to ensure the config is written to disk.
     '''
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.update_sources = mocker.MagicMock()
-    cl.api_runner = mocker.MagicMock()
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.update_sources = mocker.MagicMock()
+    co.api_runner = mocker.MagicMock()
     current_object = mocker.MagicMock()
     test_filename = "1-my-file-location-msg.gpg"
-    cl.api_runner.result = ("", test_filename)
-    cl.call_reset = mocker.MagicMock()
-    cl.set_status = mocker.MagicMock()
-    cl.on_download_timeout(current_object)
-    cl.set_status.assert_called_once_with(
+    co.api_runner.result = ("", test_filename)
+    co.call_reset = mocker.MagicMock()
+    co.set_status = mocker.MagicMock()
+    co.on_download_timeout(current_object)
+    co.set_status.assert_called_once_with(
         "The connection to the SecureDrop server timed out. Please try again.")
 
 
-def test_Client_on_file_download_Reply(homedir, config, mocker):
+def test_Controller_on_file_download_Reply(homedir, config, mocker):
     """
     If the handler is passed a reply, check the download_reply
     function is the one called against the API.
@@ -1123,7 +1123,7 @@ def test_Client_on_file_download_Reply(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
     source = factory.Source()
     journalist = db.User('Testy mcTestface')
     reply = db.Reply(uuid='reply-uuid',
@@ -1131,20 +1131,20 @@ def test_Client_on_file_download_Reply(homedir, config, mocker):
                      source=source,
                      filename='1-my-reply.gpg',
                      size=123)  # Not a sdclientapi.Submission
-    cl.call_api = mocker.MagicMock()
-    cl.api = mocker.MagicMock()
+    co.call_api = mocker.MagicMock()
+    co.api = mocker.MagicMock()
     reply_sdk_object = mocker.MagicMock()
     mock_reply = mocker.patch('sdclientapi.Reply')
     mock_reply.return_value = reply_sdk_object
-    cl.on_file_download(source, reply)
-    cl.call_api.assert_called_once_with(cl.api.download_reply,
-                                        cl.on_file_downloaded,
-                                        cl.on_download_timeout,
+    co.on_file_download(source, reply)
+    co.call_api.assert_called_once_with(co.api.download_reply,
+                                        co.on_file_downloaded,
+                                        co.on_download_timeout,
                                         reply_sdk_object,
-                                        cl.data_dir, current_object=reply)
+                                        co.data_dir, current_object=reply)
 
 
-def test_Client_on_file_open(homedir, config, mocker):
+def test_Controller_on_file_open(homedir, config, mocker):
     """
     If running on Qubes, a new QProcess with the expected command and args
     should be started.
@@ -1152,74 +1152,74 @@ def test_Client_on_file_open(homedir, config, mocker):
     """
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.proxy = True
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.proxy = True
     mock_submission = mocker.MagicMock()
     mock_submission.filename = '1-test.pdf'
     mock_subprocess = mocker.MagicMock()
     mock_process = mocker.MagicMock(return_value=mock_subprocess)
     mocker.patch('securedrop_client.logic.QProcess', mock_process)
-    cl.on_file_open(mock_submission)
-    mock_process.assert_called_once_with(cl)
+    co.on_file_open(mock_submission)
+    mock_process.assert_called_once_with(co)
     mock_subprocess.start.call_count == 1
 
 
-def test_Client_on_delete_action_timeout(homedir, config, mocker):
+def test_Controller_on_delete_action_timeout(homedir, config, mocker):
     '''
     Using the `config` fixture to ensure the config is written to disk.
     '''
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl._on_delete_action_timeout()
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co._on_delete_action_timeout()
     message = 'The connection to SecureDrop timed out. Please try again.'
-    cl.gui.update_error_status.assert_called_with(message)
+    co.gui.update_error_status.assert_called_with(message)
 
 
-def test_Client_on_delete_source_complete_with_results(homedir, config, mocker):
+def test_Controller_on_delete_source_complete_with_results(homedir, config, mocker):
     '''
     Using the `config` fixture to ensure the config is written to disk.
     '''
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.sync_api = mocker.MagicMock()
-    cl._on_delete_source_complete(True)
-    cl.sync_api.assert_called_with()
-    cl.gui.clear_error_status.assert_called_with()
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.sync_api = mocker.MagicMock()
+    co._on_delete_source_complete(True)
+    co.sync_api.assert_called_with()
+    co.gui.clear_error_status.assert_called_with()
 
 
-def test_Client_on_delete_source_complete_without_results(homedir, config, mocker):
+def test_Controller_on_delete_source_complete_without_results(homedir, config, mocker):
     '''
     Using the `config` fixture to ensure the config is written to disk.
     '''
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl._on_delete_source_complete(False)
-    cl.gui.update_error_status.assert_called_with('Failed to delete source at server')
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co._on_delete_source_complete(False)
+    co.gui.update_error_status.assert_called_with('Failed to delete source at server')
 
 
-def test_Client_delete_source(homedir, config, mocker):
+def test_Controller_delete_source(homedir, config, mocker):
     '''
     Using the `config` fixture to ensure the config is written to disk.
     '''
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
     mock_source = mocker.MagicMock()
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.call_api = mocker.MagicMock()
-    cl.api = mocker.MagicMock()
-    cl.delete_source(mock_source)
-    cl.call_api.assert_called_with(
-        cl.api.delete_source,
-        cl._on_delete_source_complete,
-        cl._on_delete_action_timeout,
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.call_api = mocker.MagicMock()
+    co.api = mocker.MagicMock()
+    co.delete_source(mock_source)
+    co.call_api.assert_called_with(
+        co.api.delete_source,
+        co._on_delete_source_complete,
+        co._on_delete_action_timeout,
         mock_source
     )
 
 
-def test_Client_send_reply_success(homedir, mocker):
+def test_Controller_send_reply_success(homedir, mocker):
     '''
     Check that the "happy path" of encrypting a message and sending it to the sever behaves as
     expected.
@@ -1227,12 +1227,12 @@ def test_Client_send_reply_success(homedir, mocker):
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
 
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
 
-    cl.call_api = mocker.Mock()
-    cl.api = mocker.Mock()
+    co.call_api = mocker.Mock()
+    co.api = mocker.Mock()
     encrypted_reply = 's3kr1t m3ss1dg3'
-    mock_encrypt = mocker.patch.object(cl.gpg, 'encrypt_to_source', return_value=encrypted_reply)
+    mock_encrypt = mocker.patch.object(co.gpg, 'encrypt_to_source', return_value=encrypted_reply)
     source_uuid = 'abc123'
     msg_uuid = 'xyz456'
     msg = 'wat'
@@ -1240,16 +1240,16 @@ def test_Client_send_reply_success(homedir, mocker):
     mock_source_init = mocker.patch('securedrop_client.logic.sdclientapi.Source',
                                     return_value=mock_sdk_source)
 
-    cl.send_reply(source_uuid, msg_uuid, msg)
+    co.send_reply(source_uuid, msg_uuid, msg)
 
     # ensure message is encrypted
     mock_encrypt.assert_called_once_with(source_uuid, msg)
 
     # ensure api is called
-    cl.call_api.assert_called_once_with(
-        cl.api.reply_source,
-        cl._on_reply_complete,
-        cl._on_reply_timeout,
+    co.call_api.assert_called_once_with(
+        co.api.reply_source,
+        co._on_reply_complete,
+        co._on_reply_timeout,
         mock_sdk_source,
         encrypted_reply,
         msg_uuid,
@@ -1259,27 +1259,27 @@ def test_Client_send_reply_success(homedir, mocker):
     assert mock_source_init.called  # to prevent stale mocks
 
 
-def test_Client_send_reply_gpg_error(homedir, mocker):
+def test_Controller_send_reply_gpg_error(homedir, mocker):
     '''
     Check that if gpg fails when sending a message, we alert the UI and do *not* call the API.
     '''
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
 
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
 
-    cl.call_api = mocker.Mock()
-    cl.api = mocker.Mock()
-    mock_encrypt = mocker.patch.object(cl.gpg, 'encrypt_to_source', side_effect=Exception)
+    co.call_api = mocker.Mock()
+    co.api = mocker.Mock()
+    mock_encrypt = mocker.patch.object(co.gpg, 'encrypt_to_source', side_effect=Exception)
     source_uuid = 'abc123'
     msg_uuid = 'xyz456'
     msg = 'wat'
     mock_sdk_source = mocker.Mock()
     mock_source_init = mocker.patch('securedrop_client.logic.sdclientapi.Source',
                                     return_value=mock_sdk_source)
-    mock_reply_failed = mocker.patch.object(cl, 'reply_failed')
+    mock_reply_failed = mocker.patch.object(co, 'reply_failed')
 
-    cl.send_reply(source_uuid, msg_uuid, msg)
+    co.send_reply(source_uuid, msg_uuid, msg)
 
     # ensure there is an attempt to encrypt the message
     mock_encrypt.assert_called_once_with(source_uuid, msg)
@@ -1288,12 +1288,12 @@ def test_Client_send_reply_gpg_error(homedir, mocker):
     mock_reply_failed.emit.assert_called_once_with(msg_uuid)
 
     # ensure api not is called after a gpg error
-    assert not cl.call_api.called
+    assert not co.call_api.called
 
     assert mock_source_init.called  # to prevent stale mocks
 
 
-def test_Client_on_reply_complete_success(homedir, mocker):
+def test_Controller_on_reply_complete_success(homedir, mocker):
     '''
     Check that when the result is a success, the client emits the correct signal.
     '''
@@ -1301,71 +1301,71 @@ def test_Client_on_reply_complete_success(homedir, mocker):
     mock_session = mocker.MagicMock()
     mock_reply_init = mocker.patch('securedrop_client.logic.db.Reply')
 
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.api = mocker.Mock()
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.api = mocker.Mock()
     journalist_uuid = 'abc123'
-    cl.api.token = {'journalist_uuid': journalist_uuid}
-    mock_reply_succeeded = mocker.patch.object(cl, 'reply_succeeded')
-    mock_reply_failed = mocker.patch.object(cl, 'reply_failed')
+    co.api.token = {'journalist_uuid': journalist_uuid}
+    mock_reply_succeeded = mocker.patch.object(co, 'reply_succeeded')
+    mock_reply_failed = mocker.patch.object(co, 'reply_failed')
 
     reply = sdlocalobjects.Reply(uuid='xyz456', filename='1-wat.gpg')
 
     source_uuid = 'foo111'
     msg_uuid = 'bar222'
     current_object = (source_uuid, msg_uuid)
-    cl._on_reply_complete(reply, current_object)
-    cl.session.commit.assert_called_once_with()
+    co._on_reply_complete(reply, current_object)
+    co.session.commit.assert_called_once_with()
     mock_reply_succeeded.emit.assert_called_once_with(msg_uuid)
     assert not mock_reply_failed.emit.called
 
     assert mock_reply_init.called  # to prevent stale mocks
 
 
-def test_Client_on_reply_complete_failure(homedir, mocker):
+def test_Controller_on_reply_complete_failure(homedir, mocker):
     '''
     Check that when the result is a failure, the client emits the correct signal.
     '''
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
 
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.api = mocker.Mock()
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.api = mocker.Mock()
     journalist_uuid = 'abc123'
-    cl.api.token = {'journalist_uuid': journalist_uuid}
-    mock_reply_succeeded = mocker.patch.object(cl, 'reply_succeeded')
-    mock_reply_failed = mocker.patch.object(cl, 'reply_failed')
+    co.api.token = {'journalist_uuid': journalist_uuid}
+    mock_reply_succeeded = mocker.patch.object(co, 'reply_succeeded')
+    mock_reply_failed = mocker.patch.object(co, 'reply_failed')
 
     source_uuid = 'foo111'
     msg_uuid = 'bar222'
     current_object = (source_uuid, msg_uuid)
-    cl._on_reply_complete(Exception, current_object)
+    co._on_reply_complete(Exception, current_object)
     mock_reply_failed.emit.assert_called_once_with(msg_uuid)
     assert not mock_reply_succeeded.emit.called
 
 
-def test_Client_on_reply_timeout(homedir, mocker):
+def test_Controller_on_reply_timeout(homedir, mocker):
     '''
     Check that when the reply timesout, the correct signal is emitted.
     '''
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
 
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    cl.api = mocker.Mock()
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    co.api = mocker.Mock()
     journalist_uuid = 'abc123'
-    cl.api.token = {'journalist_uuid': journalist_uuid}
-    mock_reply_succeeded = mocker.patch.object(cl, 'reply_succeeded')
-    mock_reply_failed = mocker.patch.object(cl, 'reply_failed')
+    co.api.token = {'journalist_uuid': journalist_uuid}
+    mock_reply_succeeded = mocker.patch.object(co, 'reply_succeeded')
+    mock_reply_failed = mocker.patch.object(co, 'reply_failed')
 
     source_uuid = 'foo111'
     msg_uuid = 'bar222'
     current_object = (source_uuid, msg_uuid)
-    cl._on_reply_timeout(current_object)
+    co._on_reply_timeout(current_object)
     mock_reply_failed.emit.assert_called_once_with(msg_uuid)
     assert not mock_reply_succeeded.emit.called
 
 
-def test_Client_is_authenticated_property(homedir, mocker):
+def test_Controller_is_authenticated_property(homedir, mocker):
     '''
     Check that the @property `is_authenticated`:
       - Cannot be deleted
@@ -1375,28 +1375,28 @@ def test_Client_is_authenticated_property(homedir, mocker):
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
 
-    cl = Client('http://localhost', mock_gui, mock_session, homedir)
-    mock_signal = mocker.patch.object(cl, 'authentication_state')
+    co = Controller('http://localhost', mock_gui, mock_session, homedir)
+    mock_signal = mocker.patch.object(co, 'authentication_state')
 
     # default state is unauthenticated
-    assert cl.is_authenticated is False
+    assert co.is_authenticated is False
 
     # the property cannot be deleted
     with pytest.raises(AttributeError):
-        del cl.is_authenticated
+        del co.is_authenticated
 
     # setting the signal to its current value does not fire the signal
-    cl.is_authenticated = False
+    co.is_authenticated = False
     assert not mock_signal.emit.called
-    assert cl.is_authenticated is False
+    assert co.is_authenticated is False
 
     # setting the property to True sends a signal
-    cl.is_authenticated = True
+    co.is_authenticated = True
     mock_signal.emit.assert_called_once_with(True)
-    assert cl.is_authenticated is True
+    assert co.is_authenticated is True
 
     mock_signal.reset_mock()
 
-    cl.is_authenticated = False
+    co.is_authenticated = False
     mock_signal.emit.assert_called_once_with(False)
-    assert cl.is_authenticated is False
+    assert co.is_authenticated is False


### PR DESCRIPTION
Fixes #70 

We have had the problem of overloaded terms making discussion of the app confusing. Right now client means:

- The entire app
- The SDK's API client
- The "controller"

This reduces use of the client down to two distinct things.