### PR TITLE
Add DownloadJob

### DIFF
--- a/alembic/versions/fecf1191b6f0_remove_decryption_vs_content_contraint.py
+++ b/alembic/versions/fecf1191b6f0_remove_decryption_vs_content_contraint.py
@@ -17,16 +17,188 @@ depends_on = None
 
 
 def upgrade():
-    op.drop_constraint('messages_compare_is_decrypted_vs_content', 'messages')
-    op.drop_constraint('replies_compare_is_decrypted_vs_content', 'replies')
+    # Save existing tables we want to modify.
+    op.rename_table('messages', 'messages_tmp')
+    op.rename_table('replies', 'replies_tmp')
+
+    # Create new tables without the constraint.
+    op.create_table(
+        'messages',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('uuid', sa.String(length=36), nullable=False),
+        sa.Column('source_id', sa.Integer(), nullable=False),
+        sa.Column('filename', sa.String(length=255), nullable=False),
+        sa.Column('file_counter', sa.Integer(), nullable=False),
+        sa.Column('size', sa.Integer(), nullable=False),
+        sa.Column('content', sa.Text(), nullable=True),
+        sa.Column('is_decrypted', sa.Boolean(name='is_decrypted'), nullable=True),
+        sa.Column(
+            'is_downloaded',
+            sa.Boolean(name='is_downloaded'),
+            server_default=sa.text("0"),
+            nullable=False),
+        sa.Column(
+            'is_read',
+            sa.Boolean(name='is_read'),
+            server_default=sa.text("0"),
+            nullable=False),
+        sa.Column('download_url', sa.String(length=255), nullable=False),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_messages')),
+        sa.UniqueConstraint('source_id', 'file_counter', name='uq_messages_source_id_file_counter'),
+        sa.UniqueConstraint('uuid', name=op.f('uq_messages_uuid')),
+        sa.ForeignKeyConstraint(
+            ['source_id'],
+            ['sources.id'],
+            name=op.f('fk_messages_source_id_sources')),
+        sa.CheckConstraint(
+            'CASE WHEN is_downloaded = 0 THEN content IS NULL ELSE 1 END',
+            name=op.f('ck_message_compare_download_vs_content')),
+        sa.CheckConstraint(
+            'CASE WHEN is_downloaded = 0 THEN is_decrypted IS NULL ELSE 1 END',
+            name='messages_compare_is_downloaded_vs_is_decrypted'))
+
+    op.create_table(
+        'replies',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('uuid', sa.String(length=36), nullable=False),
+        sa.Column('source_id', sa.Integer(), nullable=False),
+        sa.Column('filename', sa.String(length=255), nullable=False),
+        sa.Column('file_counter', sa.Integer(), nullable=False),
+        sa.Column('size', sa.Integer(), nullable=True),
+        sa.Column('content', sa.Text(), nullable=True),
+        sa.Column('is_decrypted', sa.Boolean(name='is_decrypted'), nullable=True),
+        sa.Column('is_downloaded', sa.Boolean(name='is_downloaded'), nullable=True),
+        sa.Column('journalist_id', sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_replies')),
+        sa.UniqueConstraint('source_id', 'file_counter', name='uq_messages_source_id_file_counter'),
+        sa.UniqueConstraint('uuid', name=op.f('uq_replies_uuid')),
+        sa.ForeignKeyConstraint(
+            ['source_id'],
+            ['sources.id'],
+            name=op.f('fk_replies_source_id_sources')),
+        sa.ForeignKeyConstraint(
+            ['journalist_id'],
+            ['users.id'],
+            name=op.f('fk_replies_journalist_id_users')),
+        sa.CheckConstraint(
+            'CASE WHEN is_downloaded = 0 THEN content IS NULL ELSE 1 END',
+            name='replies_compare_download_vs_content'),
+        sa.CheckConstraint(
+            'CASE WHEN is_downloaded = 0 THEN is_decrypted IS NULL ELSE 1 END',
+            name='replies_compare_is_downloaded_vs_is_decrypted'))
+
+    # Copy existing data into new tables.
+    conn = op.get_bind()
+    conn.execute('''
+        INSERT INTO messages
+        SELECT id, uuid, source_id, filename, file_counter, size, content, is_decrypted,
+               is_downloaded, is_read, download_url
+        FROM messages_tmp
+    ''')
+    conn.execute('''
+        INSERT INTO replies
+        SELECT id, uuid, source_id, filename, file_counter, size, content, is_decrypted,
+              is_downloaded, journalist_id
+        FROM replies_tmp
+    ''')
+
+    # Delete the old tables.
+    op.drop_table('messages_tmp')
+    op.drop_table('replies_tmp')
 
 
 def downgrade():
-    op.create_check_constraint(
-        'messages_compare_is_decrypted_vs_content',
+    # Save existing tables we want to modify.
+    op.rename_table('messages', 'messages_tmp')
+    op.rename_table('replies', 'replies_tmp')
+
+    # Create new tables with the constraint.
+    op.create_table(
         'messages',
-        'CASE WHEN is_decrypted = 0 THEN content IS NULL ELSE 1 END')
-    op.create_check_constraint(
-        'replies_compare_is_decrypted_vs_content',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('uuid', sa.String(length=36), nullable=False),
+        sa.Column('source_id', sa.Integer(), nullable=False),
+        sa.Column('filename', sa.String(length=255), nullable=False),
+        sa.Column('file_counter', sa.Integer(), nullable=False),
+        sa.Column('size', sa.Integer(), nullable=False),
+        sa.Column('content', sa.Text(), nullable=True),
+        sa.Column('is_decrypted', sa.Boolean(name='is_decrypted'), nullable=True),
+        sa.Column(
+            'is_downloaded',
+            sa.Boolean(name='is_downloaded'),
+            server_default=sa.text("0"),
+            nullable=False),
+        sa.Column(
+            'is_read',
+            sa.Boolean(name='is_read'),
+            server_default=sa.text("0"),
+            nullable=False),
+        sa.Column('download_url', sa.String(length=255), nullable=False),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_messages')),
+        sa.UniqueConstraint('source_id', 'file_counter', name='uq_messages_source_id_file_counter'),
+        sa.UniqueConstraint('uuid', name=op.f('uq_messages_uuid')),
+        sa.ForeignKeyConstraint(
+            ['source_id'],
+            ['sources.id'],
+            name=op.f('fk_messages_source_id_sources')),
+        sa.CheckConstraint(
+            'CASE WHEN is_downloaded = 0 THEN content IS NULL ELSE 1 END',
+            name=op.f('ck_message_compare_download_vs_content')),
+        sa.CheckConstraint(
+            'CASE WHEN is_downloaded = 0 THEN is_decrypted IS NULL ELSE 1 END',
+            name='messages_compare_is_downloaded_vs_is_decrypted'),
+        sa.CheckConstraint(
+            'CASE WHEN is_decrypted = 0 THEN content IS NULL ELSE 1 END',
+            name='messages_compare_is_decrypted_vs_content'))
+
+    op.create_table(
         'replies',
-        'CASE WHEN is_decrypted = 0 THEN content IS NULL ELSE 1 END')
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('uuid', sa.String(length=36), nullable=False),
+        sa.Column('source_id', sa.Integer(), nullable=False),
+        sa.Column('filename', sa.String(length=255), nullable=False),
+        sa.Column('file_counter', sa.Integer(), nullable=False),
+        sa.Column('size', sa.Integer(), nullable=True),
+        sa.Column('content', sa.Text(), nullable=True),
+        sa.Column('is_decrypted', sa.Boolean(name='is_decrypted'), nullable=True),
+        sa.Column('is_downloaded', sa.Boolean(name='is_downloaded'), nullable=True),
+        sa.Column('journalist_id', sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_replies')),
+        sa.UniqueConstraint('source_id', 'file_counter', name='uq_messages_source_id_file_counter'),
+        sa.UniqueConstraint('uuid', name=op.f('uq_replies_uuid')),
+        sa.ForeignKeyConstraint(
+            ['source_id'],
+            ['sources.id'],
+            name=op.f('fk_replies_source_id_sources')),
+        sa.ForeignKeyConstraint(
+            ['journalist_id'],
+            ['users.id'],
+            name=op.f('fk_replies_journalist_id_users')),
+        sa.CheckConstraint(
+            'CASE WHEN is_downloaded = 0 THEN content IS NULL ELSE 1 END',
+            name='replies_compare_download_vs_content'),
+        sa.CheckConstraint(
+            'CASE WHEN is_downloaded = 0 THEN is_decrypted IS NULL ELSE 1 END',
+            name='replies_compare_is_downloaded_vs_is_decrypted'),
+        sa.CheckConstraint(
+            'CASE WHEN is_decrypted = 0 THEN content IS NULL ELSE 1 END',
+            name='replies_compare_is_decrypted_vs_content'))
+
+    # Copy existing data into new tables.
+    conn = op.get_bind()
+    conn.execute('''
+        INSERT INTO messages
+        SELECT id, uuid, source_id, filename, file_counter, size, content, is_decrypted,
+               is_downloaded, download_url, is_read
+        FROM messages_tmp
+    ''')
+    conn.execute('''
+        INSERT INTO replies
+        SELECT id, uuid, source_id, filename, file_counter, size, content, is_decrypted,
+              is_downloaded, journalist_id
+        FROM replies_tmp
+    ''')
+
+    # Delete the old tables.
+    op.drop_table('messages_tmp')
+    op.drop_table('replies_tmp')

--- a/alembic/versions/fecf1191b6f0_remove_decryption_vs_content_contraint.py
+++ b/alembic/versions/fecf1191b6f0_remove_decryption_vs_content_contraint.py
@@ -1,0 +1,32 @@
+"""remove decryption_vs_content contraint
+
+Revision ID: fecf1191b6f0
+Revises: 2f363b3d680e
+Create Date: 2019-06-18 19:14:17.862910
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'fecf1191b6f0'
+down_revision = '2f363b3d680e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint('messages_compare_is_decrypted_vs_content', 'messages')
+    op.drop_constraint('replies_compare_is_decrypted_vs_content', 'replies')
+
+
+def downgrade():
+    op.create_check_constraint(
+        'messages_compare_is_decrypted_vs_content',
+        'messages',
+        'CASE WHEN is_decrypted = 0 THEN content IS NULL ELSE 1 END')
+    op.create_check_constraint(
+        'replies_compare_is_decrypted_vs_content',
+        'replies',
+        'CASE WHEN is_decrypted = 0 THEN content IS NULL ELSE 1 END')

--- a/securedrop_client/api_jobs/downloads.py
+++ b/securedrop_client/api_jobs/downloads.py
@@ -2,171 +2,111 @@ import binascii
 import hashlib
 import logging
 import os
-import sdclientapi
 import shutil
 from tempfile import NamedTemporaryFile
-from typing import Any, Union, Type, Tuple
+from typing import Any, Union, Tuple
 
-from sdclientapi import API
+from sdclientapi import API, BaseError
+from sdclientapi import Submission as SdkSubmission
 from sqlalchemy.orm.session import Session
 
 from securedrop_client.api_jobs.base import ApiJob
 from securedrop_client.crypto import GpgHelper, CryptoError
-from securedrop_client.db import File, Message, Reply
-from securedrop_client.storage import mark_as_downloaded, set_decryption_status_with_content
+from securedrop_client.db import File, Message
+from securedrop_client.storage import mark_as_decrypted, mark_as_downloaded, \
+    set_message_or_reply_content
 
 logger = logging.getLogger(__name__)
 
 
-class MessageDownloadJob(ApiJob):
+class DownloadJob(ApiJob):
     '''
-    Download and decrypt a message from a source.
+    Download and decrypt a file that contains either a message, reply, or file submission.
     '''
-    def __init__(self, uuid: str, data_dir: str, gpg: GpgHelper) -> None:
-        super().__init__()
-        self.uuid = uuid
-        self.data_dir = data_dir
-        self.gpg = gpg
-        self.db_model_type = Message
-
-    def call_api(self, api_client: API, session: Session) -> Any:
-        '''
-        Download and decrypt.
-        '''
-        db_object = session.query(self.db_model_type).filter_by(uuid=self.uuid).one()
-
-        if db_object.is_decrypted:
-            return db_object.uuid
-
-        if db_object.is_downloaded:
-            self._decrypt_file(session, db_object, os.path.join(self.data_dir, db_object.filename))
-            return db_object.uuid
-
-        self._download(api_client, db_object, session)
-        self._decrypt_file(session, db_object, os.path.join(self.data_dir, db_object.filename))
-        return db_object.uuid
-
-    def _download(self, api: API, db_object: Message, session: Session) -> None:
-        '''
-        Download the file. Check file integrity and move it to the data directory before marking it
-        as downloaded.
-
-        Note: On Qubes OS, files are downloaded to ~/QubesIncoming.
-        '''
-        etag, download_path = self._make_call(db_object, api)
-
-        shutil.move(download_path, os.path.join(self.data_dir, db_object.filename))
-        mark_as_downloaded(type(db_object), db_object.uuid, session)
-
-    def _make_call(self, db_object: Message, api_client: API) -> Tuple[str, str]:
-        sdk_obj = sdclientapi.Submission(uuid=db_object.uuid)
-        sdk_obj.filename = db_object.filename
-        sdk_obj.source_uuid = db_object.source.uuid
-        return api_client.download_submission(sdk_obj)
-
-    def _decrypt_file(
-        self,
-        session: Session,
-        db_object: Union[File, Message, Reply],
-        filepath: str,
-    ) -> None:
-        '''
-        Decrypt file and store its plaintext content.
-
-        If the plaintext content is a message or a reply, store it in the local database, otherwise
-        store the document in the filesystem.
-        '''
-        try:
-            # Store plaintext in a temporary file that will be deleted when the file closes. It's
-            # needed just long enough to store the plaintext in the local db.
-            plaintextfile = NamedTemporaryFile('w+')
-
-            self.gpg.decrypt_submission_or_reply(
-                filepath,
-                plaintextfile.name,
-                is_doc=False)
-
-            plaintext = open(plaintextfile.name).read()
-            set_decryption_status_with_content(
-                model_type=type(db_object),
-                uuid=db_object.uuid,
-                is_decrypted=True,
-                session=session,
-                content=plaintext)
-
-            logger.info("File decrypted: {}".format(db_object.filename))
-        except CryptoError:
-            set_decryption_status_with_content(
-                model_type=type(db_object),
-                uuid=db_object.uuid,
-                is_decrypted=False,
-                session=session)
-
-            logger.info("Failed to decrypt file: {}".format(db_object.filename))
-
-
-class FileDownloadJob(ApiJob):
 
     CHUNK_SIZE = 4096
 
-    def __init__(
-        self,
-        submission_type: Union[Type[File], Type[Message]],
-        submission_uuid: str,
-        data_dir: str,
-        gpg: GpgHelper,
-    ) -> None:
+    def __init__(self, data_dir: str) -> None:
         super().__init__()
         self.data_dir = data_dir
-        self.submission_type = submission_type
-        self.submission_uuid = submission_uuid
-        self.gpg = gpg
+
+    def call_download_api(self, api: API, db_object: Union[File, Message]) -> Tuple[str, str]:
+        '''
+        Method for making the actual API call to downlod the file and handling the result.
+
+        This MUST return the (etag, filepath) tuple response from the server and MUST raise an
+        exception if and only if the download fails.
+        '''
+        raise NotImplementedError
+
+    def call_decrypt(self, filepath: str, session: Session = None) -> None:
+        '''
+        Method for decrypting the file and storing the plaintext result.
+
+        This MUST raise an exception if and only if the decryption fails.
+        '''
+        raise NotImplementedError
+
+    def get_db_object(self, session: Session) -> Union[File, Message]:
+        '''
+        Get the database object associated with this job.
+        '''
+        raise NotImplementedError
 
     def call_api(self, api_client: API, session: Session) -> Any:
         '''
-        Download and decrypt.
+        Download and decrypt the file associated with the database object.
         '''
-        db_object = session.query(self.submission_type).filter_by(uuid=self.submission_uuid).one()
+        db_object = self.get_db_object(session)
 
         if db_object.is_decrypted:
             return db_object.uuid
 
         if db_object.is_downloaded:
-            self._decrypt_file(session, db_object, os.path.join(self.data_dir, db_object.filename))
+            self._decrypt(os.path.join(self.data_dir, db_object.filename), db_object, session)
             return db_object.uuid
 
         self._download(api_client, db_object, session)
-        self._decrypt_file(session, db_object, os.path.join(self.data_dir, db_object.filename))
+        self._decrypt(os.path.join(self.data_dir, db_object.filename), db_object, session)
         return db_object.uuid
 
-    def _download(self, api_client: API, db_object: File, session: Session) -> None:
+    def _download(self, api: API, db_object: Union[File, Message], session: Session) -> None:
         '''
-        Download the file. Check file integrity and move it to the data directory before marking it
-        as downloaded.
+        Download the encrypted file. Check file integrity and move it to the data directory before
+        marking it as downloaded.
 
         Note: On Qubes OS, files are downloaded to ~/QubesIncoming.
         '''
-        etag, download_path = self._make_call(db_object, api_client)
+        try:
+            etag, download_path = self.call_download_api(api, db_object)
 
-        if not self._check_file_integrity(etag, download_path):
-            raise RuntimeError('Downloaded file had an invalid checksum.')
+            if not self._check_file_integrity(etag, download_path):
+                raise RuntimeError('Downloaded file had an invalid checksum.')
 
-        data_path = os.path.join(self.data_dir, db_object.filename)
-        shutil.move(download_path, data_path)
+            shutil.move(download_path, os.path.join(self.data_dir, db_object.filename))
+            mark_as_downloaded(type(db_object), db_object.uuid, session)
+            logger.info("File downloaded: {}".format(db_object.filename))
+        except BaseError as e:
+            logger.debug("Failed to download file: {}".format(db_object.filename))
+            raise e
 
-        mark_as_downloaded(type(db_object), db_object.uuid, session)
-
-    def _make_call(self, db_object: Union[File, Message], api_client: API) -> Tuple[str, str]:
-        sdk_obj = sdclientapi.Submission(uuid=db_object.uuid)
-        sdk_obj.filename = db_object.filename
-        sdk_obj.source_uuid = db_object.source.uuid
-        return api_client.download_submission(sdk_obj)
+    def _decrypt(self, filepath: str, db_object: Union[File, Message], session: Session) -> None:
+        '''
+        Decrypt the file located at the given filepath and mark it as decrypted.
+        '''
+        try:
+            self.call_decrypt(filepath, session)
+            mark_as_decrypted(type(db_object), db_object.uuid, session)
+            logger.info("File decrypted: {}".format(os.path.basename(filepath)))
+        except CryptoError as e:
+            mark_as_decrypted(type(db_object), db_object.uuid, session, is_decrypted=False)
+            logger.debug("Failed to decrypt file: {}".format(os.path.basename(filepath)))
+            raise e
 
     @classmethod
     def _check_file_integrity(cls, etag: str, file_path: str) -> bool:
         '''
-        Checks if the file is valid.
-        :return: `True` if valid or unknown, `False` otherwise.
+        Return True if file checksum is valid or unknown, otherwise return False.
         '''
         if not etag:
             logger.debug('No ETag. Skipping integrity check for file at {}'.format(file_path))
@@ -191,41 +131,85 @@ class FileDownloadJob(ApiJob):
         calculated_checksum = binascii.hexlify(hasher.digest()).decode('utf-8')
         return calculated_checksum == checksum
 
-    def _decrypt_file(
-        self,
-        session: Session,
-        db_object: Union[File, Message, Reply],
-        filepath: str,
-    ) -> None:
+
+class MessageDownloadJob(DownloadJob):
+    '''
+    Download and decrypt a message from a source.
+    '''
+
+    def __init__(self, uuid: str, data_dir: str, gpg: GpgHelper) -> None:
+        super().__init__(data_dir)
+        self.uuid = uuid
+        self.gpg = gpg
+
+    def get_db_object(self, session: Session) -> Message:
         '''
-        If a File: decrypt and save plaintext to a file on the filesystem.
-        If a Message or Reply: decrypt and save plaintext to local database.
+        Override DownloadJob.
         '''
-        try:
-            # Store plaintext in a file named after the downloaded file name, but without the
-            # extensions, e.g. 1-impractical_thing-doc.gz.gpg -> 1-impractical_thing-doc
-            fn_no_ext, _ = os.path.splitext(os.path.splitext(os.path.basename(filepath))[0])
-            plaintext_filepath = os.path.join(self.data_dir, fn_no_ext)
+        return session.query(Message).filter_by(uuid=self.uuid).one()
 
-            self.gpg.decrypt_submission_or_reply(
-                filepath,
-                plaintext_filepath,
-                is_doc=True)
+    def call_download_api(self, api: API, db_object: Message) -> Tuple[str, str]:
+        '''
+        Override DownloadJob.
+        '''
+        sdk_object = SdkSubmission(uuid=db_object.uuid)
+        sdk_object.source_uuid = db_object.source.uuid
+        sdk_object.filename = db_object.filename
+        return api.download_submission(sdk_object)
 
-            set_decryption_status_with_content(
-                model_type=type(db_object),
-                uuid=db_object.uuid,
-                is_decrypted=True,
-                session=session)
+    def call_decrypt(self, filepath: str, session: Session = None) -> None:
+        '''
+        Override DownloadJob.
 
-            logger.debug("File decrypted: {}".format(db_object.filename))
-        except CryptoError as e:
-            set_decryption_status_with_content(
-                model_type=type(db_object),
-                uuid=db_object.uuid,
-                is_decrypted=False,
-                session=session)
+        Decrypt the file located at the given filepath and store its plaintext content in the local
+        database.
 
-            logger.debug("Failed to decrypt file: {}".format(db_object.filename))
+        The file containing the plaintext should be deleted once the content is stored in the db.
+        '''
+        with NamedTemporaryFile('w+') as plaintext_file:
+            self.gpg.decrypt_submission_or_reply(filepath, plaintext_file.name, is_doc=False)
+            set_message_or_reply_content(
+                model_type=Message,
+                uuid=self.uuid,
+                session=session,
+                content=plaintext_file.read())
 
-            raise e
+
+class FileDownloadJob(DownloadJob):
+    '''
+    Download and decrypt a file from a source.
+    '''
+
+    def __init__(self, uuid: str, data_dir: str, gpg: GpgHelper) -> None:
+        super().__init__(data_dir)
+        self.uuid = uuid
+        self.gpg = gpg
+
+    def get_db_object(self, session: Session) -> File:
+        '''
+        Override DownloadJob.
+        '''
+        return session.query(File).filter_by(uuid=self.uuid).one()
+
+    def call_download_api(self, api: API, db_object: File) -> Tuple[str, str]:
+        '''
+        Override DownloadJob.
+        '''
+        sdk_object = SdkSubmission(uuid=db_object.uuid)
+        sdk_object.source_uuid = db_object.source.uuid
+        sdk_object.filename = db_object.filename
+        return api.download_submission(sdk_object)
+
+    def call_decrypt(self, filepath: str, session: Session = None) -> None:
+        '''
+        Override DownloadJob.
+
+        Decrypt the file located at the given filepath and store its plaintext content in a file on
+        the filesystem.
+
+        The file storing the plaintext should have the same name as the downloaded file but without
+        the file extensions, e.g. 1-impractical_thing-doc.gz.gpg -> 1-impractical_thing-doc
+        '''
+        fn_no_ext, _ = os.path.splitext(os.path.splitext(os.path.basename(filepath))[0])
+        plaintext_filepath = os.path.join(self.data_dir, fn_no_ext)
+        self.gpg.decrypt_submission_or_reply(filepath, plaintext_filepath, is_doc=True)

--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -80,8 +80,6 @@ class Message(Base):
         Boolean(name='is_decrypted'),
         CheckConstraint('CASE WHEN is_downloaded = 0 THEN is_decrypted IS NULL ELSE 1 END',
                         name='messages_compare_is_downloaded_vs_is_decrypted'),
-        CheckConstraint('CASE WHEN is_decrypted = 0 THEN content IS NULL ELSE 1 END',
-                        name='messages_compare_is_decrypted_vs_content'),
         nullable=True,
     )
 
@@ -192,8 +190,6 @@ class Reply(Base):
         Boolean(name='is_decrypted'),
         CheckConstraint('CASE WHEN is_downloaded = 0 THEN is_decrypted IS NULL ELSE 1 END',
                         name='replies_compare_is_downloaded_vs_is_decrypted'),
-        CheckConstraint('CASE WHEN is_decrypted = 0 THEN content IS NULL ELSE 1 END',
-                        name='replies_compare_is_decrypted_vs_content'),
         nullable=True,
     )
 

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -550,7 +550,6 @@ class Controller(QObject):
         """
         if self.api:
             job = FileDownloadJob(
-                submission_type,
                 submission_uuid,
                 self.data_dir,
                 self.gpg,

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -361,21 +361,33 @@ def mark_as_downloaded(
     session.commit()
 
 
-def set_decryption_status_with_content(
+def mark_as_decrypted(
     model_type: Union[Type[File], Type[Message], Type[Reply]],
     uuid: str,
-    is_decrypted: bool,
     session: Session,
-    content: str = None
+    is_decrypted: bool = True
+) -> None:
+    """
+    Mark object as downloaded in the database.
+    """
+    db_obj = session.query(model_type).filter_by(uuid=uuid).one()
+    db_obj.is_decrypted = is_decrypted
+    session.add(db_obj)
+    session.commit()
+
+
+def set_message_or_reply_content(
+    model_type: Union[Type[Message], Type[Reply]],
+    uuid: str,
+    content: str,
+    session: Session
 ) -> None:
     """
     Mark whether or not the object is decrypted. If it's not decrypted, do not set content. If the
     object is a File, do not set content (filesystem storage is used instead).
     """
     db_obj = session.query(model_type).filter_by(uuid=uuid).one_or_none()
-    db_obj.is_decrypted = is_decrypted
-    if content is not None:
-        db_obj.content = content
+    db_obj.content = content
     session.add(db_obj)
     session.commit()
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -866,7 +866,6 @@ def test_Controller_on_file_download_Submission(homedir, config, session, mocker
     co.on_submission_download(db.File, file_.uuid)
 
     mock_job_cls.assert_called_once_with(
-        db.File,
         file_.uuid,
         co.data_dir,
         co.gpg,

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -4,7 +4,6 @@ Testing for the ApiJobQueue and related classes.
 from queue import Queue
 from sdclientapi import RequestTimeoutError
 
-from securedrop_client import db
 from securedrop_client.api_jobs.downloads import FileDownloadJob
 from securedrop_client.api_jobs.base import ApiInaccessibleError
 from securedrop_client.queue import RunnableQueue, ApiJobQueue
@@ -215,7 +214,7 @@ def test_ApiJobQueue_enqueue(mocker):
     job_queue.download_file_queue.api_client = 'has a value'
     mock_start_queues = mocker.patch.object(job_queue, 'start_queues')
 
-    dl_job = FileDownloadJob(db.File, 'mock', 'mock', 'mock')
+    dl_job = FileDownloadJob('mock', 'mock', 'mock')
     job_queue.enqueue(dl_job)
 
     mock_download_file_queue.queue.put_nowait.assert_called_once_with(dl_job)


### PR DESCRIPTION
## Description

Closes #406

This is part of breaking down a large PR https://github.com/freedomofpress/securedrop-client/pull/409

This and following smaller refactors are a way to help us avoid bugs around file management when we download and decrypt, which is tricky.

## Summary of changes

* Moved `call_api`, `_download`, and `_check_file_integrity` into a new base class called `DownloadJob` from `FileDownloadJob` and `MessageDownloadJob`.  `_decrypt` will also be moved into `DownloadJob` from its derived classes in a followup PR.

* This also introduces new behavior: checking file integrity of everything that gets downloaded. So now message downloads also get checked.

# Test Plan

No need to test in Qubes, but always feel free. This PR doesn't modify how we decrypt or download, and the extra file integrity checks is not qubes-specific.

1. Send messages and files as a source
2. Refresh on the client to see messages downloaded and decrytped. Click on files to trigger a download and decrypt. When you see "Open" next to the filename you know it's decrypted. 
3. [optional] query the db to make sure statuses look correct