### PR TITLE
set realistic timeouts, scale file/message download timeouts using file size metadata

### DIFF
--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -112,6 +112,11 @@ class ApiJobQueue(QObject):
 
     def login(self, api_client: API) -> None:
         logger.debug('Passing API token to queues')
+
+        # Setting realistic (shorter) timeout for general requests so that user feedback
+        # is faster
+        api_client.default_request_timeout = 5
+
         self.main_queue.api_client = api_client
         self.download_file_queue.api_client = api_client
         self.start_queues()

--- a/tests/api_jobs/test_downloads.py
+++ b/tests/api_jobs/test_downloads.py
@@ -318,7 +318,7 @@ def test_FileDownloadJob_happy_path_no_etag(mocker, homedir, session, session_ma
     gpg = GpgHelper(homedir, session_maker, is_qubes=False)
     mock_decrypt = patch_decrypt(mocker, homedir, gpg, file_.filename)
 
-    def fake_download(sdk_obj: SdkSubmission) -> Tuple[str, str]:
+    def fake_download(sdk_obj: SdkSubmission, timeout: int) -> Tuple[str, str]:
         '''
         :return: (etag, path_to_dl)
         '''
@@ -357,7 +357,7 @@ def test_FileDownloadJob_happy_path_sha256_etag(mocker, homedir, session, sessio
     gpg = GpgHelper(homedir, session_maker, is_qubes=False)
     mock_decrypt = patch_decrypt(mocker, homedir, gpg, file_.filename)
 
-    def fake_download(sdk_obj: SdkSubmission) -> Tuple[str, str]:
+    def fake_download(sdk_obj: SdkSubmission, timeout: int) -> Tuple[str, str]:
         '''
         :return: (etag, path_to_dl)
         '''
@@ -393,7 +393,7 @@ def test_FileDownloadJob_bad_sha256_etag(mocker, homedir, session, session_maker
 
     gpg = GpgHelper(homedir, session_maker, is_qubes=False)
 
-    def fake_download(sdk_obj: SdkSubmission) -> Tuple[str, str]:
+    def fake_download(sdk_obj: SdkSubmission, timeout: int) -> Tuple[str, str]:
         '''
         :return: (etag, path_to_dl)
         '''
@@ -426,7 +426,7 @@ def test_FileDownloadJob_happy_path_unknown_etag(mocker, homedir, session, sessi
 
     gpg = GpgHelper(homedir, session_maker, is_qubes=False)
 
-    def fake_download(sdk_obj: SdkSubmission) -> Tuple[str, str]:
+    def fake_download(sdk_obj: SdkSubmission, timeout: int) -> Tuple[str, str]:
         '''
         :return: (etag, path_to_dl)
         '''
@@ -467,7 +467,7 @@ def test_FileDownloadJob_decryption_error(mocker, homedir, session, session_make
     gpg = GpgHelper(homedir, session_maker, is_qubes=False)
     mock_decrypt = mocker.patch.object(gpg, 'decrypt_submission_or_reply', side_effect=CryptoError)
 
-    def fake_download(sdk_obj: SdkSubmission) -> Tuple[str, str]:
+    def fake_download(sdk_obj: SdkSubmission, timeout: int) -> Tuple[str, str]:
         '''
         :return: (etag, path_to_dl)
         '''


### PR DESCRIPTION
# Description

Fixes #430

# Test Plan

- [ ] Test that you can still download files/messages without issue

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs, network (via the RPC service) traffic, or fine tuning of the graphical user interface, Qubes testing is required. Please check as applicable:

 - [x] I have tested in Qubes using Tor + RPC proxy + split-gpg to ensure that downloads are snippy
 - [ ] I do not have a Qubes OS workstation (the reviewer will need to test these changes in Qubes)