### PR TITLE
WIP Create PauseQueueJob

### DIFF
--- a/securedrop_client/api_jobs/base.py
+++ b/securedrop_client/api_jobs/base.py
@@ -25,7 +25,7 @@ class ApiInaccessibleError(Exception):
 class PauseQueueJob(QObject):
     def __init__(self):
         super().__init__()
-        self.order_number = 1
+        self.order_number = None
 
 
 class ApiJob(QObject):

--- a/securedrop_client/api_jobs/base.py
+++ b/securedrop_client/api_jobs/base.py
@@ -22,6 +22,12 @@ class ApiInaccessibleError(Exception):
         super().__init__(message)
 
 
+class PauseQueueJob(QObject):
+    def __init__(self):
+        super().__init__()
+        self.order_number = 1
+
+
 class ApiJob(QObject):
 
     '''

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -178,12 +178,12 @@ class Window(QMainWindow):
         """
         self.top_pane.update_activity_status(message, duration)
 
-    def update_error_status(self, message: str, duration=10000):
+    def update_error_status(self, message: str, duration=10000, retry=False) -> None:
         """
         Display an error status message to the user. Optionally, supply a duration
         (in milliseconds), the default will continuously show the message.
         """
-        self.top_pane.update_error_status(message, duration)
+        self.top_pane.update_error_status(message, duration, retry)
 
     def clear_error_status(self):
         """

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -363,10 +363,12 @@ class ErrorStatusBar(QWidget):
 
     def update_message(self, message: str, duration: int):
         """
-        Display a status message to the user for a given duration.
+        Display a status message to the user for a given duration. If the duration is zero,
+        continuously show message.
         """
         self.status_bar.showMessage(message, duration)
-        self.status_timer.start(duration)
+        if duration != 0:
+            self.status_timer.start(duration)
         self._show()
 
     def clear_message(self):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -99,6 +99,7 @@ class TopPane(QWidget):
 
     def setup(self, controller):
         self.refresh.setup(controller)
+        self.error_status_bar.setup(controller)
 
     def enable_refresh(self):
         self.refresh.enable()
@@ -377,6 +378,15 @@ class ErrorStatusBar(QWidget):
 
     def _on_status_timeout(self):
         self._hide()
+
+    def setup(self, controller):
+        self.controller = controller
+        self.retry_button.clicked.connect(self._on_retry_clicked)
+
+    def _on_retry_clicked(self) -> None:
+        self.clear_message()
+        self._hide()
+        self.controller.resume_queues()
 
     def update_message(self, message: str, duration: int, retry: bool) -> None:
         """

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -109,8 +109,8 @@ class TopPane(QWidget):
     def update_activity_status(self, message: str, duration: int):
         self.activity_status_bar.update_message(message, duration)
 
-    def update_error_status(self, message: str, duration: int):
-        self.error_status_bar.update_message(message, duration)
+    def update_error_status(self, message: str, duration: int, retry: bool):
+        self.error_status_bar.update_message(message, duration, retry)
 
     def clear_error_status(self):
         self.error_status_bar.clear_message()
@@ -303,6 +303,15 @@ class ErrorStatusBar(QWidget):
         font-size: 14px;
         color: #0c3e75;
     }
+    QPushButton#retry_button {
+        border: none;
+        padding-right: 30px;
+        background-color: #fff;
+        color: #0065db;
+        font-family: 'Source Sans Pro';
+        font-weight: 600;
+        font-size: 12px;
+    }
     '''
 
     def __init__(self):
@@ -334,15 +343,22 @@ class ErrorStatusBar(QWidget):
         self.status_bar.setObjectName('error_status_bar')  # Set css id
         self.status_bar.setSizeGripEnabled(False)
 
+        # Retry button
+        self.retry_button = QPushButton('RETRY')
+        self.retry_button.setObjectName('retry_button')
+        self.retry_button.setFixedHeight(42)
+
         # Add widgets to layout
         layout.addWidget(self.vertical_bar)
         layout.addWidget(self.label)
         layout.addWidget(self.status_bar)
+        layout.addWidget(self.retry_button)
 
         # Hide until a message needs to be displayed
         self.vertical_bar.hide()
         self.label.hide()
         self.status_bar.hide()
+        self.retry_button.hide()
 
         # Only show errors for a set duration
         self.status_timer = QTimer()
@@ -352,6 +368,7 @@ class ErrorStatusBar(QWidget):
         self.vertical_bar.hide()
         self.label.hide()
         self.status_bar.hide()
+        self.retry_button.hide()
 
     def _show(self):
         self.vertical_bar.show()
@@ -361,14 +378,19 @@ class ErrorStatusBar(QWidget):
     def _on_status_timeout(self):
         self._hide()
 
-    def update_message(self, message: str, duration: int):
+    def update_message(self, message: str, duration: int, retry: bool) -> None:
         """
         Display a status message to the user for a given duration. If the duration is zero,
         continuously show message.
         """
+        if retry:
+            self.retry_button.show()
+
         self.status_bar.showMessage(message, duration)
+
         if duration != 0:
             self.status_timer.start(duration)
+
         self._show()
 
     def clear_message(self):

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -262,7 +262,10 @@ class Controller(QObject):
         new_api_thread.start()
 
     def on_queue_paused(self) -> None:
-        self.gui.update_error_status(_('The SecureDrop server cannot be reached.'), duration=0)
+        self.gui.update_error_status(
+            _('The SecureDrop server cannot be reached.'),
+            duration=0,
+            retry=True)
 
     def on_api_timeout(self) -> None:
         self.gui.update_error_status(_('The connection to the SecureDrop server timed out. '

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -315,10 +315,6 @@ class Controller(QObject):
                       self.on_get_current_user_failure)
         self.api_job_queue.login(self.api)
 
-        # Clear the sidebar error status bar if a message was shown
-        # to the user indicating they should log in.
-        self.gui.clear_error_status()
-
         self.is_authenticated = True
 
     def on_authenticate_failure(self, result: Exception) -> None:
@@ -450,7 +446,6 @@ class Controller(QObject):
         After we star a source, we should sync the API such that the local database is updated.
         """
         self.sync_api()  # Syncing the API also updates the source list UI
-        self.gui.clear_error_status()
 
     def on_update_star_failure(self, result: UpdateStarJobException) -> None:
         """
@@ -468,13 +463,8 @@ class Controller(QObject):
         if not self.api:  # Then we should tell the user they need to login.
             self.on_action_requiring_login()
             return
-        else:  # Clear the error status bar
-            self.gui.clear_error_status()
 
-        job = UpdateStarJob(
-                source_db_object.uuid,
-                source_db_object.is_starred
-        )
+        job = UpdateStarJob(source_db_object.uuid, source_db_object.is_starred)
         job.success_signal.connect(self.on_update_star_success, type=Qt.QueuedConnection)
         job.failure_signal.connect(self.on_update_star_failure, type=Qt.QueuedConnection)
 
@@ -638,7 +628,6 @@ class Controller(QObject):
         Handler for when a source deletion succeeds.
         """
         self.sync_api()
-        self.gui.clear_error_status()
 
     def on_delete_source_failure(self, result: Exception) -> None:
         logging.info("failed to delete source at server")

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -267,6 +267,9 @@ class Controller(QObject):
             duration=0,
             retry=True)
 
+    def resume_queues(self) -> None:
+        self.api_job_queue.resume_queues()
+
     def on_api_timeout(self) -> None:
         self.gui.update_error_status(_('The connection to the SecureDrop server timed out. '
                                        'Please try again.'))
@@ -446,7 +449,6 @@ class Controller(QObject):
         """
         self.sync_api()  # Syncing the API also updates the source list UI
         self.gui.clear_error_status()
-        self.api_job_queue.enqueue(PauseQueueJob())
 
     def on_update_star_failure(self, result: UpdateStarJobException) -> None:
         """

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -271,8 +271,10 @@ class Controller(QObject):
         self.api_job_queue.resume_queues()
 
     def on_api_timeout(self) -> None:
-        self.gui.update_error_status(_('The connection to the SecureDrop server timed out. '
-                                       'Please try again.'))
+        self.gui.update_error_status(
+            _('The SecureDrop server cannot be reached.'),
+            duration=0,
+            retry=True)
 
     def completed_api_call(self, thread_id, user_callback):
         """

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -143,8 +143,7 @@ class ApiJobQueue(QObject):
             self.download_file_thread.start()
 
     def resume_queues(self) -> None:
-        self.download_file_queue.resume()
-        self.main_queue.resume()
+        self.start_queues()
 
     def enqueue(self, job: ApiJob) -> None:
         # Additional defense in depth to prevent jobs being added to the queue when not


### PR DESCRIPTION
# Description

This is not ready to be reviewed but I'm opening a PR here to get an early preview of how I am intending to use a queue job to pause the queue. While working on this I realized that we would have to resume the main queue in order to process a logout job. Since we currently don't have a logout job, this isn't something that needs to be written right now, but we should be thinking about it. 

Also, I don't see a need to persist anything on pause or on logout. We should update our local database to mark a reply or file as "pending" as soon as the jobs are created. Then when we log back in, the client can show anything that was in "pending" status as failed (or more intelligently pick up the file download jobs from where they left off).

We should discuss some of the details further as a team, but for now, I think it should be fine to move forward with a PauseQueueJob that has highest prioirty (until LogoutJob is created... but maybe we'll decide against it).

Resolves https://github.com/freedomofpress/securedrop-client/issues/443

# Test Plan


# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs, network (via the RPC service) traffic, or fine tuning of the graphical user interface, Qubes testing is required. Please check as applicable:

 - [ ] I have tested these changes in Qubes
 - [ ] I do not have a Qubes OS workstation (the reviewer will need to test these changes in Qubes)