### PR TITLE
deauth queue when user logs out (#397), restart threads if they fail (#380)

### DIFF
--- a/securedrop_client/api_jobs/base.py
+++ b/securedrop_client/api_jobs/base.py
@@ -41,6 +41,9 @@ class ApiJob(QObject):
             result = self.call_api(api_client, session)
         except AuthError as e:
             raise ApiInaccessibleError() from e
+        except ApiInaccessibleError as e:
+            # Do not let ApiInaccessibleError emit the regular failure signal, raise now
+            raise ApiInaccessibleError() from e
         except RequestTimeoutError:
             logger.debug('Job {} timed out'.format(self))
             raise

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -93,6 +93,12 @@ class ApiJobQueue(QObject):
             self.download_file_thread.start()
 
     def enqueue(self, job: ApiJob) -> None:
+        # Additional defense in depth to prevent jobs being added to the queue when not
+        # logged in.
+        if not self.main_queue.api_client or not self.download_file_queue.api_client:
+            logger.info('Not adding job, we are not logged in')
+            return
+
         # First check the queues are started in case they died for some reason.
         self.start_queues()
 

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -7,7 +7,7 @@ from sdclientapi import API, RequestTimeoutError
 from sqlalchemy.orm import scoped_session
 from typing import Optional  # noqa: F401
 
-from securedrop_client.api_jobs.base import ApiJob
+from securedrop_client.api_jobs.base import ApiJob, ApiInaccessibleError
 from securedrop_client.api_jobs.downloads import FileDownloadJob
 
 
@@ -28,8 +28,8 @@ class RunnableQueue(QObject):
         self._process(False)
 
     def _process(self, exit_loop: bool) -> None:
-        session = self.session_maker()
         while True:
+            session = self.session_maker()
             # retry the "cached" job if it exists, otherwise get the next job
             if self.last_job is not None:
                 job = self.last_job
@@ -41,10 +41,15 @@ class RunnableQueue(QObject):
                 job._do_call_api(self.api_client, session)
             except RequestTimeoutError:
                 self.last_job = job  # "cache" the last job since we can't re-queue it
-                return
+            except ApiInaccessibleError:
+                # This is a guard against #397, we should pause the queue execution when this
+                # happens in the future and flag the situation to the user (see ticket #379).
+                logger.error('Client is not authenticated, skipping job...')
+            finally:
+                # process events to allow this thread to handle incoming signals
+                QApplication.processEvents()
 
-            # process events to allow this thread to handle incoming signals
-            QApplication.processEvents()
+                session.close()
 
             if exit_loop:
                 return
@@ -68,15 +73,32 @@ class ApiJobQueue(QObject):
         self.main_thread.started.connect(self.main_queue.process)
         self.download_file_thread.started.connect(self.download_file_queue.process)
 
-    def start_queues(self, api_client: API) -> None:
+    def logout(self) -> None:
+        self.main_queue.api_client = None
+        self.download_file_queue.api_client = None
+
+    def login(self, api_client: API) -> None:
+        logger.debug('Passing API token to queues')
         self.main_queue.api_client = api_client
         self.download_file_queue.api_client = api_client
+        self.start_queues()
 
-        self.main_thread.start()
-        self.download_file_thread.start()
+    def start_queues(self) -> None:
+        if not self.main_thread.isRunning():
+            logger.debug('Starting main thread')
+            self.main_thread.start()
+
+        if not self.download_file_thread.isRunning():
+            logger.debug('Starting download thread')
+            self.download_file_thread.start()
 
     def enqueue(self, job: ApiJob) -> None:
+        # First check the queues are started in case they died for some reason.
+        self.start_queues()
+
         if isinstance(job, FileDownloadJob):
+            logger.debug('Adding job to download queue')
             self.download_file_queue.queue.put_nowait(job)
         else:
+            logger.debug('Adding job to main queue')
             self.main_queue.queue.put_nowait(job)


### PR DESCRIPTION
# Description

Fixes #397
Fixes #380

# Test Plan

In a single run of the client:

1. Log in
2. Ensure you can download a file (must be a file not a message)
3. Log out 
4. Ensure that you cannot download a file (there isn't good user messaging in the UI - see [my comment here](https://github.com/freedomofpress/securedrop-client/issues/379#issuecomment-499218609))
5. Log back in
6. Ensure you _can_ download the file now

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs, network (via the RPC service) traffic, or fine tuning of the graphical user interface, Qubes testing is required. Please check as applicable:

 - [ ] I have tested these changes in Qubes
 - [ ] I do not have a Qubes OS workstation (the reviewer will need to test these changes in Qubes)