### PR TITLE
Create class for starring

### DIFF
--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -49,6 +49,10 @@ class SvgToggleButton(QPushButton):
     def disable(self):
         self.setEnabled(False)
 
+    def set_icon(self, on: str, off: str):
+        self.icon = load_toggle_icon(on=on, off=off)
+        self.setIcon(self.icon)
+
 
 class SvgPushButton(QPushButton):
     """

--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -20,7 +20,34 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from PyQt5.QtWidgets import QLabel, QHBoxLayout, QPushButton
 from PyQt5.QtCore import QSize
 
-from securedrop_client.resources import load_svg, load_icon
+from securedrop_client.resources import load_svg, load_icon, load_toggle_icon
+
+
+class SvgToggleButton(QPushButton):
+    def __init__(self, on: str, off: str, svg_size=None):
+        super().__init__()
+
+        # Set layout
+        layout = QHBoxLayout(self)
+        self.setLayout(layout)
+
+        # Remove margins and spacing
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        # Add SVG icon and set its size
+        self.icon = load_toggle_icon(on=on, off=off)
+        self.setIcon(self.icon)
+        self.setIconSize(svg_size) if svg_size else self.setIconSize(QSize())
+
+        # Make this a toggle button
+        self.setCheckable(True)
+
+    def enable(self):
+        self.setEnabled(True)
+
+    def disable(self):
+        self.setEnabled(False)
 
 
 class SvgPushButton(QPushButton):
@@ -58,6 +85,12 @@ class SvgPushButton(QPushButton):
         self.icon = load_icon(normal=normal, disabled=disabled, active=active, selected=selected)
         self.setIcon(self.icon)
         self.setIconSize(svg_size) if svg_size else self.setIconSize(QSize())
+
+    def enable(self):
+        self.setEnabled(True)
+
+    def disable(self):
+        self.setEnabled(False)
 
 
 class SvgLabel(QLabel):

--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -24,6 +24,20 @@ from securedrop_client.resources import load_svg, load_icon, load_toggle_icon
 
 
 class SvgToggleButton(QPushButton):
+    """
+    A toggle button used to display the contents of Scalable Vector Graphics (SVG) files provided
+    for an on and off state.
+
+    Parameters
+    ----------
+    on: str
+        The name of the SVG file to add to the button for on state.
+    off: str
+        The name of the SVG file to add to the button for off state.
+    svg_size: QSize, optional
+        The display size of the SVG, defaults to filling the entire size of the widget.
+    """
+
     def __init__(self, on: str, off: str, svg_size=None):
         super().__init__()
 
@@ -58,7 +72,6 @@ class SvgPushButton(QPushButton):
     """
     A widget used to display the contents of Scalable Vector Graphics (SVG) files provided for
     associated user action modes, see https://doc.qt.io/qt-5/qicon.html#Mode-enum.
-
 
     Parameters
     ----------

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -857,11 +857,11 @@ class StarToggleButton(SvgToggleButton):
 
     def setup(self, controller):
         self.controller = controller
-        self.controller.authentication_state.connect(self._on_authentication_changed)
+        self.controller.authentication_state.connect(self.on_authentication_changed)
         # Also set up connection for current authentication state
-        self._on_authentication_changed(self.controller.is_authenticated)
+        self.on_authentication_changed(self.controller.is_authenticated)
 
-    def _on_authentication_changed(self, authenticated: bool):
+    def on_authentication_changed(self, authenticated: bool):
         """
         If authenticated, then toggling the button should call `update_star`. Otherwise, pressing
         the button should show an error message to the user.

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -855,7 +855,8 @@ class StarToggleButton(SvgToggleButton):
 
     def on_authentication_changed(self, authenticated: bool):
         """
-        Set up toggle handlers based on whehter or not the user is authenticated.
+        Set up handlers based on whether or not the user is authenticated. Connect to 'pressed'
+        event instead of 'toggled' event when not authenticated because toggling will be disabled.
         """
         if authenticated:
             self.toggled.connect(self.on_toggle)
@@ -870,7 +871,7 @@ class StarToggleButton(SvgToggleButton):
 
     def on_toggle_offline(self):
         """
-        Show error message and prevent toggle by setting checkable to False. Unfortunately,
+        Show error message and disable toggle by setting checkable to False. Unfortunately,
         disabling toggle doesn't freeze state, rather it always displays the off state when a user
         tries to toggle. In order to save on state we update the icon's off state image to display
         on (hack).

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -527,6 +527,7 @@ class Controller(QObject):
             self.gui.update_error_status(error)
 
     def update_star(self, source_db_object):
+        logger.debug("in update_star 1")
         """
         Star or unstar. The callback here is the API sync as we first make sure
         that we apply the change to the server, and then update locally.

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -527,7 +527,6 @@ class Controller(QObject):
             self.gui.update_error_status(error)
 
     def update_star(self, source_db_object):
-        logger.debug("in update_star 1")
         """
         Star or unstar. The callback here is the API sync as we first make sure
         that we apply the change to the server, and then update locally.

--- a/securedrop_client/resources/__init__.py
+++ b/securedrop_client/resources/__init__.py
@@ -57,10 +57,8 @@ def load_toggle_icon(on: str, off: str) -> QIcon:
 
     icon = QIcon()
 
-    icon.addFile(path(on), mode=QIcon.Normal, state=QIcon.On)
-    icon.addFile(path(off), mode=QIcon.Normal, state=QIcon.Off)
-    icon.addFile(path(off), mode=QIcon.Disabled, state=QIcon.Off)
-    icon.addFile(path(off), mode=QIcon.Disabled, state=QIcon.Off)
+    icon.addFile(path(on), state=QIcon.On)
+    icon.addFile(path(off), state=QIcon.Off)
 
     return icon
 

--- a/securedrop_client/resources/__init__.py
+++ b/securedrop_client/resources/__init__.py
@@ -36,6 +36,35 @@ def path(name, resource_dir="images/"):
     return resource_filename(__name__, resource_dir + name)
 
 
+def load_toggle_icon(on: str, off: str) -> QIcon:
+    """
+    Add the contents of Scalable Vector Graphics (SVG) files provided for associated icon states,
+    see https://doc.qt.io/qt-5/qicon.html#State-enum.
+
+    Parameters
+    ----------
+    on: str
+        file name to the on-state image
+    off: str
+        file name to the on-state image
+
+    Returns
+    -------
+    QIcon
+        The icon that displays the contents of the SVG files.
+
+    """
+
+    icon = QIcon()
+
+    icon.addFile(path(on), mode=QIcon.Normal, state=QIcon.On)
+    icon.addFile(path(off), mode=QIcon.Normal, state=QIcon.Off)
+    icon.addFile(path(off), mode=QIcon.Disabled, state=QIcon.Off)
+    icon.addFile(path(off), mode=QIcon.Disabled, state=QIcon.Off)
+
+    return icon
+
+
 def load_icon(normal: str, disabled: str = None, active=None, selected=None) -> QIcon:
     """
     Add the contents of Scalable Vector Graphics (SVG) files provided for associated icon modes,

--- a/tests/gui/test_init.py
+++ b/tests/gui/test_init.py
@@ -1,0 +1,130 @@
+"""
+Tests for the gui helper functions in __init__.py
+"""
+
+from PyQt5.QtCore import QSize
+from PyQt5.QtWidgets import QApplication
+
+from securedrop_client.gui import SvgPushButton, SvgLabel, SvgToggleButton
+
+app = QApplication([])
+
+
+def test_SvgToggleButton_init(mocker):
+    """
+    Ensure SvgToggleButton is checkable, which allows it to be a toggle button and that the expected
+    methods are called correctly to set the icon and size.
+    """
+    svg_size = QSize(1, 1)
+    icon = mocker.MagicMock()
+    load_toggle_icon_fn = mocker.patch('securedrop_client.gui.load_toggle_icon', return_value=icon)
+    setIcon_fn = mocker.patch('securedrop_client.gui.SvgToggleButton.setIcon')
+    setIconSize_fn = mocker.patch('securedrop_client.gui.SvgToggleButton.setIconSize')
+
+    stb = SvgToggleButton(on='mock_on', off='mock_off', svg_size=svg_size)
+
+    assert stb.isCheckable() is True
+    load_toggle_icon_fn.assert_called_once_with(on='mock_on', off='mock_off')
+    setIcon_fn.assert_called_once_with(icon)
+    setIconSize_fn.assert_called_once_with(svg_size)
+
+
+def test_SvgToggleButton_enable(mocker):
+    """
+    Ensure enable.
+    """
+    stb = SvgToggleButton(on='mock_on', off='mock_off')
+    stb.enable()
+    assert stb.isEnabled() is True
+
+
+def test_SvgToggleButton_disable(mocker):
+    """
+    Ensure disable.
+    """
+    stb = SvgToggleButton(on='mock_on', off='mock_off')
+    stb.disable()
+    assert stb.isEnabled() is False
+
+
+def test_SvgToggleButton_toggle(mocker):
+    """
+    Make sure we're not calling this a toggle button for no reason.
+    """
+    stb = SvgToggleButton(on='mock_on', off='mock_off')
+    stb.toggle()
+    assert stb.isChecked() is True
+    stb.toggle()
+    assert stb.isChecked() is False
+    stb.toggle()
+    assert stb.isChecked() is True
+
+
+def test_SvgToggleButton_set_icon(mocker):
+    """
+    Ensure set_icon loads and sets the icon.
+    """
+    setIcon_fn = mocker.patch('securedrop_client.gui.SvgToggleButton.setIcon')
+    icon = mocker.MagicMock()
+    load_toggle_icon_fn = mocker.patch('securedrop_client.gui.load_toggle_icon', return_value=icon)
+    stb = SvgToggleButton(on='mock_on', off='mock_off')
+
+    stb.set_icon(on='mock_on', off='mock_off')
+
+    load_toggle_icon_fn.assert_called_with(on='mock_on', off='mock_off')
+    setIcon_fn.assert_called_with(icon)
+    assert stb.icon == icon
+
+
+def test_SvgPushButton_init(mocker):
+    """
+    Ensure SvgPushButton calls the expected methods correctly to set the icon and size.
+    """
+    svg_size = QSize(1, 1)
+    icon = mocker.MagicMock()
+    load_icon_fn = mocker.patch('securedrop_client.gui.load_icon', return_value=icon)
+    setIcon_fn = mocker.patch('securedrop_client.gui.SvgPushButton.setIcon')
+    setIconSize_fn = mocker.patch('securedrop_client.gui.SvgPushButton.setIconSize')
+
+    spb = SvgPushButton(
+        normal='mock1', disabled='mock2', active='mock3', selected='mock4', svg_size=svg_size)
+
+    assert spb.isCheckable() is False
+    load_icon_fn.assert_called_once_with(
+        normal='mock1', disabled='mock2', active='mock3', selected='mock4')
+    setIcon_fn.assert_called_once_with(icon)
+    setIconSize_fn.assert_called_once_with(svg_size)
+
+
+def test_SvgPushButton_enable(mocker):
+    """
+    Ensure enable.
+    """
+    spb = SvgPushButton(normal='mock1', disabled='mock2', active='mock3', selected='mock4')
+    spb.enable()
+    assert spb.isEnabled() is True
+
+
+def test_SvgPushButton_disable(mocker):
+    """
+    Ensure disable.
+    """
+    spb = SvgPushButton(normal='mock1', disabled='mock2', active='mock3', selected='mock4')
+    spb.disable()
+    assert spb.isEnabled() is False
+
+
+def test_SvgLabel_init(mocker):
+    """
+    Ensure SvgLabel calls the expected methods correctly to set the icon and size.
+    """
+    svg_size = QSize(1, 1)
+    svg = mocker.MagicMock()
+    load_svg_fn = mocker.patch('securedrop_client.gui.load_svg', return_value=svg)
+    mocker.patch('securedrop_client.gui.QHBoxLayout.addWidget')
+
+    sl = SvgLabel(filename='mock', svg_size=svg_size)
+
+    load_svg_fn.assert_called_once_with('mock')
+    sl.svg.setFixedSize.assert_called_once_with(svg_size)
+    assert sl.svg == svg

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -578,6 +578,7 @@ def test_StarToggleButton_init_source_starred(mocker):
 def test_StarToggleButton_init_source_unstarred(mocker):
     source = mocker.MagicMock()
     source.is_starred = False
+    source.setChecked = mocker.MagicMock()
 
     stb = StarToggleButton(source)
 
@@ -600,81 +601,98 @@ def test_StarToggleButton_setup(mocker):
     on_authentication_changed_fn.assert_called_with('mock')
 
 
-def test_StarToggleButton_on_authentication_changed_authenticated(mocker):
+def test_StarToggleButton_on_authentication_changed_while_authenticated_and_checked(mocker):
     """
-    If on_authentication_changed is set up correctly, then calling setup and toggle should result in
-    two calls to update_star when the user is authenticated.
+    If on_authentication_changed is set up correctly, then calling toggle on a checked button should
+    result in the button being unchecked.
     """
     source = mocker.MagicMock()
     stb = StarToggleButton(source=source)
-    controller = mocker.MagicMock()
-    stb.controller = controller
-    stb.enable = mocker.MagicMock()
-
+    stb.setChecked(True)
+    stb.on_toggle = mocker.MagicMock()
     stb.on_authentication_changed(authenticated=True)
+
     stb.toggle()
 
-    assert stb.enable.called is True
-    stb.controller.update_star.assert_called_once_with(source)
+    assert stb.on_toggle.called is True
+    assert stb.isChecked() is False
 
 
-def test_StarToggleButton_on_authentication_changed_offline_mode(mocker):
+def test_StarToggleButton_on_authentication_changed_while_authenticated_and_not_checked(mocker):
+    """
+    If on_authentication_changed is set up correctly, then calling toggle on an unchecked button
+    should result in the button being unchecked.
+    """
     source = mocker.MagicMock()
     stb = StarToggleButton(source=source)
-    controller = mocker.MagicMock()
-    stb.controller = controller
-    stb.disable = mocker.MagicMock()
+    stb.setChecked(False)
+    stb.on_toggle = mocker.MagicMock()
+    stb.on_authentication_changed(authenticated=True)
+
+    stb.toggle()
+
+    assert stb.on_toggle.called is True
+    assert stb.isChecked() is True
+
+
+def test_StarToggleButton_on_authentication_changed_while_offline_mode(mocker):
+    """
+    Ensure on_authentication_changed is set up correctly for offline mode.
+    """
+    source = mocker.MagicMock()
+    stb = StarToggleButton(source=source)
+    stb.on_toggle_offline = mocker.MagicMock()
+    stb.on_toggle = mocker.MagicMock()
 
     stb.on_authentication_changed(authenticated=False)
     stb.click()
 
-    assert stb.disable.called is True
-    stb.controller.on_action_requiring_login.assert_called_once_with()
+    assert stb.on_toggle_offline.called is True
+    assert stb.on_toggle.called is False
 
 
-def test_StarToggleButton_enable(mocker):
+def test_StarToggleButton_on_toggle(mocker):
     """
     Ensure correct star icon images are loaded for the enabled button.
     """
     source = mocker.MagicMock()
-    source.is_starred = True
-
     stb = StarToggleButton(source)
-    stb.set_icon = mocker.MagicMock()
+    stb.controller = mocker.MagicMock()
 
-    stb.enable()
+    stb.on_toggle()
 
-    stb.set_icon.assert_called_once_with(on='star_on.svg', off='star_off.svg')
+    stb.controller.update_star.assert_called_once_with(source)
+    assert stb.isCheckable() is True
 
 
-def test_StarToggleButton_disable_for_starred_source(mocker):
+def test_StarToggleButton_on_toggle_offline(mocker):
+    """
+    Ensure toggle is disabled when offline.
+    """
+    source = mocker.MagicMock()
+    stb = StarToggleButton(source)
+    stb.controller = mocker.MagicMock()
+
+    stb.on_toggle_offline()
+
+    stb.controller.on_action_requiring_login.assert_called_once_with()
+    assert stb.isCheckable() is False
+
+
+def test_StarToggleButton_on_toggle_offline_when_checked(mocker):
     """
     Ensure correct star icon images are loaded for the disabled button.
     """
     source = mocker.MagicMock()
     source.is_starred = True
-
     stb = StarToggleButton(source)
-    stb.set_icon = mocker.MagicMock()
+    stb.controller = mocker.MagicMock()
+    set_icon_fn = mocker.patch('securedrop_client.gui.SvgToggleButton.set_icon')
+    stb.on_toggle_offline()
 
-    stb.disable()
-
-    stb.set_icon.assert_called_once_with(on='star_on.svg', off='star_on.svg')
-
-
-def test_StarToggleButton_disable_for_unstarred_source(mocker):
-    """
-    Ensure correct star icon images are loaded for the disabled button.
-    """
-    source = mocker.MagicMock()
-    source.is_starred = False
-
-    stb = StarToggleButton(source)
-    stb.set_icon = mocker.MagicMock()
-
-    stb.disable()
-
-    stb.set_icon.assert_called_once_with(on='star_off.svg', off='star_off.svg')
+    stb.controller.on_action_requiring_login.assert_called_once_with()
+    assert stb.isCheckable() is False
+    set_icon_fn.assert_called_with(on='star_on.svg', off='star_on.svg')
 
 
 def test_LoginDialog_setup(mocker):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -566,7 +566,7 @@ def test_SourceWidget_delete_source_when_user_chooses_cancel(mocker, session, so
 
 
 def test_StarToggleButton_init_source_starred(mocker):
-    source = mocker.MagicMock()
+    source = factory.Source()
     source.is_starred = True
 
     stb = StarToggleButton(source)
@@ -576,9 +576,8 @@ def test_StarToggleButton_init_source_starred(mocker):
 
 
 def test_StarToggleButton_init_source_unstarred(mocker):
-    source = mocker.MagicMock()
+    source = factory.Source()
     source.is_starred = False
-    source.setChecked = mocker.MagicMock()
 
     stb = StarToggleButton(source)
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -11,7 +11,7 @@ from securedrop_client.gui.widgets import MainView, SourceList, SourceWidget, Lo
     SpeechBubble, ConversationWidget, MessageWidget, ReplyWidget, FileWidget, ConversationView, \
     DeleteSourceMessageBox, DeleteSourceAction, SourceMenu, TopPane, LeftPane, RefreshButton, \
     ErrorStatusBar, ActivityStatusBar, UserProfile, UserButton, UserMenu, LoginButton, \
-    ReplyBoxWidget, SourceConversationWrapper
+    ReplyBoxWidget, SourceConversationWrapper, StarToggleButton
 
 
 app = QApplication([])
@@ -481,11 +481,13 @@ def test_SourceWidget_setup(mocker):
     """
     mock_controller = mocker.MagicMock()
     mock_source = mocker.MagicMock()
-
     sw = SourceWidget(None, mock_source)
+    sw.star = mocker.MagicMock()
+
     sw.setup(mock_controller)
 
     assert sw.controller == mock_controller
+    sw.star.setup.assert_called_once_with(mock_controller)
 
 
 def test_SourceWidget_html_init(mocker):
@@ -506,44 +508,6 @@ def test_SourceWidget_html_init(mocker):
     sw.name.setText.assert_called_once_with('<strong>foo &lt;b&gt;bar&lt;/b&gt; baz</strong>')
 
 
-def test_SourceWidget_update_starred(mocker):
-    """
-    Ensure the widget displays the expected details from the source.
-    """
-    mock_source = mocker.MagicMock()
-    mock_source.journalist_designation = 'foo bar baz'
-    mock_source.is_starred = True
-
-    sw = SourceWidget(None, mock_source)
-    sw.name = mocker.MagicMock()
-    sw.summary_layout = mocker.MagicMock()
-
-    mock_load = mocker.patch('securedrop_client.gui.widgets.load_svg')
-    sw.update()
-
-    mock_load.assert_called_once_with('star_on.svg')
-    sw.name.setText.assert_called_once_with('<strong>foo bar baz</strong>')
-
-
-def test_SourceWidget_update_unstarred(mocker):
-    """
-    Ensure the widget displays the expected details from the source.
-    """
-    mock_source = mocker.MagicMock()
-    mock_source.journalist_designation = 'foo bar baz'
-    mock_source.is_starred = False
-
-    sw = SourceWidget(None, mock_source)
-    sw.name = mocker.MagicMock()
-    sw.summary_layout = mocker.MagicMock()
-
-    mock_load = mocker.patch('securedrop_client.gui.widgets.load_svg')
-    sw.update()
-
-    mock_load.assert_called_once_with('star_off.svg')
-    sw.name.setText.assert_called_once_with('<strong>foo bar baz</strong>')
-
-
 def test_SourceWidget_update_attachment_icon():
     """
     Attachment icon identicates document count
@@ -558,22 +522,6 @@ def test_SourceWidget_update_attachment_icon():
 
     sw.update()
     assert sw.attached.isHidden()
-
-
-def test_SourceWidget_toggle_star(mocker):
-    """
-    The toggle_star method should call self.controller.update_star
-    """
-    mock_controller = mocker.MagicMock()
-    mock_source = mocker.MagicMock()
-    event = mocker.MagicMock()
-
-    sw = SourceWidget(None, mock_source)
-    sw.controller = mock_controller
-    sw.controller.update_star = mocker.MagicMock()
-
-    sw.toggle_star(event)
-    sw.controller.update_star.assert_called_once_with(mock_source)
 
 
 def test_SourceWidget_delete_source(mocker, session, source):
@@ -615,6 +563,118 @@ def test_SourceWidget_delete_source_when_user_chooses_cancel(mocker, session, so
     )
     sw.delete_source(None)
     sw.controller.delete_source.assert_not_called()
+
+
+def test_StarToggleButton_init_source_starred(mocker):
+    source = mocker.MagicMock()
+    source.is_starred = True
+
+    stb = StarToggleButton(source)
+
+    assert stb.source == source
+    assert stb.isChecked() is True
+
+
+def test_StarToggleButton_init_source_unstarred(mocker):
+    source = mocker.MagicMock()
+    source.is_starred = False
+
+    stb = StarToggleButton(source)
+
+    assert stb.source == source
+    assert stb.isChecked() is False
+
+
+def test_StarToggleButton_setup(mocker):
+    star_toggle_button = StarToggleButton(source=mocker.MagicMock())
+    controller = mocker.MagicMock()
+    controller.authentication_state = mocker.MagicMock()
+    controller.is_authenticated = 'mock'
+    on_authentication_changed_fn = mocker.patch.object(
+        StarToggleButton, 'on_authentication_changed')
+
+    star_toggle_button.setup(controller)
+
+    assert star_toggle_button.controller == controller
+    controller.authentication_state.connect.assert_called_once_with(on_authentication_changed_fn)
+    on_authentication_changed_fn.assert_called_with('mock')
+
+
+def test_StarToggleButton_on_authentication_changed_authenticated(mocker):
+    """
+    If on_authentication_changed is set up correctly, then calling setup and toggle should result in
+    two calls to update_star when the user is authenticated.
+    """
+    source = mocker.MagicMock()
+    stb = StarToggleButton(source=source)
+    controller = mocker.MagicMock()
+    stb.controller = controller
+    stb.enable = mocker.MagicMock()
+
+    stb.on_authentication_changed(authenticated=True)
+    stb.toggle()
+
+    assert stb.enable.called is True
+    stb.controller.update_star.assert_called_once_with(source)
+
+
+def test_StarToggleButton_on_authentication_changed_offline_mode(mocker):
+    source = mocker.MagicMock()
+    stb = StarToggleButton(source=source)
+    controller = mocker.MagicMock()
+    stb.controller = controller
+    stb.disable = mocker.MagicMock()
+
+    stb.on_authentication_changed(authenticated=False)
+    stb.click()
+
+    assert stb.disable.called is True
+    stb.controller.on_action_requiring_login.assert_called_once_with()
+
+
+def test_StarToggleButton_enable(mocker):
+    """
+    Ensure correct star icon images are loaded for the enabled button.
+    """
+    source = mocker.MagicMock()
+    source.is_starred = True
+
+    stb = StarToggleButton(source)
+    stb.set_icon = mocker.MagicMock()
+
+    stb.enable()
+
+    stb.set_icon.assert_called_once_with(on='star_on.svg', off='star_off.svg')
+
+
+def test_StarToggleButton_disable_for_starred_source(mocker):
+    """
+    Ensure correct star icon images are loaded for the disabled button.
+    """
+    source = mocker.MagicMock()
+    source.is_starred = True
+
+    stb = StarToggleButton(source)
+    stb.set_icon = mocker.MagicMock()
+
+    stb.disable()
+
+    stb.set_icon.assert_called_once_with(on='star_on.svg', off='star_on.svg')
+
+
+def test_StarToggleButton_disable_for_unstarred_source(mocker):
+    """
+    Ensure correct star icon images are loaded for the disabled button.
+    """
+    source = mocker.MagicMock()
+    source.is_starred = False
+
+    stb = StarToggleButton(source)
+    stb.set_icon = mocker.MagicMock()
+
+    stb.disable()
+
+    stb.set_icon.assert_called_once_with(on='star_off.svg', off='star_off.svg')
 
 
 def test_LoginDialog_setup(mocker):


### PR DESCRIPTION
## Description

Move logic for toggling stars from `SourceWidget` to `StarToggleButton`. This change should not be noticeable when running the client. The behavior is the same. However, this change made it very easy to add a star toggle to the conversation view and for stars to update state when either button is pressed.

## Test

1. Toggle star when in offline mode.
2. Toggle star when authenticated.

Make sure star toggling behavior hasn't changed.