### PR TITLE
app: add color bar on bottom of message bubbles, set standard message spacing

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1294,6 +1294,7 @@ class SpeechBubble(QWidget):
     #speech_bubble {
         padding: 8px;
         min-height: 32px;
+        min-width: 556px;
         border: 1px solid #999;
         border-bottom: 0;
     }
@@ -1301,7 +1302,6 @@ class SpeechBubble(QWidget):
         padding: 0px;
         background-color: #102781;
         min-height: 5px;
-        max-height: 5px;
         border: 0px;
     }
     '''
@@ -1314,20 +1314,18 @@ class SpeechBubble(QWidget):
         self.setStyleSheet(self.CSS)
 
         layout = QVBoxLayout()
+        layout.setSpacing(0)
+        self.setLayout(layout)
         self.message = QLabel(html.escape(text, quote=False))
         self.message.setObjectName('speech_bubble')
         self.message.setWordWrap(True)
-        self.message.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.message.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
         layout.addWidget(self.message)
-        layout.insertStretch(0)
 
         self.color_bar = QWidget()
         self.color_bar.setObjectName('color_bar')
-        self.color_bar.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.color_bar.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
         layout.addWidget(self.color_bar)
-        layout.setSpacing(0)
-
-        self.setLayout(layout)
 
         update_signal.connect(self._update_text)
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1538,6 +1538,8 @@ class ConversationView(QWidget):
     https://github.com/freedomofpress/securedrop-client/issues/273
     """
 
+    CONVERSATION_SPACING = 28
+
     def __init__(
         self,
         source_db_object: Source,
@@ -1551,6 +1553,7 @@ class ConversationView(QWidget):
         self.container.setObjectName('container')
         self.conversation_layout = QVBoxLayout()
         self.conversation_layout.setContentsMargins(0, 0, 0, 0)
+        self.conversation_layout.setSpacing(self.CONVERSATION_SPACING)
         self.container.setLayout(self.conversation_layout)
         self.container.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1293,8 +1293,16 @@ class SpeechBubble(QWidget):
     CSS = '''
     #speech_bubble {
         padding: 8px;
-        min-height:32px;
-        border:1px solid #999;
+        min-height: 32px;
+        border: 1px solid #999;
+        border-bottom: 0;
+    }
+    #color_bar {
+        padding: 0px;
+        background-color: #102781;
+        min-height: 5px;
+        max-height: 5px;
+        border: 0px;
     }
     '''
 
@@ -1306,12 +1314,20 @@ class SpeechBubble(QWidget):
         self.setStyleSheet(self.CSS)
 
         layout = QVBoxLayout()
-        self.setLayout(layout)
         self.message = QLabel(html.escape(text, quote=False))
         self.message.setObjectName('speech_bubble')
         self.message.setWordWrap(True)
         self.message.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         layout.addWidget(self.message)
+        layout.insertStretch(0)
+
+        self.color_bar = QWidget()
+        self.color_bar.setObjectName('color_bar')
+        self.color_bar.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        layout.addWidget(self.color_bar)
+        layout.setSpacing(0)
+
+        self.setLayout(layout)
 
         update_signal.connect(self._update_text)
 
@@ -1366,15 +1382,7 @@ class MessageWidget(ConversationWidget):
     """
 
     CSS = '''
-    background-color: qlineargradient(
-        x1: 0,
-        y1: 0,
-        x2: 0,
-        y2: 1,
-        stop: 0 #fff,
-        stop: 0.9 #fff,
-        stop: 1 #9211ff
-    );
+    background-color: #ffffff;
     '''
 
     def __init__(self, message_id: str, message: str, update_signal) -> None:
@@ -1396,15 +1404,15 @@ class ReplyWidget(ConversationWidget):
     """
 
     CSS = '''
-    background-color: qlineargradient(
-        x1: 0,
-        y1: 0,
-        x2: 0,
-        y2: 1,
-        stop: 0 #fff,
-        stop: 0.9 #fff,
-        stop: 1 #05edfe
-    );
+    background-color: #ffffff;
+    '''
+
+    CSS_COLOR_BAR_REPLY_FAIL = '''
+    background-color: #ff3366;
+    '''
+
+    CSS_COLOR_BAR_REPLY = '''
+    background-color: #0065db;
     '''
 
     def __init__(
@@ -1426,6 +1434,7 @@ class ReplyWidget(ConversationWidget):
 
         # Set styles
         self.setStyleSheet(self.CSS)
+        self.speech_bubble.color_bar.setStyleSheet(self.CSS_COLOR_BAR_REPLY)
 
         message_succeeded_signal.connect(self._on_reply_success)
         message_failed_signal.connect(self._on_reply_failure)
@@ -1447,6 +1456,7 @@ class ReplyWidget(ConversationWidget):
         """
         if message_id == self.message_id:
             logger.debug('Message {} failed'.format(message_id))
+            self.speech_bubble.color_bar.setStyleSheet(self.CSS_COLOR_BAR_REPLY_FAIL)
 
 
 class FileWidget(QWidget):


### PR DESCRIPTION
# Description

Sets standard message spacing and message width as speced in zeplin. Closes #466 

Adds a tiny 5px color bar (as defined in zeplin) to the bottom of each message:

<img width="879" alt="Screen Shot 2019-07-05 at 3 04 25 PM" src="https://user-images.githubusercontent.com/7832803/60747007-491a7880-9f37-11e9-994c-71b22c457979.png">

and the reply will turn coral on reply failure: 

<img width="580" alt="Screen Shot 2019-07-05 at 3 06 03 PM" src="https://user-images.githubusercontent.com/7832803/60747005-43249780-9f37-11e9-8850-0ed980302c0a.png">

Closes #365 (will file followups for the other reply failure tasks)

# Test plan

Test the GUI changes seem reasonable, and also verify the reply failure case updates the UI (I put in an `abort(500, 'TEST')` [here](https://github.com/freedomofpress/securedrop/blob/develop/securedrop/journalist_app/api.py#L233) to test)

Also follow STR from #466 in order to test that the message spacing is now uniform 28px and cannot push down the color bar. 

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs, network (via the RPC service) traffic, or fine tuning of the graphical user interface, Qubes testing is required. Please check as applicable:

 - [ ] I have tested these changes in Qubes
 - [ ] I do not have a Qubes OS workstation (the reviewer will need to test these changes in Qubes)
 - [x] GUI changes only, no qubes testing needed