### PR TITLE
fix dropdown arrow

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -467,7 +467,7 @@ class UserButton(SvgPushButton):
     '''
 
     def __init__(self):
-        super().__init__('dropdown_arrow.svg', svg_size=QSize())
+        super().__init__('dropdown_arrow.svg', svg_size=QSize(9, 6))
 
         # Set css id
         self.setObjectName('user_button')


### PR DESCRIPTION
## Description

I noticed when testing the client on macOS that the dropdown arrow didn't scale nicely. I thought this was fixed since it looked fine to me on debian. It would be helpful to add future scaling code that can resize without changing aspect ratio of icon images and SVGs. I've seen some useful QImage methods for this, but I don't think we want to have to convert our SvgWidgets or Icons to QImages. I might be wrong, I need more time to research this. For now, I just updated the dropdown arrow so that it can look sharp like the others.

#### Before
<img width="201" alt="Screen Shot 2019-04-24 at 9 48 45 AM" src="https://user-images.githubusercontent.com/4522213/56701697-3f61d280-66b5-11e9-9b3d-60a2f4e64198.png">

#### After
<img width="157" alt="Screen Shot 2019-04-24 at 9 47 15 AM" src="https://user-images.githubusercontent.com/4522213/56701717-50124880-66b5-11e9-9614-d165f11ededd.png">
