### PR TITLE
Tweak login text for accuracy

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1006,7 +1006,7 @@ class LoginDialog(QDialog):
         self.title.setTextFormat(Qt.RichText)
 
         self.instructions = QLabel(_('You may read all documents and messages '
-                                     'shown here, without signing in. To '
+                                     'offline, without signing in. To '
                                      'correspond with a Source or to check '
                                      'the server for updates, you must sign '
                                      'in.'))


### PR DESCRIPTION
Since we no longer display the whole client window on launch, the
"shown here" message is now inaccurate. This text will likely go away
in the final rev; this is just to keep things in an internally
consistent state until then.