### PR TITLE
Use gloabl session maker

### DIFF
--- a/create_dev_data.py
+++ b/create_dev_data.py
@@ -2,11 +2,15 @@
 import json
 import os
 import sys
+
 from securedrop_client.config import Config
-from securedrop_client.db import Base, make_session_maker
+from securedrop_client.db import Base, Session, make_engine
+
 
 sdc_home = sys.argv[1]
-session = make_session_maker(sdc_home)()
+
+engine = make_engine(sdc_home)
+session = Session(bind=engine)
 Base.metadata.create_all(bind=session.get_bind())
 
 with open(os.path.join(sdc_home, Config.CONFIG_NAME), 'w') as f:

--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -25,14 +25,16 @@ import signal
 import sys
 import socket
 from argparse import ArgumentParser
+
 from PyQt5.QtWidgets import QApplication, QMessageBox
 from PyQt5.QtCore import Qt, QTimer
 from logging.handlers import TimedRotatingFileHandler
+
 from securedrop_client import __version__
 from securedrop_client.logic import Controller
 from securedrop_client.gui.main import Window
 from securedrop_client.resources import load_icon, load_css
-from securedrop_client.db import make_session_maker
+from securedrop_client.db import Session, make_engine
 from securedrop_client.utils import safe_mkdir
 
 DEFAULT_SDC_HOME = '~/.securedrop_client'
@@ -184,15 +186,15 @@ def start_app(args, qt_args) -> None:
 
     prevent_second_instance(app, args.sdc_home)
 
-    session_maker = make_session_maker(args.sdc_home)
-
     gui = Window()
 
     app.setWindowIcon(load_icon(gui.icon))
     app.setStyleSheet(load_css('sdclient.css'))
 
-    controller = Controller("http://localhost:8081/", gui, session_maker,
-                            args.sdc_home, not args.no_proxy)
+    engine = make_engine(args.sdc_home)
+    Session.configure(bind=engine)
+
+    controller = Controller("http://localhost:8081/", gui, args.sdc_home, not args.no_proxy)
     controller.setup()
 
     configure_signal_handlers(app)

--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -6,8 +6,7 @@ from sqlalchemy import Boolean, Column, create_engine, DateTime, ForeignKey, Int
     Text, MetaData, CheckConstraint, text, UniqueConstraint
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship, backref, scoped_session, sessionmaker
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import relationship, backref, sessionmaker
 
 
 Session = sessionmaker()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1250,7 +1250,7 @@ class ReplyWidget(ConversationWidget):
         message_failed_signal.connect(self._on_reply_failure)
 
     @pyqtSlot(str, str)
-    def _on_reply_success(self, message_id: str, source_uuid: str) -> None:
+    def _on_reply_success(self, source_uuid: str, message_id: str) -> None:
         """
         Conditionally update this ReplyWidget's state if and only if the message_id of the emitted
         signal matches the message_id of this widget.
@@ -1259,7 +1259,7 @@ class ReplyWidget(ConversationWidget):
             logger.debug('Reply {} succeeded'.format(message_id))
 
     @pyqtSlot(str, str)
-    def _on_reply_failure(self, message_id: str, source_uuid: str) -> None:
+    def _on_reply_failure(self, source_uuid: str, message_id: str) -> None:
         """
         Conditionally update this ReplyWidget's state if and only if the message_id of the emitted
         signal matches the message_id of this widget.
@@ -1369,9 +1369,6 @@ class ConversationView(QWidget):
         main_layout.addWidget(self.scroll)
         self.setLayout(main_layout)
 
-        self.controller.reply_succeeded.connect(self.on_reply_succeeded)
-        self.controller.reply_failed.connect(self.on_reply_failed)
-
         self.update_conversation(self.source.collection)
 
     def clear_conversation(self):
@@ -1462,14 +1459,6 @@ class ConversationView(QWidget):
         """
         if source_uuid == self.source.uuid:
             self.add_reply_from_reply_box(reply_uuid, reply_text)
-
-    def on_reply_succeeded(self, reply_uuid: str, source_uuid: str) -> None:
-        if source_uuid == self.source.uuid:
-            pass
-
-    def on_reply_failed(self, reply_uuid: str, source_uuid: str) -> None:
-        if source_uuid == self.source.uuid:
-            pass
 
 
 class SourceConversationWrapper(QWidget):

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -601,8 +601,8 @@ class Controller(QObject):
     def on_reply_success(self, result, current_object: Tuple[str, str]) -> None:
         source_uuid, reply_uuid = current_object
         storage.add_reply(reply_uuid, source_uuid, self.api.token_journalist_uuid, result.filename)
-        self.reply_succeeded.emit(reply_uuid, source_uuid)
+        self.reply_succeeded.emit(source_uuid, reply_uuid)
 
     def on_reply_failure(self, result, current_object: Tuple[str, str]) -> None:
         source_uuid, reply_uuid = current_object
-        self.reply_failed.emit(reply_uuid, source_uuid)
+        self.reply_failed.emit(source_uuid, reply_uuid)

--- a/securedrop_client/message_sync.py
+++ b/securedrop_client/message_sync.py
@@ -28,9 +28,7 @@ from typing import Callable, Union
 from PyQt5.QtCore import QObject, pyqtSignal
 from securedrop_client import storage
 from securedrop_client.crypto import GpgHelper, CryptoError
-from securedrop_client.db import File, Message, Reply
-from sqlalchemy.orm import scoped_session
-from sqlalchemy.orm.session import Session
+from securedrop_client.db import Session, File, Message, Reply
 from tempfile import NamedTemporaryFile
 
 
@@ -43,12 +41,10 @@ class APISyncObject(QObject):
         self,
         api: API,
         gpg: GpgHelper,
-        session_maker: scoped_session,
     ) -> None:
         super().__init__()
         self.api = api
         self.gpg = gpg
-        self.session_maker = session_maker
 
     def decrypt_the_thing(
         self,
@@ -93,7 +89,7 @@ class MessageSync(APISyncObject):
     message_ready = pyqtSignal([str, str])
 
     def run(self, loop: bool = True) -> None:
-        session = self.session_maker()
+        session = Session()
         while True:
             submissions = storage.find_new_messages(session)
 
@@ -149,7 +145,7 @@ class ReplySync(APISyncObject):
     reply_ready = pyqtSignal([str, str])
 
     def run(self, loop: bool = True) -> None:
-        session = self.session_maker()
+        session = Session()
         while True:
             replies = storage.find_new_replies(session)
 

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -27,7 +27,6 @@ from typing import List, Tuple, Type, Union
 
 from sqlalchemy import or_
 from sqlalchemy.orm import scoped_session
-from sqlalchemy.orm.exc import NoResultFound
 
 from securedrop_client.db import Session, Source, Message, File, Reply, User
 from sdclientapi import API
@@ -136,8 +135,11 @@ def update_local_storage(remote_sources: List[SDKSource],
 
     session.close()
 
+
 def update_sources(remote_sources: List[SDKSource],
-                   local_sources: List[Source], session: scoped_session, data_dir: str) -> None:
+                   local_sources: List[Source],
+                   session: scoped_session,
+                   data_dir: str) -> None:
     """
     Given collections of remote sources, the current local sources and a
     session to the local database, ensure the state of the local database
@@ -385,8 +387,10 @@ def mark_message_as_downloaded(uuid: str, session: scoped_session) -> None:
     session.commit()
 
 
-def set_object_decryption_status_with_content(obj: Union[File, Message, Reply], session: scoped_session,
-                                              is_successful: bool, content: str = None) -> None:
+def set_object_decryption_status_with_content(obj: Union[File, Message, Reply],
+                                              session: scoped_session,
+                                              is_successful: bool,
+                                              content: str = None) -> None:
     """Mark object as decrypted or not in the database."""
 
     model = type(obj)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,13 @@ def _alembic_config(homedir):
 
 
 @pytest.fixture(scope='function')
+def SessionFactory(homedir):
+    engine = make_engine(homedir)
+    Session = sessionmaker(bind=engine)
+    return Session
+
+
+@pytest.fixture(scope='function')
 def session(homedir):
     """
     This fixture recreates the test db every time it is used

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -414,7 +414,6 @@ def test_MainView_on_source_changed(mocker):
     source = factory.Source()
     mv.set_conversation.get_current_source = mocker.MagicMock(return_value=source)
     mv.controller = mocker.MagicMock(is_authenticated=True)
-    mocker.patch('securedrop_client.gui.widgets.source_exists', return_value=True)
     scw = mocker.MagicMock()
     mocker.patch('securedrop_client.gui.widgets.SourceConversationWrapper', return_value=scw)
 
@@ -431,7 +430,6 @@ def test_MainView_on_source_changed_when_source_no_longer_exists(mocker):
     mv = MainView(None)
     mv.clear_conversation = mocker.MagicMock()
     mv.controller = mocker.MagicMock(is_authenticated=True)
-    mocker.patch('securedrop_client.gui.widgets.source_exists', return_value=False)
 
     mv.on_source_changed()
 
@@ -621,8 +619,8 @@ def test_SourceWidget_delete_source(mocker, session, source):
 
 def test_SourceWidget_delete_source_when_user_chooses_cancel(mocker, session, source):
     source = source['source']  # to get the Source object
-    file_ = factory.File(source=source)
-    session.add(file_)
+    file = factory.File(source=source)
+    session.add(file)
     message = factory.Message(source=source)
     session.add(message)
     session.commit()
@@ -1136,9 +1134,8 @@ def test_FileWidget_init_left(mocker):
     """
     mock_controller = mocker.MagicMock()
     mock_signal = mocker.MagicMock()  # not important for this test
-    mock_uuid = 'mock'
-
-    fw = FileWidget(mock_uuid, mock_controller, mock_signal)
+    file = factory.File()
+    fw = FileWidget(file, mock_controller, mock_signal)
 
     assert isinstance(fw.layout.takeAt(0), QWidgetItem)
     assert isinstance(fw.layout.takeAt(0), QWidgetItem)
@@ -1152,23 +1149,16 @@ def test_FileWidget_mousePressEvent_download(mocker, session, source):
     """
     mock_signal = mocker.MagicMock()  # not important for this test
 
-    file_ = factory.File(source=source['source'],
-                         is_downloaded=False,
-                         is_decrypted=None)
-    session.add(file_)
+    file = factory.File(source=source['source'], is_downloaded=False, is_decrypted=None)
+    session.add(file)
     session.commit()
 
-    mock_get_file = mocker.MagicMock(return_value=file_)
-    mock_controller = mocker.MagicMock(get_file=mock_get_file)
+    mock_controller = mocker.MagicMock()
 
-    fw = FileWidget(file_.uuid, mock_controller, mock_signal)
-    mock_get_file.assert_called_once_with(file_.uuid)
-    mock_get_file.reset_mock()
+    fw = FileWidget(file, mock_controller, mock_signal)
 
     fw.mouseReleaseEvent(None)
-    mock_get_file.assert_called_once_with(file_.uuid)
-    mock_controller.on_submission_download.assert_called_once_with(
-        db.File, file_.uuid)
+    mock_controller.on_submission_download.assert_called_once_with(db.File, file.uuid)
 
 
 def test_FileWidget_mousePressEvent_open(mocker, session, source):
@@ -1177,16 +1167,15 @@ def test_FileWidget_mousePressEvent_open(mocker, session, source):
     """
     mock_signal = mocker.MagicMock()  # not important for this test
 
-    file_ = factory.File(source=source['source'], is_downloaded=True)
-    session.add(file_)
+    file = factory.File(source=source['source'], is_downloaded=True)
+    session.add(file)
     session.commit()
 
-    mock_get_file = mocker.MagicMock(return_value=file_)
-    mock_controller = mocker.MagicMock(get_file=mock_get_file)
+    mock_controller = mocker.MagicMock()
 
-    fw = FileWidget(file_.uuid, mock_controller, mock_signal)
+    fw = FileWidget(file, mock_controller, mock_signal)
     fw.mouseReleaseEvent(None)
-    fw.controller.on_file_open.assert_called_once_with(file_.uuid)
+    fw.controller.on_file_open.assert_called_once_with(file)
 
 
 def test_FileWidget_clear_deletes_items(mocker, session, source):
@@ -1195,14 +1184,13 @@ def test_FileWidget_clear_deletes_items(mocker, session, source):
     """
     mock_signal = mocker.MagicMock()  # not important for this test
 
-    file_ = factory.File(source=source['source'], is_downloaded=True)
-    session.add(file_)
+    file = factory.File(source=source['source'], is_downloaded=True)
+    session.add(file)
     session.commit()
 
-    mock_get_file = mocker.MagicMock(return_value=file_)
-    mock_controller = mocker.MagicMock(get_file=mock_get_file)
+    mock_controller = mocker.MagicMock()
 
-    fw = FileWidget(file_.uuid, mock_controller, mock_signal)
+    fw = FileWidget(file, mock_controller, mock_signal)
     assert fw.layout.count() != 0
 
     fw.clear()
@@ -1216,18 +1204,18 @@ def test_FileWidget_on_file_download_updates_items_when_uuid_matches(mocker, sou
     """
     mock_signal = mocker.MagicMock()  # not important for this test
 
-    file_ = factory.File(source=source['source'], is_downloaded=True)
-    session.add(file_)
+    file = factory.File(source=source['source'], is_downloaded=True)
+    session.add(file)
     session.commit()
 
-    mock_get_file = mocker.MagicMock(return_value=file_)
+    mock_get_file = mocker.MagicMock(return_value=file)
     mock_controller = mocker.MagicMock(get_file=mock_get_file)
 
-    fw = FileWidget(file_.uuid, mock_controller, mock_signal)
+    fw = FileWidget(file, mock_controller, mock_signal)
     fw.clear = mocker.MagicMock()
     fw.update = mocker.MagicMock()
 
-    fw._on_file_downloaded(file_.uuid)
+    fw._on_file_downloaded(file.uuid)
 
     fw.clear.assert_called_once_with()
     fw.update.assert_called_once_with()
@@ -1241,14 +1229,14 @@ def test_FileWidget_on_file_download_updates_items_when_uuid_does_not_match(
     """
     mock_signal = mocker.MagicMock()  # not important for this test
 
-    file_ = factory.File(source=source['source'], is_downloaded=True)
-    session.add(file_)
+    file = factory.File(source=source['source'], is_downloaded=True)
+    session.add(file)
     session.commit()
 
-    mock_get_file = mocker.MagicMock(return_value=file_)
+    mock_get_file = mocker.MagicMock(return_value=file)
     mock_controller = mocker.MagicMock(get_file=mock_get_file)
 
-    fw = FileWidget(file_.uuid, mock_controller, mock_signal)
+    fw = FileWidget(file, mock_controller, mock_signal)
     fw.clear = mocker.MagicMock()
     fw.update = mocker.MagicMock()
 
@@ -1545,14 +1533,11 @@ def test_ConversationView_add_not_downloaded_file(mocker, homedir, source, sessi
     Adding a file results in a new FileWidget added to the layout with the
     proper QLabel.
     """
-    file_ = factory.File(source=source['source'],
-                         is_downloaded=False,
-                         is_decrypted=None,
-                         size=123)
-    session.add(file_)
+    file = factory.File(source=source['source'], is_downloaded=False, is_decrypted=None, size=123)
+    session.add(file)
     session.commit()
 
-    mock_get_file = mocker.MagicMock(return_value=file_)
+    mock_get_file = mocker.MagicMock(return_value=file)
     mocked_controller = mocker.MagicMock(get_file=mock_get_file)
 
     cv = ConversationView(source['source'], mocked_controller)
@@ -1562,7 +1547,7 @@ def test_ConversationView_add_not_downloaded_file(mocker, homedir, source, sessi
     mocker.patch('securedrop_client.gui.widgets.QHBoxLayout.addWidget')
     mocker.patch('securedrop_client.gui.widgets.FileWidget.setLayout')
 
-    cv.add_file(source['source'], file_)
+    cv.add_file(source['source'], file)
     mock_label.assert_called_with("Download (123 bytes)")
     assert cv.conversation_layout.addWidget.call_count == 1
 
@@ -1595,8 +1580,8 @@ def test_DeleteSourceMessage_launch_when_user_chooses_cancel(mocker, source):
 
 def test_DeleteSourceMssageBox_launch_when_user_chooses_yes(mocker, source, session):
     source = source['source']  # to get the Source object
-    file_ = factory.File(source=source)
-    session.add(file_)
+    file = factory.File(source=source)
+    session.add(file)
     message = factory.Message(source=source)
     session.add(message)
     message = factory.Message(source=source)
@@ -1638,8 +1623,8 @@ def test_DeleteSourceMssageBox_launch_when_user_chooses_yes(mocker, source, sess
 
 def test_DeleteSourceMessageBox_construct_message(mocker, source, session):
     source = source['source']  # to get the Source object
-    file_ = factory.File(source=source)
-    session.add(file_)
+    file = factory.File(source=source)
+    session.add(file)
     message = factory.Message(source=source)
     session.add(message)
     message = factory.Message(source=source)
@@ -1804,17 +1789,17 @@ def test_ReplyWidget_success_failure_slots(mocker):
 
     # check the success slog
     mock_logger = mocker.patch('securedrop_client.gui.widgets.logger')
-    widget._on_reply_success(msg_id + "x")
+    widget._on_reply_success('mock', msg_id + "x")
     assert not mock_logger.debug.called
-    widget._on_reply_success(msg_id)
+    widget._on_reply_success('mock', msg_id)
     assert mock_logger.debug.called
     mock_logger.reset_mock()
 
     # check the failure slot
     mock_logger = mocker.patch('securedrop_client.gui.widgets.logger')
-    widget._on_reply_failure(msg_id + "x")
+    widget._on_reply_failure('mock', msg_id + "x")
     assert not mock_logger.debug.called
-    widget._on_reply_failure(msg_id)
+    widget._on_reply_failure('mock', msg_id)
     assert mock_logger.debug.called
 
 
@@ -1902,8 +1887,8 @@ def test_update_conversation_maintains_old_items(mocker, session):
     session.add(source)
     session.flush()
 
-    file_ = factory.File(filename='1-source-doc.gpg', source=source)
-    session.add(file_)
+    file = factory.File(filename='1-source-doc.gpg', source=source)
+    session.add(file)
     message = factory.Message(filename='2-source-msg.gpg', source=source)
     session.add(message)
     reply = factory.Reply(filename='3-source-reply.gpg', source=source)
@@ -1927,8 +1912,8 @@ def test_update_conversation_adds_new_items(mocker, session):
     session.add(source)
     session.flush()
 
-    file_ = factory.File(filename='1-source-doc.gpg', source=source)
-    session.add(file_)
+    file = factory.File(filename='1-source-doc.gpg', source=source)
+    session.add(file)
     message = factory.Message(filename='2-source-msg.gpg', source=source)
     session.add(message)
     reply = factory.Reply(filename='3-source-reply.gpg', source=source)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -111,7 +111,6 @@ def test_start_app(homedir, mocker):
     """
     Ensure the expected things are configured and the application is started.
     """
-    mock_session_maker = mocker.MagicMock()
     mock_args = mocker.MagicMock()
     mock_qt_args = mocker.MagicMock()
     mock_args.sdc_home = str(homedir)
@@ -123,14 +122,11 @@ def test_start_app(homedir, mocker):
     mock_controller = mocker.patch('securedrop_client.app.Controller')
     mocker.patch('securedrop_client.app.prevent_second_instance')
     mocker.patch('securedrop_client.app.sys')
-    mocker.patch('securedrop_client.app.make_session_maker', return_value=mock_session_maker)
 
     start_app(mock_args, mock_qt_args)
     mock_app.assert_called_once_with(mock_qt_args)
     mock_win.assert_called_once_with()
-    mock_controller.assert_called_once_with('http://localhost:8081/',
-                                            mock_win(), mock_session_maker,
-                                            homedir, False)
+    mock_controller.assert_called_once_with('http://localhost:8081/', mock_win(), homedir, False)
 
 
 PERMISSIONS_CASES = [
@@ -170,7 +166,6 @@ PERMISSIONS_CASES = [
 def test_create_app_dir_permissions(tmpdir, mocker):
 
     for idx, case in enumerate(PERMISSIONS_CASES):
-        mock_session_maker = mocker.MagicMock()
         mock_args = mocker.MagicMock()
         mock_qt_args = mocker.MagicMock()
 
@@ -192,7 +187,6 @@ def test_create_app_dir_permissions(tmpdir, mocker):
         mocker.patch('securedrop_client.app.Controller')
         mocker.patch('securedrop_client.app.sys')
         mocker.patch('securedrop_client.app.prevent_second_instance')
-        mocker.patch('securedrop_client.app.make_session_maker', return_value=mock_session_maker)
 
         def func():
             start_app(mock_args, mock_qt_args)
@@ -245,7 +239,7 @@ def test_signal_interception(mocker, homedir):
     mocker.patch('securedrop_client.app.QApplication')
     mocker.patch('securedrop_client.app.prevent_second_instance')
     mocker.patch('sys.exit')
-    mocker.patch('securedrop_client.db.make_session_maker')
+    mocker.patch('securedrop_client.db.make_engine')
     mocker.patch('securedrop_client.app.init')
     mocker.patch('securedrop_client.logic.Controller.setup')
     mocker.patch('securedrop_client.logic.GpgHelper')

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -13,12 +13,12 @@ with open(os.path.join(os.path.dirname(__file__), 'files', 'securedrop.gpg.asc')
     JOURNO_KEY = f.read()
 
 
-def test_message_logic(homedir, config, mocker, session_maker):
+def test_message_logic(homedir, config, mocker):
     """
     Ensure that messages are handled.
     Using the `config` fixture to ensure the config is written to disk.
     """
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    gpg = GpgHelper(homedir, is_qubes=False)
 
     test_msg = 'tests/files/test-msg.gpg'
     expected_output_filename = 'test-msg'
@@ -32,12 +32,12 @@ def test_message_logic(homedir, config, mocker, session_maker):
     assert dest == os.path.join(homedir, 'data', expected_output_filename)
 
 
-def test_gunzip_logic(homedir, config, mocker, session_maker):
+def test_gunzip_logic(homedir, config, mocker):
     """
     Ensure that gzipped documents/files are handled
     Using the `config` fixture to ensure the config is written to disk.
     """
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    gpg = GpgHelper(homedir, is_qubes=False)
 
     test_gzip = 'tests/files/test-doc.gz.gpg'
     expected_output_filename = 'test-doc'
@@ -52,12 +52,12 @@ def test_gunzip_logic(homedir, config, mocker, session_maker):
     assert mock_unlink.call_count == 2
 
 
-def test_subprocess_raises_exception(homedir, config, mocker, session_maker):
+def test_subprocess_raises_exception(homedir, config, mocker):
     """
     Ensure that failed GPG commands raise an exception.
     Using the `config` fixture to ensure the config is written to disk.
     """
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    gpg = GpgHelper(homedir, is_qubes=False)
 
     test_gzip = 'tests/files/test-doc.gz.gpg'
     output_filename = 'test-doc'
@@ -73,21 +73,21 @@ def test_subprocess_raises_exception(homedir, config, mocker, session_maker):
     assert mock_unlink.call_count == 1
 
 
-def test_import_key(homedir, config, source, session_maker):
+def test_import_key(homedir, config, source):
     '''
     Check the happy path that we can import a single PGP key.
     Using the `config` fixture to ensure the config is written to disk.
     '''
-    helper = GpgHelper(homedir, session_maker, is_qubes=False)
+    helper = GpgHelper(homedir, is_qubes=False)
     helper.import_key(source['uuid'], source['public_key'], source['fingerprint'])
 
 
-def test_import_key_gpg_call_fail(homedir, config, mocker, session_maker):
+def test_import_key_gpg_call_fail(homedir, config, mocker):
     '''
     Check that a `CryptoError` is raised if calling `gpg` fails.
     Using the `config` fixture to ensure the config is written to disk.
     '''
-    helper = GpgHelper(homedir, session_maker, is_qubes=False)
+    helper = GpgHelper(homedir, is_qubes=False)
     err = CalledProcessError(cmd=['foo'], returncode=1)
     mock_call = mocker.patch('securedrop_client.crypto.subprocess.check_call',
                              side_effect=err)
@@ -99,12 +99,12 @@ def test_import_key_gpg_call_fail(homedir, config, mocker, session_maker):
     assert mock_call.called
 
 
-def test_encrypt(homedir, source, config, mocker, session_maker):
+def test_encrypt(homedir, source, config, mocker):
     '''
     Check that calling `encrypt` encrypts the message.
     Using the `config` fixture to ensure the config is written to disk.
     '''
-    helper = GpgHelper(homedir, session_maker, is_qubes=False)
+    helper = GpgHelper(homedir, is_qubes=False)
 
     # first we have to ensure the pubkeys are available
     helper._import(PUB_KEY)
@@ -134,12 +134,12 @@ def test_encrypt(homedir, source, config, mocker, session_maker):
     assert decrypted == plaintext
 
 
-def test_encrypt_fail(homedir, source, config, mocker, session_maker):
+def test_encrypt_fail(homedir, source, config, mocker):
     '''
     Check that a `CryptoError` is raised if the call to `gpg` fails.
     Using the `config` fixture to ensure the config is written to disk.
     '''
-    helper = GpgHelper(homedir, session_maker, is_qubes=False)
+    helper = GpgHelper(homedir, is_qubes=False)
 
     # first we have to ensure the pubkeys are available
     helper._import(PUB_KEY)

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -62,7 +62,7 @@ def test_APICallRunner_with_exception(mocker):
     cr.call_failed.emit.assert_called_once_with()
 
 
-def test_Controller_init(homedir, config, mocker, session_maker):
+def test_Controller_init(homedir, config, mocker):
     """
     The passed in gui, app and session instances are correctly referenced and,
     where appropriate, have a reference back to the client.
@@ -70,19 +70,18 @@ def test_Controller_init(homedir, config, mocker, session_maker):
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost/', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost/', mock_gui, homedir)
     assert co.hostname == 'http://localhost/'
     assert co.gui == mock_gui
-    assert co.session_maker == session_maker
     assert co.api_threads == {}
 
 
-def test_Controller_setup(homedir, config, mocker, session_maker):
+def test_Controller_setup(homedir, config, mocker):
     """
     Ensure the application is set up with the following default state:
     Using the `config` fixture to ensure the config is written to disk.
     """
-    co = Controller('http://localhost', mocker.MagicMock(), session_maker, homedir)
+    co = Controller('http://localhost', mocker.MagicMock(), homedir)
     co.update_sources = mocker.MagicMock()
 
     co.setup()
@@ -90,14 +89,14 @@ def test_Controller_setup(homedir, config, mocker, session_maker):
     co.gui.setup.assert_called_once_with(co)
 
 
-def test_Controller_start_message_thread(homedir, config, mocker, session_maker):
+def test_Controller_start_message_thread(homedir, config, mocker):
     """
     When starting message-fetching thread, make sure we do a few things.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     mock_qthread = mocker.patch('securedrop_client.logic.QThread')
     mocker.patch('securedrop_client.logic.MessageSync')
@@ -110,7 +109,7 @@ def test_Controller_start_message_thread(homedir, config, mocker, session_maker)
     co.message_thread.start.assert_called_once_with()
 
 
-def test_Controller_start_message_thread_if_already_running(homedir, config, mocker, session_maker):
+def test_Controller_start_message_thread_if_already_running(homedir, config, mocker):
     """
     Ensure that when starting the message thread, we don't start another thread
     if it's already running. Instead, we just authenticate the existing thread.
@@ -118,7 +117,7 @@ def test_Controller_start_message_thread_if_already_running(homedir, config, moc
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.api = 'api object'
     co.message_sync = mocker.MagicMock()
     co.message_thread = mocker.MagicMock()
@@ -129,14 +128,14 @@ def test_Controller_start_message_thread_if_already_running(homedir, config, moc
     co.message_thread.start.assert_not_called()
 
 
-def test_Controller_start_reply_thread(homedir, config, mocker, session_maker):
+def test_Controller_start_reply_thread(homedir, config, mocker):
     """
     When starting reply-fetching thread, make sure we do a few things.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     mock_qthread = mocker.patch('securedrop_client.logic.QThread')
     mocker.patch('securedrop_client.logic.ReplySync')
@@ -149,7 +148,7 @@ def test_Controller_start_reply_thread(homedir, config, mocker, session_maker):
     co.reply_thread.start.assert_called_once_with()
 
 
-def test_Controller_start_reply_thread_if_already_running(homedir, config, mocker, session_maker):
+def test_Controller_start_reply_thread_if_already_running(homedir, config, mocker):
     """
     Ensure that when starting the reply thread, we don't start another thread
     if it's already running. Instead, we just authenticate the existing thread.
@@ -157,7 +156,7 @@ def test_Controller_start_reply_thread_if_already_running(homedir, config, mocke
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     co.api = 'api object'
     co.reply_sync = mocker.MagicMock()
@@ -169,14 +168,14 @@ def test_Controller_start_reply_thread_if_already_running(homedir, config, mocke
     co.reply_thread.start.assert_not_called()
 
 
-def test_Controller_call_api(homedir, config, mocker, session_maker):
+def test_Controller_call_api(homedir, config, mocker):
     """
     A new thread and APICallRunner is created / setup.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     co.finish_api_call = mocker.MagicMock()
     mocker.patch('securedrop_client.logic.QThread')
@@ -200,7 +199,7 @@ def test_Controller_call_api(homedir, config, mocker, session_maker):
     runner.call_timed_out.connect.call_count == 1
 
 
-def test_Controller_login(homedir, config, mocker, session_maker):
+def test_Controller_login(homedir, config, mocker):
     """
     Ensures the API is called in the expected manner for logging in the user
     given the username, password and 2fa token.
@@ -209,7 +208,7 @@ def test_Controller_login(homedir, config, mocker, session_maker):
     mock_gui = mocker.MagicMock()
     mock_api = mocker.patch('securedrop_client.logic.sdclientapi.API')
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.call_api = mocker.MagicMock()
 
     co.login('username', 'password', '123456')
@@ -224,7 +223,7 @@ def test_Controller_login_offline_mode(homedir, config, mocker):
     Ensures user is not authenticated when logging in in offline mode and that the correct windows
     are displayed.
     """
-    co = Controller('http://localhost', mocker.MagicMock(), mocker.MagicMock(), homedir)
+    co = Controller('http://localhost', mocker.MagicMock(), homedir)
     co.call_api = mocker.MagicMock()
     co.gui = mocker.MagicMock()
     co.gui.show_main_window = mocker.MagicMock()
@@ -243,7 +242,7 @@ def test_Controller_login_offline_mode(homedir, config, mocker):
     co.update_sources.assert_called_once_with()
 
 
-def test_Controller_on_authenticate_failure(homedir, config, mocker, session_maker):
+def test_Controller_on_authenticate_failure(homedir, config, mocker):
     """
     If the server responds with a negative to the request to authenticate, make
     sure the user knows.
@@ -251,7 +250,7 @@ def test_Controller_on_authenticate_failure(homedir, config, mocker, session_mak
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     result_data = Exception('oh no')
     co.on_authenticate_failure(result_data)
@@ -261,7 +260,7 @@ def test_Controller_on_authenticate_failure(homedir, config, mocker, session_mak
                                 'verify your credentials and try again.')
 
 
-def test_Controller_on_authenticate_success(homedir, config, mocker, session_maker):
+def test_Controller_on_authenticate_success(homedir, config, mocker):
     """
     Ensure the client syncs when the user successfully logs in.
     Using the `config` fixture to ensure the config is written to disk.
@@ -269,7 +268,7 @@ def test_Controller_on_authenticate_success(homedir, config, mocker, session_mak
     mock_gui = mocker.MagicMock()
     mock_api_job_queue = mocker.patch("securedrop_client.logic.ApiJobQueue")
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.sync_api = mocker.MagicMock()
     co.api = mocker.MagicMock()
     co.start_message_thread = mocker.MagicMock()
@@ -287,12 +286,7 @@ def test_Controller_on_authenticate_success(homedir, config, mocker, session_mak
     assert mock_api_job_queue.called
 
 
-def test_Controller_completed_api_call_without_current_object(
-    homedir,
-    config,
-    mocker,
-    session_maker,
-):
+def test_Controller_completed_api_call_without_current_object(homedir, config, mocker):
     """
     Ensure that cleanup is performed if an API call returns in the expected
     time.
@@ -300,7 +294,7 @@ def test_Controller_completed_api_call_without_current_object(
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     result = 'result'
 
@@ -321,7 +315,7 @@ def test_Controller_completed_api_call_without_current_object(
     mock_user_callback.assert_called_once_with(result)
 
 
-def test_Controller_completed_api_call_with_current_object(homedir, config, mocker, session_maker):
+def test_Controller_completed_api_call_with_current_object(homedir, config, mocker):
     """
     Ensure that cleanup is performed if an API call returns in the expected
     time.
@@ -329,7 +323,7 @@ def test_Controller_completed_api_call_with_current_object(homedir, config, mock
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     result = 'result'
     current_object = 'current_object'
@@ -354,7 +348,7 @@ def test_Controller_completed_api_call_with_current_object(homedir, config, mock
                                                current_object=current_object)
 
 
-def test_Controller_on_action_requiring_login(homedir, config, mocker, session_maker):
+def test_Controller_on_action_requiring_login(homedir, config, mocker):
     """
     Ensure that when on_action_requiring_login is called, an error
     is shown in the GUI status area.
@@ -362,7 +356,7 @@ def test_Controller_on_action_requiring_login(homedir, config, mocker, session_m
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     co.on_action_requiring_login()
 
@@ -370,28 +364,28 @@ def test_Controller_on_action_requiring_login(homedir, config, mocker, session_m
         'You must sign in to perform this action.')
 
 
-def test_Controller_authenticated_yes(homedir, config, mocker, session_maker):
+def test_Controller_authenticated_yes(homedir, config, mocker):
     """
     If the API is authenticated return True.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.api = mocker.MagicMock()
     co.api.token = 'foo'
 
     assert co.authenticated() is True
 
 
-def test_Controller_authenticated_no(homedir, config, mocker, session_maker):
+def test_Controller_authenticated_no(homedir, config, mocker):
     """
     If the API is authenticated return True.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     co.api = mocker.MagicMock()
     co.api.token = None
@@ -399,27 +393,27 @@ def test_Controller_authenticated_no(homedir, config, mocker, session_maker):
     assert co.authenticated() is False
 
 
-def test_Controller_authenticated_no_api(homedir, config, mocker, session_maker):
+def test_Controller_authenticated_no_api(homedir, config, mocker):
     """
     If the API is authenticated return True.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.api = None
 
     assert co.authenticated() is False
 
 
-def test_Controller_sync_api_not_authenticated(homedir, config, mocker, session_maker):
+def test_Controller_sync_api_not_authenticated(homedir, config, mocker):
     """
     If the API isn't authenticated, don't sync.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.authenticated = mocker.MagicMock(return_value=False)
     co.call_api = mocker.MagicMock()
 
@@ -428,14 +422,14 @@ def test_Controller_sync_api_not_authenticated(homedir, config, mocker, session_
     assert co.call_api.call_count == 0
 
 
-def test_Controller_sync_api(homedir, config, mocker, session_maker):
+def test_Controller_sync_api(homedir, config, mocker):
     """
     Sync the API is authenticated.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     co.authenticated = mocker.MagicMock(return_value=True)
     co.call_api = mocker.MagicMock()
@@ -448,7 +442,7 @@ def test_Controller_sync_api(homedir, config, mocker, session_maker):
                                         co.api)
 
 
-def test_Controller_last_sync_with_file(homedir, config, mocker, session_maker):
+def test_Controller_last_sync_with_file(homedir, config, mocker):
     """
     The flag indicating the time of the last sync with the API is stored in a
     dotfile in the user's home directory. If such a file exists, ensure an
@@ -457,7 +451,7 @@ def test_Controller_last_sync_with_file(homedir, config, mocker, session_maker):
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     timestamp = '2018-10-10 18:17:13+01:00'
     mocker.patch("builtins.open", mocker.mock_open(read_data=timestamp))
@@ -468,20 +462,20 @@ def test_Controller_last_sync_with_file(homedir, config, mocker, session_maker):
     assert result.format() == timestamp
 
 
-def test_Controller_last_sync_no_file(homedir, config, mocker, session_maker):
+def test_Controller_last_sync_no_file(homedir, config, mocker):
     """
     If there's no sync file, then just return None.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     mocker.patch("builtins.open", mocker.MagicMock(side_effect=Exception()))
     assert co.last_sync() is None
 
 
-def test_Controller_on_sync_failure(homedir, config, mocker, session_maker):
+def test_Controller_on_sync_failure(homedir, config, mocker):
     """
     If there's no result to syncing, then don't attempt to update local storage
     and perhaps implement some as-yet-undefined UI update.
@@ -489,7 +483,7 @@ def test_Controller_on_sync_failure(homedir, config, mocker, session_maker):
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     co.update_sources = mocker.MagicMock()
     result_data = Exception('Boom')  # Not the expected tuple.
@@ -507,10 +501,8 @@ def test_Controller_on_sync_success(homedir, config, mocker):
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    mock_session = mocker.MagicMock()
-    mock_session_maker = mocker.MagicMock(return_value=mock_session)
 
-    co = Controller('http://localhost', mock_gui, mock_session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.update_sources = mocker.MagicMock()
     co.api_runner = mocker.MagicMock()
     co.gpg = mocker.MagicMock()
@@ -533,10 +525,8 @@ def test_Controller_on_sync_success(homedir, config, mocker):
     co.call_reset = mocker.MagicMock()
     mock_storage = mocker.patch('securedrop_client.logic.storage')
     co.on_sync_success(result_data)
-    mock_storage.update_local_storage. \
-        assert_called_once_with(mock_session, mock_sources, "submissions",
-                                "replies",
-                                os.path.join(homedir, 'data'))
+    mock_storage.update_local_storage.assert_called_once_with(
+        mock_sources, "submissions", "replies", os.path.join(homedir, 'data'))
 
     co.update_sources.assert_called_once_with()
 
@@ -548,10 +538,8 @@ def test_Controller_on_sync_success_with_non_pgp_key(homedir, config, mocker):
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    mock_session = mocker.MagicMock()
-    mock_session_maker = mocker.MagicMock(return_value=mock_session)
 
-    co = Controller('http://localhost', mock_gui, mock_session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.update_sources = mocker.MagicMock()
     co.api_runner = mocker.MagicMock()
 
@@ -566,10 +554,8 @@ def test_Controller_on_sync_success_with_non_pgp_key(homedir, config, mocker):
     co.call_reset = mocker.MagicMock()
     mock_storage = mocker.patch('securedrop_client.logic.storage')
     co.on_sync_success(result_data)
-    mock_storage.update_local_storage. \
-        assert_called_once_with(mock_session, mock_sources, "submissions",
-                                "replies",
-                                os.path.join(homedir, 'data'))
+    mock_storage.update_local_storage.assert_called_once_with(
+        mock_sources, "submissions", "replies", os.path.join(homedir, 'data'))
     co.update_sources.assert_called_once_with()
 
 
@@ -580,10 +566,8 @@ def test_Controller_on_sync_success_with_key_import_fail(homedir, config, mocker
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    mock_session = mocker.MagicMock()
-    mock_session_maker = mocker.MagicMock(return_value=mock_session)
 
-    co = Controller('http://localhost', mock_gui, mock_session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.update_sources = mocker.MagicMock()
     co.api_runner = mocker.MagicMock()
 
@@ -601,55 +585,50 @@ def test_Controller_on_sync_success_with_key_import_fail(homedir, config, mocker
     mock_storage = mocker.patch('securedrop_client.logic.storage')
     mocker.patch.object(co.gpg, 'import_key', side_effect=CryptoError)
     co.on_sync_success(result_data)
-    mock_storage.update_local_storage. \
-        assert_called_once_with(mock_session, mock_sources, "submissions",
-                                "replies",
-                                os.path.join(homedir, 'data'))
+    mock_storage.update_local_storage.assert_called_once_with(
+        mock_sources, "submissions", "replies", os.path.join(homedir, 'data'))
     co.update_sources.assert_called_once_with()
 
 
-def test_Controller_update_sync(homedir, config, mocker, session_maker):
+def test_Controller_update_sync(homedir, config, mocker):
     """
     Cause the UI to update with the result of self.last_sync().
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.last_sync = mocker.MagicMock()
     co.update_sync()
     assert co.last_sync.call_count == 1
     co.gui.show_sync.assert_called_once_with(co.last_sync())
 
 
-def test_Controller_update_sources(homedir, config, mocker):
+def test_Controller_update_sources(homedir, config, mocker, session):
     """
     Ensure the UI displays a list of the available sources from local data
     store.
     Using the `config` fixture to ensure the config is written to disk.
     """
+    mocker.patch('securedrop_client.logic.db.Session', return_value=session)
     mock_gui = mocker.MagicMock()
-    mock_session = mocker.MagicMock()
-    mock_session_maker = mocker.MagicMock(return_value=mock_session)
-
-    co = Controller('http://localhost', mock_gui, mock_session_maker, homedir)
-
+    co = Controller('http://localhost', mock_gui, homedir)
     mock_storage = mocker.patch('securedrop_client.logic.storage')
     source_list = [factory.Source(last_updated=2), factory.Source(last_updated=1)]
     mock_storage.get_local_sources.return_value = source_list
 
     co.update_sources()
 
-    mock_storage.get_local_sources.assert_called_once_with(mock_session)
+    mock_storage.get_local_sources.assert_called_once_with(session)
     mock_gui.show_sources.assert_called_once_with(source_list)
 
 
-def test_Controller_unstars_a_source_if_starred(homedir, config, mocker, session_maker):
+def test_Controller_unstars_a_source_if_starred(homedir, config, mocker):
     """
     Ensure that the client unstars a source if it is starred.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     source_db_object = mocker.MagicMock()
     source_db_object.uuid = mocker.MagicMock()
@@ -675,13 +654,13 @@ def test_Controller_unstars_a_source_if_starred(homedir, config, mocker, session
     mock_gui.clear_error_status.assert_called_once_with()
 
 
-def test_Controller_unstars_a_source_if_unstarred(homedir, config, mocker, session_maker):
+def test_Controller_unstars_a_source_if_unstarred(homedir, config, mocker):
     """
     Ensure that the client stars a source if it is unstarred.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     source_db_object = mocker.MagicMock()
     source_db_object.uuid = mocker.MagicMock()
@@ -707,14 +686,14 @@ def test_Controller_unstars_a_source_if_unstarred(homedir, config, mocker, sessi
     mock_gui.clear_error_status.assert_called_once_with()
 
 
-def test_Controller_update_star_not_logged_in(homedir, config, mocker, session_maker):
+def test_Controller_update_star_not_logged_in(homedir, config, mocker):
     """
     Ensure that starring/unstarring a source when not logged in calls
     the method that displays an error status in the left sidebar.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     source_db_object = mocker.MagicMock()
     co.on_action_requiring_login = mocker.MagicMock()
     co.api = None
@@ -722,14 +701,14 @@ def test_Controller_update_star_not_logged_in(homedir, config, mocker, session_m
     co.on_action_requiring_login.assert_called_with()
 
 
-def test_Controller_on_update_star_success(homedir, config, mocker, session_maker):
+def test_Controller_on_update_star_success(homedir, config, mocker):
     """
     If the starring occurs successfully, then a sync should occur to update
     locally.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     result = True
     co.call_reset = mocker.MagicMock()
     co.sync_api = mocker.MagicMock()
@@ -738,14 +717,14 @@ def test_Controller_on_update_star_success(homedir, config, mocker, session_make
     mock_gui.clear_error_status.assert_called_once_with()
 
 
-def test_Controller_on_update_star_failed(homedir, config, mocker, session_maker):
+def test_Controller_on_update_star_failed(homedir, config, mocker):
     """
     If the starring does not occur properly, then an error should appear
     on the error status sidebar, and a sync will not occur.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     result = Exception('boom')
     co.call_reset = mocker.MagicMock()
     co.sync_api = mocker.MagicMock()
@@ -754,14 +733,14 @@ def test_Controller_on_update_star_failed(homedir, config, mocker, session_maker
     mock_gui.update_error_status.assert_called_once_with('Failed to update star.')
 
 
-def test_Controller_logout(homedir, config, mocker, session_maker):
+def test_Controller_logout(homedir, config, mocker):
     """
     The API is reset to None and the UI is set to logged out state.
     The message and reply threads should also have the
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.api = mocker.MagicMock()
     co.message_sync = mocker.MagicMock()
     co.reply_sync = mocker.MagicMock()
@@ -774,13 +753,13 @@ def test_Controller_logout(homedir, config, mocker, session_maker):
     co.gui.logout.assert_called_once_with()
 
 
-def test_Controller_set_activity_status(homedir, config, mocker, session_maker):
+def test_Controller_set_activity_status(homedir, config, mocker):
     """
     Ensure the GUI set_status API is called.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.set_status("Hello, World!", 1000)
     mock_gui.update_activity_status.assert_called_once_with("Hello, World!", 1000)
 
@@ -805,7 +784,7 @@ PERMISSIONS_CASES = [
 ]
 
 
-def test_create_client_dir_permissions(tmpdir, mocker, session_maker):
+def test_create_client_dir_permissions(tmpdir, mocker):
     '''
     Check that creating an app behaves appropriately with different
     permissions on the various directories needed for it to function.
@@ -826,7 +805,7 @@ def test_create_client_dir_permissions(tmpdir, mocker, session_maker):
             os.mkdir(sdc_home, case['home_perms'])
 
         def func() -> None:
-            Controller('http://localhost', mock_gui, session_maker, sdc_home)
+            Controller('http://localhost', mock_gui, sdc_home)
 
         if case['should_pass']:
             func()
@@ -839,14 +818,14 @@ def test_create_client_dir_permissions(tmpdir, mocker, session_maker):
     assert mock_json.called
 
 
-def test_Controller_on_file_download_Submission(homedir, config, session, mocker, session_maker):
+def test_Controller_on_file_download_Submission(homedir, config, session, mocker):
     """
     If the handler is passed a Submission, check the download_submission
     function is the one called against the API.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     mock_success_signal = mocker.MagicMock()
     mock_failure_signal = mocker.MagicMock()
@@ -857,16 +836,16 @@ def test_Controller_on_file_download_Submission(homedir, config, session, mocker
     mock_queue = mocker.patch.object(co, 'api_job_queue')
 
     source = factory.Source()
-    file_ = factory.File(is_downloaded=None, is_decrypted=None, source=source)
+    file = factory.File(is_downloaded=None, is_decrypted=None, source=source)
     session.add(source)
-    session.add(file_)
+    session.add(file)
     session.commit()
 
-    co.on_submission_download(db.File, file_.uuid)
+    co.on_submission_download(db.File, file.uuid)
 
     mock_job_cls.assert_called_once_with(
         db.File,
-        file_.uuid,
+        file.uuid,
         co.data_dir,
         co.gpg,
     )
@@ -877,13 +856,13 @@ def test_Controller_on_file_download_Submission(homedir, config, session, mocker
         co.on_file_download_failure, type=Qt.QueuedConnection)
 
 
-def test_Controller_on_file_downloaded_success(homedir, config, mocker, session_maker):
+def test_Controller_on_file_downloaded_success(homedir, config, mocker):
     '''
     Using the `config` fixture to ensure the config is written to disk.
     '''
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     # signal when file is downloaded
     mock_file_ready = mocker.patch.object(co, 'file_ready')
@@ -894,12 +873,12 @@ def test_Controller_on_file_downloaded_success(homedir, config, mocker, session_
     mock_file_ready.emit.assert_called_once_with(mock_uuid)
 
 
-def test_Controller_on_file_downloaded_api_failure(homedir, config, mocker, session_maker):
+def test_Controller_on_file_downloaded_api_failure(homedir, config, mocker):
     '''
     Using the `config` fixture to ensure the config is written to disk.
     '''
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     # signal when file is downloaded
     mock_file_ready = mocker.patch.object(co, 'file_ready')
@@ -912,14 +891,14 @@ def test_Controller_on_file_downloaded_api_failure(homedir, config, mocker, sess
     mock_file_ready.emit.assert_not_called()
 
 
-def test_Controller_on_file_open(homedir, config, mocker, session, session_maker, source):
+def test_Controller_on_file_open(homedir, config, mocker, session, source):
     """
     If running on Qubes, a new QProcess with the expected command and args
     should be started.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.proxy = True
 
     submission = factory.File(source=source['source'])
@@ -929,41 +908,41 @@ def test_Controller_on_file_open(homedir, config, mocker, session, session_maker
     mock_subprocess = mocker.MagicMock()
     mock_process = mocker.MagicMock(return_value=mock_subprocess)
     mocker.patch('securedrop_client.logic.QProcess', mock_process)
-    co.on_file_open(submission.uuid)
+    co.on_file_open(submission)
     mock_process.assert_called_once_with(co)
     mock_subprocess.start.call_count == 1
 
 
-def test_Controller_on_delete_source_success(homedir, config, mocker, session_maker):
+def test_Controller_on_delete_source_success(homedir, config, mocker):
     '''
     Using the `config` fixture to ensure the config is written to disk.
     '''
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.sync_api = mocker.MagicMock()
     co.on_delete_source_success(True)
     co.sync_api.assert_called_with()
     co.gui.clear_error_status.assert_called_with()
 
 
-def test_Controller_on_delete_source_failure(homedir, config, mocker, session_maker):
+def test_Controller_on_delete_source_failure(homedir, config, mocker):
     '''
     Using the `config` fixture to ensure the config is written to disk.
     '''
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.sync_api = mocker.MagicMock()
     co.on_delete_source_failure(Exception())
     co.gui.update_error_status.assert_called_with('Failed to delete source at server')
 
 
-def test_Controller_delete_source(homedir, config, mocker, session_maker):
+def test_Controller_delete_source(homedir, config, mocker):
     '''
     Using the `config` fixture to ensure the config is written to disk.
     '''
     mock_gui = mocker.MagicMock()
     mock_source = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.call_api = mocker.MagicMock()
     co.api = mocker.MagicMock()
     co.delete_source(mock_source)
@@ -975,14 +954,14 @@ def test_Controller_delete_source(homedir, config, mocker, session_maker):
     )
 
 
-def test_Controller_send_reply_success(homedir, mocker, session_maker):
+def test_Controller_send_reply_success(homedir, mocker):
     '''
     Check that the "happy path" of encrypting a message and sending it to the sever behaves as
     expected.
     '''
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     co.call_api = mocker.Mock()
     co.api = mocker.Mock()
@@ -1014,13 +993,13 @@ def test_Controller_send_reply_success(homedir, mocker, session_maker):
     assert mock_source_init.called  # to prevent stale mocks
 
 
-def test_Controller_send_reply_gpg_error(homedir, mocker, session_maker):
+def test_Controller_send_reply_gpg_error(homedir, mocker):
     '''
     Check that if gpg fails when sending a message, we alert the UI and do *not* call the API.
     '''
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     co.call_api = mocker.Mock()
     co.api = mocker.Mock()
@@ -1047,7 +1026,7 @@ def test_Controller_send_reply_gpg_error(homedir, mocker, session_maker):
     assert mock_source_init.called  # to prevent stale mocks
 
 
-def test_Controller_on_reply_success(homedir, mocker, session_maker, session):
+def test_Controller_on_reply_success(homedir, mocker, session):
     '''
     Check that when the result is a success, the client emits the correct signal.
     '''
@@ -1061,7 +1040,7 @@ def test_Controller_on_reply_success(homedir, mocker, session_maker, session):
 
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.api = mocker.Mock()
 
     reply = sdclientapi.Reply(uuid='wat', filename='1-lol')
@@ -1071,22 +1050,20 @@ def test_Controller_on_reply_success(homedir, mocker, session_maker, session):
     mock_reply_failed = mocker.patch.object(co, 'reply_failed')
 
     current_object = (source.uuid, msg.uuid)
+    add_reply_fn = mocker.patch('securedrop_client.logic.storage.add_reply')
     co.on_reply_success(reply, current_object)
-    mock_reply_succeeded.emit.assert_called_once_with(msg.uuid)
+    mock_reply_succeeded.emit.assert_called_once_with(source.uuid, msg.uuid)
     assert not mock_reply_failed.emit.called
-
-    # check that this was writtent to the DB
-    replies = session.query(db.Reply).all()
-    assert len(replies) == 1
+    assert add_reply_fn.call_count == 1
 
 
-def test_Controller_on_reply_failure(homedir, mocker, session_maker):
+def test_Controller_on_reply_failure(homedir, mocker):
     '''
     Check that when the result is a failure, the client emits the correct signal.
     '''
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.api = mocker.Mock()
     journalist_uuid = 'abc123'
     co.api.token_journalist_uuid = journalist_uuid
@@ -1097,11 +1074,11 @@ def test_Controller_on_reply_failure(homedir, mocker, session_maker):
     msg_uuid = 'bar222'
     current_object = (source_uuid, msg_uuid)
     co.on_reply_failure(Exception, current_object)
-    mock_reply_failed.emit.assert_called_once_with(msg_uuid)
+    mock_reply_failed.emit.assert_called_once_with(source_uuid, msg_uuid)
     assert not mock_reply_succeeded.emit.called
 
 
-def test_Controller_is_authenticated_property(homedir, mocker, session_maker):
+def test_Controller_is_authenticated_property(homedir, mocker):
     '''
     Check that the @property `is_authenticated`:
       - Cannot be deleted
@@ -1110,7 +1087,7 @@ def test_Controller_is_authenticated_property(homedir, mocker, session_maker):
     '''
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     mock_signal = mocker.patch.object(co, 'authentication_state')
 
     # default state is unauthenticated
@@ -1157,12 +1134,12 @@ def test_APICallRunner_api_call_timeout(mocker):
     mock_timeout_signal.emit.assert_called_once_with()
 
 
-def test_Controller_api_call_timeout(homedir, config, mocker, session_maker):
+def test_Controller_api_call_timeout(homedir, config, mocker):
     '''
     Using the `config` fixture to ensure the config is written to disk.
     '''
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.on_api_timeout()
     mock_gui.update_error_status.assert_called_once_with(
         'The connection to the SecureDrop server timed out. Please try again.')

--- a/tests/test_message_sync.py
+++ b/tests/test_message_sync.py
@@ -6,7 +6,7 @@ from securedrop_client.message_sync import MessageSync, ReplySync
 from tests import factory
 
 
-def test_MessageSync_init(mocker, session_maker):
+def test_MessageSync_init(mocker):
     """
     Ensure things are set up as expected
     """
@@ -14,14 +14,13 @@ def test_MessageSync_init(mocker, session_maker):
     mock_api = mocker.MagicMock()
     mock_gpg = mocker.MagicMock()
 
-    ms = MessageSync(mock_api, mock_gpg, session_maker)
+    ms = MessageSync(mock_api, mock_gpg)
 
     assert ms.api == mock_api
     assert ms.gpg == mock_gpg
-    assert ms.session_maker == session_maker
 
 
-def test_MessageSync_run_success(mocker, session, source, session_maker, homedir):
+def test_MessageSync_run_success(mocker, session, source, homedir):
     """
     Test when a message successfully downloads and decrypts.
     Using the `homedir` fixture to get a GPG keyring.
@@ -42,7 +41,7 @@ def test_MessageSync_run_success(mocker, session, source, session_maker, homedir
         with open(plaintext_filename, 'w') as f:
             f.write(expected_content)
 
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    gpg = GpgHelper(homedir, is_qubes=False)
     mocker.patch.object(
         gpg,
         'decrypt_submission_or_reply',
@@ -50,7 +49,7 @@ def test_MessageSync_run_success(mocker, session, source, session_maker, homedir
     )
 
     api = mocker.MagicMock(session=session)
-    ms = MessageSync(api, gpg, session_maker)
+    ms = MessageSync(api, gpg)
     ms.api.download_submission = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
 
     mock_message_ready = mocker.patch.object(ms, 'message_ready')
@@ -66,7 +65,7 @@ def test_MessageSync_run_success(mocker, session, source, session_maker, homedir
     assert message.is_decrypted is True
 
 
-def test_MessageSync_run_decrypt_only(mocker, session, source, session_maker, homedir):
+def test_MessageSync_run_decrypt_only(mocker, session, source, homedir):
     """
     Test when a message successfully downloads and decrypts.
     Using the `homedir` fixture to get a GPG keyring.
@@ -87,7 +86,7 @@ def test_MessageSync_run_decrypt_only(mocker, session, source, session_maker, ho
         with open(plaintext_filename, 'w') as f:
             f.write(expected_content)
 
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    gpg = GpgHelper(homedir, is_qubes=False)
     mocker.patch.object(
         gpg,
         'decrypt_submission_or_reply',
@@ -95,7 +94,7 @@ def test_MessageSync_run_decrypt_only(mocker, session, source, session_maker, ho
     )
 
     api = mocker.MagicMock(session=session)
-    ms = MessageSync(api, gpg, session_maker)
+    ms = MessageSync(api, gpg)
     ms.api.download_submission = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
     mock_fetch = mocker.patch.object(ms, 'fetch_the_thing')
 
@@ -113,7 +112,7 @@ def test_MessageSync_run_decrypt_only(mocker, session, source, session_maker, ho
     assert not mock_fetch.called
 
 
-def test_MessageSync_run_decryption_error(mocker, session, source, session_maker, homedir):
+def test_MessageSync_run_decryption_error(mocker, session, source, homedir):
     """
     Test when a message successfully downloads, but does not successfully decrypt.
     Using the `homedir` fixture to get a GPG keyring.
@@ -130,9 +129,9 @@ def test_MessageSync_run_decryption_error(mocker, session, source, session_maker
 
     api = mocker.MagicMock(session=session)
 
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    gpg = GpgHelper(homedir, is_qubes=False)
 
-    ms = MessageSync(api, gpg, session_maker)
+    ms = MessageSync(api, gpg)
     mocker.patch.object(ms.gpg, 'decrypt_submission_or_reply', side_effect=CryptoError)
 
     ms.api.download_submission = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
@@ -148,7 +147,7 @@ def test_MessageSync_run_decryption_error(mocker, session, source, session_maker
     assert message.is_decrypted is False
 
 
-def test_MessageSync_exception(homedir, config, mocker, source, session, session_maker):
+def test_MessageSync_exception(homedir, config, mocker, source, session):
     """
     Makes sure that if an exception is raised in the download thread, the code which catches it is
     actually run.
@@ -165,8 +164,8 @@ def test_MessageSync_exception(homedir, config, mocker, source, session, session
                                 mocker.MagicMock(side_effect=Exception()))
 
     api = mocker.MagicMock()
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
-    ms = MessageSync(api, gpg, session_maker)
+    gpg = GpgHelper(homedir, is_qubes=False)
+    ms = MessageSync(api, gpg)
 
     # check that it runs without raising exceptions
     ms.run(False)
@@ -175,21 +174,21 @@ def test_MessageSync_exception(homedir, config, mocker, source, session, session
     assert mock_message.called
 
 
-def test_MessageSync_run_failure(mocker, source, session, session_maker, homedir):
+def test_MessageSync_run_failure(mocker, source, session, homedir):
     message = factory.Message(source=source['source'])
     session.add(message)
     session.commit()
 
     api = mocker.MagicMock()
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
-    ms = MessageSync(api, gpg, session_maker)
+    gpg = GpgHelper(homedir, is_qubes=False)
+    ms = MessageSync(api, gpg)
     ms.api.download_submission = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
 
     # check that it runs without raising exceptions
     ms.run(False)
 
 
-def test_ReplySync_init(mocker, session_maker):
+def test_ReplySync_init(mocker):
     """
     Ensure things are set up as expected
     """
@@ -197,14 +196,13 @@ def test_ReplySync_init(mocker, session_maker):
     mock_api = mocker.MagicMock()
     mock_gpg = mocker.MagicMock()
 
-    rs = ReplySync(mock_api, mock_gpg, session_maker)
+    rs = ReplySync(mock_api, mock_gpg)
 
     assert rs.api == mock_api
     assert rs.gpg == mock_gpg
-    assert rs.session_maker == session_maker
 
 
-def test_ReplySync_run_success(mocker, session, source, session_maker, homedir):
+def test_ReplySync_run_success(mocker, session, source, homedir):
     """
     Test when a reply successfully downloads and decrypts.
     Using the `homedir` fixture to get a GPG keyring.
@@ -225,7 +223,7 @@ def test_ReplySync_run_success(mocker, session, source, session_maker, homedir):
         with open(plaintext_filename, 'w') as f:
             f.write(expected_content)
 
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    gpg = GpgHelper(homedir, is_qubes=False)
     mocker.patch.object(
         gpg,
         'decrypt_submission_or_reply',
@@ -233,7 +231,7 @@ def test_ReplySync_run_success(mocker, session, source, session_maker, homedir):
     )
 
     api = mocker.MagicMock(session=session)
-    rs = ReplySync(api, gpg, session_maker)
+    rs = ReplySync(api, gpg)
     rs.api.download_reply = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
 
     mock_reply_ready = mocker.patch.object(rs, 'reply_ready')
@@ -249,7 +247,7 @@ def test_ReplySync_run_success(mocker, session, source, session_maker, homedir):
     assert reply.is_decrypted is True
 
 
-def test_ReplySync_run_decrypt_only(mocker, session, source, session_maker, homedir):
+def test_ReplySync_run_decrypt_only(mocker, session, source, homedir):
     """
     Test when a message successfully downloads and decrypts.
     Using the `homedir` fixture to get a GPG keyring.
@@ -270,7 +268,7 @@ def test_ReplySync_run_decrypt_only(mocker, session, source, session_maker, home
         with open(plaintext_filename, 'w') as f:
             f.write(expected_content)
 
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    gpg = GpgHelper(homedir, is_qubes=False)
     mocker.patch.object(
         gpg,
         'decrypt_submission_or_reply',
@@ -278,7 +276,7 @@ def test_ReplySync_run_decrypt_only(mocker, session, source, session_maker, home
     )
 
     api = mocker.MagicMock(session=session)
-    rs = ReplySync(api, gpg, session_maker)
+    rs = ReplySync(api, gpg)
     rs.api.download_submission = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
     mock_fetch = mocker.patch.object(rs, 'fetch_the_thing')
 
@@ -296,7 +294,7 @@ def test_ReplySync_run_decrypt_only(mocker, session, source, session_maker, home
     assert not mock_fetch.called
 
 
-def test_ReplySync_run_decryption_error(mocker, session, source, session_maker, homedir):
+def test_ReplySync_run_decryption_error(mocker, session, source, homedir):
     """
     Test when a reply successfully downloads, but does not successfully decrypt.
     Using the `homedir` fixture to get a GPG keyring.
@@ -313,9 +311,9 @@ def test_ReplySync_run_decryption_error(mocker, session, source, session_maker, 
 
     api = mocker.MagicMock(session=session)
 
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    gpg = GpgHelper(homedir, is_qubes=False)
 
-    rs = ReplySync(api, gpg, session_maker)
+    rs = ReplySync(api, gpg)
     mocker.patch.object(rs.gpg, 'decrypt_submission_or_reply', side_effect=CryptoError)
 
     rs.api.download_reply = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
@@ -331,7 +329,7 @@ def test_ReplySync_run_decryption_error(mocker, session, source, session_maker, 
     assert reply.is_decrypted is False
 
 
-def test_ReplySync_exception(homedir, config, mocker, source, session, session_maker):
+def test_ReplySync_exception(homedir, config, mocker, source, session):
     """
     Makes sure that if an exception is raised in the download thread, the code which catches it is
     actually run.
@@ -348,8 +346,8 @@ def test_ReplySync_exception(homedir, config, mocker, source, session, session_m
                               mocker.MagicMock(side_effect=Exception()))
 
     api = mocker.MagicMock()
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
-    rs = ReplySync(api, gpg, session_maker)
+    gpg = GpgHelper(homedir, is_qubes=False)
+    rs = ReplySync(api, gpg)
 
     # check that it runs without raising exceptions
     rs.run(False)
@@ -358,14 +356,14 @@ def test_ReplySync_exception(homedir, config, mocker, source, session, session_m
     assert mock_reply.called
 
 
-def test_ReplySync_run_failure(mocker, source, session, session_maker, homedir):
+def test_ReplySync_run_failure(mocker, source, session, homedir):
     reply = factory.Reply(source=source['source'])
     session.add(reply)
     session.commit()
 
     api = mocker.MagicMock()
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
-    rs = ReplySync(api, gpg, session_maker)
+    gpg = GpgHelper(homedir, is_qubes=False)
+    rs = ReplySync(api, gpg)
     rs.api.download_reply = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
 
     # check that it runs without raising exceptions

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,9 +23,9 @@ def test_string_representation_of_message():
 
 def test_string_representation_of_file():
     source = factory.Source()
-    file_ = File(source=source, uuid="test", size=123, filename="1-test.docx",
-                 download_url='http://test/test')
-    file_.__repr__()
+    file = File(source=source, uuid="test", size=123, filename="1-test.docx",
+                download_url='http://test/test')
+    file.__repr__()
 
 
 def test_string_representation_of_reply():
@@ -39,20 +39,20 @@ def test_string_representation_of_reply():
 def test_source_collection():
     # Create some test submissions and replies
     source = factory.Source()
-    file_ = File(source=source, uuid="test", size=123, filename="2-test.doc.gpg",
-                 download_url='http://test/test')
+    file = File(source=source, uuid="test", size=123, filename="2-test.doc.gpg",
+                download_url='http://test/test')
     message = Message(source=source, uuid="test", size=123, filename="3-test.doc.gpg",
                       download_url='http://test/test')
     user = User(username='hehe')
     reply = Reply(source=source, journalist=user, filename="1-reply.gpg",
                   size=1234, uuid='test')
-    source.files = [file_]
+    source.files = [file]
     source.messages = [message]
     source.replies = [reply]
 
     # Now these items should be in the source collection in the proper order
     assert source.collection[0] == reply
-    assert source.collection[1] == file_
+    assert source.collection[1] == file
     assert source.collection[2] == message
 
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -161,6 +161,18 @@ def test_update_local_storage(homedir, mocker, session):
     msg_fn.assert_called_once_with([remote_message], [local_message], session, homedir)
 
 
+def test_add_reply(mocker, SessionFactory, homedir):
+    # check that reply is to the DB
+    mocker.patch('securedrop_client.db.Session', return_value=SessionFactory)
+    mock_id = str(uuid.uuid4())
+    source = factory.Source()
+
+    add_reply(mock_id, source.uuid, mock_id, '1-spotted-potato-msg.gpg')
+
+    replies = SessionFactory().query(db.Reply).all()
+    assert len(replies) == 1
+
+
 def test_update_sources(homedir, mocker):
     """
     Check that:


### PR DESCRIPTION
# Description

Resolves issue https://github.com/freedomofpress/securedrop-client/issues/392

* Removes `make_session_maker` and now create a global session factory called `Session` in db.py and configure it in app.py.

* Controller no longer manages the application session; it not longer has a `sessionmaker` or a `session` that is accessed by widgets. We no longer need to pass around Sessions in order to share a session across separate sections of code. If we call the global session factory twice we get back the same session.

The following changes were also added while working to remove all references to the Controller's session object:

* Removes `source_exists` and its one reference in `widgets.py::on_source_changed` since it is unnecessary when we already check if the source widget exists (it will not exists if the source was deleted from the db). This is relevant since this was one of the areas of code that referenced `controller.session`. Instead of rewriting it and then removing it later, I decided to just remove it.

* Removes `controller.get_file` and reference to it in `FileWidget` constructor since we are now initializing `FileWidget` with a `File` object.

* Moves database operation for adding reply from logic.py to storage.py

* Models that have a relationship to other models now pass `lazy='subquery'` when defining their relationships in order to do subquery loading, see https://docs.sqlalchemy.org/en/13/orm/loading_relationships.html#relationship-loading-techniques. This gets used when we pass `source.collection` to `update_conversation`

# Test Plan

1. Send a file via the Source Interface and download it, see it change to "Open" status
2. Open the file and check the logs for debug "Opening file..." statement
3. Send a reply, refresh, see it remain
4. Run through relevant https://github.com/freedomofpress/securedrop-client/wiki/Test-plan checks since this touches a lot of code