### PR TITLE
Remove timeouts for API calls from the client and use SDK for timeouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,16 @@ SHELL := /bin/bash
 mypy: ## Run static type checker
 	@mypy --ignore-missing-imports securedrop_client
 	@# Add files that are 100% typed to the below call (eventually just the below line will run so that code without static type hints will fail CI)
-	@mypy --ignore-missing-imports --disallow-incomplete-defs --disallow-untyped-defs securedrop_client/db.py securedrop_client/crypto.py securedrop_client/config.py securedrop_client/gui/__init__.py securedrop_client/resources/__init__.py securedrop_client/storage.py securedrop_client/message_sync.py
+	@mypy --ignore-missing-imports \
+		--disallow-incomplete-defs \
+		--disallow-untyped-defs \
+		securedrop_client/db.py \
+		securedrop_client/crypto.py \
+		securedrop_client/config.py \
+		securedrop_client/gui/__init__.py \
+		securedrop_client/resources/__init__.py \
+		securedrop_client/storage.py \
+		securedrop_client/message_sync.py
 
 .PHONY: clean
 clean:  ## Clean the workspace of generated resources

--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,7 @@ arrow = "*"
 alembic = "*"
 python-dateutil = "*"
 sip = "*"
-securedrop-sdk = ">=0.0.8"
+securedrop-sdk = ">=0.0.9"
 SQLALchemy = "*"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "23a40e36e845a0e8f46cb8deac7058a926511ca2a7ef2f57558fc5838e17f116"
+            "sha256": "3444694e3ae32c3381edc1d9c62b9363c90dd5c0cedcb71badb046466b6932c2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -101,10 +101,10 @@
         },
         "securedrop-sdk": {
             "hashes": [
-                "sha256:eca697da2520b568a4600b11c3ab818f5855e0ce13f88495d756a894f142f2a1"
+                "sha256:43146f02c41858578f7c9997e733f2a07f8a4877f1bf9f8b4b11fd4ceffa47a9"
             ],
             "index": "pypi",
-            "version": "==0.0.8"
+            "version": "==0.0.9"
         },
         "six": {
             "hashes": [
@@ -160,8 +160,11 @@
                 "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
                 "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
                 "sha256:0bf8cbbd71adfff0ef1f3a1531e6402d13b7b01ac50a79c97ca15f030dba6306",
+                "sha256:104ab3934abaf5be871a583541e8829d6c19ce7bde2923b2751e0d3ca44db60a",
                 "sha256:10a46017fef60e16694a30627319f38a2b9b52e90182dddb6e37dcdab0f4bf95",
+                "sha256:15b111b6a0f46ee1a485414a52a7ad1d703bdf984e9ed3c288a4414d3871dcbd",
                 "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
+                "sha256:1c383d2ef13ade2acc636556fd544dba6e14fa30755f26812f54300e401f98f2",
                 "sha256:23d341cdd4a0371820eb2b0bd6b88f5003a7438bbedb33688cd33b8eae59affd",
                 "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
                 "sha256:2a5b73210bad5279ddb558d9a2bfedc7f4bf6ad7f3c988641d83c40293deaec1",
@@ -184,12 +187,17 @@
                 "sha256:7e1fe19bd6dce69d9fd159d8e4a80a8f52101380d5d3a4d374b6d3eae0e5de9c",
                 "sha256:8c3cb8c35ec4d9506979b4cf90ee9918bc2e49f84189d9bf5c36c0c1119c6558",
                 "sha256:9d6dd10d49e01571bf6e147d3b505141ffc093a06756c60b053a859cb2128b1f",
+                "sha256:9e112fcbe0148a6fa4f0a02e8d58e94470fc6cb82a5481618fea901699bf34c4",
+                "sha256:ac4fef68da01116a5c117eba4dd46f2e06847a497de5ed1d64bb99a5fda1ef91",
+                "sha256:b8815995e050764c8610dbc82641807d196927c3dbed207f0a079833ffcf588d",
                 "sha256:be6cfcd8053d13f5f5eeb284aa8a814220c3da1b0078fa859011c7fffd86dab9",
                 "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
                 "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
                 "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
+                "sha256:e4d96c07229f58cb686120f168276e434660e4358cc9cf3b0464210b04913e77",
                 "sha256:f05a636b4564104120111800021a92e43397bc12a5c72fed7036be8556e0029e",
-                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80"
+                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80",
+                "sha256:f8a923a85cb099422ad5a2e345fe877bbc89a8a8b23235824a93488150e45f6e"
             ],
             "index": "pypi",
             "version": "==4.5.1"
@@ -278,6 +286,7 @@
         },
         "pycodestyle": {
             "hashes": [
+                "sha256:74abc4e221d393ea5ce1f129ea6903209940c1ecd29e002e8c6933c2b21026e0",
                 "sha256:cbc619d09254895b0d12c2c691e237b2e91e9b2ecf5e84c26b35400f93dcfb83",
                 "sha256:cbfca99bd594a10f674d0cd97a3d802a1fdef635d4361e1a2658de47ed261e3a"
             ],
@@ -329,7 +338,8 @@
         "pytest-random-order": {
             "hashes": [
                 "sha256:23881501819fdd03e7b6885b0aae83d212f5689851ded7b5ec2bdb00ad1c6c7f",
-                "sha256:7844b4c213bd18a3102dcc735010a0b44746801b97222d70bb4ea7d4ad535a43"
+                "sha256:7844b4c213bd18a3102dcc735010a0b44746801b97222d70bb4ea7d4ad535a43",
+                "sha256:d7775600a78e419b41b23b00085f97992d40522c3904df12868503fc8d147e84"
             ],
             "index": "pypi",
             "version": "==1.0.0"
@@ -359,7 +369,7 @@
             ],
             "index": "pypi",
             "version": "==1.11.0"
-            },
+        },
         "typed-ast": {
             "hashes": [
                 "sha256:04894d268ba6eab7e093d43107869ad49e7b5ef40d1a94243ea49b352061b200",

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -17,6 +17,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import arrow
+import inspect
 import logging
 import os
 import sdclientapi
@@ -248,15 +249,9 @@ class Controller(QObject):
             runner = thread_info['runner']
             result_data = runner.result
 
-            # The callback may or may not have an associated current_object
-            if runner.current_object:
-                current_object = runner.current_object
-            else:
-                current_object = None
-
-            self.clean_thread(thread_id)
-            if current_object:
-                user_callback(result_data, current_object=current_object)
+            arg_spec = inspect.getfullargspec(user_callback)
+            if 'current_object' in arg_spec.args:
+                user_callback(result_data, current_object=runner.current_object)
             else:
                 user_callback(result_data)
 

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -25,6 +25,7 @@ import shutil
 import traceback
 import uuid
 
+from gettext import gettext as _
 from PyQt5.QtCore import QObject, QThread, pyqtSignal, QTimer, QProcess
 from sdclientapi import RequestTimeoutError
 from typing import Dict, Tuple  # noqa: F401


### PR DESCRIPTION
Fixes #323. Fixes #324. Fixes #325. Toward #326. Fixes #327.

This is the first pass that shows that we can easily remove the timeouts from the client. This is only toward #326 and doesn't fix it since we should add logic to extend the timeout to be even longer for very large files.

~Blocked by https://github.com/freedomofpress/securedrop-sdk/pull/80 (PR that adds timeouts to the SDK itself).~

## Testing

To test this, login. Then, go into SD core, go into `journalist_app/api.py`, and in `setup_g` add `import time; time.sleep(30)`. Save the file. Flask will refresh. Now all requests will be delayed by 30 seconds, and the SDK timeout is 20. This will cause all requests to raise a timeout error. Check the logs for the presence of this error.