### PR TITLE
ui: add event handler on FileWidget

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -24,7 +24,7 @@ import sys
 from gettext import gettext as _
 from typing import Dict, List  # noqa: F401
 from uuid import uuid4
-from PyQt5.QtCore import Qt, pyqtSlot, pyqtSignal, QTimer, QSize, pyqtBoundSignal, QObject
+from PyQt5.QtCore import Qt, pyqtSlot, pyqtSignal, QEvent, QTimer, QSize, pyqtBoundSignal, QObject
 from PyQt5.QtGui import QIcon, QPalette, QBrush, QColor, QFont, QLinearGradient
 from PyQt5.QtWidgets import QListWidget, QLabel, QWidget, QListWidgetItem, QHBoxLayout, \
     QPushButton, QVBoxLayout, QLineEdit, QScrollArea, QDialog, QAction, QMenu, QMessageBox, \
@@ -1668,6 +1668,10 @@ class FileWidget(QWidget):
         file_options_layout.addWidget(self.export_button)
         file_options_layout.addWidget(self.print_button)
 
+        self.download_button.installEventFilter(self)
+        # self.export_button.installEventFilter(self)
+        # self.print_button.installEventFilter(self)
+
         # File name or default string
         self.file_name = SecureQLabel(self.file.original_filename)
         self.file_name.setObjectName('file_name')
@@ -1716,6 +1720,12 @@ class FileWidget(QWidget):
         # Connect signals to slots
         file_ready_signal.connect(self._on_file_downloaded, type=Qt.QueuedConnection)
 
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.MouseButtonPress:
+            if event.button() == Qt.LeftButton:
+                self._on_left_click()
+        return QObject.event(obj, event)
+
     @pyqtSlot(str)
     def _on_file_downloaded(self, file_uuid: str) -> None:
         if file_uuid == self.file.uuid:
@@ -1734,7 +1744,7 @@ class FileWidget(QWidget):
                 do_not_retain_space.setRetainSizeWhenHidden(False)
                 self.file_options.setSizePolicy(do_not_retain_space)
 
-    def mouseReleaseEvent(self, e):
+    def _on_left_click(self):
         """
         Handle a completed click via the program logic. The download state
         of the file distinguishes which function in the logic layer to call.

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1675,6 +1675,7 @@ class FileWidget(QWidget):
         # File name or default string
         self.file_name = SecureQLabel(self.file.original_filename)
         self.file_name.setObjectName('file_name')
+        self.file_name.installEventFilter(self)
         self.no_file_name = SecureQLabel('ENCRYPTED FILE ON SERVER')
         self.no_file_name.setObjectName('no_file_name')
         self.no_file_name.setFont(file_description_font)


### PR DESCRIPTION
# Description

Previously the left click event would not be triggered on the QPushButton - instead slightly above the QPushButton on the parent FileWidget. This event handler which we can reuse for multiple buttons if we like (we can also use to trigger alternative logic for e.g. right clicks) should make it so clicking exactly on the button triggers the download action. 

Important note: The last commit I was not able to test due to an error on download due to an unrelated issue I'm also seeing on master (will file bug if I'm not able to figure out what is going on) - please test that! We do need to ensure that the left click also fires on click to open the file (since the download button will be hidden). 