### PR TITLE
Generalize decrypt

### DIFF
--- a/securedrop_client/api_jobs/downloads.py
+++ b/securedrop_client/api_jobs/downloads.py
@@ -46,7 +46,7 @@ class MessageDownloadJob(ApiJob):
         self._decrypt_file(session, db_object, os.path.join(self.data_dir, db_object.filename))
         return db_object.uuid
 
-    def _download(self, api: API, db_object: File, session: Session):
+    def _download(self, api: API, db_object: Message, session: Session) -> None:
         '''
         Download the file. Check file integrity and move it to the data directory before marking it
         as downloaded.
@@ -139,7 +139,7 @@ class FileDownloadJob(ApiJob):
         self._decrypt_file(session, db_object, os.path.join(self.data_dir, db_object.filename))
         return db_object.uuid
 
-    def _download(self, api_client: API, db_object: File, session: Session):
+    def _download(self, api_client: API, db_object: File, session: Session) -> None:
         '''
         Download the file. Check file integrity and move it to the data directory before marking it
         as downloaded.
@@ -218,7 +218,7 @@ class FileDownloadJob(ApiJob):
                 is_decrypted=True,
                 session=session)
 
-            logger.info("File decrypted: {}".format(db_object.filename))
+            logger.debug("File decrypted: {}".format(db_object.filename))
         except CryptoError as e:
             set_decryption_status_with_content(
                 model_type=type(db_object),
@@ -226,6 +226,6 @@ class FileDownloadJob(ApiJob):
                 is_decrypted=False,
                 session=session)
 
-            logger.info("Failed to decrypt file: {}".format(db_object.filename))
+            logger.debug("Failed to decrypt file: {}".format(db_object.filename))
 
             raise e

--- a/securedrop_client/crypto.py
+++ b/securedrop_client/crypto.py
@@ -55,7 +55,7 @@ class GpgHelper:
     def decrypt_submission_or_reply(self,
                                     filepath: str,
                                     plaintext_filepath: str,
-                                    is_doc: bool = False) -> None:
+                                    is_doc: bool = False) -> str:
         err = tempfile.NamedTemporaryFile(suffix=".message-error", delete=False)
         with tempfile.NamedTemporaryFile(suffix=".message") as out:
             cmd = self._gpg_cmd_base()
@@ -88,6 +88,8 @@ class GpgHelper:
                     shutil.copyfileobj(infile, outfile)
             else:
                 shutil.copy(out.name, plaintext_filepath)
+
+            return plaintext_filepath  # This return is just used by tests and should be removed
 
     def _gpg_cmd_base(self) -> list:
         if self.is_qubes:  # pragma: no cover

--- a/securedrop_client/crypto.py
+++ b/securedrop_client/crypto.py
@@ -52,8 +52,10 @@ class GpgHelper:
         config = Config.from_home_dir(self.sdc_home)
         self.journalist_key_fingerprint = config.journalist_key_fingerprint
 
-    def decrypt_submission_or_reply(self, filepath: str, target_filename: str,
-                                    is_doc: bool = False) -> str:
+    def decrypt_submission_or_reply(self,
+                                    filepath: str,
+                                    plaintext_filepath: str,
+                                    is_doc: bool = False) -> None:
         err = tempfile.NamedTemporaryFile(suffix=".message-error", delete=False)
         with tempfile.NamedTemporaryFile(suffix=".message") as out:
             cmd = self._gpg_cmd_base()
@@ -72,31 +74,20 @@ class GpgHelper:
                 os.unlink(err.name)
 
                 raise CryptoError(msg)
+
+            # Delete err file
+            err.close()
+            os.unlink(err.name)
+
+            # Delete encrypted file now that it's been successfully decrypted
+            os.unlink(filepath)
+
+            # Store the plaintext in the file located at the specified plaintext_filepath
+            if is_doc:
+                with gzip.open(out.name, 'rb') as infile, open(plaintext_filepath, 'wb') as outfile:
+                    shutil.copyfileobj(infile, outfile)
             else:
-                # Cleanup err file
-                err.close()
-                os.unlink(err.name)
-
-                os.unlink(filepath)  # success so remove original (encrypted) file
-
-                if is_doc:
-                    # Need to split twice as filename is e.g.
-                    # 1-impractical_thing-doc.gz.gpg
-                    fn_no_ext, _ = os.path.splitext(
-                        os.path.splitext(os.path.basename(filepath))[0])
-                    dest = os.path.join(self.sdc_home, "data", fn_no_ext)
-
-                    # Docs are gzipped, so gunzip the file
-                    with gzip.open(out.name, 'rb') as infile, \
-                            open(dest, 'wb') as outfile:
-                        shutil.copyfileobj(infile, outfile)
-                else:
-                    fn_no_ext, _ = os.path.splitext(target_filename)
-                    dest = os.path.join(self.sdc_home, "data", fn_no_ext)
-                    shutil.copy(out.name, dest)
-                logger.info("Downloaded and decrypted: {}".format(dest))
-
-                return dest
+                shutil.copy(out.name, plaintext_filepath)
 
     def _gpg_cmd_base(self) -> list:
         if self.is_qubes:  # pragma: no cover

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -21,15 +21,15 @@ def test_message_logic(homedir, config, mocker, session_maker):
     gpg = GpgHelper(homedir, session_maker, is_qubes=False)
 
     test_msg = 'tests/files/test-msg.gpg'
-    expected_output_filename = 'test-msg'
+    expected_output_filepath = os.path.join(homedir, 'data', 'test-msg')
 
     mock_gpg = mocker.patch('subprocess.call', return_value=0)
     mocker.patch('os.unlink')
 
-    dest = gpg.decrypt_submission_or_reply(test_msg, expected_output_filename, is_doc=False)
+    dest = gpg.decrypt_submission_or_reply(test_msg, expected_output_filepath, is_doc=False)
 
     assert mock_gpg.call_count == 1
-    assert dest == os.path.join(homedir, 'data', expected_output_filename)
+    assert dest == expected_output_filepath
 
 
 def test_gunzip_logic(homedir, config, mocker, session_maker):
@@ -40,14 +40,14 @@ def test_gunzip_logic(homedir, config, mocker, session_maker):
     gpg = GpgHelper(homedir, session_maker, is_qubes=False)
 
     test_gzip = 'tests/files/test-doc.gz.gpg'
-    expected_output_filename = 'test-doc'
+    expected_output_filepath = os.path.join(homedir, 'data', 'mock-doc')
 
     mock_gpg = mocker.patch('subprocess.call', return_value=0)
     mock_unlink = mocker.patch('os.unlink')
-    dest = gpg.decrypt_submission_or_reply(test_gzip, expected_output_filename, is_doc=True)
+    dest = gpg.decrypt_submission_or_reply(test_gzip, expected_output_filepath, is_doc=True)
 
     assert mock_gpg.call_count == 1
-    assert dest == os.path.join(homedir, 'data', expected_output_filename)
+    assert dest == expected_output_filepath
     # We should remove two files in the success scenario: err, filepath
     assert mock_unlink.call_count == 2
 


### PR DESCRIPTION
# Description

This is part of breaking down a large PR https://github.com/freedomofpress/securedrop-client/pull/409

This and following smaller refactors are a way to help us avoid bugs around file management when we download and decrypt, which is tricky.

This refactor generalizes the way we decrypt and will need to be tested on Qubes. The major changes are:

* Now if an object is already decrypted, we do not decrypt again.  The logic in `call_api` goes: if decrypted return uuid, if downloaded, just decrypt, return uuid, otherwise both download and decrypt.

* Instead of building the target file for the decrypted text inside the `decrypt_submission_or_reply` method, we now just pass it the target file. This also fixes a minor issue where `FileDownloadJob` was passing db object filenames that were unused. Renaming the parameter `target_filename` to `plaintext_filepath` to make it clearer what `decrypt_submission_or_reply` actually needs helps.

# Test Plan

Basically make sure everything works as it did before on BOTH your development machine and Qubes (if that's not your development machine). Pay attention to files on the filesystem during download and decrypt in the download, data, and temp directories. Make sure that the only files left after an api sync with new messages and files are decrypted files.

1. Send messages and files as a source
2. Refresh on the client to see messages downloaded and decrytped. Click on files to trigger a download and decrypt. When you see "Open" next to the filename you know it's decrypted. 
3. Check data, download, and any used temp directories
4. Query the db to make sure statuses look correct


# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs, network (via the RPC service) traffic, or fine tuning of the graphical user interface, Qubes testing is required. Please check as applicable:

 - [x] I have tested these changes in Qubes
 - [ ] I do not have a Qubes OS workstation (the reviewer will need to test these changes in Qubes)