### PR TITLE
move star and date in source widget

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -682,7 +682,7 @@ class SourceList(QListWidget):
     QListView::item {
         border-bottom: 1px solid #efeef7;
     }
-    QListWidget::item:selected {
+    QListView::item:selected {
         background: #efeef7;
     }
     '''
@@ -704,7 +704,7 @@ class SourceList(QListWidget):
 
         # Remove margins
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(0)
+        layout.setSpacing(4)
 
     def setup(self, controller):
         self.controller = controller
@@ -744,6 +744,12 @@ class SourceWidget(QWidget):
     """
 
     CSS = '''
+    QLabel#preview {
+        font-family: 'Source Sans Pro';
+        font-weight: 400;
+        font-size: 13px;
+        color: #383838;
+    }
     QLabel#source_name {
         font-family: 'Montserrat';
         font-weight: 500;
@@ -799,7 +805,7 @@ class SourceWidget(QWidget):
         self.name.setObjectName('source_name')
         self.preview = QLabel()
         self.preview.setObjectName('preview')
-        self.preview.setFixedSize(QSize(365, 60))
+        self.preview.setFixedSize(QSize(365, 40))
         self.preview.setWordWrap(True)
         summary_layout.addWidget(self.name)
         summary_layout.addWidget(self.preview)
@@ -847,8 +853,7 @@ class SourceWidget(QWidget):
         Updates the displayed values with the current values from self.source.
         """
         self.updated.setText(arrow.get(self.source.last_updated).humanize())
-        self.name.setText("<strong>{}</strong>".format(
-                          html.escape(self.source.journalist_designation)))
+        self.name.setText(self.source.journalist_designation)
         if self.source.document_count == 0:
             self.attached.hide()
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -676,7 +676,7 @@ class SourceList(QListWidget):
     QListView {
         border: none;
         show-decoration-selected: 0;
-        border-right: 3px solid #514d6e;
+        border-right: 3px solid #efeef7;
     }
     QListView::item:selected {
         background: #efeef7;

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -673,14 +673,10 @@ class SourceList(QListWidget):
     """
 
     CSS = '''
-    #sourcelist {
-        border: none;
-    }
     QListView {
+        border: none;
         show-decoration-selected: 0;
-    }
-    QListView::item {
-        border-bottom: 1px solid #9b9b9b;
+        border-right: 3px solid #514d6e;
     }
     QListView::item:selected {
         background: #efeef7;
@@ -704,7 +700,7 @@ class SourceList(QListWidget):
 
         # Remove margins
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(4)
+        layout.setSpacing(0)
 
     def setup(self, controller):
         self.controller = controller
@@ -744,6 +740,9 @@ class SourceWidget(QWidget):
     """
 
     CSS = '''
+    QWidget#source_widget {
+        border-bottom: 1px solid #9b9b9b;
+    }
     QLabel#preview {
         font-family: 'Source Sans Pro';
         font-weight: 400;
@@ -770,9 +769,6 @@ class SourceWidget(QWidget):
         # Store source
         self.source = source
 
-        # Set css id
-        self.setObjectName('source_widget')
-
         # Set styles
         self.setStyleSheet(self.CSS)
 
@@ -781,7 +777,7 @@ class SourceWidget(QWidget):
         self.setLayout(layout)
 
         # Remove margins and spacing
-        layout.setContentsMargins(10, 10, 10, 10)
+        layout.setContentsMargins(10, 0, 10, 0)
         layout.setSpacing(0)
 
         # Set up gutter
@@ -808,7 +804,7 @@ class SourceWidget(QWidget):
         self.preview.setFixedSize(QSize(365, 40))
         self.preview.setWordWrap(True)
         summary_layout.addWidget(self.name)
-        summary_layout.addWidget(self.preview)
+        summary_layout.addWidget(self.preview, 1)
 
         # Set up metadata
         self.metadata = QWidget()
@@ -835,9 +831,16 @@ class SourceWidget(QWidget):
         self.updated = QLabel()
         self.updated.setObjectName('timestamp')
 
+        self.source_widget = QWidget()
+        self.source_widget.setObjectName('source_widget')
+        source_widget_layout = QVBoxLayout(self.source_widget)
+        source_widget_layout.setContentsMargins(0, 10, 10, 10)
+        source_widget_layout.setSpacing(0)
+        source_widget_layout.addWidget(self.source_row, 1)
+        source_widget_layout.addWidget(self.updated, 1, Qt.AlignRight)
+
         # Add widgets to main layout
-        layout.addWidget(self.source_row, 1)
-        layout.addWidget(self.updated, 1, Qt.AlignRight)
+        layout.addWidget(self.source_widget)
 
         self.update()
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -680,7 +680,7 @@ class SourceList(QListWidget):
         show-decoration-selected: 0;
     }
     QListView::item {
-        border-bottom: 1px solid #efeef7;
+        border-bottom: 1px solid #9b9b9b;
     }
     QListView::item:selected {
         background: #efeef7;

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -676,14 +676,14 @@ class SourceList(QListWidget):
     #sourcelist {
         border: none;
     }
-    QListWidget::item:selected {
-        background: #efeef7;
-    }
     QListView {
         show-decoration-selected: 0;
     }
     QListView::item {
         border-bottom: 1px solid #efeef7;
+    }
+    QListWidget::item:selected {
+        background: #efeef7;
     }
     '''
 
@@ -695,8 +695,8 @@ class SourceList(QListWidget):
 
         # Set styles
         self.setStyleSheet(self.CSS)
-        self.setMinimumWidth(445)
-        self.setMaximumWidth(565)
+        self.setFixedWidth(445)
+        self.setUniformItemSizes(True)
 
         # Set layout
         layout = QVBoxLayout(self)
@@ -744,7 +744,7 @@ class SourceWidget(QWidget):
     """
 
     CSS = '''
-    QLabel#source-name {
+    QLabel#source_name {
         font-family: 'Montserrat';
         font-weight: 500;
         font-size: 13px;
@@ -786,9 +786,8 @@ class SourceWidget(QWidget):
         gutter_layout.setContentsMargins(0, 0, 0, 0)
         gutter_layout.setSpacing(0)
         self.star = StarToggleButton(self.source)
-        spacer = QWidget()
         gutter_layout.addWidget(self.star)
-        gutter_layout.addWidget(spacer)
+        gutter_layout.addStretch()
 
         # Set up summary
         self.summary = QWidget()
@@ -797,9 +796,10 @@ class SourceWidget(QWidget):
         summary_layout.setContentsMargins(0, 0, 0, 0)
         summary_layout.setSpacing(0)
         self.name = QLabel()
-        self.name.setObjectName('source-name')
-        self.preview = QLabel('')
+        self.name.setObjectName('source_name')
+        self.preview = QLabel()
         self.preview.setObjectName('preview')
+        self.preview.setFixedSize(QSize(365, 60))
         self.preview.setWordWrap(True)
         summary_layout.addWidget(self.name)
         summary_layout.addWidget(self.preview)
@@ -807,26 +807,25 @@ class SourceWidget(QWidget):
         # Set up metadata
         self.metadata = QWidget()
         self.metadata.setObjectName('metadata')
+        self.metadata.setMaximumWidth(30)
         metadata_layout = QVBoxLayout(self.metadata)
         metadata_layout.setContentsMargins(0, 0, 0, 0)
         metadata_layout.setSpacing(0)
-        self.attached = SvgLabel('paperclip.svg', QSize(16, 16))
+        self.attached = SvgLabel('paperclip.svg', QSize(14, 16))
         self.attached.setObjectName('paperclip')
-        self.attached.setFixedSize(QSize(20, 20))
-        spacer = QWidget()
-        metadata_layout.addWidget(self.attached, 1, Qt.AlignRight)
-        metadata_layout.addWidget(spacer, 1)
+        metadata_layout.addWidget(self.attached)
+        metadata_layout.addStretch()
 
         # Set up source row
         self.source_row = QWidget()
         source_row_layout = QHBoxLayout(self.source_row)
         source_row_layout.setContentsMargins(0, 0, 0, 0)
         source_row_layout.setSpacing(0)
-        source_row_layout.addWidget(self.gutter, 1)
-        source_row_layout.addWidget(self.summary, 1)
-        source_row_layout.addWidget(self.metadata, 1)
+        source_row_layout.addWidget(self.gutter)
+        source_row_layout.addWidget(self.summary)
+        source_row_layout.addWidget(self.metadata)
 
-        # Set up timestamp
+        # Set up timestamp row
         self.updated = QLabel()
         self.updated.setObjectName('timestamp')
 
@@ -1558,6 +1557,7 @@ class ConversationView(QWidget):
         self.conversation_layout.setSpacing(self.CONVERSATION_SPACING)
         self.container.setLayout(self.conversation_layout)
         self.container.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.setMinimumWidth(610)
 
         self.scroll = QScrollArea()
         self.scroll.setObjectName('scroll')

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -620,7 +620,7 @@ def test_SourceWidget_setup(mocker):
     The setup method adds the controller as an attribute on the SourceWidget.
     """
     mock_controller = mocker.MagicMock()
-    mock_source = mocker.MagicMock()
+    mock_source = mocker.MagicMock(journalist_designation='mock')
     sw = SourceWidget(mock_source)
     sw.star = mocker.MagicMock()
 
@@ -645,7 +645,7 @@ def test_SourceWidget_html_init(mocker):
     mocker.patch('securedrop_client.gui.SvgLabel')
     sw.update()
 
-    sw.name.setText.assert_called_once_with('<strong>foo &lt;b&gt;bar&lt;/b&gt; baz</strong>')
+    sw.name.setText.assert_called_once_with('foo <b>bar</b> baz')
 
 
 def test_SourceWidget_update_attachment_icon():
@@ -1826,7 +1826,7 @@ def test_DeleteSource_from_source_menu_when_user_is_loggedout(mocker):
 
 
 def test_DeleteSource_from_source_widget_when_user_is_loggedout(mocker):
-    mock_source = mocker.MagicMock()
+    mock_source = mocker.MagicMock(journalist_designation='mock')
     mock_controller = mocker.MagicMock(logic.Controller)
     mock_controller.api = None
     mock_event = mocker.MagicMock()


### PR DESCRIPTION
# Description

Pushing one of the commits for the preview text that's been sitting as a WIP PR for a long time. This moves the date to the bottom right corner and star to the left "gutter".
