### PR TITLE
Update securedrop-sdk to 0.0.8

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,7 @@ arrow = "*"
 alembic = "*"
 python-dateutil = "*"
 sip = "*"
-securedrop-sdk = ">=0.0.6"
+securedrop-sdk = ">=0.0.8"
 SQLALchemy = "*"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5e4ee285b923438bba06963f2c9688be06be10d29d128584da8e3c18f3c00d5d"
+            "sha256": "23a40e36e845a0e8f46cb8deac7058a926511ca2a7ef2f57558fc5838e17f116"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -101,10 +101,10 @@
         },
         "securedrop-sdk": {
             "hashes": [
-                "sha256:5014b5880429313fc721fff6d4b5c3231019e5f6260cd1a8d0e4216cbe2acf37"
+                "sha256:eca697da2520b568a4600b11c3ab818f5855e0ce13f88495d756a894f142f2a1"
             ],
             "index": "pypi",
-            "version": "==0.0.6"
+            "version": "==0.0.8"
         },
         "six": {
             "hashes": [

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -417,7 +417,7 @@ class Controller(QObject):
         Return a boolean indication that the connection to the API is
         authenticated.
         """
-        return bool(self.api and self.api.token['token'])
+        return bool(self.api and self.api.token is not None)
 
     def sync_api(self):
         """
@@ -727,7 +727,7 @@ class Controller(QObject):
             reply_db_object = db.Reply(
                 uuid=result.uuid,
                 source_id=source.id,
-                journalist_id=self.api.token['journalist_uuid'],
+                journalist_id=self.api.token_journalist_uuid,
                 filename=result.filename,
             )
             self.session.add(reply_db_object)

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -470,7 +470,7 @@ def test_Controller_authenticated_yes(homedir, config, mocker):
     mock_session = mocker.MagicMock()
     co = Controller('http://localhost', mock_gui, mock_session, homedir)
     co.api = mocker.MagicMock()
-    co.api.token = {'token': 'foo'}
+    co.api.token = 'foo'
     assert co.authenticated() is True
 
 
@@ -483,7 +483,7 @@ def test_Controller_authenticated_no(homedir, config, mocker):
     mock_session = mocker.MagicMock()
     co = Controller('http://localhost', mock_gui, mock_session, homedir)
     co.api = mocker.MagicMock()
-    co.api.token = {'token': ''}
+    co.api.token = None
     assert co.authenticated() is False
 
 
@@ -1304,7 +1304,7 @@ def test_Controller_on_reply_complete_success(homedir, mocker):
     co = Controller('http://localhost', mock_gui, mock_session, homedir)
     co.api = mocker.Mock()
     journalist_uuid = 'abc123'
-    co.api.token = {'journalist_uuid': journalist_uuid}
+    co.api.token_journalist_uuid = journalist_uuid
     mock_reply_succeeded = mocker.patch.object(co, 'reply_succeeded')
     mock_reply_failed = mocker.patch.object(co, 'reply_failed')
 
@@ -1331,7 +1331,7 @@ def test_Controller_on_reply_complete_failure(homedir, mocker):
     co = Controller('http://localhost', mock_gui, mock_session, homedir)
     co.api = mocker.Mock()
     journalist_uuid = 'abc123'
-    co.api.token = {'journalist_uuid': journalist_uuid}
+    co.api.token_journalist_uuid = journalist_uuid
     mock_reply_succeeded = mocker.patch.object(co, 'reply_succeeded')
     mock_reply_failed = mocker.patch.object(co, 'reply_failed')
 
@@ -1353,7 +1353,7 @@ def test_Controller_on_reply_timeout(homedir, mocker):
     co = Controller('http://localhost', mock_gui, mock_session, homedir)
     co.api = mocker.Mock()
     journalist_uuid = 'abc123'
-    co.api.token = {'journalist_uuid': journalist_uuid}
+    co.api.token_journalist_uuid = journalist_uuid
     mock_reply_succeeded = mocker.patch.object(co, 'reply_succeeded')
     mock_reply_failed = mocker.patch.object(co, 'reply_failed')
 


### PR DESCRIPTION
The SDK update means logic.APIController.api.token is now a str, not a dict, and the journalist UUID is stored separately in logic.APIController.token.token_journalist_uuid.

Tests/mocks updated accordingly.

Fixes #292.