### PR TITLE
remove unused sdc_home

### DIFF
--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -185,7 +185,7 @@ def start_app(args, qt_args) -> None:
 
     prevent_second_instance(app, args.sdc_home)
 
-    gui = Window(args.sdc_home)
+    gui = Window()
     app.setWindowIcon(load_icon(gui.icon))
     app.setStyleSheet(load_css('sdclient.css'))
 

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -45,7 +45,7 @@ class Window(QMainWindow):
 
     icon = 'icon.png'
 
-    def __init__(self, sdc_home: str):
+    def __init__(self):
         """
         Create the default start state. The window contains a root widget into
         which is placed:
@@ -56,7 +56,6 @@ class Window(QMainWindow):
           place for details / message contents / forms.
         """
         super().__init__()
-        self.sdc_home = sdc_home
         # Cache a dict of source.uuid -> SourceConversationWrapper
         # We do this to not create/destroy widgets constantly (because it causes UI "flicker")
         self.conversations = {}  # type: Dict
@@ -180,11 +179,11 @@ class Window(QMainWindow):
         # Show conversation for the currently-selected source if it hasn't been deleted. If the
         # current source no longer exists, clear the conversation for that source.
         if source_widget and source_exists(self.controller.session, source_widget.source.uuid):
-            self.show_conversation_for(source_widget.source, self.controller.is_authenticated)
+            self.show_conversation_for(source_widget.source)
         else:
             self.main_view.clear_conversation()
 
-    def show_conversation_for(self, source: Source, is_authenticated: bool):
+    def show_conversation_for(self, source: Source):
         """
         Show conversation of messages and replies between a source and
         journalists.
@@ -192,10 +191,7 @@ class Window(QMainWindow):
         conversation_container = self.conversations.get(source.uuid, None)
 
         if conversation_container is None:
-            conversation_container = SourceConversationWrapper(source,
-                                                               self.sdc_home,
-                                                               self.controller,
-                                                               is_authenticated)
+            conversation_container = SourceConversationWrapper(source, self.controller)
             self.conversations[source.uuid] = conversation_container
 
         self.main_view.set_conversation(conversation_container)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1328,16 +1328,9 @@ class ConversationView(QWidget):
     https://github.com/freedomofpress/securedrop-client/issues/273
     """
 
-    def __init__(
-        self,
-        source_db_object: Source,
-        sdc_home: str,
-        controller: Controller,
-        parent=None,
-    ):
-        super().__init__(parent)
+    def __init__(self, source_db_object: Source, controller: Controller):
+        super().__init__()
         self.source = source_db_object
-        self.sdc_home = sdc_home
         self.controller = controller
 
         self.container = QWidget()
@@ -1437,25 +1430,16 @@ class SourceConversationWrapper(QWidget):
     per-source resources.
     """
 
-    def __init__(
-        self,
-        source: Source,
-        sdc_home: str,
-        controller: Controller,
-        is_authenticated: bool,
-        parent=None
-    ) -> None:
-        super().__init__(parent)
+    def __init__(self, source: Source, controller: Controller) -> None:
+        super().__init__()
         self.source = source
         self.controller = controller
-        self.sdc_home = sdc_home
 
         self.layout = QVBoxLayout()
         self.layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(self.layout)
 
-        self.conversation = ConversationView(self.source, self.sdc_home, self.controller,
-                                             parent=self)
+        self.conversation = ConversationView(self.source, self.controller)
         self.source_profile = SourceProfileShortWidget(self.source, self.controller)
         self.reply_box = ReplyBoxWidget(self)
 
@@ -1464,7 +1448,7 @@ class SourceConversationWrapper(QWidget):
         self.layout.addWidget(self.reply_box, 3)
 
         self.controller.authentication_state.connect(self._show_or_hide_replybox)
-        self._show_or_hide_replybox(is_authenticated)
+        self._show_or_hide_replybox(self.controller.is_authenticated)
 
     def send_reply(self, message: str) -> None:
         msg_uuid = str(uuid4())

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -26,10 +26,9 @@ def test_init(mocker):
     mocker.patch('securedrop_client.gui.main.QHBoxLayout', mock_lo)
     mocker.patch('securedrop_client.gui.main.QMainWindow')
 
-    w = Window('mock')
+    w = Window()
 
     assert w.conversations == {}
-    assert w.sdc_home == 'mock'
     mock_li.assert_called_once_with(w.icon)
     mock_lp.assert_called_once_with()
     mock_mv.assert_called_once_with(w.main_pane)
@@ -41,7 +40,7 @@ def test_setup(mocker):
     Ensure the passed in controller is referenced and the various views are
     instantiated as expected.
     """
-    w = Window('mock')
+    w = Window()
     mock_controller = mocker.MagicMock()
     w.show_login = mocker.MagicMock()
     w.top_pane = mocker.MagicMock()
@@ -59,7 +58,7 @@ def test_setup(mocker):
 
 
 def test_show_main_window(mocker):
-    w = Window('mock')
+    w = Window()
     w.autosize_window = mocker.MagicMock()
     w.show = mocker.MagicMock()
     w.set_logged_in_as = mocker.MagicMock()
@@ -72,7 +71,7 @@ def test_show_main_window(mocker):
 
 
 def test_show_main_window_without_username(mocker):
-    w = Window('mock')
+    w = Window()
     w.autosize_window = mocker.MagicMock()
     w.show = mocker.MagicMock()
     w.set_logged_in_as = mocker.MagicMock()
@@ -88,7 +87,7 @@ def test_autosize_window(mocker):
     """
     Check the autosizing fits to the full screen size.
     """
-    w = Window('mock')
+    w = Window()
     w.resize = mocker.MagicMock()
     mock_screen = mocker.MagicMock()
     mock_screen.width.return_value = 1024
@@ -105,7 +104,7 @@ def test_show_login(mocker):
     """
     The login dialog is displayed with a clean state.
     """
-    w = Window('mock')
+    w = Window()
     w.controller = mocker.MagicMock()
     mock_ld = mocker.patch('securedrop_client.gui.main.LoginDialog')
 
@@ -120,7 +119,7 @@ def test_show_login_error(mocker):
     """
     Ensures that an error message is displayed in the login dialog.
     """
-    w = Window('mock')
+    w = Window()
     w.show_login = mocker.MagicMock()
     w.setup(mocker.MagicMock())
     w.login_dialog = mocker.MagicMock()
@@ -134,7 +133,7 @@ def test_hide_login(mocker):
     """
     Ensure the login dialog is closed and hidden.
     """
-    w = Window('mock')
+    w = Window()
     w.show_login = mocker.MagicMock()
     ld = mocker.MagicMock()
     w.login_dialog = ld
@@ -149,7 +148,7 @@ def test_show_sources(mocker):
     """
     Ensure the sources list is passed to the source list widget to be updated.
     """
-    w = Window('mock')
+    w = Window()
     w.main_view = mocker.MagicMock()
     w.show_sources([1, 2, 3])
     w.main_view.source_list.update.assert_called_once_with([1, 2, 3])
@@ -160,7 +159,7 @@ def test_update_error_status_default(mocker):
     Ensure that the error to be shown in the error status bar will be passed to the top pane with a
     default duration of 10 seconds.
     """
-    w = Window('mock')
+    w = Window()
     w.top_pane = mocker.MagicMock()
     w.update_error_status(message='test error message')
     w.top_pane.update_error_status.assert_called_once_with('test error message', 10000)
@@ -171,7 +170,7 @@ def test_update_error_status(mocker):
     Ensure that the error to be shown in the error status bar will be passed to the top pane with
     the duration of seconds provided.
     """
-    w = Window('mock')
+    w = Window()
     w.top_pane = mocker.MagicMock()
     w.update_error_status(message='test error message', duration=123)
     w.top_pane.update_error_status.assert_called_once_with('test error message', 123)
@@ -182,7 +181,7 @@ def test_update_activity_status_default(mocker):
     Ensure that the activity to be shown in the activity status bar will be passed to the top pane
     with a default duration of 0 seconds, i.e. forever.
     """
-    w = Window('mock')
+    w = Window()
     w.top_pane = mocker.MagicMock()
     w.update_activity_status(message='test message')
     w.top_pane.update_activity_status.assert_called_once_with('test message', 0)
@@ -193,7 +192,7 @@ def test_update_activity_status(mocker):
     Ensure that the activity to be shown in the activity status bar will be passed to the top pane
     with the duration of seconds provided.
     """
-    w = Window('mock')
+    w = Window()
     w.top_pane = mocker.MagicMock()
     w.update_activity_status(message='test message', duration=123)
     w.top_pane.update_activity_status.assert_called_once_with('test message', 123)
@@ -203,7 +202,7 @@ def test_clear_error_status(mocker):
     """
     Ensure clear_error_status is called.
     """
-    w = Window('mock')
+    w = Window()
     w.top_pane = mocker.MagicMock()
 
     w.clear_error_status()
@@ -215,7 +214,7 @@ def test_show_sync(mocker):
     """
     If there's a value display the result of its "humanize" method.humanize
     """
-    w = Window('mock')
+    w = Window()
     w.update_activity_status = mocker.MagicMock()
     updated_on = mocker.MagicMock()
     w.show_sync(updated_on)
@@ -227,7 +226,7 @@ def test_show_sync_no_sync(mocker):
     """
     If there's no value to display, default to a "waiting" message.
     """
-    w = Window('mock')
+    w = Window()
     w.update_activity_status = mocker.MagicMock()
     w.show_sync(None)
     w.update_activity_status.assert_called_once_with('Waiting to refresh...', 5000)
@@ -237,7 +236,7 @@ def test_set_logged_in_as(mocker):
     """
     Given a username, the left pane is appropriately called to update.
     """
-    w = Window('mock')
+    w = Window()
     w.left_pane = mocker.MagicMock()
 
     w.set_logged_in_as('test')
@@ -249,7 +248,7 @@ def test_logout(mocker):
     """
     Ensure the left pane updates to the logged out state.
     """
-    w = Window('mock')
+    w = Window()
     w.left_pane = mocker.MagicMock()
     w.top_pane = mocker.MagicMock()
 
@@ -264,22 +263,22 @@ def test_on_source_changed(mocker):
     Ensure the event handler for when a source is changed calls the
     show_conversation_for method with the expected source object.
     """
-    w = Window('mock')
+    w = Window()
     w.main_view = mocker.MagicMock()
     w.show_conversation_for = mocker.MagicMock()
-    w.controller = mocker.MagicMock(is_authenticated=True)
+    w.controller = mocker.MagicMock()
 
     w.on_source_changed()
 
     source = w.main_view.source_list.itemWidget().source
-    w.show_conversation_for.assert_called_once_with(source, True)
+    w.show_conversation_for.assert_called_once_with(source)
 
 
 def test_on_source_changed_when_source_no_longer_exists(mocker):
     """
     Test that conversation for a source is cleared when the source no longer exists.
     """
-    w = Window('mock')
+    w = Window()
     w.main_view = mocker.MagicMock()
     w.controller = mocker.MagicMock(is_authenticated=True)
     mocker.patch('securedrop_client.gui.main.source_exists', return_value=False)
@@ -293,8 +292,9 @@ def test_conversation_for(mocker):
     """
     Test that the source collection is displayed in the conversation view.
     """
-    w = Window('mock')
+    w = Window()
     w.controller = mocker.MagicMock()
+    w.controller.is_authenticated = True
     w.main_view = mocker.MagicMock()
     mock_source = mocker.MagicMock()
     mock_source.journalistic_designation = 'Testy McTestface'
@@ -313,7 +313,7 @@ def test_conversation_for(mocker):
     mocked_add_file = mocker.patch('securedrop_client.gui.widgets.ConversationView.add_file',
                                    new=mocker.Mock())
 
-    w.show_conversation_for(mock_source, is_authenticated=True)
+    w.show_conversation_for(mock_source)
 
     assert mocked_add_message.call_count > 0
     assert mocked_add_reply.call_count > 0
@@ -335,7 +335,8 @@ def test_conversation_for(mocker):
                                    new=mocker.Mock())
 
     # checking with is_authenticated=False just to ensure this doesn't break either
-    w.show_conversation_for(mock_source, is_authenticated=False)
+    w.controller.is_authenticated = False
+    w.show_conversation_for(mock_source)
 
     # because the conversation was cached, we don't call these functions again
     assert mocked_add_message.call_count == 0
@@ -348,8 +349,9 @@ def test_conversation_pending_message(mocker):
     Test that a conversation with a message that's not yet downloaded
     shows the right placeholder text
     """
-    w = Window('mock')
+    w = Window()
     w.controller = mocker.MagicMock()
+    w.controller.is_authenticated = True
     w.main_view = mocker.MagicMock()
     w._add_item_content_or = mocker.MagicMock()
     mock_source = mocker.MagicMock()
@@ -365,7 +367,7 @@ def test_conversation_pending_message(mocker):
     mocker.patch('securedrop_client.gui.main.QHBoxLayout')
     mocker.patch('securedrop_client.gui.main.QWidget')
 
-    w.show_conversation_for(mock_source, True)
+    w.show_conversation_for(mock_source)
 
     assert mocked_add_message.call_count == 1
     assert mocked_add_message.call_args == mocker.call(message)

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1175,7 +1175,7 @@ def test_ConversationView_init(mocker, homedir):
     """
     mocked_source = mocker.MagicMock()
     mocked_controller = mocker.MagicMock()
-    cv = ConversationView(mocked_source, homedir, mocked_controller)
+    cv = ConversationView(mocked_source, mocked_controller)
     assert isinstance(cv.conversation_layout, QVBoxLayout)
 
 
@@ -1188,7 +1188,7 @@ def test_ConversationView_update_conversation_position_follow(mocker, homedir):
     mocked_source = mocker.MagicMock()
     mocked_controller = mocker.MagicMock()
 
-    cv = ConversationView(mocked_source, homedir, mocked_controller)
+    cv = ConversationView(mocked_source, mocked_controller)
 
     cv.scroll.verticalScrollBar().value = mocker.MagicMock(return_value=5900)
     cv.scroll.viewport().height = mocker.MagicMock(return_value=500)
@@ -1207,7 +1207,7 @@ def test_ConversationView_update_conversation_position_stay_fixed(mocker, homedi
     mocked_source = mocker.MagicMock()
     mocked_controller = mocker.MagicMock()
 
-    cv = ConversationView(mocked_source, homedir, mocked_controller)
+    cv = ConversationView(mocked_source, mocked_controller)
 
     cv.scroll.verticalScrollBar().value = mocker.MagicMock(return_value=5500)
     cv.scroll.viewport().height = mocker.MagicMock(return_value=500)
@@ -1218,7 +1218,7 @@ def test_ConversationView_update_conversation_position_stay_fixed(mocker, homedi
     cv.scroll.verticalScrollBar().setValue.assert_not_called()
 
 
-def test_ConversationView_add_message(mocker, homedir, session, source):
+def test_ConversationView_add_message(mocker, session, source):
     """
     Adding a message results in a new MessageWidget added to the layout.
     """
@@ -1234,7 +1234,7 @@ def test_ConversationView_add_message(mocker, homedir, session, source):
     session.add(message)
     session.commit()
 
-    cv = ConversationView(source, homedir, mocked_controller)
+    cv = ConversationView(source, mocked_controller)
     cv.conversation_layout = mocker.MagicMock()
     # this is the MessageWidget that __init__() would return
     mock_msg_widget_res = mocker.MagicMock()
@@ -1251,7 +1251,7 @@ def test_ConversationView_add_message(mocker, homedir, session, source):
     cv.conversation_layout.addWidget.assert_called_once_with(mock_msg_widget_res)
 
 
-def test_ConversationView_add_message_no_content(mocker, homedir, session, source):
+def test_ConversationView_add_message_no_content(mocker, session, source):
     """
     Adding a message results in a new MessageWidget added to the layout. This case specifically
     checks that if a `Message` has `content = None` that a helpful message is displayed as would
@@ -1268,7 +1268,7 @@ def test_ConversationView_add_message_no_content(mocker, homedir, session, sourc
     session.add(message)
     session.commit()
 
-    cv = ConversationView(source, homedir, mocked_controller)
+    cv = ConversationView(source, mocked_controller)
     cv.conversation_layout = mocker.MagicMock()
     # this is the MessageWidget that __init__() would return
     mock_msg_widget_res = mocker.MagicMock()
@@ -1286,7 +1286,7 @@ def test_ConversationView_add_message_no_content(mocker, homedir, session, sourc
     cv.conversation_layout.addWidget.assert_called_once_with(mock_msg_widget_res)
 
 
-def test_ConversationView_add_reply(mocker, homedir, session, source):
+def test_ConversationView_add_reply(mocker, session, source):
     """
     Adding a message results in a new ReplyWidget added to the layout.
     """
@@ -1306,7 +1306,7 @@ def test_ConversationView_add_reply(mocker, homedir, session, source):
     session.add(reply)
     session.commit()
 
-    cv = ConversationView(source, homedir, mocked_controller)
+    cv = ConversationView(source, mocked_controller)
     cv.conversation_layout = mocker.MagicMock()
     # this is the Reply that __init__() would return
     mock_reply_widget_res = mocker.MagicMock()
@@ -1328,7 +1328,7 @@ def test_ConversationView_add_reply(mocker, homedir, session, source):
     cv.conversation_layout.addWidget.assert_called_once_with(mock_reply_widget_res)
 
 
-def test_ConversationView_add_reply_no_content(mocker, homedir, session, source):
+def test_ConversationView_add_reply_no_content(mocker, session, source):
     """
     Adding a reply results in a new ReplyWidget added to the layout. This case specifically
     checks that if a `Reply` has `content = None` that a helpful message is displayed as would
@@ -1349,7 +1349,7 @@ def test_ConversationView_add_reply_no_content(mocker, homedir, session, source)
     session.add(reply)
     session.commit()
 
-    cv = ConversationView(source, homedir, mocked_controller)
+    cv = ConversationView(source, mocked_controller)
     cv.conversation_layout = mocker.MagicMock()
     # this is the Reply that __init__() would return
     mock_reply_widget_res = mocker.MagicMock()
@@ -1379,7 +1379,7 @@ def test_ConversationView_add_downloaded_file(mocker, homedir):
     mocked_source = mocker.MagicMock()
     mocked_controller = mocker.MagicMock()
 
-    cv = ConversationView(mocked_source, homedir, mocked_controller)
+    cv = ConversationView(mocked_source, mocked_controller)
     cv.conversation_layout = mocker.MagicMock()
 
     mock_source = mocker.MagicMock()
@@ -1405,7 +1405,7 @@ def test_ConversationView_add_not_downloaded_file(mocker, homedir):
     mocked_source = mocker.MagicMock()
     mocked_controller = mocker.MagicMock()
 
-    cv = ConversationView(mocked_source, homedir, mocked_controller)
+    cv = ConversationView(mocked_source, mocked_controller)
     cv.conversation_layout = mocker.MagicMock()
 
     mock_source = mocker.MagicMock()
@@ -1600,7 +1600,7 @@ def test_SourceConversationWrapper_send_reply(mocker):
     mock_controller = mocker.MagicMock()
     mocker.patch('securedrop_client.gui.widgets.LastUpdatedLabel', return_value=QLabel('now'))
 
-    cw = SourceConversationWrapper(mock_source, 'mock home', mock_controller, True)
+    cw = SourceConversationWrapper(mock_source, mock_controller)
     mock_add_reply = mocker.Mock()
     cw.conversation.add_reply = mock_add_reply
 
@@ -1665,7 +1665,7 @@ def test_ReplyWidget_success_failure_slots(mocker):
     assert mock_logger.debug.called
 
 
-def test_update_conversation_maintains_old_items(mocker, homedir, session):
+def test_update_conversation_maintains_old_items(mocker, session):
     """
     Calling update_conversation deletes and adds old items back to layout
     """
@@ -1682,7 +1682,7 @@ def test_update_conversation_maintains_old_items(mocker, homedir, session):
     session.add(reply)
     session.commit()
 
-    cv = ConversationView(source, homedir, mock_controller)
+    cv = ConversationView(source, mock_controller)
     assert cv.conversation_layout.count() == 3
 
     cv.update_conversation(cv.source.collection)
@@ -1690,7 +1690,7 @@ def test_update_conversation_maintains_old_items(mocker, homedir, session):
     assert cv.conversation_layout.count() == 3
 
 
-def test_update_conversation_adds_new_items(mocker, homedir, session):
+def test_update_conversation_adds_new_items(mocker, session):
     """
     Calling update_conversation adds new items to layout
     """
@@ -1707,7 +1707,7 @@ def test_update_conversation_adds_new_items(mocker, homedir, session):
     session.add(reply)
     session.commit()
 
-    cv = ConversationView(source, homedir, mock_controller)
+    cv = ConversationView(source, mock_controller)
     assert cv.conversation_layout.count() == 3  # precondition
 
     # add the new message and persist
@@ -1726,7 +1726,7 @@ def test_clear_conversation_deletes_items(mocker, homedir):
     mock_controller = mocker.MagicMock()
     mock_source = mocker.MagicMock()
     message = db.Message(uuid='uuid', content='message', filename='1-foo')
-    cv = ConversationView(mock_source, homedir, mock_controller)
+    cv = ConversationView(mock_source, mock_controller)
     cv.add_message(message)
     assert cv.conversation_layout.count() == 1
 
@@ -1743,15 +1743,15 @@ def test_SourceConversationWrapper_auth_signals(mocker, homedir):
     mock_connect = mocker.MagicMock()
     mock_signal = mocker.MagicMock(connect=mock_connect)
     mock_controller = mocker.MagicMock(authentication_state=mock_signal)
-    mock_is_auth = mocker.MagicMock()
+    mock_controller.is_authenticated = mocker.MagicMock()
 
     mock_sh = mocker.patch.object(SourceConversationWrapper, '_show_or_hide_replybox')
     mocker.patch('securedrop_client.gui.widgets.LastUpdatedLabel', return_value=QLabel('now'))
 
-    SourceConversationWrapper(mock_source, 'mock home', mock_controller, mock_is_auth)
+    SourceConversationWrapper(mock_source, mock_controller)
 
     mock_connect.assert_called_once_with(mock_sh)
-    mock_sh.assert_called_with(mock_is_auth)
+    mock_sh.assert_called_with(mock_controller.is_authenticated)
 
 
 def test_SourceConversationWrapper_set_widgets_via_auth_value(mocker, homedir):
@@ -1762,7 +1762,7 @@ def test_SourceConversationWrapper_set_widgets_via_auth_value(mocker, homedir):
     mock_controller = mocker.MagicMock()
 
     mocker.patch('securedrop_client.gui.widgets.LastUpdatedLabel', return_value=QLabel('now'))
-    cw = SourceConversationWrapper(mock_source, 'mock home', mock_controller, True)
+    cw = SourceConversationWrapper(mock_source, mock_controller)
     mocker.patch.object(cw, 'layout')
     mock_reply_box = mocker.patch('securedrop_client.gui.widgets.ReplyBoxWidget',
                                   return_value=QWidget())

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -127,7 +127,7 @@ def test_start_app(homedir, mocker):
 
     start_app(mock_args, mock_qt_args)
     mock_app.assert_called_once_with(mock_qt_args)
-    mock_win.assert_called_once_with(str(homedir))
+    mock_win.assert_called_once_with()
     mock_controller.assert_called_once_with('http://localhost:8081/',
                                             mock_win(), mock_session_class(),
                                             homedir, False)


### PR DESCRIPTION
## Description

Just a quick refactor where we were passing `sdc_home` to `Window` and then not doing anything with it. We also don't need to pass the `is_authenticated` to `show_conversation_for` because we already have a reference to the `Controller`.

## Test

Client should behave exactly the same as before. Automated and [manual tests](https://github.com/freedomofpress/securedrop-client/wiki/Test-plan) should pass.