### PR TITLE
Call logout endpoint when signing out in the client

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -132,8 +132,8 @@ python-editor==1.0.3 \
 requests==2.20.0 \
     --hash=sha256:99dcfdaaeb17caf6e526f32b6a7b780461512ab3f1d992187801694cba42770c \
     --hash=sha256:a84b8c9ab6239b578f22d1c21d51b696dcfe004032bb80ea832398d6909d7279
-securedrop-sdk==0.0.9 \
-    --hash=sha256:43146f02c41858578f7c9997e733f2a07f8a4877f1bf9f8b4b11fd4ceffa47a9
+securedrop-sdk==0.0.10 \
+    --hash=sha256:07b9f9d91b26e2396ff5eb63b5e990ac969de57bbfb7c075d99ac5e269198cb0
 sip==4.19.8 \
     --hash=sha256:09f9a4e6c28afd0bafedb26ffba43375b97fe7207bd1a0d3513f79b7d168b331 \
     --hash=sha256:105edaaa1c8aa486662226360bd3999b4b89dd56de3e314d82b83ed0587d8783 \

--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,7 @@ pathlib2==2.3.2
 python-dateutil==2.7.5
 python-editor==1.0.3
 requests==2.20.0
-securedrop-sdk==0.0.9
+securedrop-sdk==0.0.10
 six==1.11.0
 SQLAlchemy==1.3.3
 urllib3==1.24.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,8 +32,8 @@ python-editor==1.0.3 \
 requests==2.20.0 \
     --hash=sha256:99dcfdaaeb17caf6e526f32b6a7b780461512ab3f1d992187801694cba42770c \
     --hash=sha256:a84b8c9ab6239b578f22d1c21d51b696dcfe004032bb80ea832398d6909d7279
-securedrop-sdk==0.0.9 \
-    --hash=sha256:43146f02c41858578f7c9997e733f2a07f8a4877f1bf9f8b4b11fd4ceffa47a9
+securedrop-sdk==0.0.10 \
+    --hash=sha256:07b9f9d91b26e2396ff5eb63b5e990ac969de57bbfb7c075d99ac5e269198cb0
 six==1.11.0 \
     --hash=sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9 \
     --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -472,9 +472,12 @@ class Controller(QObject):
 
     def logout(self):
         """
-        Reset the API object and force the UI to update into a logged out
-        state.
+        Call logout function in the API, reset the API object, and force the UI
+        to update into a logged out state.
         """
+        self.call_api(self.api.logout,
+                      self.on_logout_success,
+                      self.on_logout_failure)
         self.api = None
         self.reply_sync.api = None
         self.api_job_queue.logout()
@@ -626,3 +629,9 @@ class Controller(QObject):
         file = storage.get_file(self.session, file_uuid)
         self.session.refresh(file)
         return file
+
+    def on_logout_success(self, result) -> None:
+        logging.info('Client logout successful')
+
+    def on_logout_failure(self, result: Exception) -> None:
+        logging.info('Client logout failure')


### PR DESCRIPTION
# Description

Towards #397 , Fixes #223 .

# Test Plan
- [ ] Hash for securedrop-sdk in `requirements.txt` and `dev-requirements.txt` is correct
- Install new requirements, start client on this branch, and log in as $USER
- On the bar on the left, click on $USER and "SIGN OUT"
- [ ] Confirm server logs for journalist interface received:
```
172.17.0.1 - - [12/Jun/2019 20:23:24] "POST /api/v1/logout HTTP/1.1" 200 -
```
- [ ] Client logs confirm that logout was successful:
```
2019-06-12 16:23:24,904 - urllib3.connectionpool:393(_make_request) DEBUG    : http://localhost:8081 "POST /api/v1/logout HTTP/1.1" 200 48
2019-06-12 16:23:24,907 - securedrop_client.logic:265(completed_api_call)     INFO: Completed API call. Cleaning up and running callback.
2019-06-12 16:23:24,908 - securedrop_client.logic:628(on_logout_success)     INFO: Client logout successful
```
- Now test the negative scenario, where logout fails: log into the client, and shut down/disconnect the server
- [ ] Client logs contain error:
```
2019-06-12 16:24:06,148 - securedrop_client.logic:82(call_api) ERROR: HTTPConnectionPool(host='localhost', port=8081): Max retries exceeded with url: /api/v1/logout (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x3eb320b25f8>: Failed to establish a new connection: [Errno 111] Connection refused',))
2019-06-12 16:24:06,148 - securedrop_client.logic:265(completed_api_call)     INFO: Completed API call. Cleaning up and running callback.
2019-06-12 16:24:06,149 - securedrop_client.logic:635(on_logout_failure)     INFO: Client logout failure
```

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs, network (via the RPC service) traffic, or fine tuning of the graphical user interface, Qubes testing is required. Please check as applicable:

 - [ ] I have tested these changes in Qubes
 - [ ] I do not have a Qubes OS workstation (the reviewer will need to test these changes in Qubes)