### PR TITLE
update font weights to numbers and match zeplin

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1293,7 +1293,7 @@ class SpeechBubble(QWidget):
     """
 
     CSS = '''
-    #speech-bubble {
+    #speech_bubble {
         font-family: 'Source Sans Pro';
         font-weight: 400;
         font-size: 15px;
@@ -1303,7 +1303,7 @@ class SpeechBubble(QWidget):
         border-bottom: 0;
         background-color: #fff;
     }
-    #color-bar {
+    #color_bar {
         padding: 0px;
         background-color: #102781;
         min-height: 5px;
@@ -1322,13 +1322,13 @@ class SpeechBubble(QWidget):
         layout.setSpacing(0)
         self.setLayout(layout)
         self.message = SecureQLabel(text)
-        self.message.setObjectName('speech-bubble')
+        self.message.setObjectName('speech_bubble')
         self.message.setWordWrap(True)
         self.message.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
         layout.addWidget(self.message)
 
         self.color_bar = QWidget()
-        self.color_bar.setObjectName('color-bar')
+        self.color_bar.setObjectName('color_bar')
         self.color_bar.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
         layout.addWidget(self.color_bar)
 
@@ -1417,9 +1417,6 @@ class ReplyWidget(ConversationWidget):
                          update_signal,
                          align="right")
         self.message_id = message_id
-
-        # Set css id
-        self.setObjectName('reply-widget')
 
         # Set styles
         self.speech_bubble.color_bar.setStyleSheet(self.CSS_COLOR_BAR_REPLY)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -241,7 +241,8 @@ class ActivityStatusBar(QStatusBar):
 
     CSS = '''
     #activity_status_bar {
-        font-family: Source Sans Pro SemiBold;
+        font-family: 'Source Sans Pro';
+        font-weight: 600;
         font-size: 12px;
         color: #d3d8ea;
     }
@@ -274,7 +275,7 @@ class ErrorStatusBar(QWidget):
 
     CSS = '''
     #error_vertical_bar {
-        background-color: #f22b5d;
+        background-color: #ff3366;
     }
     #error_icon {
         background-color: qlineargradient(
@@ -297,8 +298,9 @@ class ErrorStatusBar(QWidget):
             stop: 0.2 #fff,
             stop: 1 #fff
         );
-        font-family: Source Sans Pro Regular;
-        font-size: 13px;
+        font-family: 'Source Sans Pro';
+        font-weight: 400;
+        font-size: 14px;
         color: #0c3e75;
     }
     '''
@@ -387,10 +389,11 @@ class UserProfile(QWidget):
     QLabel#user_icon {
         border: none;
         padding: 10px;
-        background-color: #b4fffa;
-        font-family: Source Sans Pro;
-        font-size: 16px;
-        color: #2a319d;
+        background-color: #9211ff;
+        font-family: 'Source Sans Pro';
+        font-weight: 600;
+        font-size: 15px;
+        color: #fff;
     }
     '''
 
@@ -459,9 +462,10 @@ class UserButton(SvgPushButton):
         border: none;
         padding-left: 6px;
         background-color: #0093da;
-        font-family: Source Sans Pro;
-        font-size: 14px;
-        color: #b4fffa;
+        font-family: 'Source Sans Pro';
+        font-weight: 700;
+        font-size: 12px;
+        color: #fff;
         text-align: left;
     }
     SvgPushButton::menu-indicator {
@@ -526,7 +530,8 @@ class LoginButton(QPushButton):
     #login {
         border: none;
         background-color: #05edfe;
-        font-family: Montserrat SemiBold;
+        font-family: 'Montserrat';
+        font-weight: 600;
         font-size: 14px;
         color: #2a319d;
     }
@@ -735,18 +740,17 @@ class SourceWidget(QWidget):
     """
 
     CSS = '''
-    QWidget#color_bar {
-        background-color: #9211ff;
-    }
-    QLabel#source_name {
-        font-family: Montserrat Medium;
+    QLabel#source-name {
+        font-family: 'Montserrat';
+        font-weight: 500;
         font-size: 13px;
-        color: #000;
+        color: #383838;
     }
     QLabel#timestamp {
-        font-family: Montserrat Medium;
+        font-family: 'Montserrat';
+        font-weight: 500;
         font-size: 13px;
-        color: #000;
+        color: #383838;
     }
     '''
 
@@ -789,7 +793,7 @@ class SourceWidget(QWidget):
         summary_layout.setContentsMargins(0, 0, 0, 0)
         summary_layout.setSpacing(0)
         self.name = QLabel()
-        self.name.setObjectName('source_name')
+        self.name.setObjectName('source-name')
         self.preview = QLabel('')
         self.preview.setObjectName('preview')
         self.preview.setWordWrap(True)
@@ -1001,7 +1005,8 @@ class SignInButton(QPushButton):
     #login {
         border: none;
         background-color: #05edfe;
-        font-family: Montserrat SemiBold;
+        font-family: 'Montserrat';
+        font-weight: 600;
         font-size: 14px;
         color: #2a319d;
     }
@@ -1043,8 +1048,9 @@ class LoginErrorBar(QWidget):
         color: #fff;
     }
     #error_status_bar {
-        font-family: Source Sans Pro Regular;
-        font-size: 14px;
+        font-family: 'Montserrat';
+        font-weight: 500;
+        font-size: 12px;
         color: #fff;
     }
     '''
@@ -1107,7 +1113,9 @@ class LoginDialog(QDialog):
     CSS = '''
     #login_form QLabel {
         color: #fff;
-        font-family: Montserrat Medium;
+        font-family: 'Montserrat';
+        font-weight: 500;
+        font-size: 13px;
     }
     #login_form QLineEdit {
         border-radius: 0px;
@@ -1285,15 +1293,17 @@ class SpeechBubble(QWidget):
     """
 
     CSS = '''
-    #speech_bubble {
-        font-family: Source Sans Pro Regular;
+    #speech-bubble {
+        font-family: 'Source Sans Pro';
+        font-weight: 400;
         font-size: 15px;
         padding: 20px;
         min-height: 32px;
         min-width: 556px;
         border-bottom: 0;
+        background-color: #fff;
     }
-    #color_bar {
+    #color-bar {
         padding: 0px;
         background-color: #102781;
         min-height: 5px;
@@ -1312,13 +1322,13 @@ class SpeechBubble(QWidget):
         layout.setSpacing(0)
         self.setLayout(layout)
         self.message = SecureQLabel(text)
-        self.message.setObjectName('speech_bubble')
+        self.message.setObjectName('speech-bubble')
         self.message.setWordWrap(True)
         self.message.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
         layout.addWidget(self.message)
 
         self.color_bar = QWidget()
-        self.color_bar.setObjectName('color_bar')
+        self.color_bar.setObjectName('color-bar')
         self.color_bar.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
         layout.addWidget(self.color_bar)
 
@@ -1374,31 +1384,17 @@ class MessageWidget(ConversationWidget):
     Represents an incoming message from the source.
     """
 
-    CSS = '''
-    background-color: #ffffff;
-    '''
-
     def __init__(self, message_id: str, message: str, update_signal) -> None:
         super().__init__(message_id,
                          message,
                          update_signal,
                          align="left")
 
-        # Set css id
-        self.setObjectName('message_widget')
-
-        # Set styles
-        self.setStyleSheet(self.CSS)
-
 
 class ReplyWidget(ConversationWidget):
     """
     Represents a reply to a source.
     """
-
-    CSS = '''
-    background-color: #ffffff;
-    '''
 
     CSS_COLOR_BAR_REPLY_FAIL = '''
     background-color: #ff3366;
@@ -1423,10 +1419,9 @@ class ReplyWidget(ConversationWidget):
         self.message_id = message_id
 
         # Set css id
-        self.setObjectName('reply_widget')
+        self.setObjectName('reply-widget')
 
         # Set styles
-        self.setStyleSheet(self.CSS)
         self.speech_bubble.color_bar.setStyleSheet(self.CSS_COLOR_BAR_REPLY)
 
         message_succeeded_signal.connect(self._on_reply_success)
@@ -1713,7 +1708,8 @@ class ReplyBoxWidget(QWidget):
 
     CSS = '''
     #replybox {
-        font-family: Montserrat Regular;
+        font-family: 'Montserrat';
+        font-weight: 400;
         font-size: 18px;
         color: #9c9dbb;
     }
@@ -1852,7 +1848,8 @@ class TitleLabel(QLabel):
 
     CSS = '''
     #conversation-title-source-name {
-        font-family: Montserrat Regular;
+        font-family: 'Montserrat';
+        font-weight: 400;
         font-size: 24px;
         color: #2a319d;
     }
@@ -1873,7 +1870,8 @@ class LastUpdatedLabel(QLabel):
 
     CSS = '''
     #conversation-title-date {
-        font-family: Montserrat ExtraLight;
+        font-family: 'Montserrat';
+        font-weight: 200;
         font-size: 24px;
         color: #2a319d;
     }

--- a/securedrop_client/resources/images/error_icon.svg
+++ b/securedrop_client/resources/images/error_icon.svg
@@ -4,7 +4,7 @@
     <title>Fill 1</title>
     <desc>Created with Sketch.</desc>
     <g id="Spex" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="ICONZZZ" transform="translate(-236.000000, -100.000000)" fill="#ce0083">
+        <g id="ICONZZZ" transform="translate(-236.000000, -100.000000)" fill="#ff3366">
             <path d="M246,118 C241.58,118 238,114.42 238,110 C238,105.58 241.58,102 246,102 C250.42,102 254,105.58 254,110 C254,114.42 250.42,118 246,118 Z M245.99,100 C240.47,100 236,104.48 236,110 C236,115.52 240.47,120 245.99,120 C251.52,120 256,115.52 256,110 C256,104.48 251.52,100 245.99,100 Z M245,111 L247,111 L247,105 L245,105 L245,111 Z M245,115 L247,115 L247,113 L245,113 L245,115 Z" id="Fill-1"></path>
         </g>
     </g>

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1101,9 +1101,12 @@ def test_SpeechBubble_init(mocker):
     mock_connect = mocker.Mock()
     mock_signal.connect = mock_connect
 
-    SpeechBubble('mock id', 'hello', mock_signal)
+    sb = SpeechBubble('mock id', 'hello', mock_signal)
+    ss = sb.styleSheet()
+
     mock_label.assert_called_once_with('hello')
     assert mock_connect.called
+    assert 'background-color' in ss
 
 
 def test_SpeechBubble_update_text(mocker):
@@ -1186,10 +1189,8 @@ def test_MessageWidget_init(mocker):
     mock_connected = mocker.Mock()
     mock_signal.connect = mock_connected
 
-    mw = MessageWidget('mock id', 'hello', mock_signal)
-    ss = mw.styleSheet()
+    MessageWidget('mock id', 'hello', mock_signal)
 
-    assert 'background-color' in ss
     assert mock_connected.called
 
 
@@ -1209,16 +1210,14 @@ def test_ReplyWidget_init(mocker):
     mock_failure_connected = mocker.Mock()
     mock_failure_signal.connect = mock_failure_connected
 
-    rw = ReplyWidget(
+    ReplyWidget(
         'mock id',
         'hello',
         mock_update_signal,
         mock_success_signal,
         mock_failure_signal,
     )
-    ss = rw.styleSheet()
 
-    assert 'background-color' in ss
     assert mock_update_connected.called
     assert mock_success_connected.called
     assert mock_failure_connected.called


### PR DESCRIPTION
# Description

Towards https://github.com/freedomofpress/securedrop-client/issues/438

Resolves https://github.com/freedomofpress/securedrop-client/issues/492 and while updating weights to match zeplin, I updated colors, and sizes to match zeplin as needed (since I was already closely looking at so many fields in zeplin)

Note: some colors and fonts do not look exactly the same because of how zeplin has styled many fonts to use different letter spacing, font stretch, shadowing, and line height. This work has been moved to a separate issue which will be tracked in https://github.com/freedomofpress/securedrop-client/issues/438

See results:
![zeplin-compare-login](https://user-images.githubusercontent.com/4522213/62251069-7f66de80-b3a3-11e9-95d2-d9414f2aa2a5.png)

![zeplin-compare-main-window](https://user-images.githubusercontent.com/4522213/62251088-8a217380-b3a3-11e9-9d66-0dafb09556dc.png)


# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs, network (via the RPC service) traffic, or fine tuning of the graphical user interface, Qubes testing is required. Please check as applicable:

 - [ ] I have tested these changes in Qubes
 - [x] I do not have a Qubes OS workstation (the reviewer will need to test these changes in Qubes)