### PR TITLE
Restructure the layout of SourceWidget

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -32,7 +32,7 @@ from PyQt5.QtWidgets import QListWidget, QLabel, QWidget, QListWidgetItem, QHBox
 from securedrop_client.db import Source, Message, File, Reply
 from securedrop_client.gui import SvgLabel, SvgPushButton, SvgToggleButton
 from securedrop_client.logic import Controller
-from securedrop_client.resources import load_svg, load_icon, load_image
+from securedrop_client.resources import load_icon, load_image
 from securedrop_client.utils import humanize_filesize
 
 logger = logging.getLogger(__name__)
@@ -588,7 +588,6 @@ class MainView(QWidget):
     def __init__(self, parent):
         super().__init__(parent)
 
-        # Set styles
         self.setStyleSheet(self.CSS)
 
         self.layout = QHBoxLayout(self)
@@ -596,15 +595,7 @@ class MainView(QWidget):
         self.layout.setSpacing(0)
         self.setLayout(self.layout)
 
-        left_column = QWidget(parent=self)
-        left_layout = QVBoxLayout()
-        left_layout.setContentsMargins(0, 0, 0, 0)
-        left_column.setLayout(left_layout)
-
-        self.source_list = SourceList(left_column)
-        left_layout.addWidget(self.source_list)
-
-        self.layout.addWidget(left_column, 4)
+        self.source_list = SourceList()
 
         self.view_layout = QVBoxLayout()
         self.view_layout.setContentsMargins(0, 0, 0, 0)
@@ -612,6 +603,7 @@ class MainView(QWidget):
         self.view_holder.setObjectName('view_holder')  # Set css id
         self.view_holder.setLayout(self.view_layout)
 
+        self.layout.addWidget(self.source_list, 4)
         self.layout.addWidget(self.view_holder, 6)
 
     def setup(self, controller):
@@ -646,24 +638,34 @@ class SourceList(QListWidget):
     """
 
     CSS = '''
+    QListWidget {
+        show-decoration-selected: 0;
+    }
     QListWidget::item:selected {
         background: #efeef7;
     }
     '''
 
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self):
+        super().__init__()
 
         # Set css id
-        self.setObjectName('source_list')
+        self.setObjectName('sourcelist')
 
         # Set styles
         self.setStyleSheet(self.CSS)
+        self.setMinimumWidth(445)
+        self.setMaximumWidth(565)
+
+        # Set layout
+        layout = QVBoxLayout(self)
+        self.setLayout(layout)
+
+        # Remove margins
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
 
     def setup(self, controller):
-        """
-        Pass through the controller object to this widget.
-        """
         self.controller = controller
 
     def update(self, sources: List[Source]):
@@ -675,7 +677,7 @@ class SourceList(QListWidget):
 
         new_current_maybe = None
         for source in sources:
-            new_source = SourceWidget(self, source)
+            new_source = SourceWidget(source)
             new_source.setup(self.controller)
 
             list_item = QListWidgetItem(self)
@@ -691,54 +693,6 @@ class SourceList(QListWidget):
             self.setCurrentItem(new_current_maybe)
 
 
-class DeleteSourceMessageBox:
-    """Use this to display operation details and confirm user choice."""
-
-    def __init__(self, parent, source, controller):
-        self.parent = parent
-        self.source = source
-        self.controller = controller
-
-    def launch(self):
-        """It will launch the message box.
-
-        The Message box will warns the user regarding the severity of the
-        operation. It will confirm the desire to delete the source. On positive
-        answer, it will delete the record of source both from SecureDrop server
-        and local state.
-        """
-        message = self._construct_message(self.source)
-        reply = QMessageBox.question(
-            self.parent, "", _(message), QMessageBox.Cancel | QMessageBox.Yes, QMessageBox.Cancel)
-
-        if reply == QMessageBox.Yes:
-            logger.debug("Deleting source %s" % (self.source.uuid,))
-            self.controller.delete_source(self.source)
-
-    def _construct_message(self, source: Source) -> str:
-        files = 0
-        messages = 0
-        replies = 0
-        for submission in source.collection:
-            if isinstance(submission, Message):
-                messages += 1
-            if isinstance(submission, Reply):
-                replies += 1
-            elif isinstance(submission, File):
-                files += 1
-
-        message = (
-            "<big>Deleting the Source account for",
-            "<b>{}</b> will also".format(source.journalist_designation,),
-            "delete {} files, {} replies, and {} messages.</big>".format(files, replies, messages),
-            "<br>",
-            "<small>This Source will no longer be able to correspond",
-            "through the log-in tied to this account.</small>",
-        )
-        message = ' '.join(message)
-        return message
-
-
 class SourceWidget(QWidget):
     """
     Used to display summary information about a source in the list view.
@@ -748,13 +702,24 @@ class SourceWidget(QWidget):
     QWidget#color_bar {
         background-color: #9211ff;
     }
+    QLabel#source_name {
+        font-family: Open Sans;
+        font-size: 16px;
+        font-weight: bold;
+        color: #000;
+    }
+    QLabel#timestamp {
+        font-family: Open Sans;
+        font-size: 12px;
+        color: #000;
+    }
     '''
 
-    def __init__(self, parent: QWidget, source: Source):
-        """
-        Set up the child widgets.
-        """
-        super().__init__(parent)
+    def __init__(self, source: Source):
+        super().__init__()
+
+        # Store source
+        self.source = source
 
         # Set css id
         self.setObjectName('source_widget')
@@ -762,38 +727,69 @@ class SourceWidget(QWidget):
         # Set styles
         self.setStyleSheet(self.CSS)
 
-        self.source = source
-
-        self.star = StarToggleButton(self.source)
-
-        self.name = QLabel()
-        self.name.setFont(QFont("Open Sans", 16))
-        self.updated = QLabel()
-        self.updated.setFont(QFont("Open Sans", 10))
-
-        layout = QVBoxLayout()
+        # Set layout
+        layout = QVBoxLayout(self)
         self.setLayout(layout)
 
-        self.summary = QWidget(self)
+        # Remove margins and spacing
+        layout.setContentsMargins(10, 10, 10, 10)
+        layout.setSpacing(0)
+
+        # Set up gutter
+        self.gutter = QWidget()
+        self.gutter.setObjectName('gutter')
+        self.gutter.setFixedWidth(30)
+        gutter_layout = QVBoxLayout(self.gutter)
+        gutter_layout.setContentsMargins(0, 0, 0, 0)
+        gutter_layout.setSpacing(0)
+        self.star = StarToggleButton(self.source)
+        spacer = QWidget()
+        gutter_layout.addWidget(self.star)
+        gutter_layout.addWidget(spacer)
+
+        # Set up summary
+        self.summary = QWidget()
         self.summary.setObjectName('summary')
-        self.summary_layout = QHBoxLayout()
-        self.summary.setLayout(self.summary_layout)
+        summary_layout = QVBoxLayout(self.summary)
+        summary_layout.setContentsMargins(0, 0, 0, 0)
+        summary_layout.setSpacing(0)
+        self.name = QLabel()
+        self.name.setObjectName('source_name')
+        self.preview = QLabel('')
+        self.preview.setObjectName('preview')
+        self.preview.setWordWrap(True)
+        summary_layout.addWidget(self.name)
+        summary_layout.addWidget(self.preview)
 
-        self.attached = load_svg('paperclip.svg')
-        self.attached.setMaximumSize(16, 16)
+        # Set up metadata
+        self.metadata = QWidget()
+        self.metadata.setObjectName('metadata')
+        metadata_layout = QVBoxLayout(self.metadata)
+        metadata_layout.setContentsMargins(0, 0, 0, 0)
+        metadata_layout.setSpacing(0)
+        self.attached = SvgLabel('paperclip.svg', QSize(16, 16))
+        self.attached.setObjectName('paperclip')
+        self.attached.setFixedSize(QSize(20, 20))
+        spacer = QWidget()
+        metadata_layout.addWidget(self.attached, 1, Qt.AlignRight)
+        metadata_layout.addWidget(spacer, 1)
 
-        self.summary_layout.addWidget(self.name)
-        self.summary_layout.addWidget(self.attached)
+        # Set up source row
+        self.source_row = QWidget()
+        source_row_layout = QHBoxLayout(self.source_row)
+        source_row_layout.setContentsMargins(0, 0, 0, 0)
+        source_row_layout.setSpacing(0)
+        source_row_layout.addWidget(self.gutter, 1)
+        source_row_layout.addWidget(self.summary, 1)
+        source_row_layout.addWidget(self.metadata, 1)
 
-        layout.addWidget(self.summary)
-        layout.addWidget(self.updated)
+        # Set up timestamp
+        self.updated = QLabel()
+        self.updated.setObjectName('timestamp')
 
-        self.delete = load_svg('cross.svg')
-        self.delete.setMaximumSize(16, 16)
-        self.delete.mouseReleaseEvent = self.delete_source
-
-        self.summary_layout.addWidget(self.delete)
-        self.summary_layout.addWidget(self.star)
+        # Add widgets to main layout
+        layout.addWidget(self.source_row, 1)
+        layout.addWidget(self.updated, 1, Qt.AlignRight)
 
         self.update()
 
@@ -880,6 +876,54 @@ class StarToggleButton(SvgToggleButton):
         self.setCheckable(False)
         if self.source.is_starred:
             self.set_icon(on='star_on.svg', off='star_on.svg')
+
+
+class DeleteSourceMessageBox:
+    """Use this to display operation details and confirm user choice."""
+
+    def __init__(self, parent, source, controller):
+        self.parent = parent
+        self.source = source
+        self.controller = controller
+
+    def launch(self):
+        """It will launch the message box.
+
+        The Message box will warns the user regarding the severity of the
+        operation. It will confirm the desire to delete the source. On positive
+        answer, it will delete the record of source both from SecureDrop server
+        and local state.
+        """
+        message = self._construct_message(self.source)
+        reply = QMessageBox.question(
+            self.parent, "", _(message), QMessageBox.Cancel | QMessageBox.Yes, QMessageBox.Cancel)
+
+        if reply == QMessageBox.Yes:
+            logger.debug("Deleting source %s" % (self.source.uuid,))
+            self.controller.delete_source(self.source)
+
+    def _construct_message(self, source: Source) -> str:
+        files = 0
+        messages = 0
+        replies = 0
+        for submission in source.collection:
+            if isinstance(submission, Message):
+                messages += 1
+            if isinstance(submission, Reply):
+                replies += 1
+            elif isinstance(submission, File):
+                files += 1
+
+        message = (
+            "<big>Deleting the Source account for",
+            "<b>{}</b> will also".format(source.journalist_designation,),
+            "delete {} files, {} replies, and {} messages.</big>".format(files, replies, messages),
+            "<br>",
+            "<small>This Source will no longer be able to correspond",
+            "through the log-in tied to this account.</small>",
+        )
+        message = ' '.join(message)
+        return message
 
 
 class LoginDialog(QDialog):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -427,7 +427,7 @@ def test_SourceList_update(mocker):
     Check the items in the source list are cleared and a new SourceWidget for
     each passed-in source is created along with an associated QListWidgetItem.
     """
-    sl = SourceList(None)
+    sl = SourceList()
 
     sl.clear = mocker.MagicMock()
     sl.addItem = mocker.MagicMock()
@@ -453,7 +453,7 @@ def test_SourceList_maintains_selection(mocker):
     """
     Maintains the selected item if present in new list
     """
-    sl = SourceList(None)
+    sl = SourceList()
     sources = [factory.Source(), factory.Source()]
     sl.setup(mocker.MagicMock())
     sl.update(sources)
@@ -471,7 +471,7 @@ def test_SourceWidget_init(mocker):
     """
     mock_source = mocker.MagicMock()
     mock_source.journalist_designation = 'foo bar baz'
-    sw = SourceWidget(None, mock_source)
+    sw = SourceWidget(mock_source)
     assert sw.source == mock_source
 
 
@@ -481,7 +481,7 @@ def test_SourceWidget_setup(mocker):
     """
     mock_controller = mocker.MagicMock()
     mock_source = mocker.MagicMock()
-    sw = SourceWidget(None, mock_source)
+    sw = SourceWidget(mock_source)
     sw.star = mocker.MagicMock()
 
     sw.setup(mock_controller)
@@ -498,11 +498,11 @@ def test_SourceWidget_html_init(mocker):
     mock_source = mocker.MagicMock()
     mock_source.journalist_designation = 'foo <b>bar</b> baz'
 
-    sw = SourceWidget(None, mock_source)
+    sw = SourceWidget(mock_source)
     sw.name = mocker.MagicMock()
     sw.summary_layout = mocker.MagicMock()
 
-    mocker.patch('securedrop_client.gui.widgets.load_svg')
+    mocker.patch('securedrop_client.gui.SvgLabel')
     sw.update()
 
     sw.name.setText.assert_called_once_with('<strong>foo &lt;b&gt;bar&lt;/b&gt; baz</strong>')
@@ -513,7 +513,7 @@ def test_SourceWidget_update_attachment_icon():
     Attachment icon identicates document count
     """
     source = factory.Source(document_count=1)
-    sw = SourceWidget(None, source)
+    sw = SourceWidget(source)
 
     sw.update()
     assert not sw.attached.isHidden()
@@ -530,7 +530,7 @@ def test_SourceWidget_delete_source(mocker, session, source):
     mock_delete_source_message = mocker.MagicMock(
         return_value=mock_delete_source_message_box_object)
 
-    sw = SourceWidget(None, source['source'])
+    sw = SourceWidget(source['source'])
     sw.controller = mock_controller
 
     mocker.patch(
@@ -554,7 +554,7 @@ def test_SourceWidget_delete_source_when_user_chooses_cancel(mocker, session, so
     mock_message_box_question.return_value = QMessageBox.Cancel
 
     mock_controller = mocker.MagicMock()
-    sw = SourceWidget(None, source)
+    sw = SourceWidget(source)
     sw.controller = mock_controller
 
     mocker.patch(
@@ -1585,7 +1585,7 @@ def test_DeleteSource_from_source_widget_when_user_is_loggedout(mocker):
         'securedrop_client.gui.widgets.DeleteSourceMessageBox',
         mock_delete_source_message_box
     ):
-        source_widget = SourceWidget(None, mock_source)
+        source_widget = SourceWidget(mock_source)
         source_widget.setup(mock_controller)
         source_widget.delete_source(mock_event)
         mock_delete_source_message_box_obj.launch.assert_not_called()


### PR DESCRIPTION
## Description

Resolves #280

This restructures `SourceWidget` to show timestamp, star, delete, and attachment icons in preparation for:

* Delete icon overlay Attachment icon: #300
* Add message preview: #135
* And to look similar to: 
![zeplin-styleguide](https://user-images.githubusercontent.com/4522213/56702357-6a015a80-66b8-11e9-8e8d-758c39677673.png)

We have a separate issue for styling and polishing, which will fix off-by-one pixels issues, etc.

## Summary of Changes

* There is now a `timestamp` row. The change here is a proposal for the team, leaning on @ninavizz and @eloquence for feedback. I noticed when testing the changes that our "x days ago" humanized timestamp is cut off by the message preview. I suggest that, for now, we lower the timestamp so that we won't have this problem, and create a new Issue if we want a different solution. I could also place the timestamp somewhere else in this PR if we find another location that makes sense. See images:

Trying to match Zeplin:
![sourcelist_higlight](https://user-images.githubusercontent.com/4522213/56702625-e183b980-66b9-11e9-8887-a8be74111e48.png)

My proposal until further discussion about how to handle the timestamp getting cut off:
![sourcelist-proposal](https://user-images.githubusercontent.com/4522213/56702641-f5c7b680-66b9-11e9-9eeb-3798c817e077.png)

* Note: the images above are showing preview sample text that was not included in this PR. 
* There is now a gutter section that shows the star toggle button.
* There is now a metadata section that shows the attachment icon which will be replaced by the delete icon when the source is selected in a follow-up PR for #300.
* Instead of placing the delete icon in a random location, I decided to remove it until #300 is resolved. I can add it back if we want. I just don't know where to add it since it's spec'd out as an overlay.
* There is now a fixed preview section that is empty since I need to implement messages previews in a follow-up PR for #135. I noticed in Zeplin that the source list items are all the same height, which I need to talk to @ninavizz about to make sure my assumption that a blank message will not be resized to be smaller than items with messages.

## Test

1. Create messages with attachments and see that icons show up in the metadata section.
2. Make sure you can see the star in the gutter section.
3. Make sure each source item is the same height. 
4. Resize window a bunch to make sure things don't get cut off and look right.

## Known issues

* https://github.com/freedomofpress/securedrop-client/issues/331