### PR TITLE
Fixes the login with latest SDK python API changes

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -341,7 +341,7 @@ class Controller(QObject):
         """
         Handles the result of an authentication call against the API.
         """
-        if isinstance(result, bool) and result:
+        if not isinstance(result, Exception):
             # It worked! Sync with the API and update the UI.
             self.gui.hide_login()
             self.sync_api()

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -273,7 +273,7 @@ def test_Controller_on_authenticate_failed(homedir, config, mocker):
     mock_gui = mocker.MagicMock()
     mock_session = mocker.MagicMock()
     co = Controller('http://localhost', mock_gui, mock_session, homedir)
-    result_data = 'false'
+    result_data = Exception('oh no')
     co.on_authenticate(result_data)
     mock_gui.show_login_error.\
         assert_called_once_with(error='There was a problem signing in. Please '


### PR DESCRIPTION
Changes the check on the completion handler to correctly check for the presence of an `Exception`. This supersedes https://github.com/freedomofpress/securedrop-sdk/pull/74