### PR TITLE
fix sync bug

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -403,6 +403,7 @@ class Controller(QObject):
                 except CryptoError:
                     logger.warning('Failed to import key for source {}'.format(source.uuid))
 
+        self.sync_events.emit('synced')
         self.update_sources()
 
     def on_sync_failure(self, result: Exception) -> None:


### PR DESCRIPTION
# Description

Fixes #issue https://github.com/freedomofpress/securedrop-client/issues/386 by adding back "synced" signal.

# Test Plan

Run through STR in issue and see the actual behavior match expected behavior:

Refresh icon returns back to static image after sync, indicating that the gui is properly being notified of a sync finishing.
