### PR TITLE
Pause queue on auth errors, connection failures and timeouts

### DIFF
--- a/securedrop_client/api_jobs/base.py
+++ b/securedrop_client/api_jobs/base.py
@@ -65,13 +65,16 @@ class ApiJob(QObject):
             try:
                 self.remaining_attempts -= 1
                 result = self.call_api(api_client, session)
-            except (ApiInaccessibleError, AuthError) as e:
+            except (AuthError, ApiInaccessibleError) as e:
+                logger.error('Client is not authenticated')
                 raise ApiInaccessibleError() from e
             except RequestTimeoutError as e:
                 if self.remaining_attempts == 0:
                     self.failure_signal.emit(e)
                     raise
             except Exception as e:
+                logger.error('Job {} raised an exception: {}: {}'.format(self, type(e).__name__, e))
+                logger.error('Skipping job')
                 self.failure_signal.emit(e)
                 raise
             else:

--- a/securedrop_client/api_jobs/base.py
+++ b/securedrop_client/api_jobs/base.py
@@ -21,6 +21,12 @@ class ApiInaccessibleError(Exception):
         super().__init__(message)
 
 
+class PauseQueueJob(QObject):
+    def __init__(self) -> None:
+        super().__init__()
+        self.order_number = None
+
+
 class ApiJob(QObject):
 
     '''

--- a/securedrop_client/api_jobs/base.py
+++ b/securedrop_client/api_jobs/base.py
@@ -70,15 +70,12 @@ class ApiJob(QueueJob):
                 self.remaining_attempts -= 1
                 result = self.call_api(api_client, session)
             except (AuthError, ApiInaccessibleError) as e:
-                logger.error('Client is not authenticated')
                 raise ApiInaccessibleError() from e
             except RequestTimeoutError as e:
                 if self.remaining_attempts == 0:
                     self.failure_signal.emit(e)
                     raise
             except Exception as e:
-                logger.error('Job {} raised an exception: {}: {}'.format(self, type(e).__name__, e))
-                logger.error('Skipping job')
                 self.failure_signal.emit(e)
                 raise
             else:

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -178,12 +178,12 @@ class Window(QMainWindow):
         """
         self.top_pane.update_activity_status(message, duration)
 
-    def update_error_status(self, message: str, duration=10000):
+    def update_error_status(self, message: str, duration=10000, retry=False) -> None:
         """
         Display an error status message to the user. Optionally, supply a duration
         (in milliseconds), the default will continuously show the message.
         """
-        self.top_pane.update_error_status(message, duration)
+        self.top_pane.update_error_status(message, duration, retry)
 
     def clear_error_status(self):
         """

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -367,10 +367,12 @@ class ErrorStatusBar(QWidget):
 
     def update_message(self, message: str, duration: int):
         """
-        Display a status message to the user for a given duration.
+        Display a status message to the user for a given duration. If the duration is zero,
+        continuously show message.
         """
         self.status_bar.showMessage(message, duration)
-        self.status_timer.start(duration)
+        if duration != 0:
+            self.status_timer.start(duration)
         self._show()
 
     def clear_message(self):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1864,13 +1864,6 @@ class ConversationView(QWidget):
 
         self.update_conversation(self.source.collection)
 
-        # Refresh the session to update any replies that failed from a network timeout
-        self.controller.reply_succeeded.connect(self.refresh_conversation)
-
-    def refresh_conversation(self):
-        self.controller.session.refresh(self.source)
-        self.update_conversation(self.source.collection)
-
     def clear_conversation(self):
         while self.conversation_layout.count():
             child = self.conversation_layout.takeAt(0)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -99,6 +99,7 @@ class TopPane(QWidget):
 
     def setup(self, controller):
         self.refresh.setup(controller)
+        self.error_status_bar.setup(controller)
 
     def enable_refresh(self):
         self.refresh.enable()
@@ -381,6 +382,15 @@ class ErrorStatusBar(QWidget):
 
     def _on_status_timeout(self):
         self._hide()
+
+    def setup(self, controller):
+        self.controller = controller
+        self.retry_button.clicked.connect(self._on_retry_clicked)
+
+    def _on_retry_clicked(self) -> None:
+        self.clear_message()
+        self._hide()
+        self.controller.resume_queues()
 
     def update_message(self, message: str, duration: int, retry: bool) -> None:
         """

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -109,8 +109,8 @@ class TopPane(QWidget):
     def update_activity_status(self, message: str, duration: int):
         self.activity_status_bar.update_message(message, duration)
 
-    def update_error_status(self, message: str, duration: int):
-        self.error_status_bar.update_message(message, duration)
+    def update_error_status(self, message: str, duration: int, retry: bool):
+        self.error_status_bar.update_message(message, duration, retry)
 
     def clear_error_status(self):
         self.error_status_bar.clear_message()
@@ -307,6 +307,15 @@ class ErrorStatusBar(QWidget):
         font-size: 14px;
         color: #0c3e75;
     }
+    QPushButton#retry_button {
+        border: none;
+        padding-right: 30px;
+        background-color: #fff;
+        color: #0065db;
+        font-family: 'Source Sans Pro';
+        font-weight: 600;
+        font-size: 12px;
+    }
     '''
 
     def __init__(self):
@@ -338,15 +347,22 @@ class ErrorStatusBar(QWidget):
         self.status_bar.setObjectName('error_status_bar')  # Set css id
         self.status_bar.setSizeGripEnabled(False)
 
+        # Retry button
+        self.retry_button = QPushButton('RETRY')
+        self.retry_button.setObjectName('retry_button')
+        self.retry_button.setFixedHeight(42)
+
         # Add widgets to layout
         layout.addWidget(self.vertical_bar)
         layout.addWidget(self.label)
         layout.addWidget(self.status_bar)
+        layout.addWidget(self.retry_button)
 
         # Hide until a message needs to be displayed
         self.vertical_bar.hide()
         self.label.hide()
         self.status_bar.hide()
+        self.retry_button.hide()
 
         # Only show errors for a set duration
         self.status_timer = QTimer()
@@ -356,6 +372,7 @@ class ErrorStatusBar(QWidget):
         self.vertical_bar.hide()
         self.label.hide()
         self.status_bar.hide()
+        self.retry_button.hide()
 
     def _show(self):
         self.vertical_bar.show()
@@ -365,14 +382,19 @@ class ErrorStatusBar(QWidget):
     def _on_status_timeout(self):
         self._hide()
 
-    def update_message(self, message: str, duration: int):
+    def update_message(self, message: str, duration: int, retry: bool) -> None:
         """
         Display a status message to the user for a given duration. If the duration is zero,
         continuously show message.
         """
+        if retry:
+            self.retry_button.show()
+
         self.status_bar.showMessage(message, duration)
+
         if duration != 0:
             self.status_timer.start(duration)
+
         self._show()
 
     def clear_message(self):

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -272,8 +272,10 @@ class Controller(QObject):
         self.api_job_queue.resume_queues()
 
     def on_api_timeout(self) -> None:
-        self.gui.update_error_status(_('The connection to the SecureDrop server timed out. '
-                                       'Please try again.'))
+        self.gui.update_error_status(
+            _('The SecureDrop server cannot be reached.'),
+            duration=0,
+            retry=True)
 
     def completed_api_call(self, thread_id, user_callback):
         """

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -316,10 +316,6 @@ class Controller(QObject):
                       self.on_get_current_user_failure)
         self.api_job_queue.login(self.api)
 
-        # Clear the sidebar error status bar if a message was shown
-        # to the user indicating they should log in.
-        self.gui.clear_error_status()
-
         self.is_authenticated = True
 
     def on_authenticate_failure(self, result: Exception) -> None:
@@ -451,7 +447,6 @@ class Controller(QObject):
         After we star a source, we should sync the API such that the local database is updated.
         """
         self.sync_api()  # Syncing the API also updates the source list UI
-        self.gui.clear_error_status()
 
     def on_update_star_failure(self, result: UpdateStarJobException) -> None:
         """
@@ -469,13 +464,8 @@ class Controller(QObject):
         if not self.api:  # Then we should tell the user they need to login.
             self.on_action_requiring_login()
             return
-        else:  # Clear the error status bar
-            self.gui.clear_error_status()
 
-        job = UpdateStarJob(
-                source_db_object.uuid,
-                source_db_object.is_starred
-        )
+        job = UpdateStarJob(source_db_object.uuid, source_db_object.is_starred)
         job.success_signal.connect(self.on_update_star_success, type=Qt.QueuedConnection)
         job.failure_signal.connect(self.on_update_star_failure, type=Qt.QueuedConnection)
 
@@ -638,7 +628,6 @@ class Controller(QObject):
         Handler for when a source deletion succeeds.
         """
         self.sync_api()
-        self.gui.clear_error_status()
 
     def on_delete_source_failure(self, result: Exception) -> None:
         logging.info("failed to delete source at server")

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -665,6 +665,7 @@ class Controller(QObject):
     def on_reply_success(self, reply_uuid: str) -> None:
         logger.debug('{} sent successfully'.format(reply_uuid))
         self.reply_succeeded.emit(reply_uuid)
+        self.sync_api()
 
     def on_reply_failure(
         self,

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -248,7 +248,6 @@ class Controller(QObject):
             lambda: self.completed_api_call(new_thread_id, success_callback))
         new_api_runner.call_failed.connect(
             lambda: self.completed_api_call(new_thread_id, failure_callback))
-        new_api_runner.call_timed_out.connect(self.on_api_timeout)
 
         # when the thread starts, we want to run `call_api` on `api_runner`
         new_api_thread.started.connect(new_api_runner.call_api)
@@ -270,9 +269,6 @@ class Controller(QObject):
 
     def resume_queues(self) -> None:
         self.api_job_queue.resume_queues()
-
-    def on_api_timeout(self) -> None:
-        logger.debug('Metadata sync failed due to timeout')
 
     def completed_api_call(self, thread_id, user_callback):
         """

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -262,10 +262,13 @@ class Controller(QObject):
         new_api_thread.start()
 
     def on_queue_paused(self) -> None:
-        self.gui.update_error_status(
-            _('The SecureDrop server cannot be reached.'),
-            duration=0,
-            retry=True)
+        if self.api is None:
+            self.gui.update_error_status(_('The SecureDrop server cannot be reached.'))
+        else:
+            self.gui.update_error_status(
+                _('The SecureDrop server cannot be reached.'),
+                duration=0,
+                retry=True)
 
     def resume_queues(self) -> None:
         self.api_job_queue.resume_queues()

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -272,10 +272,7 @@ class Controller(QObject):
         self.api_job_queue.resume_queues()
 
     def on_api_timeout(self) -> None:
-        self.gui.update_error_status(
-            _('The SecureDrop server cannot be reached.'),
-            duration=0,
-            retry=True)
+        logger.debug('Metadata sync failed due to timeout')
 
     def completed_api_call(self, thread_id, user_callback):
         """
@@ -424,7 +421,10 @@ class Controller(QObject):
         """
         Called when syncronisation of data via the API fails.
         """
-        logger.debug('Sync failed: "{}".'.format(result))
+        self.gui.update_error_status(
+            _('The SecureDrop server cannot be reached.'),
+            duration=0,
+            retry=True)
 
     def update_sync(self):
         """

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -263,7 +263,10 @@ class Controller(QObject):
         new_api_thread.start()
 
     def on_queue_paused(self) -> None:
-        self.gui.update_error_status(_('The SecureDrop server cannot be reached.'), duration=0)
+        self.gui.update_error_status(
+            _('The SecureDrop server cannot be reached.'),
+            duration=0,
+            retry=True)
 
     def on_api_timeout(self) -> None:
         self.gui.update_error_status(_('The connection to the SecureDrop server timed out. '

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -35,7 +35,6 @@ from securedrop_client.api_jobs.downloads import FileDownloadJob, MessageDownloa
     ReplyDownloadJob, DownloadChecksumMismatchException
 from securedrop_client.api_jobs.uploads import SendReplyJob, SendReplyJobError, \
     SendReplyJobTimeoutError
-from securedrop_client.api_jobs.base import PauseQueueJob
 from securedrop_client.api_jobs.updatestar import UpdateStarJob, UpdateStarJobException
 from securedrop_client.crypto import GpgHelper, CryptoError
 from securedrop_client.queue import ApiJobQueue

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -312,6 +312,7 @@ class Controller(QObject):
         self.api_job_queue.login(self.api)
 
         self.is_authenticated = True
+        self.resume_queues()
 
     def on_authenticate_failure(self, result: Exception) -> None:
         # Failed to authenticate. Reset state with failure message.

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -268,6 +268,9 @@ class Controller(QObject):
             duration=0,
             retry=True)
 
+    def resume_queues(self) -> None:
+        self.api_job_queue.resume_queues()
+
     def on_api_timeout(self) -> None:
         self.gui.update_error_status(_('The connection to the SecureDrop server timed out. '
                                        'Please try again.'))
@@ -447,7 +450,6 @@ class Controller(QObject):
         """
         self.sync_api()  # Syncing the API also updates the source list UI
         self.gui.clear_error_status()
-        self.api_job_queue.enqueue(PauseQueueJob())
 
     def on_update_star_failure(self, result: UpdateStarJobException) -> None:
         """

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -159,6 +159,7 @@ class ApiJobQueue(QObject):
 
     def resume_queues(self) -> None:
         logger.info("Resuming queues")
+        self.start_queues()
         self.main_queue.process()
         self.download_file_queue.process()
 

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -178,6 +178,7 @@ class ApiJobQueue(QObject):
             logger.debug('Adding pause job to both queues')
             self.main_queue.add_job(priority, job)
             self.download_file_queue.add_job(priority, job)
+            self.paused.emit()
         elif isinstance(job, FileDownloadJob):
             logger.debug('Adding job to download queue')
             self.download_file_queue.add_job(priority, job)

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -154,12 +154,12 @@ def test_show_sources(mocker):
 def test_update_error_status_default(mocker):
     """
     Ensure that the error to be shown in the error status bar will be passed to the top pane with a
-    default duration of 10 seconds.
+    default duration of 10 seconds and no retry link.
     """
     w = Window()
     w.top_pane = mocker.MagicMock()
     w.update_error_status(message='test error message')
-    w.top_pane.update_error_status.assert_called_once_with('test error message', 10000)
+    w.top_pane.update_error_status.assert_called_once_with('test error message', 10000, False)
 
 
 def test_update_error_status(mocker):
@@ -170,7 +170,7 @@ def test_update_error_status(mocker):
     w = Window()
     w.top_pane = mocker.MagicMock()
     w.update_error_status(message='test error message', duration=123)
-    w.top_pane.update_error_status.assert_called_once_with('test error message', 123)
+    w.top_pane.update_error_status.assert_called_once_with('test error message', 123, False)
 
 
 def test_update_activity_status_default(mocker):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1428,21 +1428,6 @@ def test_ConversationView_init(mocker, homedir):
     assert isinstance(cv.conversation_layout, QVBoxLayout)
 
 
-def test_ConversationView_refresh_conversation(mocker, homedir):
-    """
-    Ensure that the session refreshes whenever there is a new reply in case there are previously
-    failed replies.
-    """
-    source = factory.Source()
-    cv = ConversationView(source, mocker.MagicMock())
-    mocker.patch.object(cv, 'update_conversation')
-
-    cv.refresh_conversation()
-
-    cv.controller.session.refresh.assert_called_with(source)
-    cv.update_conversation.assert_called_once_with(source.collection)
-
-
 def test_ConversationView_update_conversation_position_follow(mocker, homedir):
     """
     Check the signal handler sets the correct value for the scrollbar to be

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -84,9 +84,9 @@ def test_TopPane_update_error_status(mocker):
     tp = TopPane()
     tp.error_status_bar = mocker.MagicMock()
 
-    tp.update_error_status(message='test message', duration=5)
+    tp.update_error_status(message='test message', duration=5, retry=True)
 
-    tp.error_status_bar.update_message.assert_called_once_with('test message', 5)
+    tp.error_status_bar.update_message.assert_called_once_with('test message', 5, True)
 
 
 def test_TopPane_clear_error_status(mocker):
@@ -217,7 +217,7 @@ def test_ErrorStatusBar_update_message(mocker):
     esb.status_bar = mocker.MagicMock()
     esb.status_timer = mocker.MagicMock()
 
-    esb.update_message(message='test message', duration=123)
+    esb.update_message(message='test message', duration=123, retry=True)
 
     esb.status_bar.showMessage.assert_called_once_with('test message', 123)
     esb.status_timer.start.assert_called_once_with(123)
@@ -253,6 +253,17 @@ def test_ErrorStatusBar_on_status_timeout(mocker):
     esb = ErrorStatusBar()
     esb._on_status_timeout()
     assert esb.isHidden()
+
+
+def test_ErrorStatusBar_on_retry_clicked(mocker):
+    controller = mocker.MagicMock()
+    esb = ErrorStatusBar()
+    esb.setup(controller)
+
+    esb._on_retry_clicked()
+
+    assert esb.isHidden()
+    controller.resume_queues.assert_called_once_with()
 
 
 def test_ActivityStatusBar_update_message(mocker):

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -202,7 +202,6 @@ def test_Controller_on_authenticate_success(homedir, config, mocker, session_mak
     co.on_authenticate_success(True)
 
     co.sync_api.assert_called_once_with()
-    co.gui.clear_error_status.assert_called_once_with()
     assert mock_api_job_queue.called
     login.assert_called_with(co.api)
 
@@ -650,7 +649,6 @@ def test_Controller_on_update_star_success(homedir, config, mocker, session_make
     co.sync_api = mocker.MagicMock()
     co.on_update_star_success(result)
     co.sync_api.assert_called_once_with()
-    mock_gui.clear_error_status.assert_called_once_with()
 
 
 def test_Controller_on_update_star_failed(homedir, config, mocker, session_maker):
@@ -1192,7 +1190,6 @@ def test_Controller_on_delete_source_success(homedir, config, mocker, session_ma
     co.sync_api = mocker.MagicMock()
     co.on_delete_source_success(True)
     co.sync_api.assert_called_with()
-    co.gui.clear_error_status.assert_called_with()
 
 
 def test_Controller_on_delete_source_failure(homedir, config, mocker, session_maker):

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1375,7 +1375,7 @@ def test_Controller_api_call_timeout(homedir, config, mocker, session_maker):
     co = Controller('http://localhost', mock_gui, session_maker, homedir)
     co.on_api_timeout()
     mock_gui.update_error_status.assert_called_once_with(
-        'The connection to the SecureDrop server timed out. Please try again.')
+        'The SecureDrop server cannot be reached.', duration=0, retry=True)
 
 
 def test_Controller_call_update_star_success(homedir, config, mocker, session_maker, session):

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1361,21 +1361,6 @@ def test_Controller_on_queue_paused(homedir, config, mocker, session_maker):
         'The SecureDrop server cannot be reached.', duration=0, retry=True)
 
 
-def test_Controller_api_call_timeout(homedir, config, mocker, session_maker):
-    '''
-    Using the `config` fixture to ensure the config is written to disk.
-    '''
-    debug_logger = mocker.patch('securedrop_client.logic.logger.debug')
-    storage = mocker.patch('securedrop_client.logic.storage')
-    mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
-
-    co.on_api_timeout()
-
-    assert storage.update_local_storage.call_count == 0
-    debug_logger.assert_called_once_with('Metadata failed due to timeout')
-
-
 def test_Controller_call_update_star_success(homedir, config, mocker, session_maker, session):
     '''
     Check that a UpdateStar is submitted to the queue when update_star is called.

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1261,6 +1261,7 @@ def test_Controller_on_reply_success(homedir, mocker, session_maker, session):
     Check that when the method is called, the client emits the correct signal.
     '''
     co = Controller('http://localhost', mocker.MagicMock(), session_maker, homedir)
+    mocker.patch.object(co, 'sync_api')
     reply_succeeded = mocker.patch.object(co, 'reply_succeeded')
     reply_failed = mocker.patch.object(co, 'reply_failed')
     reply = factory.Reply(source=factory.Source())
@@ -1268,9 +1269,10 @@ def test_Controller_on_reply_success(homedir, mocker, session_maker, session):
 
     co.on_reply_success(reply.uuid)
 
-    debug_logger.assert_called_once_with('{} sent successfully'.format(reply.uuid))
+    assert debug_logger.call_args_list[0][0][0] == '{} sent successfully'.format(reply.uuid)
     reply_succeeded.emit.assert_called_once_with(reply.uuid)
     reply_failed.emit.assert_not_called()
+    co.sync_api.assert_called_once_with()
 
 
 def test_Controller_on_reply_failure(homedir, mocker, session_maker):

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -191,6 +191,7 @@ def test_Controller_on_authenticate_success(homedir, config, mocker, session_mak
     co.sync_api = mocker.MagicMock()
     co.api = mocker.MagicMock()
     co.call_api = mocker.MagicMock()
+    co.resume_queues = mocker.MagicMock()
     login = mocker.patch.object(co.api_job_queue, 'login')
     current_user_api_result = {
         'uuid': 'mock_uuid',
@@ -204,6 +205,7 @@ def test_Controller_on_authenticate_success(homedir, config, mocker, session_mak
     co.sync_api.assert_called_once_with()
     assert mock_api_job_queue.called
     login.assert_called_with(co.api)
+    co.resume_queues.assert_called_once_with()
 
 
 def test_Controller_on_get_current_user_success(mocker, session_maker, session, homedir):

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1354,11 +1354,27 @@ def test_APICallRunner_api_call_timeout(mocker):
 
 
 def test_Controller_on_queue_paused(homedir, config, mocker, session_maker):
+    '''
+    Check that a paused queue is communicated to the user via the error status bar with retry option
+    '''
     mock_gui = mocker.MagicMock()
     co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co.api = 'mock'
     co.on_queue_paused()
     mock_gui.update_error_status.assert_called_once_with(
         'The SecureDrop server cannot be reached.', duration=0, retry=True)
+
+
+def test_Controller_on_queue_paused_when_logged_out(homedir, config, mocker, session_maker):
+    '''
+    Check that a paused queue is communicated to the user via the error status bar. There should not
+    be a retry option displayed to the user
+    '''
+    mock_gui = mocker.MagicMock()
+    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co.api = None
+    co.on_queue_paused()
+    mock_gui.update_error_status.assert_called_once_with('The SecureDrop server cannot be reached.')
 
 
 def test_Controller_call_update_star_success(homedir, config, mocker, session_maker, session):

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1332,6 +1332,13 @@ def test_Controller_is_authenticated_property(homedir, mocker, session_maker):
     assert co.is_authenticated is False
 
 
+def test_Controller_resume_queues(homedir, mocker, session_maker):
+    co = Controller('http://localhost', mocker.MagicMock(), session_maker, homedir)
+    co.api_job_queue = mocker.MagicMock()
+    co.resume_queues()
+    co.api_job_queue.resume_queues.assert_called_once_with()
+
+
 def test_APICallRunner_api_call_timeout(mocker):
     """
     Ensure that if a RequestTimeoutError is raised, both the failure and timeout signals are
@@ -1357,7 +1364,7 @@ def test_Controller_on_queue_paused(homedir, config, mocker, session_maker):
     co = Controller('http://localhost', mock_gui, session_maker, homedir)
     co.on_queue_paused()
     mock_gui.update_error_status.assert_called_once_with(
-        'The SecureDrop server cannot be reached.', duration=0)
+        'The SecureDrop server cannot be reached.', duration=0, retry=True)
 
 
 def test_Controller_api_call_timeout(homedir, config, mocker, session_maker):

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1352,6 +1352,14 @@ def test_APICallRunner_api_call_timeout(mocker):
     mock_timeout_signal.emit.assert_called_once_with()
 
 
+def test_Controller_on_queue_paused(homedir, config, mocker, session_maker):
+    mock_gui = mocker.MagicMock()
+    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co.on_queue_paused()
+    mock_gui.update_error_status.assert_called_once_with(
+        'The SecureDrop server cannot be reached.', duration=0)
+
+
 def test_Controller_api_call_timeout(homedir, config, mocker, session_maker):
     '''
     Using the `config` fixture to ensure the config is written to disk.

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -309,6 +309,7 @@ def test_ApiJobQueue_enqueue_no_auth(mocker):
     mock_start_queues = mocker.patch.object(job_queue, 'start_queues')
 
     dummy_job = factory.dummy_job_factory(mocker, 'mock')()
+    job_queue.JOB_PRIORITIES = {type(dummy_job): 1}
     job_queue.enqueue(dummy_job)
 
     assert not mock_download_file_add_job.called

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -202,7 +202,6 @@ def test_RunnableQueue_does_not_run_jobs_when_not_authed(mocker):
     '''
     queue = RunnableQueue(mocker.MagicMock(), mocker.MagicMock())
     queue.pause = mocker.MagicMock()
-    mock_logger = mocker.patch('securedrop_client.api_jobs.base.logger')
 
     # ApiInaccessibleError will cause the queue to pause, use our fake pause method instead
     def fake_pause() -> None:
@@ -217,7 +216,6 @@ def test_RunnableQueue_does_not_run_jobs_when_not_authed(mocker):
     # attempt to process job1 knowing that it times out
     queue.process()
     assert queue.queue.qsize() == 1  # queue contains: job1
-    assert "Client is not authenticated" in mock_logger.error.call_args[0][0]
 
 
 def test_ApiJobQueue_enqueue(mocker):

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -331,9 +331,11 @@ def test_ApiJobQueue_resume_queues(mocker):
     job_queue = ApiJobQueue(mocker.MagicMock(), mocker.MagicMock())
     job_queue.main_queue = mocker.MagicMock()
     job_queue.download_file_queue = mocker.MagicMock()
+    job_queue.start_queues = mocker.MagicMock()
 
     job_queue.resume_queues()
 
+    job_queue.start_queues.assert_called_once_with()
     job_queue.main_queue.process.assert_called_with()
     job_queue.download_file_queue.process.assert_called_with()
 


### PR DESCRIPTION
# Description

The queues now pause when there is either an auth error, api connection failure, or request timeout error. The queues resume when the user clicks "Retry" or upon a sync/refresh after the issues are resolved.

Resolves https://github.com/freedomofpress/securedrop-client/issues/443
Towards https://github.com/freedomofpress/securedrop-client/issues/391

# Test Plan

Make sure acceptance criteria is satisfied: https://github.com/freedomofpress/securedrop-client/issues/391#issue-449547635, and follow these steps:

#### RequestTimeoutError with Retry link
1. Send reply after pausing the staging app server vm, wait and observe 5 Keyring access qubes notication popups and reply bar turn red in the gui and the SecureDrop error message and Retry link.
2. Unpause the staging app server vm
3. Click Retry link and wait until the next sync happens or manually click the refresh icon and see the reply bar turn blue

#### ApiInaccessibleError
1. Send reply after pausing the staging app server vm
2. Log out before the 5th timeout retry so that the final error will be an `ApiInaccessibleError` and see the reply bar turn red in the gui and the SecureDrop error message **without** the Retry link.
3. Unpause the staging app server vm
4. Log back in
5. The queue is automatically resumedd and you should see the reply bar turn blue

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes