### PR TITLE
ignore Esc key pressed event

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -868,6 +868,14 @@ class LoginDialog(QDialog):
         if not self.parent.isVisible():
             sys.exit(0)
 
+    def keyPressEvent(self, event):
+        """
+        Override default QDialog behavior that closes the dialog window when the Esc key is pressed.
+        Instead, ignore the event.
+        """
+        if event.key() == Qt.Key_Escape:
+            event.ignore()
+
     def setup(self, controller):
         self.controller = controller
         self.setMinimumSize(600, 400)

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -3,6 +3,8 @@ Make sure the UI widgets are configured correctly and work as expected.
 """
 from PyQt5.QtWidgets import QWidget, QApplication, QWidgetItem, QSpacerItem, QVBoxLayout, \
     QMessageBox, QLabel, QMainWindow
+from PyQt5.QtCore import Qt
+
 from tests import factory
 from securedrop_client import db, logic
 from securedrop_client.gui.widgets import MainView, SourceList, SourceWidget, LoginDialog, \
@@ -788,6 +790,19 @@ def test_LoginDialog_validate_input_ok(mocker):
     assert ld.setDisabled.call_count == 1
     assert ld.error.call_count == 0
     mock_controller.login.assert_called_once_with('foo', 'nicelongpassword', '123456')
+
+
+def test_LoginDialog_keyPressEvent(mocker):
+    """
+    Ensure we don't hide the login dialog when Esc key is pressed.
+    """
+    ld = LoginDialog(None)
+    event = mocker.MagicMock()
+    event.key = mocker.MagicMock(return_value=Qt.Key_Escape)
+
+    ld.keyPressEvent(event)
+
+    event.ignore.assert_called_once_with()
 
 
 def test_LoginDialog_closeEvent_exits(mocker):


### PR DESCRIPTION
## Description

Fixes #318 
 
Override default behavior for Esc key pressed event, see https://doc.qt.io/qt-5/qdialog.html#escape-key:

> If the user presses the Esc key in a dialog, QDialog::reject() will be called. This will cause the window to close: The close event cannot be ignored.

Looks like `QDialog::reject` actually hides the modal dialog rather than closing it. Either way, we don't want to hide or close the dialog, especially now that we show a "standalone" modal dialog when the application starts.

## Test

Bug fix, see #318 