### PR TITLE
Same bg for scrollarea, conversation view, selected source

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -669,7 +669,6 @@ class SourceList(QListWidget):
     CSS = '''
     QListWidget::item:selected {
         background: #efeef7;
-        border: none;
     }
     QListView {
         show-decoration-selected: 0;
@@ -1534,6 +1533,16 @@ class ConversationView(QWidget):
 
     CONVERSATION_SPACING = 28
 
+    CSS = '''
+    #container {
+        background: #efeef7;
+    }
+    #scroll {
+        background: #efeef7;
+        border: none;
+    }
+    '''
+
     def __init__(
         self,
         source_db_object: Source,
@@ -1542,6 +1551,9 @@ class ConversationView(QWidget):
         super().__init__()
         self.source = source_db_object
         self.controller = controller
+
+        # Set styles
+        self.setStyleSheet(self.CSS)
 
         self.container = QWidget()
         self.container.setObjectName('container')

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -577,7 +577,7 @@ class MainView(QWidget):
 
     CSS = '''
     #view_holder {
-        background-color: #fff;
+        background-color: #efeef7;
     }
     '''
 
@@ -669,6 +669,13 @@ class SourceList(QListWidget):
     CSS = '''
     QListWidget::item:selected {
         background: #efeef7;
+        border: none;
+    }
+    QListView {
+        show-decoration-selected: 0;
+    }
+    QListView::item {
+        border-bottom: 1px solid #efeef7;
     }
     '''
 
@@ -1285,7 +1292,6 @@ class SpeechBubble(QWidget):
         padding: 8px;
         min-height: 32px;
         min-width: 556px;
-        border: 1px solid #999;
         border-bottom: 0;
     }
     #color_bar {


### PR DESCRIPTION
# Description

This issue focuses on using the same background color for scrollarea, conversation view, selected source.

Towards https://github.com/freedomofpress/securedrop-client/issues/299

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs, network (via the RPC service) traffic, or fine tuning of the graphical user interface, Qubes testing is required. Please check as applicable:

 - [ ] I have tested these changes in Qubes
 - [x] I do not have a Qubes OS workstation (the reviewer will need to test these changes in Qubes)