### PR TITLE
remove now unnecessary QApplication.processEvents calls

### DIFF
--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -1,7 +1,6 @@
 import logging
 
 from PyQt5.QtCore import QObject, QThread, pyqtSlot
-from PyQt5.QtWidgets import QApplication
 from queue import Queue
 from sdclientapi import API, RequestTimeoutError
 from sqlalchemy.orm import scoped_session
@@ -48,9 +47,6 @@ class RunnableQueue(QObject):
                 # happens in the future and flag the situation to the user (see ticket #379).
                 logger.error('Client is not authenticated, skipping job...')
             finally:
-                # process events to allow this thread to handle incoming signals
-                QApplication.processEvents()
-
                 session.close()
 
             if exit_loop:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -26,7 +26,6 @@ def test_RunnableQueue_happy_path(mocker):
     '''
     Add one job to the queue, run it.
     '''
-    mock_process_events = mocker.patch('securedrop_client.queue.QApplication.processEvents')
     mock_api_client = mocker.MagicMock()
     mock_session = mocker.MagicMock()
     mock_session_maker = mocker.MagicMock(return_value=mock_session)
@@ -39,9 +38,6 @@ def test_RunnableQueue_happy_path(mocker):
 
     queue._process(exit_loop=True)
 
-    # this needs to be called at the end of the loop
-    assert mock_process_events.called
-
     assert queue.last_job is None
     assert queue.queue.empty()
 
@@ -51,7 +47,6 @@ def test_RunnableQueue_job_timeout(mocker):
     Add two jobs to the queue. The first times out, and then gets "cached" for the next pass
     through the loop.
     '''
-    mock_process_events = mocker.patch('securedrop_client.queue.QApplication.processEvents')
     mock_api_client = mocker.MagicMock()
     mock_session = mocker.MagicMock()
     mock_session_maker = mocker.MagicMock(return_value=mock_session)
@@ -94,9 +89,6 @@ def test_RunnableQueue_job_timeout(mocker):
     # check that job2 still has 5 (the default) remaining attempts
     assert queue.last_job.remaining_attempts == times_to_try
 
-    # ensure we don't have stale mocks
-    assert mock_process_events.called
-
 
 def test_RunnableQueue_job_ApiInaccessibleError(mocker):
     '''
@@ -106,7 +98,6 @@ def test_RunnableQueue_job_ApiInaccessibleError(mocker):
     ApiInaccessibleError occurs, see #379).
     '''
 
-    mock_process_events = mocker.patch('securedrop_client.queue.QApplication.processEvents')
     mock_api_client = mocker.MagicMock()
     mock_session = mocker.MagicMock()
     mock_session_maker = mocker.MagicMock(return_value=mock_session)
@@ -135,9 +126,6 @@ def test_RunnableQueue_job_ApiInaccessibleError(mocker):
     # check that all jobs are gone
     assert queue.queue.empty()
 
-    # ensure we don't have stale mocks
-    assert mock_process_events.called
-
 
 def test_RunnableQueue_job_generic_exception(mocker):
     '''
@@ -145,7 +133,6 @@ def test_RunnableQueue_job_generic_exception(mocker):
     Ensure that the queue continues processing jobs and the second job is attempted.
     '''
 
-    mock_process_events = mocker.patch('securedrop_client.queue.QApplication.processEvents')
     mock_api_client = mocker.MagicMock()
     mock_session = mocker.MagicMock()
     mock_session_maker = mocker.MagicMock(return_value=mock_session)
@@ -176,16 +163,11 @@ def test_RunnableQueue_job_generic_exception(mocker):
     # check that all jobs are gone
     assert queue.queue.empty()
 
-    # ensure we don't have stale mocks
-    assert mock_process_events.called
-
 
 def test_RunnableQueue_does_not_run_jobs_when_not_authed(mocker):
     '''
     Add a job to the queue, ensure we don't run it when not authenticated.
     '''
-    mock_process_events = mocker.patch('securedrop_client.queue.QApplication.processEvents')
-
     mock_api_client = mocker.MagicMock()
     mock_session = mocker.MagicMock()
     mock_session_maker = mocker.MagicMock(return_value=mock_session)
@@ -204,8 +186,6 @@ def test_RunnableQueue_does_not_run_jobs_when_not_authed(mocker):
 
     # assert we logged an error message
     assert "Client is not authenticated" in mock_logger.error.call_args[0][0]
-
-    assert mock_process_events.called
 
 
 def test_ApiJobQueue_enqueue(mocker):


### PR DESCRIPTION
# Description

Fixes #419. @creviera is correct: since we're not running this queue in the GUI thread, events will be processed without needing to explicitly call `QApplication.processEvents`.

# Test Plan

You can verify for yourself that events are being processed by checking out this diff, adding a `time.sleep(5)` at the end of the queue loop [here](https://github.com/freedomofpress/securedrop-client/blob/master/securedrop_client/queue.py#L51)  and running the application. You'll see each job finish and the UI update as expected after each job. 

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs, network (via the RPC service) traffic, or fine tuning of the graphical user interface, Qubes testing is required. Please check as applicable:

 - [ ] I have tested these changes in Qubes
 - [ ] I do not have a Qubes OS workstation (the reviewer will need to test these changes in Qubes)
 - [x] These changes do not need to be tested in Qubes, qt only