### PR TITLE
ci: fail build if build requirements need update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
             git clone https://github.com/freedomofpress/securedrop-debian-packaging.git
             cd securedrop-debian-packaging
             make install-deps && make fetch-wheels
+            PKG_DIR=~/project make requirements
 
       - run:
           name: Tag and make source tarball


### PR DESCRIPTION
# Description

This is a followup from: #422

`master` must _always_ produce a packaged client that is in a working state after build: in #422 we verified that the build succeeds on `master`. However: if `build-requirements.txt` is out of sync with `requirements.txt`, the client may not work as expected if it relies on functionality added in the new dependency added in `requirements.txt`. This would have been the case if #421 was merged as is (in that branch `requirements.txt` is updated but _not_ `build-requirements.txt`)

This PR runs `make requirements` prior to build such that the build will fail if `build-requirements.txt` is out of sync with `requirements.txt`

# Test Plan

1. See branch `ci-test-this-job-fails`, which updates a dependency in `requirements.txt` without updating the `build-requirements.txt`
2. See that the build failed: https://circleci.com/gh/freedomofpress/securedrop-client/1020