### PR TITLE
pr template: ensure Qubes testing is done with RPC service, split-gpg

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @heartsucker @redshiftzero @creviera
+*       @kushaldas @redshiftzero @creviera

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,8 @@ Fixes #issue.
 
 # Checklist
 
-If these changes modify code paths involving cryptography, the opening of files in VMs, network (via the RPC service) traffic, or fine tuning of the graphical user interface, Qubes testing is required. Please check as applicable:
+If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:
 
- - [ ] I have tested these changes in Qubes
- - [ ] I do not have a Qubes OS workstation (the reviewer will need to test these changes in Qubes)
+ - [ ] I have tested these changes in the appropriate Qubes environment
+ - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
+ - [ ] These changes should not need testing in Qubes


### PR DESCRIPTION
# Description

Followup to recent Qubes dev env changes, we want to ensure that since there are multiple ways of testing or developing on Qubes (as specified in the README), that changes are done in a dev env with the RPC service and split-gpg