### PR TITLE
Add SecureQLabel

### DIFF
--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -17,8 +17,12 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from PyQt5.QtWidgets import QLabel, QHBoxLayout, QPushButton
-from PyQt5.QtCore import QSize
+import html
+
+from typing import Union
+
+from PyQt5.QtWidgets import QLabel, QHBoxLayout, QPushButton, QWidget
+from PyQt5.QtCore import QSize, Qt
 
 from securedrop_client.resources import load_svg, load_icon, load_toggle_icon
 
@@ -87,8 +91,14 @@ class SvgPushButton(QPushButton):
         The display size of the SVG, defaults to filling the entire size of the widget.
     """
 
-    def __init__(self, normal: str, disabled: str = None, active: str = None,
-                 selected: str = None, svg_size: str = None) -> None:
+    def __init__(
+        self,
+        normal: str,
+        disabled: str = None,
+        active: str = None,
+        selected: str = None,
+        svg_size: str = None,
+    ) -> None:
         super().__init__()
 
         # Set layout
@@ -136,3 +146,17 @@ class SvgLabel(QLabel):
         self.svg = load_svg(filename)
         self.svg.setFixedSize(svg_size) if svg_size else self.svg.setFixedSize(QSize())
         layout.addWidget(self.svg)
+
+
+class SecureQLabel(QLabel):
+    def __init__(
+        self,
+        text: str = "",
+        parent: QWidget = None,
+        flags: Union[Qt.WindowFlags, Qt.WindowType] = Qt.WindowFlags(),
+    ):
+        super().__init__(parent, flags)
+        self.setText(text)
+
+    def setText(self, text: str) -> None:
+        super().setText(html.escape(text))

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -32,7 +32,7 @@ from PyQt5.QtWidgets import QListWidget, QLabel, QWidget, QListWidgetItem, QHBox
 
 from securedrop_client.db import Source, Message, File, Reply, User
 from securedrop_client.storage import source_exists
-from securedrop_client.gui import SvgLabel, SvgPushButton, SvgToggleButton
+from securedrop_client.gui import SecureQLabel, SvgLabel, SvgPushButton, SvgToggleButton
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_icon, load_image
 from securedrop_client.utils import humanize_filesize
@@ -1319,7 +1319,7 @@ class SpeechBubble(QWidget):
         layout = QVBoxLayout()
         layout.setSpacing(0)
         self.setLayout(layout)
-        self.message = QLabel(html.escape(text, quote=False))
+        self.message = SecureQLabel(text)
         self.message.setObjectName('speech_bubble')
         self.message.setWordWrap(True)
         self.message.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
@@ -1340,7 +1340,7 @@ class SpeechBubble(QWidget):
         """
 
         if message_id == self.message_id:
-            self.message.setText(html.escape(text, quote=False))
+            self.message.setText(text)
 
 
 class ConversationWidget(QWidget):
@@ -1489,10 +1489,10 @@ class FileWidget(QWidget):
         icon.setPixmap(load_image('file.png'))
 
         if self.file.is_downloaded:
-            description = QLabel(html.escape(self.file.original_filename or self.file.filename))
+            description = SecureQLabel(self.file.original_filename or self.file.filename)
         else:
             human_filesize = humanize_filesize(self.file.size)
-            description = QLabel("Download ({})".format(human_filesize))
+            description = SecureQLabel("Download ({})".format(human_filesize))
 
         self.layout.addWidget(icon)
         self.layout.addWidget(description, 5)

--- a/tests/gui/test_init.py
+++ b/tests/gui/test_init.py
@@ -2,10 +2,12 @@
 Tests for the gui helper functions in __init__.py
 """
 
+import html
+
 from PyQt5.QtCore import QSize
 from PyQt5.QtWidgets import QApplication
 
-from securedrop_client.gui import SvgPushButton, SvgLabel, SvgToggleButton
+from securedrop_client.gui import SecureQLabel, SvgPushButton, SvgLabel, SvgToggleButton
 
 app = QApplication([])
 
@@ -128,3 +130,18 @@ def test_SvgLabel_init(mocker):
     load_svg_fn.assert_called_once_with('mock')
     sl.svg.setFixedSize.assert_called_once_with(svg_size)
     assert sl.svg == svg
+
+
+def test_SecureQLabel_init():
+    label_text = '<script>alert("hi!");</script>'
+    sl = SecureQLabel(label_text)
+    assert sl.text() == html.escape(label_text)
+
+
+def test_SecureQLabel_setText():
+    sl = SecureQLabel("hello")
+    assert sl.text() == "hello"
+
+    label_text = '<script>alert("hi!");</script>'
+    sl.setText(label_text)
+    assert sl.text() == html.escape(label_text)

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1,6 +1,8 @@
 """
 Make sure the UI widgets are configured correctly and work as expected.
 """
+import html
+
 from PyQt5.QtWidgets import QWidget, QApplication, QWidgetItem, QSpacerItem, QVBoxLayout, \
     QMessageBox, QMainWindow, QTextEdit
 from PyQt5.QtCore import Qt
@@ -1092,7 +1094,7 @@ def test_SpeechBubble_init(mocker):
     Check the speech bubble is configured correctly (there's a label containing
     the passed in text).
     """
-    mock_label = mocker.patch('securedrop_client.gui.widgets.QLabel')
+    mock_label = mocker.patch('securedrop_client.gui.widgets.SecureQLabel')
     mocker.patch('securedrop_client.gui.widgets.QVBoxLayout')
     mocker.patch('securedrop_client.gui.widgets.SpeechBubble.setLayout')
     mock_signal = mocker.Mock()
@@ -1129,25 +1131,19 @@ def test_SpeechBubble_html_init(mocker):
     Check the speech bubble is configured correctly (there's a label containing
     the passed in text, with HTML escaped properly).
     """
-    mock_label = mocker.patch('securedrop_client.gui.widgets.QLabel')
-    mocker.patch('securedrop_client.gui.widgets.QVBoxLayout')
-    mocker.patch('securedrop_client.gui.widgets.SpeechBubble.setLayout')
     mock_signal = mocker.MagicMock()
 
-    SpeechBubble('mock id', '<b>hello</b>', mock_signal)
-    mock_label.assert_called_once_with('&lt;b&gt;hello&lt;/b&gt;')
+    bubble = SpeechBubble('mock id', '<b>hello</b>', mock_signal)
+    assert bubble.message.text() == html.escape('<b>hello</b>')
 
 
 def test_SpeechBubble_with_apostrophe_in_text(mocker):
     """Check Speech Bubble is displaying text with apostrophe correctly."""
-    mock_label = mocker.patch('securedrop_client.gui.widgets.QLabel')
-    mocker.patch('securedrop_client.gui.widgets.QVBoxLayout')
-    mocker.patch('securedrop_client.gui.widgets.SpeechBubble.setLayout')
     mock_signal = mocker.MagicMock()
 
     message = "I'm sure, you are reading my message."
-    SpeechBubble('mock id', message, mock_signal)
-    mock_label.assert_called_once_with(message)
+    bubble = SpeechBubble('mock id', message, mock_signal)
+    assert bubble.message.text() == html.escape(message)
 
 
 def test_ConversationWidget_init_left(mocker):
@@ -1616,6 +1612,7 @@ def test_ConversationView_add_downloaded_file(mocker, homedir, source, session):
     proper QLabel.
     """
     file_ = factory.File(source=source['source'])
+    file_.is_downloaded = True
     session.add(file_)
     session.commit()
 
@@ -1625,7 +1622,7 @@ def test_ConversationView_add_downloaded_file(mocker, homedir, source, session):
     cv = ConversationView(source['source'], mocked_controller)
     cv.conversation_layout = mocker.MagicMock()
 
-    mock_label = mocker.patch('securedrop_client.gui.widgets.QLabel')
+    mock_label = mocker.patch('securedrop_client.gui.widgets.SecureQLabel')
     mocker.patch('securedrop_client.gui.widgets.QHBoxLayout.addWidget')
     mocker.patch('securedrop_client.gui.widgets.FileWidget.setLayout')
 
@@ -1656,7 +1653,7 @@ def test_ConversationView_add_not_downloaded_file(mocker, homedir, source, sessi
     cv = ConversationView(source['source'], mocked_controller)
     cv.conversation_layout = mocker.MagicMock()
 
-    mock_label = mocker.patch('securedrop_client.gui.widgets.QLabel')
+    mock_label = mocker.patch('securedrop_client.gui.widgets.SecureQLabel')
     mocker.patch('securedrop_client.gui.widgets.QHBoxLayout.addWidget')
     mocker.patch('securedrop_client.gui.widgets.FileWidget.setLayout')
 


### PR DESCRIPTION
# Description

`SecureQLabel` automatically applies `html.escape` to its text.

Fixes #369.

# Test Plan

- run `make check`
- Run the client against a SecureDrop server and confirm that the places where `QLabel` has been replaced with `SecureQLabel` (speech bubbles, the file Download button) still work and that if you submit a message or reply containing HTML, that it appears in the conversation as escaped text.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs, network (via the RPC service) traffic, or fine tuning of the graphical user interface, Qubes testing is required. Please check as applicable:

 - [x] I have tested these changes in Qubes
 - [ ] I do not have a Qubes OS workstation (the reviewer will need to test these changes in Qubes)