### PR TITLE
SecureQLabel now does not escape quotes

### DIFF
--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -159,4 +159,4 @@ class SecureQLabel(QLabel):
         self.setText(text)
 
     def setText(self, text: str) -> None:
-        super().setText(html.escape(text))
+        super().setText(html.escape(text, quote=False))

--- a/tests/gui/test_init.py
+++ b/tests/gui/test_init.py
@@ -135,7 +135,7 @@ def test_SvgLabel_init(mocker):
 def test_SecureQLabel_init():
     label_text = '<script>alert("hi!");</script>'
     sl = SecureQLabel(label_text)
-    assert sl.text() == html.escape(label_text)
+    assert sl.text() == html.escape(label_text, quote=False)
 
 
 def test_SecureQLabel_setText():
@@ -144,4 +144,9 @@ def test_SecureQLabel_setText():
 
     label_text = '<script>alert("hi!");</script>'
     sl.setText(label_text)
-    assert sl.text() == html.escape(label_text)
+    assert sl.text() == html.escape(label_text, quote=False)
+
+
+def test_SecureQLabel_quotes_not_escaped_for_readability():
+    sl = SecureQLabel("'hello'")
+    assert sl.text() == "'hello'"

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1146,7 +1146,7 @@ def test_SpeechBubble_with_apostrophe_in_text(mocker):
 
     message = "I'm sure, you are reading my message."
     bubble = SpeechBubble('mock id', message, mock_signal)
-    assert bubble.message.text() == html.escape(message)
+    assert bubble.message.text() == html.escape(message, quote=False)
 
 
 def test_ConversationWidget_init_left(mocker):


### PR DESCRIPTION
# Description

Fixes #183

# Test Plan

Submit a message with quotes, see that it appears normally:

<img width="694" alt="Screen Shot 2019-08-03 at 12 36 26 AM" src="https://user-images.githubusercontent.com/7832803/62407487-4c7d4000-b587-11e9-821a-97446630e1e3.png">

instead of:

<img width="494" alt="Screen Shot 2019-08-03 at 12 36 49 AM" src="https://user-images.githubusercontent.com/7832803/62407490-5141f400-b587-11e9-9426-f8128d6aaaed.png">


# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs, network (via the RPC service) traffic, or fine tuning of the graphical user interface, Qubes testing is required. Please check as applicable:

 - [ ] I have tested these changes in Qubes
 - [ ] I do not have a Qubes OS workstation (the reviewer will need to test these changes in Qubes)
 - [x] changes do not need testing in qubes