### PR TITLE
gui: center all popup windows

### DIFF
--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -23,8 +23,7 @@ import logging
 
 from gettext import gettext as _
 from typing import Dict, List, Optional  # noqa: F401
-from PyQt5.QtWidgets import QMainWindow, QWidget, QHBoxLayout, QVBoxLayout, QDesktopWidget, \
-    QApplication
+from PyQt5.QtWidgets import QMainWindow, QWidget, QHBoxLayout, QVBoxLayout, QDesktopWidget
 
 from securedrop_client import __version__
 from securedrop_client.db import Source, User
@@ -116,8 +115,14 @@ class Window(QMainWindow):
         Show the login form.
         """
         self.login_dialog = LoginDialog(self)
-        self.login_dialog.move(
-            QApplication.desktop().screen().rect().center() - self.rect().center())
+
+        # Always display the login dialog centered in the screen.
+        screen_size = QDesktopWidget().screenGeometry()
+        login_dialog_size = self.login_dialog.geometry()
+        x_center = (screen_size.width() - login_dialog_size.width()) / 2
+        y_center = (screen_size.height() - login_dialog_size.height()) / 2
+        self.login_dialog.move(x_center, y_center)
+
         self.login_dialog.setup(self.controller)
         self.login_dialog.reset()
         self.login_dialog.exec()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -851,7 +851,7 @@ class SourceWidget(QWidget):
             self.controller.on_action_requiring_login()
             return
         else:
-            messagebox = DeleteSourceMessageBox(self, self.source, self.controller)
+            messagebox = DeleteSourceMessageBox(self.source, self.controller)
             messagebox.launch()
 
 
@@ -917,8 +917,7 @@ class StarToggleButton(SvgToggleButton):
 class DeleteSourceMessageBox:
     """Use this to display operation details and confirm user choice."""
 
-    def __init__(self, parent, source, controller):
-        self.parent = parent
+    def __init__(self, source, controller):
         self.source = source
         self.controller = controller
 
@@ -932,7 +931,7 @@ class DeleteSourceMessageBox:
         """
         message = self._construct_message(self.source)
         reply = QMessageBox.question(
-            self.parent, "", _(message), QMessageBox.Cancel | QMessageBox.Yes, QMessageBox.Cancel)
+            None, "", _(message), QMessageBox.Cancel | QMessageBox.Yes, QMessageBox.Cancel)
 
         if reply == QMessageBox.Yes:
             logger.debug("Deleting source %s" % (self.source.uuid,))
@@ -1767,9 +1766,7 @@ class DeleteSourceAction(QAction):
 
         super().__init__(self.text, parent)
 
-        self.messagebox = DeleteSourceMessageBox(
-            parent, self.source, self.controller
-        )
+        self.messagebox = DeleteSourceMessageBox(self.source, self.controller)
         self.triggered.connect(self.trigger)
 
     def trigger(self):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1667,7 +1667,7 @@ def test_ConversationView_add_not_downloaded_file(mocker, homedir, source, sessi
 
 def test_DeleteSourceMessageBox_init(mocker, source):
     mock_controller = mocker.MagicMock()
-    DeleteSourceMessageBox(None, source['source'], mock_controller)
+    DeleteSourceMessageBox(source['source'], mock_controller)
 
 
 def test_DeleteSourceMessage_launch_when_user_chooses_cancel(mocker, source):
@@ -1677,7 +1677,7 @@ def test_DeleteSourceMessage_launch_when_user_chooses_cancel(mocker, source):
     mock_message_box_question.return_value = QMessageBox.Cancel
     mock_controller = mocker.MagicMock()
 
-    delete_source_message_box = DeleteSourceMessageBox(None, source, mock_controller)
+    delete_source_message_box = DeleteSourceMessageBox(source, mock_controller)
 
     mocker.patch(
         "securedrop_client.gui.widgets.QMessageBox.question",
@@ -1704,7 +1704,7 @@ def test_DeleteSourceMssageBox_launch_when_user_chooses_yes(mocker, source, sess
     mock_message_box_question.return_value = QMessageBox.Yes
     mock_controller = mocker.MagicMock()
 
-    delete_source_message_box = DeleteSourceMessageBox(None, source, mock_controller)
+    delete_source_message_box = DeleteSourceMessageBox(source, mock_controller)
 
     mocker.patch(
         "securedrop_client.gui.widgets.QMessageBox.question",
@@ -1745,7 +1745,7 @@ def test_DeleteSourceMessageBox_construct_message(mocker, source, session):
 
     mock_controller = mocker.MagicMock()
 
-    delete_source_message_box = DeleteSourceMessageBox(None, source, mock_controller)
+    delete_source_message_box = DeleteSourceMessageBox(source, mock_controller)
 
     message = delete_source_message_box._construct_message(source)
 


### PR DESCRIPTION
# Description

Fixes #322

# Test Plan

- [ ] confirm LoginDialog starts in center of screen when app first launches
- [ ] confirm when in offline mode, clicking "sign in" in the left sidebar starts the LoginDialog in the center of the screen
- [ ] confirm that the source deletion dialog launches in the center of the screen when clicked via the "..." button

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs, network (via the RPC service) traffic, or fine tuning of the graphical user interface, Qubes testing is required. Please check as applicable:

 - [ ] I have tested these changes in Qubes
 - [ ] I do not have a Qubes OS workstation (the reviewer will need to test these changes in Qubes)
 - [x] UI/qt only