### PR TITLE
[WIP] Show preview of last activity in the source list

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -762,6 +762,13 @@ class SourceWidget(QWidget):
         # Store source
         self.source = source
 
+        # Get preview text
+        last_activity = source.collection[-1]
+        if isinstance(last_activity, File):
+            self.preview_text = last_activity.filename and last_activity.filename
+        else:
+            self.preview_text = last_activity.content and last_activity.content[0:100]
+
         # Set css id
         self.setObjectName('source_widget')
 
@@ -795,7 +802,7 @@ class SourceWidget(QWidget):
         summary_layout.setSpacing(0)
         self.name = QLabel()
         self.name.setObjectName('source_name')
-        self.preview = QLabel()
+        self.preview = QLabel(self.preview_text)
         self.preview.setObjectName('preview')
         self.preview.setFixedSize(QSize(365, 60))
         self.preview.setWordWrap(True)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -763,7 +763,10 @@ class SourceWidget(QWidget):
 
         # Connect controller sync signal in order to update preview text
         self.controller = controller
-        self.controller.sync_events.connect(self.on_synced)
+        # self.controller.sync_events.connect(self.on_synced)
+        self.controller.reply_succeeded.connect(self.on_synced)
+        self.controller.message_ready.connect(self.on_synced)
+        self.controller.file_ready.connect(self.on_synced)
 
         # Set css id
         self.setObjectName('source_widget')
@@ -851,12 +854,14 @@ class SourceWidget(QWidget):
         """
         Get preview text from last activity and display it in the preview section.
         """
-        if (data == 'synced'):
+        self.controller.session.refresh(self.source)
+        if (self.source.collection[-1].uuid == data):
             last_activity = self.source.collection[-1]
             if isinstance(last_activity, File):
                 self.preview.setText('— file only —')
             else:
                 self.preview.setText(last_activity.content and last_activity.content[0:100])
+        self.update()
 
     def delete_source(self, event):
         if self.controller.api is None:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -667,6 +667,12 @@ class SourceList(QListWidget):
     """
 
     CSS = '''
+    QListView {
+        show-decoration-selected: 0;
+    }
+    QListWidget::item {
+        border-bottom: 1px solid #efeef7;
+    }
     QListWidget::item:selected {
         background: #efeef7;
     }
@@ -686,8 +692,8 @@ class SourceList(QListWidget):
 
         # Set styles
         self.setStyleSheet(self.CSS)
-        self.setMinimumWidth(445)
-        self.setMaximumWidth(565)
+        self.setFixedWidth(445)
+        self.setUniformItemSizes(True)
 
         # Set layout
         layout = QVBoxLayout(self)
@@ -778,9 +784,8 @@ class SourceWidget(QWidget):
         gutter_layout.setContentsMargins(0, 0, 0, 0)
         gutter_layout.setSpacing(0)
         self.star = StarToggleButton(self.source)
-        spacer = QWidget()
         gutter_layout.addWidget(self.star)
-        gutter_layout.addWidget(spacer)
+        gutter_layout.addStretch()
 
         # Set up summary
         self.summary = QWidget()
@@ -790,8 +795,9 @@ class SourceWidget(QWidget):
         summary_layout.setSpacing(0)
         self.name = QLabel()
         self.name.setObjectName('source_name')
-        self.preview = QLabel('')
+        self.preview = QLabel()
         self.preview.setObjectName('preview')
+        self.preview.setFixedSize(QSize(365, 60))
         self.preview.setWordWrap(True)
         summary_layout.addWidget(self.name)
         summary_layout.addWidget(self.preview)
@@ -799,26 +805,25 @@ class SourceWidget(QWidget):
         # Set up metadata
         self.metadata = QWidget()
         self.metadata.setObjectName('metadata')
+        self.metadata.setMaximumWidth(30)
         metadata_layout = QVBoxLayout(self.metadata)
         metadata_layout.setContentsMargins(0, 0, 0, 0)
         metadata_layout.setSpacing(0)
-        self.attached = SvgLabel('paperclip.svg', QSize(16, 16))
+        self.attached = SvgLabel('paperclip.svg', QSize(14, 16))
         self.attached.setObjectName('paperclip')
-        self.attached.setFixedSize(QSize(20, 20))
-        spacer = QWidget()
-        metadata_layout.addWidget(self.attached, 1, Qt.AlignRight)
-        metadata_layout.addWidget(spacer, 1)
+        metadata_layout.addWidget(self.attached)
+        metadata_layout.addStretch()
 
         # Set up source row
         self.source_row = QWidget()
         source_row_layout = QHBoxLayout(self.source_row)
         source_row_layout.setContentsMargins(0, 0, 0, 0)
         source_row_layout.setSpacing(0)
-        source_row_layout.addWidget(self.gutter, 1)
-        source_row_layout.addWidget(self.summary, 1)
-        source_row_layout.addWidget(self.metadata, 1)
+        source_row_layout.addWidget(self.gutter)
+        source_row_layout.addWidget(self.summary)
+        source_row_layout.addWidget(self.metadata)
 
-        # Set up timestamp
+        # Set up timestamp row
         self.updated = QLabel()
         self.updated.setObjectName('timestamp')
 
@@ -1562,6 +1567,7 @@ class ConversationView(QWidget):
         self.conversation_layout.setSpacing(self.CONVERSATION_SPACING)
         self.container.setLayout(self.conversation_layout)
         self.container.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.setMinimumWidth(610)
 
         self.scroll = QScrollArea()
         self.scroll.setObjectName('scroll')


### PR DESCRIPTION
## Description

Resolves https://github.com/freedomofpress/securedrop-client/issues/135

This isn't ready for a code review, but I wanted to show an early preview of what a message preview could look like for the first iteration to get early feedback/ initiate conversation here.

This implementation shows a preview of most recent activity for a source conversation. That activity can be a file, reply from a journalist (might not be the journalist logged in), or message from a source. If it's a file, the filename is displayed (this is mostly what I'd like feedback on -- should this be a place holder or should there be the line `—submitted a file, no message—` as written up in #135?

#### Message not yet available
![message-not-yet-available](https://user-images.githubusercontent.com/4522213/56936231-140f2700-6aab-11e9-8987-c6016c492412.png)

#### File submission without a message
![file-but-no-message](https://user-images.githubusercontent.com/4522213/56936249-386b0380-6aab-11e9-81aa-8ec4b94e78a0.png)

#### Preview text where last activity was a source message
![preview-100-chars](https://user-images.githubusercontent.com/4522213/56936253-415bd500-6aab-11e9-8eed-9d4b5188dc88.png)

#### Preview text where last activity was a reply
![preview-last-activity-is-a-reply](https://user-images.githubusercontent.com/4522213/56936301-897af780-6aab-11e9-8dfa-8d11954e4659.png)
