### PR TITLE
Update docs around upgrading dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,11 @@ pip install --require-hashes -r dev-requirements.txt
 
 ## Updating dependencies
 
+We have several dependency files: `dev-requirements.txt` and `requirements.txt` point to python software foundation hashes, and `build-requirements.txt` points to our builds of the wheels from our own pip mirror. Whenever a dependency in `build-requirements.txt` changes, our team needs to manually review the code in the dependency diff with a focus on spotting vulnerabilities.
+
 If you're adding or updating a dependency, you need to:
 
-1. Modify either `dev-requirements.in` and `requirements.in` (depending on whether it is prod or dev only) and then run `make update-pip-dependencies`. This will generate `dev-requirements.txt` and `requirements.txt`.
+1. Modify either `requirements.in` or `dev-requirements.in` (depending on whether it is prod or dev only) and then run `make update-pip-requirements`. This will generate `dev-requirements.txt` and `requirements.txt`.
 
 2. For building a debian package from this project, we use the requirements in
 `build-requirements.txt` which uses our pip mirror, i.e. the hashes in that file point to


### PR DESCRIPTION
# Description

~Upgrade our PyQt dev dependency and~ **update readme docs about updating dependencies.**

~Even though we're no longer seeing #273 occur, we know that the upstream qt bug was fixed in a version of Qt later than the one we've been using.~

~Resolves https://github.com/freedomofpress/securedrop-client/issues/273~