### PR TITLE
app: automatically rerun download jobs until the hashes validate

### DIFF
--- a/tests/api_jobs/test_downloads.py
+++ b/tests/api_jobs/test_downloads.py
@@ -6,7 +6,7 @@ from sdclientapi import BaseError
 from sdclientapi import Submission as SdkSubmission
 
 from securedrop_client.api_jobs.downloads import DownloadJob, FileDownloadJob, MessageDownloadJob, \
-    ReplyDownloadJob
+    ReplyDownloadJob, DownloadChecksumMismatchException
 from securedrop_client.crypto import GpgHelper, CryptoError
 from tests import factory
 
@@ -406,8 +406,7 @@ def test_FileDownloadJob_bad_sha256_etag(mocker, homedir, session, session_maker
         gpg,
     )
 
-    # we currently don't handle errors in the checksum
-    with pytest.raises(RuntimeError):
+    with pytest.raises(DownloadChecksumMismatchException):
         job.call_api(api_client, session)
 
 


### PR DESCRIPTION
# Description

Fixes #383

Notes:

* The job will keep getting added to the queue until it succeeds (the retry is only for hash mismatches, not for ETags missing or other kinds of download failures).
* To that end, I know we discussed this, but I haven't made the downloads autofail if the ETags are missing or the hash algorithm is wrong. These ETags exist only to prevent corrupted downloads and are not a security mitigation, and failing to open files (failing closed) even if the downloads are likely fine seems aggressive. Again, note that this PR still has the downloads fail if the hash is present _but incorrect_.
* I'm not raising any messaging to the user when this validation/hash mismatch is happening. I could imagine that "Your download failed! Trying again..." might be a useful status to raise, but to prevent a storm of error messages getting raised to the user, for now I'm doing this retry transparently in the background. 

# Test Plan

## ETags are correct

0. Run the server without modification
1. Ensure that files, messages, replies are downloaded _once_ without issue

## ETags are incorrect

0. Apply this diff to server:

```diff
diff --git a/securedrop/journalist_app/utils.py b/securedrop/journalist_app/utils.py
index 6f9bcadac..4902787df 100644
--- a/securedrop/journalist_app/utils.py
+++ b/securedrop/journalist_app/utils.py
@@ -346,7 +346,7 @@ def serve_file_with_etag(db_obj):
         add_checksum_for_file(db.session, db_obj, file_path)

     response.direct_passthrough = False
-    response.headers['Etag'] = db_obj.checksum
+    response.headers['Etag'] = 'sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08'
     return response
```

1. You should see downloads fail and then get resubmitted to the queue e.g.:

```
2019-06-26 14:33:33,761 - securedrop_client.logic:536(on_reply_download_failure) DEBUG: Failed to download reply: Downloaded file had an invalid checksum.
2019-06-26 14:33:33,761 - securedrop_client.logic:540(on_reply_download_failure) DEBUG: Failure due to checksum mismatch, retrying 41c2a192-f76a-4acd-b3e3-eb6d481cf0a4
2019-06-26 14:33:33,761 - securedrop_client.queue:111(enqueue) DEBUG: Adding job to main queue
```

# Checklist

- [x] I have tested these two above scenarios in Qubes. Note that testing in Qubes I don't think is necessary for this specific change but is always appreciated (to shake out any other issues). 