### PR TITLE
Issue 411 user profile name

### DIFF
--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -27,7 +27,7 @@ from PyQt5.QtWidgets import QMainWindow, QWidget, QHBoxLayout, QVBoxLayout, QDes
     QApplication
 
 from securedrop_client import __version__
-from securedrop_client.db import Source
+from securedrop_client.db import Source, User
 from securedrop_client.logic import Controller  # noqa: F401
 from securedrop_client.gui.widgets import TopPane, LeftPane, MainView, LoginDialog
 from securedrop_client.resources import load_icon
@@ -93,12 +93,15 @@ class Window(QMainWindow):
         self.main_view.setup(self.controller)
         self.show_login()
 
-    def show_main_window(self, username: str = None) -> None:
+    def show_main_window(self, db_user: User = None) -> None:
+        """
+        Show main application window.
+        """
         self.autosize_window()
         self.show()
 
-        if username:
-            self.set_logged_in_as(username)
+        if db_user:
+            self.set_logged_in_as(db_user)
 
     def autosize_window(self):
         """
@@ -149,11 +152,11 @@ class Window(QMainWindow):
         else:
             self.update_activity_status(_('Waiting to refresh...'), 5000)
 
-    def set_logged_in_as(self, username):
+    def set_logged_in_as(self, db_user: User):
         """
         Update the UI to show user logged in with username.
         """
-        self.left_pane.set_logged_in_as(username)
+        self.left_pane.set_logged_in_as(db_user)
         self.top_pane.enable_refresh()
 
     def logout(self):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -433,7 +433,7 @@ class UserProfile(QWidget):
 
     def set_user(self, db_user: User):
         self.user_icon.setText(_(db_user.initials))
-        self.user_button.set_username(db_user.username)
+        self.user_button.set_username(db_user.fullname)
 
     def show(self):
         self.login_button.hide()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -30,7 +30,7 @@ from PyQt5.QtWidgets import QListWidget, QLabel, QWidget, QListWidgetItem, QHBox
     QPushButton, QVBoxLayout, QLineEdit, QScrollArea, QDialog, QAction, QMenu, QMessageBox, \
     QToolButton, QSizePolicy, QTextEdit, QStatusBar, QGraphicsDropShadowEffect
 
-from securedrop_client.db import Source, Message, File, Reply
+from securedrop_client.db import Source, Message, File, Reply, User
 from securedrop_client.storage import source_exists
 from securedrop_client.gui import SvgLabel, SvgPushButton, SvgToggleButton
 from securedrop_client.logic import Controller
@@ -156,11 +156,11 @@ class LeftPane(QWidget):
     def setup(self, window, controller):
         self.user_profile.setup(window, controller)
 
-    def set_logged_in_as(self, username):
+    def set_logged_in_as(self, db_user: User):
         """
         Update the UI to reflect that the user is logged in as "username".
         """
-        self.user_profile.set_username(username)
+        self.user_profile.set_user(db_user)
         self.user_profile.show()
 
     def set_logged_out(self):
@@ -431,9 +431,9 @@ class UserProfile(QWidget):
         self.user_button.setup(controller)
         self.login_button.setup(window)
 
-    def set_username(self, username):
-        self.user_icon.setText(_('jo'))
-        self.user_button.set_username(username)
+    def set_user(self, db_user: User):
+        self.user_icon.setText(_(db_user.initials))
+        self.user_button.set_username(db_user.username)
 
     def show(self):
         self.login_button.hide()

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -318,7 +318,7 @@ class Controller(QObject):
             result['first_name'],
             result['last_name'],
             self.session)
-        self.gui.show_main_window(user.username)
+        self.gui.show_main_window(user)
 
     def on_get_current_user_failure(self, result: Exception) -> None:
         self.api = None

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -58,12 +58,13 @@ def test_show_main_window(mocker):
     w.autosize_window = mocker.MagicMock()
     w.show = mocker.MagicMock()
     w.set_logged_in_as = mocker.MagicMock()
+    user = mocker.MagicMock()
 
-    w.show_main_window(username='test_username')
+    w.show_main_window(db_user=user)
 
     w.autosize_window.assert_called_once_with()
     w.show.assert_called_once_with()
-    w.set_logged_in_as.assert_called_once_with('test_username')
+    w.set_logged_in_as.assert_called_once_with(user)
 
 
 def test_show_main_window_without_username(mocker):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -128,11 +128,12 @@ def test_LeftPane_set_logged_in_as(mocker):
     """
     lp = LeftPane()
     lp.user_profile = mocker.MagicMock()
+    user = mocker.MagicMock()
 
-    lp.set_logged_in_as('test')
+    lp.set_logged_in_as(user)
 
     lp.user_profile.show.assert_called_once_with()
-    lp.user_profile.set_username.assert_called_once_with('test')
+    lp.user_profile.set_user.assert_called_once_with(user)
 
 
 def test_LeftPane_set_logged_out(mocker):
@@ -274,15 +275,16 @@ def test_UserProfile_setup(mocker):
     up.login_button.setup.assert_called_once_with(window)
 
 
-def test_UserProfile_set_username(mocker):
+def test_UserProfile_set_user(mocker):
     up = UserProfile()
     up.user_icon = mocker.MagicMock()
     up.user_button = mocker.MagicMock()
+    user = factory.User(firstname='firstname_mock', lastname='lastname_mock')
 
-    up.set_username('test_username')
+    up.set_user(user)
 
-    up.user_icon.setText.assert_called_once_with('jo')  # testing current behavior as placeholder
-    up.user_button.set_username.assert_called_once_with('test_username')
+    up.user_icon.setText.assert_called_with('fl')
+    up.user_button.set_username.assert_called_with('firstname_mock lastname_mock')
 
 
 def test_UserProfile_show(mocker):

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -227,7 +227,7 @@ def test_Controller_on_get_current_user_success(mocker, session_maker, session, 
     assert user.lastname == 'lastname_mock'
     assert user.fullname == 'firstname_mock lastname_mock'
     assert user.initials == 'fl'
-    co.gui.show_main_window.assert_called_with('mock_username')
+    co.gui.show_main_window.assert_called_with(user)
 
 
 def test_Controller_on_get_current_user_success_no_name(mocker, session_maker, session, homedir):
@@ -252,7 +252,7 @@ def test_Controller_on_get_current_user_success_no_name(mocker, session_maker, s
     assert user.lastname is None
     assert user.fullname == 'mock_username'
     assert user.initials == 'mo'
-    co.gui.show_main_window.assert_called_with('mock_username')
+    co.gui.show_main_window.assert_called_with(user)
 
 
 def test_Controller_on_get_current_user_failure(homedir, mocker, session_maker):


### PR DESCRIPTION
# Description

Resolves #411 without the ellipsis or hover-over overlay, which I believe @rmol is working on a generic solution for.

Here's an example of what this looks like (without styling) and only a first name:
![fullname](https://user-images.githubusercontent.com/4522213/60378029-35b85c00-99d1-11e9-9e3c-71777159e960.png)

Here's an example of what this looks like (again, without styling) and with a long first and last name:
![long_name](https://user-images.githubusercontent.com/4522213/60378036-554f8480-99d1-11e9-88d6-8c7b8f1ea177.png)

# Test Plan

Log in to the journalist interface and try setting different names to see initials and fullname change in user profile widget.
