### PR TITLE
Keep trying failed replies

### DIFF
--- a/securedrop_client/api_jobs/base.py
+++ b/securedrop_client/api_jobs/base.py
@@ -1,7 +1,7 @@
 import logging
 
 from PyQt5.QtCore import QObject, pyqtSignal
-from sdclientapi import API, AuthError
+from sdclientapi import API, AuthError, RequestTimeoutError
 from sqlalchemy.orm.session import Session
 from typing import Any, Optional, TypeVar
 
@@ -61,10 +61,13 @@ class ApiJob(QObject):
                 result = self.call_api(api_client, session)
             except (ApiInaccessibleError, AuthError) as e:
                 raise ApiInaccessibleError() from e
-            except Exception as e:
+            except RequestTimeoutError as e:
                 if self.remaining_attempts == 0:
                     self.failure_signal.emit(e)
                     raise
+            except Exception as e:
+                self.failure_signal.emit(e)
+                raise
             else:
                 self.success_signal.emit(result)
                 break

--- a/securedrop_client/api_jobs/base.py
+++ b/securedrop_client/api_jobs/base.py
@@ -1,10 +1,9 @@
 import logging
 
 from PyQt5.QtCore import QObject, pyqtSignal
-from sdclientapi import API, RequestTimeoutError, AuthError
+from sdclientapi import API, AuthError
 from sqlalchemy.orm.session import Session
 from typing import Any, Optional, TypeVar
-
 
 logger = logging.getLogger(__name__)
 
@@ -60,20 +59,12 @@ class ApiJob(QObject):
             try:
                 self.remaining_attempts -= 1
                 result = self.call_api(api_client, session)
-            except AuthError as e:
+            except (ApiInaccessibleError, AuthError) as e:
                 raise ApiInaccessibleError() from e
-            except ApiInaccessibleError as e:
-                # Do not let ApiInaccessibleError emit the regular failure signal, raise now
-                raise ApiInaccessibleError() from e
-            except RequestTimeoutError:
-                logger.debug('Job {} timed out'.format(self))
-                if self.remaining_attempts == 0:
-                    raise
             except Exception as e:
-                logger.error('Job {} raised an exception: {}: {}'
-                             .format(self, type(e).__name__, e))
-                self.failure_signal.emit(e)
-                break
+                if self.remaining_attempts == 0:
+                    self.failure_signal.emit(e)
+                    raise
             else:
                 self.success_signal.emit(result)
                 break

--- a/securedrop_client/api_jobs/uploads.py
+++ b/securedrop_client/api_jobs/uploads.py
@@ -63,7 +63,11 @@ class SendReplyJobError(Exception):
         self.reply_uuid = reply_uuid
 
 
-class SendReplyJobTimeoutError(Exception):
-    def __init__(self, message: str, reply_uuid: str):
-        super().__init__(message)
+class SendReplyJobTimeoutError(RequestTimeoutError):
+    def __init__(self, message: str, reply_uuid: str) -> None:
+        super().__init__()
         self.reply_uuid = reply_uuid
+        self.message = message
+
+    def __str__(self) -> str:
+        return self.message

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -33,7 +33,8 @@ from securedrop_client import storage
 from securedrop_client import db
 from securedrop_client.api_jobs.downloads import FileDownloadJob, MessageDownloadJob, \
     ReplyDownloadJob, DownloadChecksumMismatchException
-from securedrop_client.api_jobs.uploads import SendReplyJob, SendReplyJobException
+from securedrop_client.api_jobs.uploads import SendReplyJob, SendReplyJobError, \
+    SendReplyJobTimeoutError
 from securedrop_client.api_jobs.updatestar import UpdateStarJob, UpdateStarJobException
 from securedrop_client.crypto import GpgHelper, CryptoError
 from securedrop_client.queue import ApiJobQueue
@@ -665,7 +666,10 @@ class Controller(QObject):
         logger.debug('{} sent successfully'.format(reply_uuid))
         self.reply_succeeded.emit(reply_uuid)
 
-    def on_reply_failure(self, exception: SendReplyJobException) -> None:
+    def on_reply_failure(
+        self,
+        exception: Union[SendReplyJobError, SendReplyJobTimeoutError]
+    ) -> None:
         logger.debug('{} failed to send'.format(exception.reply_uuid))
         self.reply_failed.emit(exception.reply_uuid)
 

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -10,7 +10,7 @@ from typing import Optional, Tuple  # noqa: F401
 from securedrop_client.api_jobs.base import ApiJob, ApiInaccessibleError, DEFAULT_NUM_ATTEMPTS
 from securedrop_client.api_jobs.downloads import (FileDownloadJob, MessageDownloadJob,
                                                   ReplyDownloadJob)
-from securedrop_client.api_jobs.uploads import SendReplyJob, SendReplyJobTimeoutError
+from securedrop_client.api_jobs.uploads import SendReplyJob
 from securedrop_client.api_jobs.updatestar import UpdateStarJob
 
 
@@ -56,7 +56,7 @@ class RunnableQueue(QObject):
 
             try:
                 job._do_call_api(self.api_client, session)
-            except (RequestTimeoutError, SendReplyJobTimeoutError):
+            except RequestTimeoutError:
                 logger.debug('Job {} timed out'.format(job))
 
                 # Reset number of remaining attempts for this job to the default and
@@ -71,7 +71,6 @@ class RunnableQueue(QObject):
                 # (see ticket #379).
                 logger.error('Client is not authenticated, skipping job...')
             except Exception as e:
-                # we should re-enqueue the job and pause queue processing
                 logger.error('Job {} raised  exception: {}: {}'.format(job, type(e).__name__, e))
             finally:
                 session.close()

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -10,7 +10,7 @@ from typing import Optional, Tuple  # noqa: F401
 from securedrop_client.api_jobs.base import ApiJob, ApiInaccessibleError, DEFAULT_NUM_ATTEMPTS
 from securedrop_client.api_jobs.downloads import (FileDownloadJob, MessageDownloadJob,
                                                   ReplyDownloadJob)
-from securedrop_client.api_jobs.uploads import SendReplyJob
+from securedrop_client.api_jobs.uploads import SendReplyJob, SendReplyJobTimeoutError
 from securedrop_client.api_jobs.updatestar import UpdateStarJob
 
 
@@ -56,18 +56,23 @@ class RunnableQueue(QObject):
 
             try:
                 job._do_call_api(self.api_client, session)
-            except RequestTimeoutError:
-                # Reset number of remaining attempts for this job to the default
-                job.remaining_attempts = DEFAULT_NUM_ATTEMPTS
+            except (RequestTimeoutError, SendReplyJobTimeoutError):
+                logger.debug('Job {} timed out'.format(job))
 
-                # Resubmit job without modifying counter to ensure jobs with equal
+                # Reset number of remaining attempts for this job to the default and
+                # resubmit job without modifying counter to ensure jobs with equal
                 # priorities are processed in the order that they were submitted
                 # _by the user_ to the queue.
+                job.remaining_attempts = DEFAULT_NUM_ATTEMPTS
                 self.queue.put_nowait((priority, job))
             except ApiInaccessibleError:
-                # This is a guard against #397, we should pause the queue execution when this
-                # happens in the future and flag the situation to the user (see ticket #379).
+                # This is a guard against #397, we should re-enqueue the job and pause queue
+                # processing when this happens in the future and flag the situation to the user
+                # (see ticket #379).
                 logger.error('Client is not authenticated, skipping job...')
+            except Exception as e:
+                # we should re-enqueue the job and pause queue processing
+                logger.error('Job {} raised  exception: {}: {}'.format(job, type(e).__name__, e))
             finally:
                 session.close()
 

--- a/tests/api_jobs/test_base.py
+++ b/tests/api_jobs/test_base.py
@@ -80,7 +80,7 @@ def test_ApiJob_timeout_error(mocker):
         api_job._do_call_api(mock_api_client, mock_session)
 
     assert not api_job.success_signal.emit.called
-    assert not api_job.failure_signal.emit.called
+    assert api_job.failure_signal.emit.called
 
 
 def test_ApiJob_other_error(mocker):
@@ -91,7 +91,8 @@ def test_ApiJob_other_error(mocker):
     mock_api_client = mocker.MagicMock()
     mock_session = mocker.MagicMock()
 
-    api_job._do_call_api(mock_api_client, mock_session)
+    with pytest.raises(Exception):
+        api_job._do_call_api(mock_api_client, mock_session)
 
     assert not api_job.success_signal.emit.called
     api_job.failure_signal.emit.assert_called_once_with(return_value)
@@ -157,7 +158,7 @@ def test_ApiJob_retry_timeout(mocker):
     assert api_job.remaining_attempts == 0
 
     assert not api_job.success_signal.emit.called
-    assert not api_job.failure_signal.emit.called
+    assert api_job.failure_signal.emit.called
 
 
 def test_ApiJob_comparison(mocker):

--- a/tests/api_jobs/test_uploads.py
+++ b/tests/api_jobs/test_uploads.py
@@ -2,7 +2,7 @@ import pytest
 import sdclientapi
 
 from securedrop_client import db
-from securedrop_client.api_jobs.uploads import SendReplyJob, SendReplyJobException
+from securedrop_client.api_jobs.uploads import SendReplyJob, SendReplyJobError
 from securedrop_client.crypto import GpgHelper, CryptoError
 from tests import factory
 
@@ -55,7 +55,7 @@ def test_send_reply_success(homedir, mocker, session, session_maker):
 def test_send_reply_failure_gpg_error(homedir, mocker, session, session_maker):
     '''
     Check that if gpg fails when sending a message, we do not call the API, and ensure that
-    SendReplyJobException is raised when there is a CryptoError so we can handle it in
+    SendReplyJobError is raised when there is a CryptoError so we can handle it in
     ApiJob._do_call_api.
     '''
     source = factory.Source()
@@ -86,7 +86,7 @@ def test_send_reply_failure_gpg_error(homedir, mocker, session, session_maker):
         gpg,
     )
 
-    with pytest.raises(SendReplyJobException):
+    with pytest.raises(SendReplyJobError):
         job.call_api(api_client, session)
 
     # Ensure we attempted to encrypt the message
@@ -100,7 +100,7 @@ def test_send_reply_failure_gpg_error(homedir, mocker, session, session_maker):
 
 def test_send_reply_failure_unknown_error(homedir, mocker, session, session_maker):
     '''
-    Check that if the SendReplyJob api call fails when sending a message that SendReplyJobException
+    Check that if the SendReplyJob api call fails when sending a message that SendReplyJobError
     is raised and the reply is not added to the local database.
     '''
     source = factory.Source()
@@ -122,7 +122,7 @@ def test_send_reply_failure_unknown_error(homedir, mocker, session, session_make
 
 def test_send_reply_failure_when_repr_is_none(homedir, mocker, session, session_maker):
     '''
-    Check that the SendReplyJob api call results in a SendReplyJobException and nothing else, e.g.
+    Check that the SendReplyJob api call results in a SendReplyJobError and nothing else, e.g.
     no TypeError, when an api call results in an exception that returns None for __repr__
     (regression test).
     '''
@@ -140,7 +140,7 @@ def test_send_reply_failure_when_repr_is_none(homedir, mocker, session, session_
     job = SendReplyJob(source.uuid, 'mock_reply_uuid', 'mock_message', gpg)
 
     with pytest.raises(
-            SendReplyJobException,
+            SendReplyJobError,
             match=r'Failed to send reply for source mock_reply_uuid due to Exception: mock'):
         job.call_api(api_client, session)
 

--- a/tests/api_jobs/test_uploads.py
+++ b/tests/api_jobs/test_uploads.py
@@ -8,6 +8,11 @@ from securedrop_client.crypto import GpgHelper, CryptoError
 from tests import factory
 
 
+def test_SendReplyJobTimeoutError():
+    error = SendReplyJobTimeoutError('mock_message', 'mock_reply_id')
+    assert str(error) == 'mock_message'
+
+
 def test_send_reply_success(homedir, mocker, session, session_maker):
     '''
     Check that the "happy path" of encrypting a message and sending it to the

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -14,7 +14,7 @@ from securedrop_client import storage, db
 from securedrop_client.crypto import CryptoError
 from securedrop_client.logic import APICallRunner, Controller
 from securedrop_client.api_jobs.downloads import DownloadChecksumMismatchException
-from securedrop_client.api_jobs.uploads import SendReplyJobException
+from securedrop_client.api_jobs.uploads import SendReplyJobError
 
 with open(os.path.join(os.path.dirname(__file__), 'files', 'test-key.gpg.pub.asc')) as f:
     PUB_KEY = f.read()
@@ -1288,7 +1288,7 @@ def test_Controller_on_reply_failure(homedir, mocker, session_maker):
     reply_failed = mocker.patch.object(co, 'reply_failed')
     debug_logger = mocker.patch('securedrop_client.logic.logger.debug')
 
-    exception = SendReplyJobException('mock_error_message', 'mock_reply_uuid')
+    exception = SendReplyJobError('mock_error_message', 'mock_reply_uuid')
     co.on_reply_failure(exception)
 
     debug_logger.assert_called_once_with('{} failed to send'.format('mock_reply_uuid'))


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/533
Towards https://github.com/freedomofpress/securedrop-client/issues/443

Now when SendReplyJob fails because of a timeout, the api call is retried 5 times, and then re-processed in the queue until the timeout issue is resolved.  

This is the same behavior for other jobs that receive timeout errors.

Note: This does not fix https://github.com/freedomofpress/securedrop-client/issues/294 because that happens when replies are in the queue and never reach the server (the timeout issue is never resolved during the client session).

# Test Plan

In addition to making sure the two issues are no longer reproduced, follow these steps to test:

1. Send reply after pausing the staging app server vm, wait and observe 5 `Keyring access` qubes notication popups and reply bar turn red in the gui
2. Unpause the staging app server vm, wait until the next sync happens or manually click the refresh icon and see the reply bar turn blue

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes