### PR TITLE
Add sd-svs-qubes-gpg-domain.sh to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ include files/mimeapps.list
 include files/open-in-dvm.desktop
 include files/securedrop-client
 include files/securedrop-client.desktop
+include files/sd-svs-qubes-gpg-domain.sh
 
 recursive-include alembic *
 recursive-include securedrop_client *


### PR DESCRIPTION
# Description

Fixes https://circleci.com/gh/freedomofpress/securedrop-debian-packaging/272?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link and required to test/merge https://github.com/freedomofpress/securedrop-debian-packaging/pull/72

# Test Plan
- [ ] `python3 setup.py sdist` completes succesfully
- check out https://github.com/freedomofpress/securedrop-debian-packaging/tree/sd-svs-filehandlers-in-package
- [ ] PKG_VERSION=0.0.8 PKG_PATH=../securedrop-client/dist/securedrop-client-0.0.8.tar.gz make securedrop-client completes successfully
# Checklist

 - [x] I have tested these changes in Qubes
 - [ ] I do not have a Qubes OS workstation (the reviewer will need to test these changes in Qubes)