### PR TITLE
Fix conversation refresh bugs 467, 463

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -637,6 +637,9 @@ class MainView(QWidget):
             # else we create it.
             try:
                 conversation_wrapper = self.source_conversations[source]
+
+                # Redraw the conversation view such that new messages, replies, files appear.
+                conversation_wrapper.conversation_view.update_conversation(source.collection)
             except KeyError:
                 conversation_wrapper = SourceConversationWrapper(source, self.controller)
                 self.source_conversations[source] = conversation_wrapper

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -489,7 +489,8 @@ def test_MainView_on_source_changed_SourceConversationWrapper_is_preserved(mocke
     session.commit()
 
     source_conversation_init = mocker.patch(
-        'securedrop_client.gui.widgets.SourceConversationWrapper.__init__', return_value=None)
+        'securedrop_client.gui.widgets.SourceConversationWrapper.__init__',
+        return_value=None)
 
     # We expect on the first call, SourceConversationWrapper.__init__ should be called.
     mv.source_list.get_current_source = mocker.MagicMock(return_value=source)
@@ -516,8 +517,16 @@ def test_MainView_on_source_changed_SourceConversationWrapper_is_preserved(mocke
     # But if we click back (call on_source_changed again) to the source,
     # its SourceConversationWrapper should _not_ be recreated.
     mv.source_list.get_current_source = mocker.MagicMock(return_value=source)
+    conversation_wrapper = mv.source_conversations[source]
+    conversation_wrapper.conversation_view = mocker.MagicMock()
+    conversation_wrapper.conversation_view.update_conversation = mocker.MagicMock()
+
     mv.on_source_changed()
+
     assert mv.set_conversation.call_count == 1
+
+    # Conversation should be redrawn even for existing source (bug #467).
+    assert conversation_wrapper.conversation_view.update_conversation.call_count == 1
     assert source_conversation_init.call_count == 0
 
 


### PR DESCRIPTION
# Description

Fixes #467 
Fixes #463

(medium term refactor in #473, this fix unblocks other development tasks for now)

# Test Plan

0. Log into client
1. Create new source via source interface
2. Refresh client and click on source
3. Add message in source interface
4. Refresh again, new message should appear
5. Add message in source interface
6. Star source
7. New message should appear

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs, network (via the RPC service) traffic, or fine tuning of the graphical user interface, Qubes testing is required. Please check as applicable:

 - [ ] I have tested these changes in Qubes
 - [ ] I do not have a Qubes OS workstation (the reviewer will need to test these changes in Qubes)
 - [x] Qt/UI changes only