### PR TITLE
Implementation of the API queue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ mypy: ## Run static type checker
 		securedrop_client/gui/__init__.py \
 		securedrop_client/resources/__init__.py \
 		securedrop_client/storage.py \
-		securedrop_client/message_sync.py
+		securedrop_client/message_sync.py \
+		securedrop_client/queue.py
 
 .PHONY: clean
 clean:  ## Clean the workspace of generated resources

--- a/create_dev_data.py
+++ b/create_dev_data.py
@@ -3,10 +3,11 @@ import json
 import os
 import sys
 from securedrop_client.config import Config
-from securedrop_client.db import Base, make_engine
+from securedrop_client.db import Base, make_session_maker
 
 sdc_home = sys.argv[1]
-Base.metadata.create_all(make_engine(sdc_home))
+session = make_session_maker(sdc_home)()
+Base.metadata.create_all(bind=session.get_bind())
 
 with open(os.path.join(sdc_home, Config.CONFIG_NAME), 'w') as f:
     f.write(json.dumps({

--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -25,7 +25,6 @@ import signal
 import sys
 import socket
 from argparse import ArgumentParser
-from sqlalchemy.orm import sessionmaker
 from PyQt5.QtWidgets import QApplication, QMessageBox
 from PyQt5.QtCore import Qt, QTimer
 from logging.handlers import TimedRotatingFileHandler
@@ -33,7 +32,7 @@ from securedrop_client import __version__
 from securedrop_client.logic import Controller
 from securedrop_client.gui.main import Window
 from securedrop_client.resources import load_icon, load_css
-from securedrop_client.db import make_engine
+from securedrop_client.db import make_session_maker
 from securedrop_client.utils import safe_mkdir
 
 DEFAULT_SDC_HOME = '~/.securedrop_client'
@@ -185,15 +184,14 @@ def start_app(args, qt_args) -> None:
 
     prevent_second_instance(app, args.sdc_home)
 
-    gui = Window()
+    session_maker = make_session_maker(args.sdc_home)
+
+    gui = Window(session_maker)
+
     app.setWindowIcon(load_icon(gui.icon))
     app.setStyleSheet(load_css('sdclient.css'))
 
-    engine = make_engine(args.sdc_home)
-    Session = sessionmaker(bind=engine)
-    session = Session()
-
-    controller = Controller("http://localhost:8081/", gui, session,
+    controller = Controller("http://localhost:8081/", gui, session_maker,
                             args.sdc_home, not args.no_proxy)
     controller.setup()
 

--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -186,7 +186,7 @@ def start_app(args, qt_args) -> None:
 
     session_maker = make_session_maker(args.sdc_home)
 
-    gui = Window(session_maker)
+    gui = Window()
 
     app.setWindowIcon(load_icon(gui.icon))
     app.setStyleSheet(load_css('sdclient.css'))

--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -216,8 +216,5 @@ class User(Base):
     uuid = Column(String(36), unique=True, nullable=False)
     username = Column(String(255), nullable=False)
 
-    def __init__(self, username: str) -> None:
-        self.username = username
-
     def __repr__(self) -> str:
         return "<Journalist: {}>".format(self.username)

--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -4,9 +4,8 @@ from typing import Any, List, Union  # noqa: F401
 
 from sqlalchemy import Boolean, Column, create_engine, DateTime, ForeignKey, Integer, String, \
     Text, MetaData, CheckConstraint, text, UniqueConstraint
-from sqlalchemy.engine import Engine
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship, backref
+from sqlalchemy.orm import relationship, backref, scoped_session, sessionmaker
 
 
 convention = {
@@ -22,9 +21,11 @@ metadata = MetaData(naming_convention=convention)
 Base = declarative_base(metadata=metadata)  # type: Any
 
 
-def make_engine(home: str) -> Engine:
+def make_session_maker(home: str) -> scoped_session:
     db_path = os.path.join(home, 'svs.sqlite')
-    return create_engine('sqlite:///{}'.format(db_path))
+    engine = create_engine('sqlite:///{}'.format(db_path))
+    maker = sessionmaker(bind=engine)
+    return scoped_session(maker)
 
 
 class Source(Base):

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -25,7 +25,6 @@ from gettext import gettext as _
 from typing import Dict, List, Optional  # noqa: F401
 from PyQt5.QtWidgets import QMainWindow, QWidget, QHBoxLayout, QVBoxLayout, QDesktopWidget, \
     QApplication
-from sqlalchemy.orm import scoped_session
 
 from securedrop_client import __version__
 from securedrop_client.db import Source
@@ -44,7 +43,7 @@ class Window(QMainWindow):
 
     icon = 'icon.png'
 
-    def __init__(self, session_maker: scoped_session) -> None:
+    def __init__(self) -> None:
         """
         Create the default start state. The window contains a root widget into
         which is placed:
@@ -69,7 +68,7 @@ class Window(QMainWindow):
         layout.setSpacing(0)
         self.main_pane.setLayout(layout)
         self.left_pane = LeftPane()
-        self.main_view = MainView(session_maker, self.main_pane)
+        self.main_view = MainView(self.main_pane)
         layout.addWidget(self.left_pane, 1)
         layout.addWidget(self.main_view, 8)
 

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -20,11 +20,12 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import logging
+
 from gettext import gettext as _
 from typing import Dict, List, Optional  # noqa: F401
-
 from PyQt5.QtWidgets import QMainWindow, QWidget, QHBoxLayout, QVBoxLayout, QDesktopWidget, \
     QApplication
+from sqlalchemy.orm import scoped_session
 
 from securedrop_client import __version__
 from securedrop_client.db import Source
@@ -43,7 +44,7 @@ class Window(QMainWindow):
 
     icon = 'icon.png'
 
-    def __init__(self):
+    def __init__(self, session_maker: scoped_session) -> None:
         """
         Create the default start state. The window contains a root widget into
         which is placed:
@@ -68,7 +69,7 @@ class Window(QMainWindow):
         layout.setSpacing(0)
         self.main_pane.setLayout(layout)
         self.left_pane = LeftPane()
-        self.main_view = MainView(self.main_pane)
+        self.main_view = MainView(session_maker, self.main_pane)
         layout.addWidget(self.left_pane, 1)
         layout.addWidget(self.main_view, 8)
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1277,18 +1277,13 @@ class FileWidget(QWidget):
     def __init__(self, source_db_object, submission_db_object,
                  controller, file_ready_signal, align="left"):
         """
-        Given some text, an indication of alignment ('left' or 'right') and
-        a reference to the controller, make something to display a file.
-
-        Align is set to left by default because currently SecureDrop can only
-        accept files from sources to journalists.
+        Given some text and a reference to the controller, make something to display a file.
         """
         super().__init__()
         self.controller = controller
         self.source = source_db_object
         self.submission = submission_db_object
         self.file_uuid = self.submission.uuid
-        self.align = align
 
         self.layout = QHBoxLayout()
         self.update()
@@ -1296,7 +1291,7 @@ class FileWidget(QWidget):
 
         file_ready_signal.connect(self._on_file_download)
 
-    def update(self):
+    def update(self) -> None:
         icon = QLabel()
         icon.setPixmap(load_image('file.png'))
 
@@ -1306,18 +1301,11 @@ class FileWidget(QWidget):
             human_filesize = humanize_filesize(self.submission.size)
             description = QLabel("Download ({})".format(human_filesize))
 
-        if self.align != "left":
-            # Float right...
-            self.layout.addStretch(5)
-
         self.layout.addWidget(icon)
         self.layout.addWidget(description, 5)
+        self.layout.addStretch(5)
 
-        if self.align == "left":
-            # Add space on right hand side...
-            self.layout.addStretch(5)
-
-    def clear(self):
+    def clear(self) -> None:
         while self.layout.count():
             child = self.layout.takeAt(0)
             if child.widget():

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -494,7 +494,7 @@ class Controller(QObject):
         """
         self.gui.update_activity_status(message, duration)
 
-    def on_file_open(self, file_db_object):
+    def on_file_open(self, file_uuid: str) -> None:
         """
         Open the already downloaded file associated with the message (which is a `File`).
         """

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -501,8 +501,8 @@ class Controller(QObject):
         # Once downloaded, submissions are stored in the data directory
         # with the same filename as the server, except with the .gz.gpg
         # stripped off.
-        server_filename = file_db_object.filename
-        fn_no_ext, _ = os.path.splitext(os.path.splitext(server_filename)[0])
+        file = self.get_file(file_uuid)
+        fn_no_ext, _ = os.path.splitext(os.path.splitext(file.filename)[0])
         submission_filepath = os.path.join(self.data_dir, fn_no_ext)
 
         if self.proxy:
@@ -641,3 +641,8 @@ class Controller(QObject):
     def on_reply_failure(self, result, current_object: Tuple[str, str]) -> None:
         source_uuid, reply_uuid = current_object
         self.reply_failed.emit(reply_uuid)
+
+    def get_file(self, file_uuid: str) -> db.File:
+        file = storage.get_file(self.session, file_uuid)
+        self.session.refresh(file)
+        return file

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -21,21 +21,21 @@ import inspect
 import logging
 import os
 import sdclientapi
-import shutil
 import traceback
 import uuid
 
 from gettext import gettext as _
-from PyQt5.QtCore import QObject, QThread, pyqtSignal, QTimer, QProcess
+from PyQt5.QtCore import QObject, QThread, pyqtSignal, QTimer, QProcess, Qt
 from sdclientapi import RequestTimeoutError
-from typing import Dict, Tuple  # noqa: F401
 from sqlalchemy.orm.session import sessionmaker
+from typing import Dict, Tuple, Union, Any, Type  # noqa: F401
 
 from securedrop_client import storage
 from securedrop_client import db
-from securedrop_client.utils import check_dir_permissions
 from securedrop_client.crypto import GpgHelper, CryptoError
 from securedrop_client.message_sync import MessageSync, ReplySync
+from securedrop_client.queue import ApiJobQueue, DownloadSubmissionJob
+from securedrop_client.utils import check_dir_permissions
 
 logger = logging.getLogger(__name__)
 
@@ -149,6 +149,9 @@ class Controller(QObject):
         # Reference to the SqlAlchemy `sessionmaker` and `session`
         self.session_maker = session_maker
         self.session = session_maker()
+
+        # Queue that handles running API job
+        self.api_job_queue = ApiJobQueue(self.api, self.session_maker)
 
         # Contains active threads calling the API.
         self.api_threads = {}  # type: Dict[str, Dict]
@@ -311,8 +314,11 @@ class Controller(QObject):
         self.gui.hide_login()
         self.sync_api()
         self.gui.show_main_window(self.api.username)
+
         self.start_message_thread()
         self.start_reply_thread()
+
+        self.api_job_queue.start_queues(self.api)
 
         # Clear the sidebar error status bar if a message was shown
         # to the user indicating they should log in.
@@ -512,79 +518,57 @@ class Controller(QObject):
             # Non Qubes OS. Just log the event for now.
             logger.info('Opening file "{}".'.format(submission_filepath))
 
-    def on_file_download(self, source_db_object, message):
+    def on_reply_download(self, source_db_object: db.Source, reply: db.Reply) -> None:
         """
-        Download the file associated with the associated message (which may
-        be a Submission or Reply).
+        Download the file associated with the Reply.
         """
         if not self.api:  # Then we should tell the user they need to login.
             self.on_action_requiring_login()
             return
 
-        if isinstance(message, db.File) or isinstance(message, db.Message):
-            # Handle submissions.
-            func = self.api.download_submission
-            sdk_object = sdclientapi.Submission(uuid=message.uuid)
-            sdk_object.filename = message.filename
-            sdk_object.source_uuid = source_db_object.uuid
-        elif isinstance(message, db.Reply):
-            # Handle journalist's replies.
-            func = self.api.download_reply
-            sdk_object = sdclientapi.Reply(uuid=message.uuid)
-            sdk_object.filename = message.filename
-            sdk_object.source_uuid = source_db_object.uuid
+        sdk_object = sdclientapi.Reply(uuid=reply.uuid)
+        sdk_object.filename = reply.filename
+        sdk_object.source_uuid = source_db_object.uuid
 
         self.set_status(_('Downloading {}'.format(sdk_object.filename)))
-        self.call_api(func,
+
+        self.call_api(self.api.download_reply,
                       self.on_file_download_success,
                       self.on_file_download_failure,
                       sdk_object,
                       self.data_dir,
-                      current_object=message)
+                      current_object=reply)
 
-    def on_file_download_success(self, result, current_object):
+    def on_submission_download(
+        self,
+        submission_type: Union[Type[db.File], Type[db.Message]],
+        submission_uuid: str,
+    ) -> None:
         """
-        Called when a file has downloaded. Cause a refresh to the conversation view to display the
-        contents of the new file.
+        Download the file associated with the Submission (which may be a File or Message).
         """
-        file_uuid = current_object.uuid
-        server_filename = current_object.filename
-        _, filename = result
-        # The filename contains the location where the file has been
-        # stored. On non-Qubes OSes, this will be the data directory.
-        # On Qubes OS, this will a ~/QubesIncoming directory. In case
-        # we are on Qubes, we should move the file to the data directory
-        # and name it the same as the server (e.g. spotless-tater-msg.gpg).
-        filepath_in_datadir = os.path.join(self.data_dir, server_filename)
-        shutil.move(filename, filepath_in_datadir)
-        storage.mark_file_as_downloaded(file_uuid, self.session)
+        job = DownloadSubmissionJob(
+            submission_type,
+            submission_uuid,
+            self.data_dir,
+            self.gpg,
+        )
+        job.success_signal.connect(self.on_file_download_success, type=Qt.QueuedConnection)
+        job.failure_signal.connect(self.on_file_download_failure, type=Qt.QueuedConnection)
 
-        try:
-            # Attempt to decrypt the file.
-            self.gpg.decrypt_submission_or_reply(
-                filepath_in_datadir, server_filename, is_doc=True)
-            storage.set_object_decryption_status_with_content(
-                current_object, self.session, True)
-        except CryptoError as e:
-            logger.debug('Failed to decrypt file {}: {}'.format(server_filename, e))
-            storage.set_object_decryption_status_with_content(
-                current_object, self.session, False)
-            self.set_status("Failed to decrypt file, "
-                            "please try again or talk to your administrator.")
-            # TODO: We should save the downloaded content, and just
-            # try to decrypt again if there was a failure.
-            return  # If we failed we should stop here.
+        self.api_job_queue.enqueue(job)
+        self.set_status(_('Downloading file'))
 
-        self.set_status('Finished downloading {}'.format(current_object.filename))
-        self.file_ready.emit(file_uuid)
+    def on_file_download_success(self, result: Any) -> None:
+        """
+        Called when a file has downloaded.
+        """
+        self.file_ready.emit(result)
 
-    def on_file_download_failure(self, result, current_object):
+    def on_file_download_failure(self, exception: Exception) -> None:
         """
         Called when a file fails to download.
         """
-        server_filename = current_object.filename
-        logger.debug('Failed to download file {}'.format(server_filename))
-        # Update the UI in some way to indicate a failure state.
         self.set_status("The file download failed. Please try again.")
 
     def on_delete_source_success(self, result) -> None:

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -518,27 +518,6 @@ class Controller(QObject):
             # Non Qubes OS. Just log the event for now.
             logger.info('Opening file "{}".'.format(submission_filepath))
 
-    def on_reply_download(self, source_db_object: db.Source, reply: db.Reply) -> None:
-        """
-        Download the file associated with the Reply.
-        """
-        if not self.api:  # Then we should tell the user they need to login.
-            self.on_action_requiring_login()
-            return
-
-        sdk_object = sdclientapi.Reply(uuid=reply.uuid)
-        sdk_object.filename = reply.filename
-        sdk_object.source_uuid = source_db_object.uuid
-
-        self.set_status(_('Downloading {}'.format(sdk_object.filename)))
-
-        self.call_api(self.api.download_reply,
-                      self.on_file_download_success,
-                      self.on_file_download_failure,
-                      sdk_object,
-                      self.data_dir,
-                      current_object=reply)
-
     def on_submission_download(
         self,
         submission_type: Union[Type[db.File], Type[db.Message]],

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -178,9 +178,9 @@ class RunnableQueue(QObject):
 
     @pyqtSlot()
     def process(self) -> None:  # pragma: nocover
-        self.__process(False)
+        self._process(False)
 
-    def __process(self, exit_loop: bool) -> None:
+    def _process(self, exit_loop: bool) -> None:
         session = self.session_maker()
         while True:
             # retry the "cached" job if it exists, otherwise get the next job

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -1,0 +1,235 @@
+import binascii
+import hashlib
+import logging
+import os
+import sdclientapi
+import shutil
+
+from PyQt5.QtCore import QObject, QThread, pyqtSlot, pyqtSignal
+from PyQt5.QtWidgets import QApplication
+from queue import Queue
+from sdclientapi import API, RequestTimeoutError, AuthError
+from sqlalchemy.orm import scoped_session
+from sqlalchemy.orm.session import Session
+from typing import Any, Union, Optional, Type, Tuple
+
+from securedrop_client import storage
+from securedrop_client.crypto import GpgHelper, CryptoError
+from securedrop_client.db import File, Message
+
+
+logger = logging.getLogger(__name__)
+
+
+class ApiInaccessibleError(Exception):
+
+    def __init__(self, message: Optional[str] = None) -> None:
+        if not message:
+            message = ('API is inaccessible either because there is no client or because the '
+                       'client is not properly authenticated.')
+        super().__init__(message)
+
+
+class ApiJob(QObject):
+
+    '''
+    Signal that is emitted after an job finishes successfully.
+    '''
+    success_signal = pyqtSignal('PyQt_PyObject')
+
+    '''
+    Signal that is emitted if there is a failure during the job.
+    '''
+    failure_signal = pyqtSignal(Exception)
+
+    def __init__(self) -> None:
+        super().__init__(None)  # `None` because the QOjbect has no parent
+
+    def _do_call_api(self, api_client: API, session: Session) -> None:
+        if not api_client:
+            raise ApiInaccessibleError()
+
+        try:
+            result = self.call_api(api_client, session)
+        except AuthError as e:
+            raise ApiInaccessibleError() from e
+        except RequestTimeoutError:
+            logger.debug('Job {} timed out'.format(self))
+            raise
+        except Exception as e:
+            logger.error('Job {} raised an exception: {}: {}'
+                         .format(self, type(e).__name__, e))
+            self.failure_signal.emit(e)
+        else:
+            self.success_signal.emit(result)
+
+    def call_api(self, api_client: API, session: Session) -> Any:
+        '''
+        Method for making the actual API call and handling the result.
+
+        This MUST resturn a value if the API call and other tasks were successful and MUST raise
+        an exception if and only iff the tasks failed. Presence of a raise exception indicates a
+        failure.
+        '''
+        raise NotImplementedError
+
+
+class DownloadSubmissionJob(ApiJob):
+
+    CHUNK_SIZE = 4096
+
+    def __init__(
+        self,
+        submission_type: Union[Type[File], Type[Message]],
+        submission_uuid: str,
+        data_dir: str,
+        gpg: GpgHelper,
+    ) -> None:
+        super().__init__()
+        self.data_dir = data_dir
+        self.submission_type = submission_type
+        self.submission_uuid = submission_uuid
+        self.gpg = gpg
+
+    def call_api(self, api_client: API, session: Session) -> Any:
+        db_object = session.query(self.submission_type) \
+            .filter_by(uuid=self.submission_uuid).one()
+
+        etag, download_path = self._make_call(db_object, api_client)
+
+        if not self._check_file_integrity(etag, download_path):
+            raise RuntimeError('Downloaded file had an invalid checksum.')
+
+        self._decrypt_file(session, db_object, download_path)
+
+        return db_object.uuid
+
+    def _make_call(self, db_object: Union[File, Message], api_client: API) -> Tuple[str, str]:
+        sdk_obj = sdclientapi.Submission(uuid=db_object.uuid)
+        sdk_obj.filename = db_object.filename
+        sdk_obj.source_uuid = db_object.source.uuid
+
+        return api_client.download_submission(sdk_obj)
+
+    @classmethod
+    def _check_file_integrity(cls, etag: str, file_path: str) -> bool:
+        '''
+        Checks if the file is valid.
+        :return: `True` if valid or unknown, `False` otherwise.
+        '''
+        if not etag:
+            logger.debug('No ETag. Skipping integrity check for file at {}'.format(file_path))
+            return True
+
+        alg, checksum = etag.split(':')
+
+        if alg == 'sha256':
+            hasher = hashlib.sha256()
+        else:
+            logger.debug('Unknown hash algorithm ({}). Skipping integrity check for file at {}'
+                         .format(alg, file_path))
+            return True
+
+        with open(file_path, 'rb') as f:
+            while True:
+                read_bytes = f.read(cls.CHUNK_SIZE)
+                if not read_bytes:
+                    break
+                hasher.update(read_bytes)
+
+        calculated_checksum = binascii.hexlify(hasher.digest()).decode('utf-8')
+        return calculated_checksum == checksum
+
+    def _decrypt_file(
+        self,
+        session: Session,
+        db_object: Union[File, Message],
+        file_path: str,
+    ) -> None:
+        file_uuid = db_object.uuid
+        server_filename = db_object.filename
+
+        # The filename contains the location where the file has been stored. On non-Qubes OSes, this
+        # will be the data directory. On Qubes OS, this will a ~/QubesIncoming directory. In case we
+        # are on Qubes, we should move the file to the data directory and name it the same as the
+        # server (e.g. spotless-tater-msg.gpg).
+        filepath_in_datadir = os.path.join(self.data_dir, server_filename)
+        shutil.move(file_path, filepath_in_datadir)
+        storage.mark_file_as_downloaded(file_uuid, session)
+
+        try:
+            self.gpg.decrypt_submission_or_reply(filepath_in_datadir, server_filename, is_doc=True)
+        except CryptoError as e:
+            logger.debug('Failed to decrypt file {}: {}'.format(server_filename, e))
+            storage.set_object_decryption_status_with_content(db_object, session, False)
+            raise e
+
+        storage.set_object_decryption_status_with_content(db_object, session, True)
+
+
+class RunnableQueue(QObject):
+
+    def __init__(self, api_client: API, session_maker: scoped_session) -> None:
+        super().__init__()
+        self.api_client = api_client
+        self.session_maker = session_maker
+        self.queue = Queue()  # type: Queue[ApiJob]
+        self.last_job = None  # type: Optional[ApiJob]
+
+    @pyqtSlot()
+    def process(self) -> None:  # pragma: nocover
+        self.__process(False)
+
+    def __process(self, exit_loop: bool) -> None:
+        session = self.session_maker()
+        while True:
+            # retry the "cached" job if it exists, otherwise get the next job
+            if self.last_job is not None:
+                job = self.last_job
+                self.last_job = None
+            else:
+                job = self.queue.get(block=True)
+
+            try:
+                job._do_call_api(self.api_client, session)
+            except RequestTimeoutError:
+                self.last_job = job  # "cache" the last job since we can't re-queue it
+                return
+
+            # process events to allow this thread to handle incoming signals
+            QApplication.processEvents()
+
+            if exit_loop:
+                return
+
+
+class ApiJobQueue(QObject):
+
+    def __init__(self, api_client: API, session_maker: scoped_session) -> None:
+        super().__init__(None)
+        self.api_client = api_client
+
+        self.main_thread = QThread()
+        self.download_thread = QThread()
+
+        self.main_queue = RunnableQueue(self.api_client, session_maker)
+        self.download_queue = RunnableQueue(self.api_client, session_maker)
+
+        self.main_queue.moveToThread(self.main_thread)
+        self.download_queue.moveToThread(self.download_thread)
+
+        self.main_thread.started.connect(self.main_queue.process)
+        self.download_thread.started.connect(self.download_queue.process)
+
+    def start_queues(self, api_client: API) -> None:
+        self.main_queue.api_client = api_client
+        self.download_queue.api_client = api_client
+
+        self.main_thread.start()
+        self.download_thread.start()
+
+    def enqueue(self, job: ApiJob) -> None:
+        if isinstance(job, DownloadSubmissionJob):
+            self.download_queue.queue.put_nowait(job)
+        else:
+            self.main_queue.queue.put_nowait(job)

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -422,3 +422,6 @@ def source_exists(session: Session, source_uuid: str) -> bool:
         return True
     except NoResultFound:
         return False
+
+def get_file(session: Session, file_uuid: str) -> File:
+    return session.query(File).filter_by(uuid=file_uuid).one()

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -303,7 +303,7 @@ def find_or_create_user(uuid: str, username: str, session: Session) -> User:
         return user
     else:
         # User does not exist in the local database.
-        new_user = User(username)
+        new_user = User(username=username)
         new_user.uuid = uuid
         session.add(new_user)
         session.commit()

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -423,5 +423,6 @@ def source_exists(session: Session, source_uuid: str) -> bool:
     except NoResultFound:
         return False
 
+
 def get_file(session: Session, file_uuid: str) -> File:
     return session.query(File).filter_by(uuid=file_uuid).one()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,7 @@ from configparser import ConfigParser
 from datetime import datetime
 from securedrop_client.config import Config
 from securedrop_client.app import configure_locale_and_language
-from securedrop_client.db import Base, make_engine, Source
-from sqlalchemy.orm import sessionmaker
+from securedrop_client.db import Base, make_session_maker, Source
 from uuid import uuid4
 
 
@@ -82,13 +81,16 @@ def _alembic_config(homedir):
 
 
 @pytest.fixture(scope='function')
-def session(homedir):
-    engine = make_engine(homedir)
-    Base.metadata.create_all(bind=engine, checkfirst=False)
-    Session = sessionmaker(bind=engine)
-    session = Session()
-    yield session
-    session.close()
+def session_maker(homedir):
+    return make_session_maker(homedir)
+
+
+@pytest.fixture(scope='function')
+def session(session_maker):
+    sess = session_maker()
+    Base.metadata.create_all(bind=sess.get_bind(), checkfirst=False)
+    yield sess
+    sess.close()
 
 
 @pytest.fixture(scope='function')

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -83,7 +83,7 @@ def File(**attrs):
     FILE_COUNT += 1
     defaults = dict(
         uuid='source-uuid-{}'.format(FILE_COUNT),
-        filename='{}-reply.gpg'.format(FILE_COUNT),
+        filename='{}-doc.gz.gpg'.format(FILE_COUNT),
         size=123,
         download_url='http://wat.onion/abc',
         is_decrypted=True,

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -8,6 +8,20 @@ SOURCE_COUNT = 0
 MESSAGE_COUNT = 0
 FILE_COUNT = 0
 REPLY_COUNT = 0
+USER_COUNT = 0
+
+
+def User(**attrs):
+    global USER_COUNT
+    USER_COUNT += 1
+    defaults = dict(
+        uuid='user-uuid-{}'.format(USER_COUNT),
+        username='test-user-id-{}'.format(USER_COUNT),
+    )
+
+    defaults.update(attrs)
+
+    return db.User(**defaults)
 
 
 def Source(**attrs):

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -22,12 +22,13 @@ def test_init(mocker):
     mock_mv = mocker.patch('securedrop_client.gui.main.MainView')
     mocker.patch('securedrop_client.gui.main.QHBoxLayout', mock_lo)
     mocker.patch('securedrop_client.gui.main.QMainWindow')
+    mock_session_maker = mocker.MagicMock()
 
-    w = Window()
+    w = Window(mock_session_maker)
 
     mock_li.assert_called_once_with(w.icon)
     mock_lp.assert_called_once_with()
-    mock_mv.assert_called_once_with(w.main_pane)
+    mock_mv.assert_called_once_with(mock_session_maker, w.main_pane)
     assert mock_lo().addWidget.call_count == 2
 
 
@@ -36,8 +37,10 @@ def test_setup(mocker):
     Ensure the passed in controller is referenced and the various views are
     instantiated as expected.
     """
-    w = Window()
+    mock_session_maker = mocker.MagicMock()
     mock_controller = mocker.MagicMock()
+
+    w = Window(mock_session_maker)
     w.show_login = mocker.MagicMock()
     w.top_pane = mocker.MagicMock()
     w.left_pane = mocker.MagicMock()
@@ -53,7 +56,8 @@ def test_setup(mocker):
 
 
 def test_show_main_window(mocker):
-    w = Window()
+    mock_session_maker = mocker.MagicMock()
+    w = Window(mock_session_maker)
     w.autosize_window = mocker.MagicMock()
     w.show = mocker.MagicMock()
     w.set_logged_in_as = mocker.MagicMock()
@@ -66,7 +70,8 @@ def test_show_main_window(mocker):
 
 
 def test_show_main_window_without_username(mocker):
-    w = Window()
+    mock_session_maker = mocker.MagicMock()
+    w = Window(mock_session_maker)
     w.autosize_window = mocker.MagicMock()
     w.show = mocker.MagicMock()
     w.set_logged_in_as = mocker.MagicMock()
@@ -82,7 +87,8 @@ def test_autosize_window(mocker):
     """
     Check the autosizing fits to the full screen size.
     """
-    w = Window()
+    mock_session_maker = mocker.MagicMock()
+    w = Window(mock_session_maker)
     w.resize = mocker.MagicMock()
     mock_screen = mocker.MagicMock()
     mock_screen.width.return_value = 1024
@@ -99,7 +105,8 @@ def test_show_login(mocker):
     """
     The login dialog is displayed with a clean state.
     """
-    w = Window()
+    mock_session_maker = mocker.MagicMock()
+    w = Window(mock_session_maker)
     w.controller = mocker.MagicMock()
     mock_ld = mocker.patch('securedrop_client.gui.main.LoginDialog')
 
@@ -114,7 +121,8 @@ def test_show_login_error(mocker):
     """
     Ensures that an error message is displayed in the login dialog.
     """
-    w = Window()
+    mock_session_maker = mocker.MagicMock()
+    w = Window(mock_session_maker)
     w.show_login = mocker.MagicMock()
     w.setup(mocker.MagicMock())
     w.login_dialog = mocker.MagicMock()
@@ -128,7 +136,8 @@ def test_hide_login(mocker):
     """
     Ensure the login dialog is closed and hidden.
     """
-    w = Window()
+    mock_session_maker = mocker.MagicMock()
+    w = Window(mock_session_maker)
     w.show_login = mocker.MagicMock()
     ld = mocker.MagicMock()
     w.login_dialog = ld
@@ -143,7 +152,8 @@ def test_show_sources(mocker):
     """
     Ensure the sources list is passed to the main view to be updated.
     """
-    w = Window()
+    mock_session_maker = mocker.MagicMock()
+    w = Window(mock_session_maker)
     w.main_view = mocker.MagicMock()
     w.show_sources([1, 2, 3])
     w.main_view.show_sources.assert_called_once_with([1, 2, 3])
@@ -154,7 +164,8 @@ def test_update_error_status_default(mocker):
     Ensure that the error to be shown in the error status bar will be passed to the top pane with a
     default duration of 10 seconds.
     """
-    w = Window()
+    mock_session_maker = mocker.MagicMock()
+    w = Window(mock_session_maker)
     w.top_pane = mocker.MagicMock()
     w.update_error_status(message='test error message')
     w.top_pane.update_error_status.assert_called_once_with('test error message', 10000)
@@ -165,7 +176,8 @@ def test_update_error_status(mocker):
     Ensure that the error to be shown in the error status bar will be passed to the top pane with
     the duration of seconds provided.
     """
-    w = Window()
+    mock_session_maker = mocker.MagicMock()
+    w = Window(mock_session_maker)
     w.top_pane = mocker.MagicMock()
     w.update_error_status(message='test error message', duration=123)
     w.top_pane.update_error_status.assert_called_once_with('test error message', 123)
@@ -176,7 +188,8 @@ def test_update_activity_status_default(mocker):
     Ensure that the activity to be shown in the activity status bar will be passed to the top pane
     with a default duration of 0 seconds, i.e. forever.
     """
-    w = Window()
+    mock_session_maker = mocker.MagicMock()
+    w = Window(mock_session_maker)
     w.top_pane = mocker.MagicMock()
     w.update_activity_status(message='test message')
     w.top_pane.update_activity_status.assert_called_once_with('test message', 0)
@@ -187,7 +200,8 @@ def test_update_activity_status(mocker):
     Ensure that the activity to be shown in the activity status bar will be passed to the top pane
     with the duration of seconds provided.
     """
-    w = Window()
+    mock_session_maker = mocker.MagicMock()
+    w = Window(mock_session_maker)
     w.top_pane = mocker.MagicMock()
     w.update_activity_status(message='test message', duration=123)
     w.top_pane.update_activity_status.assert_called_once_with('test message', 123)
@@ -197,7 +211,8 @@ def test_clear_error_status(mocker):
     """
     Ensure clear_error_status is called.
     """
-    w = Window()
+    mock_session_maker = mocker.MagicMock()
+    w = Window(mock_session_maker)
     w.top_pane = mocker.MagicMock()
 
     w.clear_error_status()
@@ -209,7 +224,8 @@ def test_show_sync(mocker):
     """
     If there's a value display the result of its "humanize" method.humanize
     """
-    w = Window()
+    mock_session_maker = mocker.MagicMock()
+    w = Window(mock_session_maker)
     w.update_activity_status = mocker.MagicMock()
     updated_on = mocker.MagicMock()
     w.show_sync(updated_on)
@@ -221,7 +237,8 @@ def test_show_sync_no_sync(mocker):
     """
     If there's no value to display, default to a "waiting" message.
     """
-    w = Window()
+    mock_session_maker = mocker.MagicMock()
+    w = Window(mock_session_maker)
     w.update_activity_status = mocker.MagicMock()
     w.show_sync(None)
     w.update_activity_status.assert_called_once_with('Waiting to refresh...', 5000)
@@ -231,7 +248,8 @@ def test_set_logged_in_as(mocker):
     """
     Given a username, the left pane is appropriately called to update.
     """
-    w = Window()
+    mock_session_maker = mocker.MagicMock()
+    w = Window(mock_session_maker)
     w.left_pane = mocker.MagicMock()
 
     w.set_logged_in_as('test')
@@ -243,7 +261,8 @@ def test_logout(mocker):
     """
     Ensure the left pane updates to the logged out state.
     """
-    w = Window()
+    mock_session_maker = mocker.MagicMock()
+    w = Window(mock_session_maker)
     w.left_pane = mocker.MagicMock()
     w.top_pane = mocker.MagicMock()
 

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -22,13 +22,12 @@ def test_init(mocker):
     mock_mv = mocker.patch('securedrop_client.gui.main.MainView')
     mocker.patch('securedrop_client.gui.main.QHBoxLayout', mock_lo)
     mocker.patch('securedrop_client.gui.main.QMainWindow')
-    mock_session_maker = mocker.MagicMock()
 
-    w = Window(mock_session_maker)
+    w = Window()
 
     mock_li.assert_called_once_with(w.icon)
     mock_lp.assert_called_once_with()
-    mock_mv.assert_called_once_with(mock_session_maker, w.main_pane)
+    mock_mv.assert_called_once_with(w.main_pane)
     assert mock_lo().addWidget.call_count == 2
 
 
@@ -37,10 +36,9 @@ def test_setup(mocker):
     Ensure the passed in controller is referenced and the various views are
     instantiated as expected.
     """
-    mock_session_maker = mocker.MagicMock()
     mock_controller = mocker.MagicMock()
 
-    w = Window(mock_session_maker)
+    w = Window()
     w.show_login = mocker.MagicMock()
     w.top_pane = mocker.MagicMock()
     w.left_pane = mocker.MagicMock()
@@ -56,8 +54,7 @@ def test_setup(mocker):
 
 
 def test_show_main_window(mocker):
-    mock_session_maker = mocker.MagicMock()
-    w = Window(mock_session_maker)
+    w = Window()
     w.autosize_window = mocker.MagicMock()
     w.show = mocker.MagicMock()
     w.set_logged_in_as = mocker.MagicMock()
@@ -70,8 +67,7 @@ def test_show_main_window(mocker):
 
 
 def test_show_main_window_without_username(mocker):
-    mock_session_maker = mocker.MagicMock()
-    w = Window(mock_session_maker)
+    w = Window()
     w.autosize_window = mocker.MagicMock()
     w.show = mocker.MagicMock()
     w.set_logged_in_as = mocker.MagicMock()
@@ -87,8 +83,7 @@ def test_autosize_window(mocker):
     """
     Check the autosizing fits to the full screen size.
     """
-    mock_session_maker = mocker.MagicMock()
-    w = Window(mock_session_maker)
+    w = Window()
     w.resize = mocker.MagicMock()
     mock_screen = mocker.MagicMock()
     mock_screen.width.return_value = 1024
@@ -105,8 +100,7 @@ def test_show_login(mocker):
     """
     The login dialog is displayed with a clean state.
     """
-    mock_session_maker = mocker.MagicMock()
-    w = Window(mock_session_maker)
+    w = Window()
     w.controller = mocker.MagicMock()
     mock_ld = mocker.patch('securedrop_client.gui.main.LoginDialog')
 
@@ -121,8 +115,7 @@ def test_show_login_error(mocker):
     """
     Ensures that an error message is displayed in the login dialog.
     """
-    mock_session_maker = mocker.MagicMock()
-    w = Window(mock_session_maker)
+    w = Window()
     w.show_login = mocker.MagicMock()
     w.setup(mocker.MagicMock())
     w.login_dialog = mocker.MagicMock()
@@ -136,8 +129,7 @@ def test_hide_login(mocker):
     """
     Ensure the login dialog is closed and hidden.
     """
-    mock_session_maker = mocker.MagicMock()
-    w = Window(mock_session_maker)
+    w = Window()
     w.show_login = mocker.MagicMock()
     ld = mocker.MagicMock()
     w.login_dialog = ld
@@ -152,8 +144,7 @@ def test_show_sources(mocker):
     """
     Ensure the sources list is passed to the main view to be updated.
     """
-    mock_session_maker = mocker.MagicMock()
-    w = Window(mock_session_maker)
+    w = Window()
     w.main_view = mocker.MagicMock()
     w.show_sources([1, 2, 3])
     w.main_view.show_sources.assert_called_once_with([1, 2, 3])
@@ -164,8 +155,7 @@ def test_update_error_status_default(mocker):
     Ensure that the error to be shown in the error status bar will be passed to the top pane with a
     default duration of 10 seconds.
     """
-    mock_session_maker = mocker.MagicMock()
-    w = Window(mock_session_maker)
+    w = Window()
     w.top_pane = mocker.MagicMock()
     w.update_error_status(message='test error message')
     w.top_pane.update_error_status.assert_called_once_with('test error message', 10000)
@@ -176,8 +166,7 @@ def test_update_error_status(mocker):
     Ensure that the error to be shown in the error status bar will be passed to the top pane with
     the duration of seconds provided.
     """
-    mock_session_maker = mocker.MagicMock()
-    w = Window(mock_session_maker)
+    w = Window()
     w.top_pane = mocker.MagicMock()
     w.update_error_status(message='test error message', duration=123)
     w.top_pane.update_error_status.assert_called_once_with('test error message', 123)
@@ -188,8 +177,7 @@ def test_update_activity_status_default(mocker):
     Ensure that the activity to be shown in the activity status bar will be passed to the top pane
     with a default duration of 0 seconds, i.e. forever.
     """
-    mock_session_maker = mocker.MagicMock()
-    w = Window(mock_session_maker)
+    w = Window()
     w.top_pane = mocker.MagicMock()
     w.update_activity_status(message='test message')
     w.top_pane.update_activity_status.assert_called_once_with('test message', 0)
@@ -200,8 +188,7 @@ def test_update_activity_status(mocker):
     Ensure that the activity to be shown in the activity status bar will be passed to the top pane
     with the duration of seconds provided.
     """
-    mock_session_maker = mocker.MagicMock()
-    w = Window(mock_session_maker)
+    w = Window()
     w.top_pane = mocker.MagicMock()
     w.update_activity_status(message='test message', duration=123)
     w.top_pane.update_activity_status.assert_called_once_with('test message', 123)
@@ -211,8 +198,7 @@ def test_clear_error_status(mocker):
     """
     Ensure clear_error_status is called.
     """
-    mock_session_maker = mocker.MagicMock()
-    w = Window(mock_session_maker)
+    w = Window()
     w.top_pane = mocker.MagicMock()
 
     w.clear_error_status()
@@ -224,8 +210,7 @@ def test_show_sync(mocker):
     """
     If there's a value display the result of its "humanize" method.humanize
     """
-    mock_session_maker = mocker.MagicMock()
-    w = Window(mock_session_maker)
+    w = Window()
     w.update_activity_status = mocker.MagicMock()
     updated_on = mocker.MagicMock()
     w.show_sync(updated_on)
@@ -237,8 +222,7 @@ def test_show_sync_no_sync(mocker):
     """
     If there's no value to display, default to a "waiting" message.
     """
-    mock_session_maker = mocker.MagicMock()
-    w = Window(mock_session_maker)
+    w = Window()
     w.update_activity_status = mocker.MagicMock()
     w.show_sync(None)
     w.update_activity_status.assert_called_once_with('Waiting to refresh...', 5000)
@@ -248,8 +232,7 @@ def test_set_logged_in_as(mocker):
     """
     Given a username, the left pane is appropriately called to update.
     """
-    mock_session_maker = mocker.MagicMock()
-    w = Window(mock_session_maker)
+    w = Window()
     w.left_pane = mocker.MagicMock()
 
     w.set_logged_in_as('test')
@@ -261,8 +244,7 @@ def test_logout(mocker):
     """
     Ensure the left pane updates to the logged out state.
     """
-    mock_session_maker = mocker.MagicMock()
-    w = Window(mock_session_maker)
+    w = Window()
     w.left_pane = mocker.MagicMock()
     w.top_pane = mocker.MagicMock()
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1139,27 +1139,11 @@ def test_FileWidget_init_left(mocker):
     source = factory.Source()
     file_ = factory.File(is_downloaded=True)
 
-    fw = FileWidget(source, file_, mock_controller, mock_signal, align='left')
+    fw = FileWidget(source, file_, mock_controller, mock_signal)
 
     assert isinstance(fw.layout.takeAt(0), QWidgetItem)
     assert isinstance(fw.layout.takeAt(0), QWidgetItem)
     assert isinstance(fw.layout.takeAt(0), QSpacerItem)
-    assert fw.controller == mock_controller
-
-
-def test_FileWidget_init_right(mocker):
-    """
-    Check the FileWidget is configured correctly for align-right.
-    """
-    mock_controller = mocker.MagicMock()
-    mock_signal = mocker.MagicMock()  # not important for this test
-    source = factory.Source()
-    file_ = factory.File(is_downloaded=True)
-
-    fw = FileWidget(source, file_, mock_controller, mock_signal, align='right')
-    assert isinstance(fw.layout.takeAt(0), QSpacerItem)
-    assert isinstance(fw.layout.takeAt(0), QWidgetItem)
-    assert isinstance(fw.layout.takeAt(0), QWidgetItem)
     assert fw.controller == mock_controller
 
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -376,6 +376,7 @@ def test_MainView_init():
     """
     Ensure the MainView instance is correctly set up.
     """
+    mock_session_maker = mocker.MagicMock()
     mv = MainView(None)
     assert isinstance(mv.source_list, SourceList)
     assert isinstance(mv.view_holder, QWidget)

--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -9,10 +9,9 @@ from alembic.config import Config as AlembicConfig
 from alembic.script import ScriptDirectory
 from os import path
 from sqlalchemy import text
-from sqlalchemy.orm import sessionmaker
 
 from . import conftest
-from securedrop_client.db import make_engine, Base, convention
+from securedrop_client.db import make_session_maker, Base, convention
 
 MIGRATION_PATH = path.join(path.dirname(__file__), '..', 'alembic', 'versions')
 
@@ -98,25 +97,24 @@ def test_alembic_head_matches_db_models(tmpdir):
     '''
     models_homedir = str(tmpdir.mkdir('models'))
     subprocess.check_call(['sqlite3', os.path.join(models_homedir, 'svs.sqlite'), '.databases'])
-    engine = make_engine(models_homedir)
-    Base.metadata.create_all(bind=engine, checkfirst=False)
+
+    session_maker = make_session_maker(models_homedir)
+    session = session_maker()
+    Base.metadata.create_all(bind=session.get_bind(), checkfirst=False)
     assert Base.metadata.naming_convention == convention
-    session = sessionmaker(engine)()
     models_schema = get_schema(session)
-    Base.metadata.drop_all(bind=engine)
+    Base.metadata.drop_all(bind=session.get_bind())
     session.close()
-    engine.dispose()
 
     alembic_homedir = str(tmpdir.mkdir('alembic'))
     subprocess.check_call(['sqlite3', os.path.join(alembic_homedir, 'svs.sqlite'), '.databases'])
-    engine = make_engine(alembic_homedir)
-    session = sessionmaker(engine)()
+    session_maker = make_session_maker(alembic_homedir)
+    session = session_maker()
     alembic_config = conftest._alembic_config(alembic_homedir)
     upgrade(alembic_config, 'head')
     alembic_schema = get_schema(session)
-    Base.metadata.drop_all(bind=engine)
+    Base.metadata.drop_all(bind=session.get_bind())
     session.close()
-    engine.dispose()
 
     # The initial migration creates the table 'alembic_version', but this is
     # not present in the schema created by `Base.metadata.create_all()`.
@@ -160,13 +158,13 @@ def test_schema_unchanged_after_up_then_downgrade(alembic_config,
         # get the database to some base state.
         pass
 
-    session = sessionmaker(make_engine(str(tmpdir.mkdir('original'))))()
+    session = make_session_maker(str(tmpdir.mkdir('original')))()
     original_schema = get_schema(session)
 
     upgrade(alembic_config, '+1')
     downgrade(alembic_config, '-1')
 
-    session = sessionmaker(make_engine(str(tmpdir.mkdir('reverted'))))()
+    session = make_session_maker(str(tmpdir.mkdir('reverted')))()
     reverted_schema = get_schema(session)
 
     # The initial migration is a degenerate case because it creates the table

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -111,7 +111,7 @@ def test_start_app(homedir, mocker):
     """
     Ensure the expected things are configured and the application is started.
     """
-    mock_session_class = mocker.MagicMock()
+    mock_session_maker = mocker.MagicMock()
     mock_args = mocker.MagicMock()
     mock_qt_args = mocker.MagicMock()
     mock_args.sdc_home = str(homedir)
@@ -123,13 +123,13 @@ def test_start_app(homedir, mocker):
     mock_controller = mocker.patch('securedrop_client.app.Controller')
     mocker.patch('securedrop_client.app.prevent_second_instance')
     mocker.patch('securedrop_client.app.sys')
-    mocker.patch('securedrop_client.app.sessionmaker', return_value=mock_session_class)
+    mocker.patch('securedrop_client.app.make_session_maker', return_value=mock_session_maker)
 
     start_app(mock_args, mock_qt_args)
     mock_app.assert_called_once_with(mock_qt_args)
-    mock_win.assert_called_once_with()
+    mock_win.assert_called_once_with(mock_session_maker)
     mock_controller.assert_called_once_with('http://localhost:8081/',
-                                            mock_win(), mock_session_class(),
+                                            mock_win(), mock_session_maker,
                                             homedir, False)
 
 
@@ -170,7 +170,7 @@ PERMISSIONS_CASES = [
 def test_create_app_dir_permissions(tmpdir, mocker):
 
     for idx, case in enumerate(PERMISSIONS_CASES):
-        mock_session_class = mocker.MagicMock()
+        mock_session_maker = mocker.MagicMock()
         mock_args = mocker.MagicMock()
         mock_qt_args = mocker.MagicMock()
 
@@ -192,7 +192,7 @@ def test_create_app_dir_permissions(tmpdir, mocker):
         mocker.patch('securedrop_client.app.Controller')
         mocker.patch('securedrop_client.app.sys')
         mocker.patch('securedrop_client.app.prevent_second_instance')
-        mocker.patch('securedrop_client.app.sessionmaker', return_value=mock_session_class)
+        mocker.patch('securedrop_client.app.make_session_maker', return_value=mock_session_maker)
 
         def func():
             start_app(mock_args, mock_qt_args)
@@ -245,7 +245,7 @@ def test_signal_interception(mocker, homedir):
     mocker.patch('securedrop_client.app.QApplication')
     mocker.patch('securedrop_client.app.prevent_second_instance')
     mocker.patch('sys.exit')
-    mocker.patch('securedrop_client.db.make_engine')
+    mocker.patch('securedrop_client.db.make_session_maker')
     mocker.patch('securedrop_client.app.init')
     mocker.patch('securedrop_client.logic.Controller.setup')
     mocker.patch('securedrop_client.logic.GpgHelper')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -127,7 +127,7 @@ def test_start_app(homedir, mocker):
 
     start_app(mock_args, mock_qt_args)
     mock_app.assert_called_once_with(mock_qt_args)
-    mock_win.assert_called_once_with(mock_session_maker)
+    mock_win.assert_called_once_with()
     mock_controller.assert_called_once_with('http://localhost:8081/',
                                             mock_win(), mock_session_maker,
                                             homedir, False)

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -13,12 +13,12 @@ with open(os.path.join(os.path.dirname(__file__), 'files', 'securedrop.gpg.asc')
     JOURNO_KEY = f.read()
 
 
-def test_message_logic(homedir, config, mocker):
+def test_message_logic(homedir, config, mocker, session_maker):
     """
     Ensure that messages are handled.
     Using the `config` fixture to ensure the config is written to disk.
     """
-    gpg = GpgHelper(homedir, is_qubes=False)
+    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
 
     test_msg = 'tests/files/test-msg.gpg'
     expected_output_filename = 'test-msg'
@@ -32,12 +32,12 @@ def test_message_logic(homedir, config, mocker):
     assert dest == os.path.join(homedir, 'data', expected_output_filename)
 
 
-def test_gunzip_logic(homedir, config, mocker):
+def test_gunzip_logic(homedir, config, mocker, session_maker):
     """
     Ensure that gzipped documents/files are handled
     Using the `config` fixture to ensure the config is written to disk.
     """
-    gpg = GpgHelper(homedir, is_qubes=False)
+    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
 
     test_gzip = 'tests/files/test-doc.gz.gpg'
     expected_output_filename = 'test-doc'
@@ -52,12 +52,12 @@ def test_gunzip_logic(homedir, config, mocker):
     assert mock_unlink.call_count == 2
 
 
-def test_subprocess_raises_exception(homedir, config, mocker):
+def test_subprocess_raises_exception(homedir, config, mocker, session_maker):
     """
     Ensure that failed GPG commands raise an exception.
     Using the `config` fixture to ensure the config is written to disk.
     """
-    gpg = GpgHelper(homedir, is_qubes=False)
+    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
 
     test_gzip = 'tests/files/test-doc.gz.gpg'
     output_filename = 'test-doc'
@@ -73,21 +73,21 @@ def test_subprocess_raises_exception(homedir, config, mocker):
     assert mock_unlink.call_count == 1
 
 
-def test_import_key(homedir, config, source):
+def test_import_key(homedir, config, source, session_maker):
     '''
     Check the happy path that we can import a single PGP key.
     Using the `config` fixture to ensure the config is written to disk.
     '''
-    helper = GpgHelper(homedir, is_qubes=False)
+    helper = GpgHelper(homedir, session_maker, is_qubes=False)
     helper.import_key(source['uuid'], source['public_key'], source['fingerprint'])
 
 
-def test_import_key_gpg_call_fail(homedir, config, mocker):
+def test_import_key_gpg_call_fail(homedir, config, mocker, session_maker):
     '''
     Check that a `CryptoError` is raised if calling `gpg` fails.
     Using the `config` fixture to ensure the config is written to disk.
     '''
-    helper = GpgHelper(homedir, is_qubes=False)
+    helper = GpgHelper(homedir, session_maker, is_qubes=False)
     err = CalledProcessError(cmd=['foo'], returncode=1)
     mock_call = mocker.patch('securedrop_client.crypto.subprocess.check_call',
                              side_effect=err)
@@ -99,12 +99,12 @@ def test_import_key_gpg_call_fail(homedir, config, mocker):
     assert mock_call.called
 
 
-def test_encrypt(homedir, source, config, mocker):
+def test_encrypt(homedir, source, config, mocker, session_maker):
     '''
     Check that calling `encrypt` encrypts the message.
     Using the `config` fixture to ensure the config is written to disk.
     '''
-    helper = GpgHelper(homedir, is_qubes=False)
+    helper = GpgHelper(homedir, session_maker, is_qubes=False)
 
     # first we have to ensure the pubkeys are available
     helper._import(PUB_KEY)
@@ -134,12 +134,12 @@ def test_encrypt(homedir, source, config, mocker):
     assert decrypted == plaintext
 
 
-def test_encrypt_fail(homedir, source, config, mocker):
+def test_encrypt_fail(homedir, source, config, mocker, session_maker):
     '''
     Check that a `CryptoError` is raised if the call to `gpg` fails.
     Using the `config` fixture to ensure the config is written to disk.
     '''
-    helper = GpgHelper(homedir, is_qubes=False)
+    helper = GpgHelper(homedir, session_maker, is_qubes=False)
 
     # first we have to ensure the pubkeys are available
     helper._import(PUB_KEY)

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -8,7 +8,7 @@ import pytest
 import sdclientapi
 
 from PyQt5.QtCore import Qt
-from sdclientapi import sdlocalobjects, RequestTimeoutError
+from sdclientapi import RequestTimeoutError
 from tests import factory
 
 from securedrop_client import storage, db
@@ -912,7 +912,7 @@ def test_Controller_on_file_downloaded_api_failure(homedir, config, mocker, sess
     mock_file_ready.emit.assert_not_called()
 
 
-def test_Controller_on_file_open(homedir, config, mocker, session_maker):
+def test_Controller_on_file_open(homedir, config, mocker, session, session_maker, source):
     """
     If running on Qubes, a new QProcess with the expected command and args
     should be started.
@@ -921,12 +921,15 @@ def test_Controller_on_file_open(homedir, config, mocker, session_maker):
     mock_gui = mocker.MagicMock()
     co = Controller('http://localhost', mock_gui, session_maker, homedir)
     co.proxy = True
-    mock_submission = mocker.MagicMock()
-    mock_submission.filename = '1-test.pdf'
+
+    submission = factory.File(source=source['source'])
+    session.add(submission)
+    session.commit()
+
     mock_subprocess = mocker.MagicMock()
     mock_process = mocker.MagicMock(return_value=mock_subprocess)
     mocker.patch('securedrop_client.logic.QProcess', mock_process)
-    co.on_file_open(mock_submission)
+    co.on_file_open(submission.uuid)
     mock_process.assert_called_once_with(co)
     mock_subprocess.start.call_count == 1
 

--- a/tests/test_message_sync.py
+++ b/tests/test_message_sync.py
@@ -1,32 +1,31 @@
 """
 Make sure the message sync object behaves as expected.
 """
-from securedrop_client.crypto import CryptoError
+from securedrop_client.crypto import GpgHelper, CryptoError
 from securedrop_client.message_sync import MessageSync, ReplySync
 from tests import factory
 
 
-def test_MessageSync_init(mocker, homedir):
+def test_MessageSync_init(mocker, session_maker):
     """
     Ensure things are set up as expected
     """
-    # patch the session and use our own
-    mock_session_class = mocker.MagicMock()
-    mocker.patch('securedrop_client.db.make_engine')
-    mocker.patch('securedrop_client.message_sync.sessionmaker', return_value=mock_session_class)
 
-    api = mocker.MagicMock()
-    is_qubes = False
+    mock_api = mocker.MagicMock()
+    mock_gpg = mocker.MagicMock()
 
-    ms = MessageSync(api, homedir, is_qubes)
+    ms = MessageSync(mock_api, mock_gpg, session_maker)
 
-    assert ms.home == homedir
-    assert ms.api == api
-    assert ms.session == mock_session_class()
+    assert ms.api == mock_api
+    assert ms.gpg == mock_gpg
+    assert ms.session_maker == session_maker
 
 
-def test_MessageSync_run_success(mocker, session, source):
-    """Test when a message successfully downloads and decrypts."""
+def test_MessageSync_run_success(mocker, session, source, session_maker, homedir):
+    """
+    Test when a message successfully downloads and decrypts.
+    Using the `homedir` fixture to get a GPG keyring.
+    """
     message = factory.Message(source=source['source'],
                               is_downloaded=False,
                               is_decrypted=None,
@@ -36,17 +35,6 @@ def test_MessageSync_run_success(mocker, session, source):
 
     expected_content = 'foo'
 
-    def set_object_decryption_status_with_content_side_effect(*nargs, **kwargs):
-        message.content = expected_content
-
-    # mock the fetching of submissions
-    mocker.patch('securedrop_client.storage.find_new_messages', return_value=[message])
-    mock_download_status = mocker.patch(
-        'securedrop_client.message_sync.storage.mark_message_as_downloaded')
-    mock_decryption_status = mocker.patch(
-        'securedrop_client.message_sync.storage.set_object_decryption_status_with_content',
-        side_effect=set_object_decryption_status_with_content_side_effect)
-
     # don't create the signal
     mocker.patch('securedrop_client.message_sync.pyqtSignal')
 
@@ -54,13 +42,15 @@ def test_MessageSync_run_success(mocker, session, source):
         with open(plaintext_filename, 'w') as f:
             f.write(expected_content)
 
-    # mock the GpgHelper creation since we don't have directories/keys setup
-    mock_gpg_helper = mocker.MagicMock(decrypt_submission_or_reply=mock_decrypt_submission_or_reply)
-    mocker.patch('securedrop_client.message_sync.GpgHelper', return_value=mock_gpg_helper)
+    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    mocker.patch.object(
+        gpg,
+        'decrypt_submission_or_reply',
+        side_effect=mock_decrypt_submission_or_reply,
+    )
 
     api = mocker.MagicMock(session=session)
-    ms = MessageSync(api, 'mock', True)
-    ms.session = session  # "patch" it with a real session
+    ms = MessageSync(api, gpg, session_maker)
     ms.api.download_submission = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
 
     mock_message_ready = mocker.patch.object(ms, 'message_ready')
@@ -68,13 +58,19 @@ def test_MessageSync_run_success(mocker, session, source):
     # check that it runs without raising exceptions
     ms.run(False)
 
-    mock_decryption_status.assert_called_once_with(message, api.session, True, expected_content)
-    mock_download_status.called_once_with(message, api.mock_session)
     mock_message_ready.emit.assert_called_once_with(message.uuid, expected_content)
 
+    session.refresh(message)
+    assert message.content == expected_content
+    assert message.is_downloaded is True
+    assert message.is_decrypted is True
 
-def test_MessageSync_run_decryption_error(mocker, session, source):
-    """Test when a message successfully downloads, but does not successfully decrypt."""
+
+def test_MessageSync_run_decryption_error(mocker, session, source, session_maker, homedir):
+    """
+    Test when a message successfully downloads, but does not successfully decrypt.
+    Using the `homedir` fixture to get a GPG keyring.
+    """
     message = factory.Message(source=source['source'],
                               is_downloaded=False,
                               is_decrypted=None,
@@ -82,22 +78,14 @@ def test_MessageSync_run_decryption_error(mocker, session, source):
     session.add(message)
     session.commit()
 
-    # mock the fetching of submissions
-    mocker.patch('securedrop_client.storage.find_new_messages', return_value=[message])
-    mock_download_status = mocker.patch(
-        'securedrop_client.message_sync.storage.mark_message_as_downloaded')
-    mock_decryption_status = mocker.patch(
-        'securedrop_client.message_sync.storage.set_object_decryption_status_with_content')
-
     # don't create the signal
     mocker.patch('securedrop_client.message_sync.pyqtSignal')
-    # mock the GpgHelper creation since we don't have directories/keys setup
-    mocker.patch('securedrop_client.message_sync.GpgHelper')
 
     api = mocker.MagicMock(session=session)
 
-    ms = MessageSync(api, 'mock', True)
-    ms.session = session  # "patch" it with a real session
+    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+
+    ms = MessageSync(api, gpg, session_maker)
     mocker.patch.object(ms.gpg, 'decrypt_submission_or_reply', side_effect=CryptoError)
 
     ms.api.download_submission = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
@@ -107,60 +95,73 @@ def test_MessageSync_run_decryption_error(mocker, session, source):
     # check that it runs without raising exceptions
     ms.run(False)
 
-    mock_download_status.assert_called_once_with(message.uuid, session)
-    mock_decryption_status.assert_called_once_with(message, api.session, False)
     mock_message_ready.emit.assert_called_once_with(message.uuid, '<Message not yet available>')
+    assert message.content is None
+    assert message.is_downloaded is True
+    assert message.is_decrypted is False
 
 
-def test_MessageSync_exception(homedir, config, mocker, source):
+def test_MessageSync_exception(homedir, config, mocker, source, session, session_maker):
     """
-    Mostly here for code coverage- makes sure that if an exception is
-    raised in the download thread, the code which catches it is actually
-    run.
+    Makes sure that if an exception is raised in the download thread, the code which catches it is
+    actually run.
     Using the `config` fixture to ensure the config is written to disk.
     """
-    message = factory.Message(source=source['source'])
+    message = factory.Message(source=source['source'],
+                              is_downloaded=False,
+                              is_decrypted=None,
+                              content=None)
+    session.add(message)
+    session.commit()
+
+    mock_message = mocker.patch("sdclientapi.sdlocalobjects.Submission",
+                                mocker.MagicMock(side_effect=Exception()))
+
     api = mocker.MagicMock()
-    is_qubes = False
-
-    # mock to return the submission we want
-    mocker.patch('securedrop_client.storage.find_new_messages', return_value=[message])
-    mocker.patch('securedrop_client.storage.find_new_files', return_value=[])
-    # mock to prevent GpgHelper from raising errors on init
-    mocker.patch('securedrop_client.crypto.safe_mkdir')
-
-    ms = MessageSync(api, str(homedir), is_qubes)
-    mocker.patch.object(ms.gpg, 'decrypt_submission_or_reply', side_effect=CryptoError)
+    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    ms = MessageSync(api, gpg, session_maker)
 
     # check that it runs without raising exceptions
     ms.run(False)
 
+    # ensure this was called and an exception was raised somewhere
+    assert mock_message.called
 
-def test_MessageSync_run_failure(mocker, source):
+
+def test_MessageSync_run_failure(mocker, source, session, session_maker, homedir):
     message = factory.Message(source=source['source'])
-
-    # mock the fetching of submissions
-    mocker.patch('securedrop_client.storage.find_new_messages', return_value=[message])
-    mocker.patch('securedrop_client.storage.find_new_files', return_value=[])
-    # mock the handling of the downloaded files
-    mocker.patch('securedrop_client.message_sync.storage.mark_file_as_downloaded')
-    mocker.patch('securedrop_client.message_sync.storage.mark_message_as_downloaded')
-    # mock the GpgHelper creation since we don't have directories/keys setup
-    mocker.patch('securedrop_client.message_sync.GpgHelper')
+    session.add(message)
+    session.commit()
 
     api = mocker.MagicMock()
-    home = "/home/user/.sd"
-    is_qubes = False
-
-    ms = MessageSync(api, home, is_qubes)
+    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    ms = MessageSync(api, gpg, session_maker)
     ms.api.download_submission = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
 
     # check that it runs without raising exceptions
     ms.run(False)
 
 
-def test_ReplySync_run_success(mocker, session, source):
-    """Test when a reply successfully downloads and decrypts."""
+def test_ReplySync_init(mocker, session_maker):
+    """
+    Ensure things are set up as expected
+    """
+
+    mock_api = mocker.MagicMock()
+    mock_gpg = mocker.MagicMock()
+
+    rs = ReplySync(mock_api, mock_gpg, session_maker)
+
+    assert rs.api == mock_api
+    assert rs.gpg == mock_gpg
+    assert rs.session_maker == session_maker
+
+
+def test_ReplySync_run_success(mocker, session, source, session_maker, homedir):
+    """
+    Test when a reply successfully downloads and decrypts.
+    Using the `homedir` fixture to get a GPG keyring.
+    """
     reply = factory.Reply(source=source['source'],
                           is_downloaded=False,
                           is_decrypted=None,
@@ -170,17 +171,6 @@ def test_ReplySync_run_success(mocker, session, source):
 
     expected_content = 'foo'
 
-    def set_object_decryption_status_with_content_side_effect(*nargs, **kwargs):
-        reply.content = expected_content
-
-    # mock the fetching of replies
-    mocker.patch('securedrop_client.storage.find_new_replies', return_value=[reply])
-    mock_download_status = mocker.patch(
-        'securedrop_client.message_sync.storage.mark_reply_as_downloaded')
-    mock_decryption_status = mocker.patch(
-        'securedrop_client.message_sync.storage.set_object_decryption_status_with_content',
-        side_effect=set_object_decryption_status_with_content_side_effect)
-
     # don't create the signal
     mocker.patch('securedrop_client.message_sync.pyqtSignal')
 
@@ -188,13 +178,15 @@ def test_ReplySync_run_success(mocker, session, source):
         with open(plaintext_filename, 'w') as f:
             f.write(expected_content)
 
-    # mock the GpgHelper creation since we don't have directories/keys setup
-    mock_gpg_helper = mocker.MagicMock(decrypt_submission_or_reply=mock_decrypt_submission_or_reply)
-    mocker.patch('securedrop_client.message_sync.GpgHelper', return_value=mock_gpg_helper)
+    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    mocker.patch.object(
+        gpg,
+        'decrypt_submission_or_reply',
+        side_effect=mock_decrypt_submission_or_reply,
+    )
 
     api = mocker.MagicMock(session=session)
-    rs = ReplySync(api, 'mock', True)
-    rs.session = session  # "patch" it with a real session
+    rs = ReplySync(api, gpg, session_maker)
     rs.api.download_reply = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
 
     mock_reply_ready = mocker.patch.object(rs, 'reply_ready')
@@ -202,34 +194,19 @@ def test_ReplySync_run_success(mocker, session, source):
     # check that it runs without raising exceptions
     rs.run(False)
 
-    mock_decryption_status.assert_called_once_with(reply, api.session, True, expected_content)
-    mock_download_status.called_once_with(reply, api.mock_session)
     mock_reply_ready.emit.assert_called_once_with(reply.uuid, expected_content)
 
+    session.refresh(reply)
+    assert reply.content == expected_content
+    assert reply.is_downloaded is True
+    assert reply.is_decrypted is True
 
-def test_ReplySync_exception(mocker):
+
+def test_ReplySync_run_decryption_error(mocker, session, source, session_maker, homedir):
     """
-    Mostly here for code coverage- makes sure that if an exception is
-    raised in the download thread, the code which catches it is actually
-    run
+    Test when a reply successfully downloads, but does not successfully decrypt.
+    Using the `homedir` fixture to get a GPG keyring.
     """
-    reply = factory.Reply()
-    api = mocker.MagicMock()
-    home = "/home/user/.sd"
-    is_qubes = False
-
-    mocker.patch('securedrop_client.storage.find_new_replies', return_value=[reply])
-    mocker.patch('securedrop_client.message_sync.GpgHelper')
-    mocker.patch("sdclientapi.sdlocalobjects.Reply", mocker.MagicMock(side_effect=Exception()))
-
-    rs = ReplySync(api, home, is_qubes)
-
-    # check that it runs without raise exceptions
-    rs.run(False)
-
-
-def test_ReplySync_run_decryption_error(mocker, session, source):
-    """Test when a reply successfully downloads, but does not successfully decrypt."""
     reply = factory.Reply(source=source['source'],
                           is_downloaded=False,
                           is_decrypted=None,
@@ -237,22 +214,14 @@ def test_ReplySync_run_decryption_error(mocker, session, source):
     session.add(reply)
     session.commit()
 
-    # mock the fetching of replies
-    mocker.patch('securedrop_client.storage.find_new_replies', return_value=[reply])
-    mock_download_status = mocker.patch(
-        'securedrop_client.message_sync.storage.mark_reply_as_downloaded')
-    mock_decryption_status = mocker.patch(
-        'securedrop_client.message_sync.storage.set_object_decryption_status_with_content')
-
     # don't create the signal
     mocker.patch('securedrop_client.message_sync.pyqtSignal')
-    # mock the GpgHelper creation since we don't have directories/keys setup
-    mocker.patch('securedrop_client.message_sync.GpgHelper')
 
     api = mocker.MagicMock(session=session)
 
-    rs = ReplySync(api, 'mock', True)
-    rs.session = session  # "patch" it with a real session
+    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+
+    rs = ReplySync(api, gpg, session_maker)
     mocker.patch.object(rs.gpg, 'decrypt_submission_or_reply', side_effect=CryptoError)
 
     rs.api.download_reply = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
@@ -262,28 +231,48 @@ def test_ReplySync_run_decryption_error(mocker, session, source):
     # check that it runs without raising exceptions
     rs.run(False)
 
-    mock_download_status.assert_called_once_with(reply.uuid, session)
-    mock_decryption_status.assert_called_once_with(reply, api.session, False)
     mock_reply_ready.emit.assert_called_once_with(reply.uuid, '<Reply not yet available>')
+    assert reply.content is None
+    assert reply.is_downloaded is True
+    assert reply.is_decrypted is False
 
 
-def test_ReplySync_run_failure(mocker, session, source):
+def test_ReplySync_exception(homedir, config, mocker, source, session, session_maker):
+    """
+    Makes sure that if an exception is raised in the download thread, the code which catches it is
+    actually run.
+    Using the `config` fixture to ensure the config is written to disk.
+    """
+    reply = factory.Reply(source=source['source'],
+                          is_downloaded=False,
+                          is_decrypted=None,
+                          content=None)
+    session.add(reply)
+    session.commit()
+
+    mock_reply = mocker.patch("sdclientapi.sdlocalobjects.Reply",
+                              mocker.MagicMock(side_effect=Exception()))
+
+    api = mocker.MagicMock()
+    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    rs = ReplySync(api, gpg, session_maker)
+
+    # check that it runs without raising exceptions
+    rs.run(False)
+
+    # ensure this was called and an exception was raised somewhere
+    assert mock_reply.called
+
+
+def test_ReplySync_run_failure(mocker, source, session, session_maker, homedir):
     reply = factory.Reply(source=source['source'])
     session.add(reply)
     session.commit()
 
-    # mock finding new replies
-    mocker.patch('securedrop_client.storage.find_new_replies', return_value=[reply])
-    # mock handling the new reply
-    mocker.patch('securedrop_client.message_sync.storage.mark_reply_as_downloaded')
-    mocker.patch('securedrop_client.message_sync.GpgHelper')
-
     api = mocker.MagicMock()
-    home = "/home/user/.sd"
-    is_qubes = False
+    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    rs = ReplySync(api, gpg, session_maker)
+    rs.api.download_reply = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
 
-    ms = ReplySync(api, home, is_qubes)
-    ms.api.download_submission = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
-
-    # check that it runs without raise exceptions
-    ms.run(False)
+    # check that it runs without raising exceptions
+    rs.run(False)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,7 @@ from securedrop_client.db import Reply, File, Message, User
 
 
 def test_string_representation_of_user():
-    user = User('hehe')
+    user = User(username='hehe')
     user.__repr__()
 
 
@@ -29,7 +29,7 @@ def test_string_representation_of_file():
 
 
 def test_string_representation_of_reply():
-    user = User('hehe')
+    user = User(username='hehe')
     source = factory.Source()
     reply = Reply(source=source, journalist=user, filename="1-reply.gpg",
                   size=1234, uuid='test')
@@ -43,7 +43,7 @@ def test_source_collection():
                  download_url='http://test/test')
     message = Message(source=source, uuid="test", size=123, filename="3-test.doc.gpg",
                       download_url='http://test/test')
-    user = User('hehe')
+    user = User(username='hehe')
     reply = Reply(source=source, journalist=user, filename="1-reply.gpg",
                   size=1234, uuid='test')
     source.files = [file_]

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,0 +1,119 @@
+'''
+Testing for the ApiJobQueue and related classes.
+'''
+import pytest
+
+from sdclientapi import AuthError, RequestTimeoutError
+
+from securedrop_client.queue import ApiInaccessibleError, ApiJob
+
+
+def test_ApiInaccessibleError_init():
+    # check default value
+    err = ApiInaccessibleError()
+    assert str(err).startswith('API is inaccessible')
+    assert isinstance(err, Exception)
+
+    # check custom
+    msg = 'foo'
+    err = ApiInaccessibleError(msg)
+    assert str(err) == msg
+
+
+def test_ApiJob_raises_NotImplemetedError():
+    job = ApiJob()
+
+    with pytest.raises(NotImplementedError):
+        job.call_api(None, None)
+
+
+def dummy_job_factory(mocker, return_value):
+    '''
+    Factory that creates dummy `ApiJob`s to DRY up test code.
+    '''
+    class DummyApiJob(ApiJob):
+        success_signal = mocker.MagicMock()
+        failure_signal = mocker.MagicMock()
+
+        def __init__(self, *nargs, **kwargs):
+            super().__init__(*nargs, **kwargs)
+
+        def call_api(self, api_client, session):
+            if isinstance(return_value, Exception):
+                raise return_value
+            else:
+                return return_value
+
+    return DummyApiJob
+
+
+def test_ApiJob_no_api(mocker):
+    return_value = 'wat'
+    api_job_cls = dummy_job_factory(mocker, return_value)
+    api_job = api_job_cls()
+
+    mock_session = mocker.MagicMock()
+
+    with pytest.raises(ApiInaccessibleError):
+        api_job._do_call_api(None, mock_session)
+
+    assert not api_job.success_signal.emit.called
+    assert not api_job.failure_signal.emit.called
+
+
+def test_ApiJob_success(mocker):
+    return_value = 'wat'
+    api_job_cls = dummy_job_factory(mocker, return_value)
+    api_job = api_job_cls()
+
+    mock_api_client = mocker.MagicMock()
+    mock_session = mocker.MagicMock()
+
+    api_job._do_call_api(mock_api_client, mock_session)
+
+    api_job.success_signal.emit.assert_called_once_with(return_value)
+    assert not api_job.failure_signal.emit.called
+
+
+def test_ApiJob_auth_error(mocker):
+    return_value = AuthError('oh no')
+    api_job_cls = dummy_job_factory(mocker, return_value)
+    api_job = api_job_cls()
+
+    mock_api_client = mocker.MagicMock()
+    mock_session = mocker.MagicMock()
+
+    with pytest.raises(ApiInaccessibleError):
+        api_job._do_call_api(mock_api_client, mock_session)
+
+    assert not api_job.success_signal.emit.called
+    assert not api_job.failure_signal.emit.called
+
+
+def test_ApiJob_timeout_error(mocker):
+    return_value = RequestTimeoutError()
+    api_job_cls = dummy_job_factory(mocker, return_value)
+    api_job = api_job_cls()
+
+    mock_api_client = mocker.MagicMock()
+    mock_session = mocker.MagicMock()
+
+    with pytest.raises(RequestTimeoutError):
+        api_job._do_call_api(mock_api_client, mock_session)
+
+    assert not api_job.success_signal.emit.called
+    assert not api_job.failure_signal.emit.called
+
+
+def test_ApiJob_other_error(mocker):
+    return_value = Exception()
+    api_job_cls = dummy_job_factory(mocker, return_value)
+    api_job = api_job_cls()
+
+    mock_api_client = mocker.MagicMock()
+    mock_session = mocker.MagicMock()
+
+    api_job._do_call_api(mock_api_client, mock_session)
+
+    assert not api_job.success_signal.emit.called
+    api_job.failure_signal.emit.assert_called_once_with(return_value)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,12 +1,19 @@
 '''
 Testing for the ApiJobQueue and related classes.
 '''
+import os
 import pytest
+import sdclientapi
 
+from . import factory
 from queue import Queue
 from sdclientapi import AuthError, RequestTimeoutError
+from typing import Tuple
 
-from securedrop_client.queue import ApiInaccessibleError, ApiJob, RunnableQueue
+from securedrop_client import db
+from securedrop_client.crypto import GpgHelper
+from securedrop_client.queue import ApiInaccessibleError, ApiJob, RunnableQueue, \
+    DownloadSubmissionJob
 
 
 def test_ApiInaccessibleError_init():
@@ -202,3 +209,158 @@ def test_RunnableQueue_job_timeout(mocker):
 
     # ensure we don't have stale mocks
     assert mock_process_events.called
+
+
+def test_DownloadSubmissionJob_happy_path_no_etag(mocker, homedir, session, session_maker):
+    source = factory.Source()
+    file_ = factory.File(source=source)
+    session.add(source)
+    session.add(file_)
+    session.commit()
+
+    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+
+    def fake_download(sdk_obj: sdclientapi.Submission) -> Tuple[str, str]:
+        '''
+        :return: (etag, path_to_dl)
+        '''
+        full_path = os.path.join(homedir, 'somepath')
+        with open(full_path, 'wb') as f:
+            f.write(b'')
+        return ('', full_path)
+
+    api_client = mocker.MagicMock()
+    api_client.download_submission = fake_download
+
+    job = DownloadSubmissionJob(
+        db.File,
+        file_.uuid,
+        homedir,
+        gpg,
+    )
+
+    mock_decrypt = mocker.patch.object(job, '_decrypt_file')
+    mock_logger = mocker.patch('securedrop_client.queue.logger')
+
+    job.call_api(api_client, session)
+
+    log_msg = mock_logger.debug.call_args_list[0][0][0]
+    assert log_msg.startswith('No ETag. Skipping integrity check')
+
+    # ensure mocks aren't stale
+    assert mock_decrypt.called
+
+
+def test_DownloadSubmissionJob_happy_path_sha256_etag(mocker, homedir, session, session_maker):
+    source = factory.Source()
+    file_ = factory.File(source=source)
+    session.add(source)
+    session.add(file_)
+    session.commit()
+
+    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+
+    def fake_download(sdk_obj: sdclientapi.Submission) -> Tuple[str, str]:
+        '''
+        :return: (etag, path_to_dl)
+        '''
+        full_path = os.path.join(homedir, 'somepath')
+        with open(full_path, 'wb') as f:
+            f.write(b'wat')
+
+        # sha256 of b'wat'
+        return ('sha256:f00a787f7492a95e165b470702f4fe9373583fbdc025b2c8bdf0262cc48fcff4',
+                full_path)
+
+    api_client = mocker.MagicMock()
+    api_client.download_submission = fake_download
+
+    job = DownloadSubmissionJob(
+        db.File,
+        file_.uuid,
+        homedir,
+        gpg,
+    )
+
+    mock_decrypt = mocker.patch.object(job, '_decrypt_file')
+
+    job.call_api(api_client, session)
+
+    # ensure mocks aren't stale
+    assert mock_decrypt.called
+
+
+def test_DownloadSubmissionJob_bad_sha256_etag(mocker, homedir, session, session_maker):
+    source = factory.Source()
+    file_ = factory.File(source=source)
+    session.add(source)
+    session.add(file_)
+    session.commit()
+
+    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+
+    def fake_download(sdk_obj: sdclientapi.Submission) -> Tuple[str, str]:
+        '''
+        :return: (etag, path_to_dl)
+        '''
+        full_path = os.path.join(homedir, 'somepath')
+        with open(full_path, 'wb') as f:
+            f.write(b'')
+
+        return ('sha256:not-a-sha-sum',
+                full_path)
+
+    api_client = mocker.MagicMock()
+    api_client.download_submission = fake_download
+
+    job = DownloadSubmissionJob(
+        db.File,
+        file_.uuid,
+        homedir,
+        gpg,
+    )
+
+    # we currently don't handle errors in the checksum
+    with pytest.raises(RuntimeError):
+        job.call_api(api_client, session)
+
+
+def test_DownloadSubmissionJob_happy_path_unknown_etag(mocker, homedir, session, session_maker):
+    source = factory.Source()
+    file_ = factory.File(source=source)
+    session.add(source)
+    session.add(file_)
+    session.commit()
+
+    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+
+    def fake_download(sdk_obj: sdclientapi.Submission) -> Tuple[str, str]:
+        '''
+        :return: (etag, path_to_dl)
+        '''
+        full_path = os.path.join(homedir, 'somepath')
+        with open(full_path, 'wb') as f:
+            f.write(b'')
+        return ('UNKNOWN:abc123',
+                full_path)
+
+    api_client = mocker.MagicMock()
+    api_client.download_submission = fake_download
+
+    job = DownloadSubmissionJob(
+        db.File,
+        file_.uuid,
+        homedir,
+        gpg,
+    )
+
+    mock_decrypt = mocker.patch.object(job, '_decrypt_file')
+    mock_logger = mocker.patch('securedrop_client.queue.logger')
+
+    job.call_api(api_client, session)
+
+    log_msg = mock_logger.debug.call_args_list[0][0][0]
+    assert log_msg.startswith('Unknown hash algorithm')
+
+    # ensure mocks aren't stale
+    assert mock_decrypt.called

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -425,7 +425,7 @@ def test_update_sources_deletes_files_associated_with_the_source(
     msg_submission = db.File(
         source=local_source, uuid="test", size=123, filename=msg_server_filename,
         download_url='http://test/test')
-    user = db.User('hehe')
+    user = db.User(username='hehe')
     reply = db.Reply(
         source=local_source, journalist=user, filename=reply_server_filename,
         size=1234, uuid='test')


### PR DESCRIPTION
Fixes #224

Adds the initial implementation of the `ApiJobQueue`. This diverged a bit from the original design spec, but still fundamentally accomplishes the task of strict ordering of replies. This PR only contains `ApiJob`s for downloading files from the API, but using the patterns here, the rest should be relatively easy to implement.

### Design Choices

An `ApiJob` only needs to implement one method called `call_api` that should do everything needed to process an API including writing it to the local DB. This method might be renamed `run_job` for clarity.

On success/failure, respective signals are emitted. These are connected to callbacks on the `Controller` which then takes action directly and possible relays the signal to other `QObjects`. In the case of a `DownloadSubmissionJob`, we don't want to directly connect the `FileWidget`s to the signals on the job because that is likely too much connectedness. Using the `Controller` as a relay helps maintain separation.

### Follow Ups

There's a few tickets we'll need to add to polish this up. Addressing all of these would require too much time and already this PR is fairly large and complex.

#### Timeout / No Auth

There is no signal for for `ApiInacessibleError` or `RequestTimeoutError`, and there needs to be as these being raised requires action from the user. As it stands now, either of these errors will either abort the thread (with no way to restart) or crash the app. I haven't tested.

#### Restarting Threads

If a thread aborts because it has no auth or timeout, there needs to be a way to restart it. Likely this would mean calling `ApiJobQueue.start_queues()` again, but as it's written now, this wouldn't restart the current threads but it would create new ones (or do some other badness).