### PR TITLE
Issue 475 reply bug

### DIFF
--- a/securedrop_client/api_jobs/uploads.py
+++ b/securedrop_client/api_jobs/uploads.py
@@ -44,13 +44,13 @@ class SendReplyJob(ApiJob):
             session.commit()
             return reply_db_object.uuid
         except CryptoError as ce:
-            error_message = "Failed to encrypt reply for source {uuid} due to {exception}".format(
-                uuid=self.source_uuid, exception=repr(ce))
-            raise SendReplyJobException(error_message, self.reply_uuid)
+            message = "Failed to encrypt reply for source {id} due to CryptoError: {error}".format(
+                id=self.source_uuid, error=ce)
+            raise SendReplyJobException(message, self.reply_uuid)
         except Exception as e:
-            error_message = "Failed to send reply for source {uuid} due to {exception}".format(
-                uuid=self.source_uuid, exception=repr(e))
-            raise SendReplyJobException(error_message, self.reply_uuid)
+            message = "Failed to send reply for source {id} due to Exception: {error}".format(
+                id=self.source_uuid, error=e)
+            raise SendReplyJobException(message, self.reply_uuid)
 
     def _make_call(self, encrypted_reply: str, api_client: API) -> sdclientapi.Reply:
         sdk_source = sdclientapi.Source(uuid=self.source_uuid)

--- a/securedrop_client/crypto.py
+++ b/securedrop_client/crypto.py
@@ -180,6 +180,15 @@ class GpgHelper:
         '''
         session = self.session_maker()
         source = session.query(Source).filter_by(uuid=source_uuid).one()
+
+        if source.fingerprint is None:
+            raise CryptoError(
+                'Could not encrypt reply due to missing fingerprint for source: {}.'.format(
+                    source_uuid))
+
+        if self.journalist_key_fingerprint is None:
+            raise CryptoError('Could not encrypt reply due to missing fingerprint for journalist')
+
         cmd = self._gpg_cmd_base()
 
         with tempfile.NamedTemporaryFile('w+') as content, \

--- a/securedrop_client/crypto.py
+++ b/securedrop_client/crypto.py
@@ -181,11 +181,13 @@ class GpgHelper:
         session = self.session_maker()
         source = session.query(Source).filter_by(uuid=source_uuid).one()
 
+        # do not attempt to encrypt if the source key is missing
         if source.fingerprint is None:
             raise CryptoError(
-                'Could not encrypt reply due to missing fingerprint for source: {}.'.format(
+                'Could not encrypt reply due to missing fingerprint for source: {}'.format(
                     source_uuid))
 
+        # do not attempt to encrypt if the journalist key is missing
         if self.journalist_key_fingerprint is None:
             raise CryptoError('Could not encrypt reply due to missing fingerprint for journalist')
 

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -204,11 +204,14 @@ def test_encrypt_fail_if_source_fingerprint_missing(homedir, source, config, moc
     db_source = session.query(Source).filter_by(uuid=source['uuid']).one()
     db_source.fingerprint = None
     session.commit()
+    check_call_fn = mocker.patch('securedrop_client.crypto.subprocess.check_call')
 
     with pytest.raises(CryptoError,
                        match=r'Could not encrypt reply due to missing fingerprint for source: {}'.
                        format(source['uuid'])):
         helper.encrypt_to_source(source['uuid'], 'mock')
+
+    check_call_fn.assert_not_called()
 
 
 def test_encrypt_fail_if_journo_fingerprint_missing(homedir, source, config, mocker, session_maker):
@@ -218,7 +221,10 @@ def test_encrypt_fail_if_journo_fingerprint_missing(homedir, source, config, moc
     '''
     helper = GpgHelper(homedir, session_maker, is_qubes=False)
     helper.journalist_key_fingerprint = None
+    check_call_fn = mocker.patch('securedrop_client.crypto.subprocess.check_call')
 
     with pytest.raises(CryptoError,
                        match=r'Could not encrypt reply due to missing fingerprint for journalist'):
         helper.encrypt_to_source(source['uuid'], 'mock')
+
+    check_call_fn.assert_not_called()


### PR DESCRIPTION
# Description

Fixes TypeError bug (partial fix for https://github.com/freedomofpress/securedrop-client/issues/475)

# Test Plan

1. Run regression test on `master` branch: `TESTS=tests/api_jobs/test_uploads.py::test_send_reply_failure_when_repr_is_none make test` see it fail
2. Run regression test on `issue-475-reply-bug` branch and see it pass
3. Send a reply in Qubes and you'll no longer see the error log: 
```
ERROR: Job <securedrop_client.api_jobs.uploads.SendReplyJob object at 0x65ed9994dc18> raised an exception: SendReplyJobException: Failed to send reply for source 31838d94-872c-496f-8828-0af5ae44c6bb due to TypeError("Can't convert 'NoneType' object to str implicitly",)
```
You will see this underlying error, which will be fixed in a follow-up PR: 
```
gpg: [stdin]: encryption failed: No public key
```

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs, network (via the RPC service) traffic, or fine tuning of the graphical user interface, Qubes testing is required. Please check as applicable:

 - [x] I have tested these changes in Qubes
 - [ ] I do not have a Qubes OS workstation (the reviewer will need to test these changes in Qubes)