### PR TITLE
use priority queue for job processing

### DIFF
--- a/securedrop_client/api_jobs/base.py
+++ b/securedrop_client/api_jobs/base.py
@@ -37,20 +37,20 @@ class ApiJob(QObject):
     def __init__(self, remaining_attempts: int = DEFAULT_NUM_ATTEMPTS) -> None:
         super().__init__(None)  # `None` because the QOjbect has no parent
         self.remaining_attempts = remaining_attempts
-        self.counter = None  # type: Optional[int]
+        self.order_number = None  # type: Optional[int]
 
     def __lt__(self, other: ApiJobType) -> bool:
         '''
         Python's PriorityQueue requires that ApiJobs are sortable as it
         retrieves the next job using sorted(list(entries))[0].
 
-        For ApiJobs that have equal priority, we need to use the counter key
+        For ApiJobs that have equal priority, we need to use the order_number key
         to break ties to ensure that objects are retrieved in FIFO order.
         '''
-        if self.counter is None or other.counter is None:
-            raise ValueError('cannot compare jobs without counters!')
+        if self.order_number is None or other.order_number is None:
+            raise ValueError('cannot compare jobs without order_number!')
 
-        return self.counter < other.counter
+        return self.order_number < other.order_number
 
     def _do_call_api(self, api_client: API, session: Session) -> None:
         if not api_client:

--- a/securedrop_client/api_jobs/base.py
+++ b/securedrop_client/api_jobs/base.py
@@ -36,6 +36,12 @@ class ApiJob(QObject):
         super().__init__(None)  # `None` because the QOjbect has no parent
         self.remaining_attempts = remaining_attempts
 
+    def __lt__(self):
+        '''
+        ApiJobs MUST be sortable.
+        '''
+        raise NotImplementedError
+
     def _do_call_api(self, api_client: API, session: Session) -> None:
         if not api_client:
             raise ApiInaccessibleError()

--- a/securedrop_client/api_jobs/base.py
+++ b/securedrop_client/api_jobs/base.py
@@ -35,12 +35,17 @@ class ApiJob(QObject):
     def __init__(self, remaining_attempts: int = DEFAULT_NUM_ATTEMPTS) -> None:
         super().__init__(None)  # `None` because the QOjbect has no parent
         self.remaining_attempts = remaining_attempts
+        self.counter = None  # type: Optional[int]
 
-    def __lt__(self):
+    def __lt__(self, other):
         '''
-        ApiJobs MUST be sortable.
+        Python's PriorityQueue requires that ApiJobs are sortable as it
+        retrieves the next job using sorted(list(entries))[0].
+
+        For ApiJobs that have equal priority, we need to use the counter key
+        to break ties to ensure that objects are retrieved in FIFO order.
         '''
-        raise NotImplementedError
+        return self.counter < other.counter
 
     def _do_call_api(self, api_client: API, session: Session) -> None:
         if not api_client:

--- a/securedrop_client/api_jobs/downloads.py
+++ b/securedrop_client/api_jobs/downloads.py
@@ -170,6 +170,9 @@ class ReplyDownloadJob(DownloadJob):
         self.uuid = uuid
         self.gpg = gpg
 
+    def __lt__(self, other):
+        return self.uuid < other.uuid
+
     def get_db_object(self, session: Session) -> Reply:
         '''
         Override DownloadJob.
@@ -214,6 +217,9 @@ class MessageDownloadJob(DownloadJob):
         super().__init__(data_dir)
         self.uuid = uuid
         self.gpg = gpg
+
+    def __lt__(self, other):
+        return self.uuid < other.uuid
 
     def get_db_object(self, session: Session) -> Message:
         '''

--- a/securedrop_client/api_jobs/downloads.py
+++ b/securedrop_client/api_jobs/downloads.py
@@ -170,9 +170,6 @@ class ReplyDownloadJob(DownloadJob):
         self.uuid = uuid
         self.gpg = gpg
 
-    def __lt__(self, other):
-        return self.uuid < other.uuid
-
     def get_db_object(self, session: Session) -> Reply:
         '''
         Override DownloadJob.
@@ -217,9 +214,6 @@ class MessageDownloadJob(DownloadJob):
         super().__init__(data_dir)
         self.uuid = uuid
         self.gpg = gpg
-
-    def __lt__(self, other):
-        return self.uuid < other.uuid
 
     def get_db_object(self, session: Session) -> Message:
         '''

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1572,6 +1572,13 @@ class ConversationView(QWidget):
         self.setLayout(main_layout)
         self.update_conversation(self.source.collection)
 
+        # Refresh the session to update any replies that failed from a network timeout
+        self.controller.reply_succeeded.connect(self.refresh_conversation)
+
+    def refresh_conversation(self):
+        self.controller.session.refresh(self.source)
+        self.update_conversation(self.source.collection)
+
     def clear_conversation(self):
         while self.conversation_layout.count():
             child = self.conversation_layout.takeAt(0)

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -16,20 +16,6 @@ from securedrop_client.api_jobs.updatestar import UpdateStarJob
 
 logger = logging.getLogger(__name__)
 
-# These are the priorities for processing jobs.
-# Lower numbers corresponds to a higher priority.
-JOB_PRIORITIES = {
-    # LogoutJob: 1,  # Not yet implemented
-    # MetadataSyncJob: 2,  # Not yet implemented
-    FileDownloadJob: 3,  # File downloads processed in separate queue
-    MessageDownloadJob: 3,
-    ReplyDownloadJob: 3,
-    # DeletionJob: 4,  # Not yet implemented
-    SendReplyJob: 5,
-    UpdateStarJob: 6,
-    # FlagJob: 6,  # Not yet implemented
-}
-
 
 class RunnableQueue(QObject):
 
@@ -90,6 +76,19 @@ class RunnableQueue(QObject):
 
 
 class ApiJobQueue(QObject):
+    # These are the priorities for processing jobs.
+    # Lower numbers corresponds to a higher priority.
+    JOB_PRIORITIES = {
+        # LogoutJob: 1,  # Not yet implemented
+        # MetadataSyncJob: 2,  # Not yet implemented
+        FileDownloadJob: 3,  # File downloads processed in separate queue
+        MessageDownloadJob: 3,
+        ReplyDownloadJob: 3,
+        # DeletionJob: 4,  # Not yet implemented
+        SendReplyJob: 5,
+        UpdateStarJob: 6,
+        # FlagJob: 6,  # Not yet implemented
+    }
 
     def __init__(self, api_client: API, session_maker: scoped_session) -> None:
         super().__init__(None)
@@ -136,8 +135,7 @@ class ApiJobQueue(QObject):
         # First check the queues are started in case they died for some reason.
         self.start_queues()
 
-        # Get job priority
-        priority = JOB_PRIORITIES[type(job)]
+        priority = self.JOB_PRIORITIES[type(job)]
 
         if isinstance(job, FileDownloadJob):
             logger.debug('Adding job to download queue')

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -32,17 +32,17 @@ class RunnableQueue(QObject):
         # stability, we need to add a counter to ensure that objects with equal
         # priorities are retrived in FIFO order.
         # See also: https://bugs.python.org/issue17794
-        self.counter = itertools.count()
+        self.order_number = itertools.count()
 
     def add_job(self, priority: int, job: ApiJob) -> None:
         """
-        Increment the queue's internal counter, assign a counter to the
-        job to track its position in the queue, and submit the job with its
-        priority to the queue.
+        Increment the queue's internal counter/order_number, assign an
+        order_number to the job to track its position in the queue,
+        and submit the job with its priority to the queue.
         """
 
-        current_counter = next(self.counter)
-        job.counter = current_counter
+        current_order_number = next(self.order_number)
+        job.order_number = current_order_number
         self.queue.put_nowait((priority, job))
 
     @pyqtSlot()
@@ -79,15 +79,15 @@ class ApiJobQueue(QObject):
     # These are the priorities for processing jobs.
     # Lower numbers corresponds to a higher priority.
     JOB_PRIORITIES = {
-        # LogoutJob: 1,  # Not yet implemented
-        # MetadataSyncJob: 2,  # Not yet implemented
-        FileDownloadJob: 3,  # File downloads processed in separate queue
-        MessageDownloadJob: 3,
-        ReplyDownloadJob: 3,
-        # DeletionJob: 4,  # Not yet implemented
-        SendReplyJob: 5,
-        UpdateStarJob: 6,
-        # FlagJob: 6,  # Not yet implemented
+        # LogoutJob: 11,  # Not yet implemented
+        # MetadataSyncJob: 12,  # Not yet implemented
+        FileDownloadJob: 13,  # File downloads processed in separate queue
+        MessageDownloadJob: 13,
+        ReplyDownloadJob: 13,
+        # DeletionJob: 14,  # Not yet implemented
+        SendReplyJob: 15,
+        UpdateStarJob: 16,
+        # FlagJob: 16,  # Not yet implemented
     }
 
     def __init__(self, api_client: API, session_maker: scoped_session) -> None:

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -5,7 +5,7 @@ from PyQt5.QtCore import QObject, QThread, pyqtSlot
 from queue import PriorityQueue
 from sdclientapi import API, RequestTimeoutError
 from sqlalchemy.orm import scoped_session
-from typing import Optional  # noqa: F401
+from typing import Optional, Tuple  # noqa: F401
 
 from securedrop_client.api_jobs.base import ApiJob, ApiInaccessibleError, DEFAULT_NUM_ATTEMPTS
 from securedrop_client.api_jobs.downloads import (FileDownloadJob, MessageDownloadJob,
@@ -37,7 +37,7 @@ class RunnableQueue(QObject):
         super().__init__()
         self.api_client = api_client
         self.session_maker = session_maker
-        self.queue = PriorityQueue()  # type: PriorityQueue[ApiJob]
+        self.queue = PriorityQueue()  # type: PriorityQueue[Tuple[int, ApiJob]]
 
         # One of the challenges of using Python's PriorityQueue is that
         # for objects (jobs) with equal priorities, they are not retrieved

--- a/tests/api_jobs/test_base.py
+++ b/tests/api_jobs/test_base.py
@@ -158,3 +158,25 @@ def test_ApiJob_retry_timeout(mocker):
 
     assert not api_job.success_signal.emit.called
     assert not api_job.failure_signal.emit.called
+
+
+def test_ApiJob_comparison(mocker):
+    return_value = 'wat'
+    api_job_cls = dummy_job_factory(mocker, return_value)
+    api_job_1 = api_job_cls()
+    api_job_1.counter = 1
+
+    api_job_2 = api_job_cls()
+    api_job_2.counter = 2
+
+    assert api_job_1 < api_job_2
+
+
+def test_ApiJob_counters_unset(mocker):
+    return_value = 'wat'
+    api_job_cls = dummy_job_factory(mocker, return_value)
+    api_job_1 = api_job_cls()
+    api_job_2 = api_job_cls()
+
+    with pytest.raises(ValueError):
+        api_job_1 < api_job_2

--- a/tests/api_jobs/test_base.py
+++ b/tests/api_jobs/test_base.py
@@ -164,15 +164,15 @@ def test_ApiJob_comparison(mocker):
     return_value = 'wat'
     api_job_cls = dummy_job_factory(mocker, return_value)
     api_job_1 = api_job_cls()
-    api_job_1.counter = 1
+    api_job_1.order_number = 1
 
     api_job_2 = api_job_cls()
-    api_job_2.counter = 2
+    api_job_2.order_number = 2
 
     assert api_job_1 < api_job_2
 
 
-def test_ApiJob_counters_unset(mocker):
+def test_ApiJob_order_number_unset(mocker):
     return_value = 'wat'
     api_job_cls = dummy_job_factory(mocker, return_value)
     api_job_1 = api_job_cls()

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1363,6 +1363,21 @@ def test_ConversationView_init(mocker, homedir):
     assert isinstance(cv.conversation_layout, QVBoxLayout)
 
 
+def test_ConversationView_refresh_conversation(mocker, homedir):
+    """
+    Ensure that the session refreshes whenever there is a new reply in case there are previously
+    failed replies.
+    """
+    source = factory.Source()
+    cv = ConversationView(source, mocker.MagicMock())
+    mocker.patch.object(cv, 'update_conversation')
+
+    cv.refresh_conversation()
+
+    cv.controller.session.refresh.assert_called_with(source)
+    cv.update_conversation.assert_called_once_with(source.collection)
+
+
 def test_ConversationView_update_conversation_position_follow(mocker, homedir):
     """
     Check the signal handler sets the correct value for the scrollbar to be

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -116,7 +116,7 @@ def test_RunnableQueue_high_priority_jobs_run_first_and_in_fifo_order(mocker):
 
 def test_RunnableQueue_resubmitted_jobs(mocker):
     """Jobs that fail due to timeout are resubmitted without modifying the job
-    counter. In this test we verify the order of job execution in
+    order_number. In this test we verify the order of job execution in
     this scenario."""
     mock_api_client = mocker.MagicMock()
     mock_session = mocker.MagicMock()


### PR DESCRIPTION
# Description

Fixes #423.

After investigation, #423 is a worthwhile architectural change as we get some major benefits:
* We can continue to use a single general (priority) queue instead of many separate queues (what we were previously considering) for different actions (i.e. a priority queue is the right data structure for the situation where e.g. we want a metadata sync to occur with high priority every 5 minutes and then other tasks at lower priorities when we get time e.g. starring or flagging). Still worth having the file download queue to be separate so that file downloads (which can take a long time) occur concurrently with other shorter-lived actions (all in the general priority queue). 
* This PR adds an execution priority for each server-related (job) action - unimplemented options are commented out intentionally- and replaces the use of Python's `Queue` with Python's `PriorityQueue`.
* Removes `RunnableQueue.last_job` while continuing to preserve job ordering in cases where jobs timeout/queue execution pauses.

Other notes to be aware of:
* A quirk of Python `PriorityQueue` is that it does not preserve FIFO ordering of objects with equal priorities. A counter was added to our job objects to ensure that the sort order of objects with equal priorities is stable (added notes inline and in commit messages to make this clear).  
* These job counters will need to persist if/when we persist the queues.

# Test Plan

I would follow the standard test plan for this one

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs, network (via the RPC service) traffic, or fine tuning of the graphical user interface, Qubes testing is required. Please check as applicable:

 - [ ] I have tested these changes in Qubes
 - [ ] I do not have a Qubes OS workstation (the reviewer will need to test these changes in Qubes)
 - [x] This really only modifies how the queue processes jobs, so testing on Qubes is not strictly necessary.