### PR TITLE
fix gpg key import / replies / encrypt to source on qubes

### DIFF
--- a/securedrop_client/crypto.py
+++ b/securedrop_client/crypto.py
@@ -158,9 +158,14 @@ class GpgHelper:
             cmd.extend(['--encrypt',
                         '-r', source.fingerprint,
                         '-r', self.journalist_key_fingerprint,
-                        '--armor',
-                        '-o-',  # write to stdout
-                        content.name])
+                        '--armor'])
+            if not self.is_qubes:
+                # In Qubes, the ciphertext will go to stdout.
+                # In addition the option below cannot be passed
+                # through the gpg client wrapper.
+                cmd.extend(['-o-'])  # write to stdout
+            cmd.extend([content.name])
+
             try:
                 subprocess.check_call(cmd, stdout=stdout, stderr=stderr)
             except subprocess.CalledProcessError as e:

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -395,10 +395,11 @@ class Controller(QObject):
         for source in remote_sources:
             if source.key and source.key.get('type', None) == 'PGP':
                 pub_key = source.key.get('public', None)
-                if not pub_key:
+                fingerprint = source.key.get('fingerprint', None)
+                if not pub_key or not fingerprint:
                     continue
                 try:
-                    self.gpg.import_key(source.uuid, pub_key)
+                    self.gpg.import_key(source.uuid, pub_key, fingerprint)
                 except CryptoError:
                     logger.warning('Failed to import key for source {}'.format(source.uuid))
 

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -79,7 +79,7 @@ def test_import_key(homedir, config, source):
     Using the `config` fixture to ensure the config is written to disk.
     '''
     helper = GpgHelper(homedir, is_qubes=False)
-    helper.import_key(source['uuid'], source['public_key'])
+    helper.import_key(source['uuid'], source['public_key'], source['fingerprint'])
 
 
 def test_import_key_gpg_call_fail(homedir, config, mocker):
@@ -99,21 +99,6 @@ def test_import_key_gpg_call_fail(homedir, config, mocker):
     assert mock_call.called
 
 
-def test_import_key_multiple_fingerprints(homedir, source, config, mocker):
-    '''
-    Check that an error is raised if multiple fingerpints are found on key import.
-    Using the `config` fixture to ensure the config is written to disk.
-    '''
-    helper = GpgHelper(homedir, is_qubes=False)
-    mock_import = mocker.patch.object(helper, '_import', returnvalue={'a', 'b'})
-
-    with pytest.raises(RuntimeError, match='Expected exactly one fingerprint\\.'):
-        helper.import_key(source['uuid'], source['public_key'])
-
-    # ensure the mock was used
-    assert mock_import.called
-
-
 def test_encrypt(homedir, source, config, mocker):
     '''
     Check that calling `encrypt` encrypts the message.
@@ -123,7 +108,7 @@ def test_encrypt(homedir, source, config, mocker):
 
     # first we have to ensure the pubkeys are available
     helper._import(PUB_KEY)
-    helper._import(JOURNO_KEY, is_private=True)
+    helper._import(JOURNO_KEY)
 
     plaintext = 'bueller?'
     cyphertext = helper.encrypt_to_source(source['uuid'], plaintext)
@@ -158,7 +143,6 @@ def test_encrypt_fail(homedir, source, config, mocker):
 
     # first we have to ensure the pubkeys are available
     helper._import(PUB_KEY)
-    helper._import(JOURNO_KEY, is_private=True)
 
     plaintext = 'bueller?'
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -533,6 +533,7 @@ def test_Controller_on_sync_success_with_key_import_fail(homedir, config, mocker
     mock_source.key = {
         'type': 'PGP',
         'public': PUB_KEY,
+        'fingerprint': 'ABCDEFGHIJKLMAO'
     }
 
     mock_sources = [mock_source]


### PR DESCRIPTION
Fixes #363 

The reviewer of this PR should test this on both Qubes and non-Qubes. If you need/want additional clarity on how to test please let me know and I will happily elaborate on any unclear parts of the test plans below.

# Testing on non Qubes

1. Make sure you’re running the server container on latest `develop` 
2. Start the client on this branch, and ensure you can successfully send a reply to a source (warning: due to #365, you should verify either using the client logs which will log a line when a reply is successfully sent OR the dev server output on the server side by watching for a 201 response from the `POST /api/v1/sources/<source uuid>/replies` endpoint)

# Testing on Qubes

1. Make sure you have applied the RPC policy change merged in https://github.com/freedomofpress/securedrop-workstation/pull/254. If you like you can test this part works by trying to import a key from `sd-svs` into `sd-gpg`. Note that if you see some error output containing a note about `no-tty` when you try to import a test gpg key, you will need to apply the (unreleased) fix merged today over in Qubes land: https://github.com/QubesOS/qubes-app-linux-split-gpg/pull/23.

2. Next, make sure your staging server is running on anything after this server-side API change was merged: https://github.com/freedomofpress/securedrop/pull/4436.

3. In your dev env in `sd-svs` AppVM on Qubes, check out the branch in this PR (I attach a NetVM to my `sd-svs` AppVM for dev purposes), run the client application (without passing `—no-proxy` to the client invokation), monitor the logs, and verify that:

- [ ] After sync, you do not see the `qubes-gpg-client: unrecognized option '--import-options’` error described in #363
- [ ] You can reply to a source (again monitor the client logs to verify it was successfully sent), and after syncing once more you continue to see the reply appear in the UI.



