### PR TITLE
Basic export integration with placeholder messaging

### DIFF
--- a/securedrop_client/export.py
+++ b/securedrop_client/export.py
@@ -86,8 +86,12 @@ class Export:
                 the return code from `check_output` is not 0.
         '''
         try:
-            command = '{} {} {}'.format(cls.QVM_OP, cls.QVM_VM, archive_path)
-            output = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
+            # There are already talks of switching to a QVM-RPC implementation for unlocking devices
+            # and exporting files, so it's important to remember to shell-escape what we pass to our
+            # check_output call, even if for the time being we're not passing user input.
+            output = subprocess.check_output(
+                [quote(cls.QVM_OP), quote(cls.QVM_VM), quote(archive_path)],
+                stderr=subprocess.STDOUT)
             return output.decode('utf-8').strip()
         except subprocess.CalledProcessError as e:
             logger.error(e)
@@ -197,8 +201,7 @@ class Export:
         logger.debug('Exporting to disk...')
 
         metadata = self.DISK_METADATA.copy()
-        metadata[self.DISK_ENCRYPTION_KEY_NAME] = quote(passphrase)
-
+        metadata[self.DISK_ENCRYPTION_KEY_NAME] = passphrase
         archive_path = self._create_archive(archive_dir, self.DISK_FN, metadata, filepaths)
 
         status = self._export_archive(archive_path)

--- a/securedrop_client/export.py
+++ b/securedrop_client/export.py
@@ -87,8 +87,10 @@ class Export:
         '''
         try:
             # There are already talks of switching to a QVM-RPC implementation for unlocking devices
-            # and exporting files, so it's important to remember to shell-escape what we pass to our
-            # check_output call, even if for the time being we're not passing user input.
+            # and exporting files, so it's important to remember to shell-escape what we pass to the
+            # shell, even if for the time being we're already protected against shell injection via
+            # Python's implementation of subprocess, see
+            # https://docs.python.org/3/library/subprocess.html#security-considerations
             output = subprocess.check_output(
                 [quote(cls.QVM_OP), quote(cls.QVM_VM), quote(archive_path)],
                 stderr=subprocess.STDOUT)

--- a/securedrop_client/export.py
+++ b/securedrop_client/export.py
@@ -1,0 +1,233 @@
+import json
+import logging
+import os
+import subprocess
+import tarfile
+
+from enum import Enum
+from io import BytesIO
+from shlex import quote
+from tempfile import TemporaryDirectory
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+
+class ExportError(Exception):
+    def __init__(self, status: str):
+        self.status = status
+
+
+class ExportStatus(Enum):
+    # On the way to success
+    USB_CONNECTED = 'USB_CONNECTED'
+    DISK_ENCRYPTED = 'USB_ENCRYPTED'
+
+    # Not too far from success
+    USB_NOT_CONNECTED = 'USB_NOT_CONNECTED'
+    BAD_PASSPHRASE = 'USB_BAD_PASSPHRASE'
+
+    # Failure
+    CALLED_PROCESS_ERROR = 'CALLED_PROCESS_ERROR'
+    DISK_ENCRYPTION_NOT_SUPPORTED_ERROR = 'USB_ENCRYPTION_NOT_SUPPORTED'
+    ERROR_USB_CONFIGURATION = 'ERROR_USB_CONFIGURATION'
+    UNEXPECTED_RETURN_STATUS = 'UNEXPECTED_RETURN_STATUS'
+
+
+class Export:
+    '''
+    This class sends files over to the Export VM so that they can be copied to a luks-encrypted USB
+    disk drive or printed by a USB-connected printer.
+
+    Files are archived in a specified format, which you can learn more about in the README for the
+    securedrop-export repository.
+    '''
+
+    QVM_OP = 'qvm-open-in-vm'
+    QVM_VM = 'sd-export-usb'
+
+    METADATA_FN = 'metadata.json'
+
+    USB_TEST_FN = 'usb-test.sd-export'
+    USB_TEST_METADATA = {
+        'device': 'usb-test'
+    }
+
+    DISK_TEST_FN = 'disk-test.sd-export'
+    DISK_TEST_METADATA = {
+        'device': 'disk-test'
+    }
+
+    DISK_FN = 'archive.sd-export'
+    DISK_METADATA = {
+        'device': 'disk',
+        'encryption_method': 'luks'
+    }
+    DISK_ENCRYPTION_KEY_NAME = 'encryption_key'
+    DISK_EXPORT_DIR = 'export_data'
+
+    def __init__(self, is_qubes: bool) -> None:
+        self.is_qubes = is_qubes
+
+    def _export_archive(cls, archive_path: str) -> str:
+        '''
+        Make the subprocess call to send the archive to the Export VM, where the archive will be
+        processed.
+
+        Args:
+            archive_path (str): The path to the archive to be processed.
+
+        Returns:
+            str: The export status returned from the Export VM processing script.
+
+        Raises:
+            ExportError: Raised if (1) CalledProcessError is encountered, which can occur when
+                trying to start the Export VM when the USB device is not attached, or (2) when
+                the return code from `check_output` is not 0.
+        '''
+        try:
+            command = '{} {} {}'.format(cls.QVM_OP, cls.QVM_VM, archive_path)
+            output = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
+            return output.decode('utf-8').strip()
+        except subprocess.CalledProcessError as e:
+            logger.error(e)
+            raise ExportError(ExportStatus.CALLED_PROCESS_ERROR.value)
+
+    def _create_archive(
+        cls, archive_dir: str, archive_fn: str, metadata: dict, filepaths: List[str] = []
+    ) -> str:
+        '''
+        Create the archive to be sent to the Export VM.
+
+        Args:
+            archive_dir (str): The path to the directory in which to create the archive.
+            archive_fn (str): The name of the archive file.
+            metadata (dict): The dictionary containing metadata to add to the archive.
+            filepaths (List[str]): The list of files to add to the archive.
+
+        Returns:
+            str: The path to newly-created archive file.
+        '''
+        archive_path = os.path.join(archive_dir, archive_fn)
+
+        with tarfile.open(archive_path, 'w:gz') as archive:
+            cls._add_virtual_file_to_archive(archive, cls.METADATA_FN, metadata)
+
+            for filepath in filepaths:
+                cls._add_file_to_archive(archive, filepath)
+
+        return archive_path
+
+    def _add_virtual_file_to_archive(
+        cls, archive: tarfile.TarFile, filename: str, filedata: dict
+    ) -> None:
+        '''
+        Add filedata to a stream of in-memory bytes and add these bytes to the archive.
+
+        Args:
+            archive (TarFile): The archive object to add the virtual file to.
+            filename (str): The name of the virtual file.
+            filedata (dict): The data to add to the bytes stream.
+
+        '''
+        filedata_string = json.dumps(filedata)
+        filedata_bytes = BytesIO(filedata_string.encode('utf-8'))
+        tarinfo = tarfile.TarInfo(filename)
+        tarinfo.size = len(filedata_string)
+        archive.addfile(tarinfo, filedata_bytes)
+
+    def _add_file_to_archive(cls, archive: tarfile.TarFile, filepath: str) -> None:
+        '''
+        Add the file to the archive. When the archive is extracted, the file should exist in a
+        directory called "export_data".
+
+        Args:
+            archive: The archive object ot add the file to.
+            filepath: The path to the file that will be added to the supplied archive.
+        '''
+        filename = os.path.basename(filepath)
+        arcname = os.path.join(cls.DISK_EXPORT_DIR, filename)
+        archive.add(filepath, arcname=arcname, recursive=False)
+
+    def _run_usb_test(self, archive_dir: str) -> None:
+        '''
+        Run usb-test.
+
+        Args:
+            archive_dir (str): The path to the directory in which to create the archive.
+
+        Raises:
+            ExportError: Raised if the usb-test does not return a USB_CONNECTED status.
+        '''
+        logger.debug('Running usb-test...')
+
+        archive_path = self._create_archive(archive_dir, self.USB_TEST_FN, self.USB_TEST_METADATA)
+        status = self._export_archive(archive_path)
+        if status != ExportStatus.USB_CONNECTED.value:
+            raise ExportError(status)
+
+    def _run_disk_test(self, archive_dir: str) -> None:
+        '''
+        Run disk-test.
+
+        Args:
+            archive_dir (str): The path to the directory in which to create the archive.
+
+        Raises:
+            ExportError: Raised if the usb-test does not return a DISK_ENCRYPTED status.
+        '''
+        logger.debug('Running disk-test...')
+
+        archive_path = self._create_archive(archive_dir, self.DISK_TEST_FN, self.DISK_TEST_METADATA)
+
+        status = self._export_archive(archive_path)
+        if status != ExportStatus.DISK_ENCRYPTED.value:
+            raise ExportError(status)
+
+    def _run_disk_export(self, archive_dir: str, filepaths: List[str], passphrase: str) -> None:
+        '''
+        Run disk-test.
+
+        Args:
+            archive_dir (str): The path to the directory in which to create the archive.
+
+        Raises:
+            ExportError: Raised if the usb-test does not return a DISK_ENCRYPTED status.
+        '''
+        logger.debug('Exporting to disk...')
+
+        metadata = self.DISK_METADATA.copy()
+        metadata[self.DISK_ENCRYPTION_KEY_NAME] = quote(passphrase)
+
+        archive_path = self._create_archive(archive_dir, self.DISK_FN, metadata, filepaths)
+
+        status = self._export_archive(archive_path)
+        if status:
+            raise ExportError(status)
+
+        logger.debug('Export successful')
+
+    def run_preflight_checks(self) -> None:
+        '''
+        Run preflight checks to verify that the usb device is connected and luks-encrypted.
+        '''
+        if not self.is_qubes:
+            return
+
+        with TemporaryDirectory() as temp_dir:
+            self._run_usb_test(temp_dir)
+            self._run_disk_test(temp_dir)
+
+    def send_file_to_usb_device(self, filepaths: List[str], passphrase: str) -> None:
+        '''
+        Export the file to the luks-encrypted usb disk drive attached to the Export VM.
+
+        Args:
+            filepath: The path of file to export.
+            passphrase: The passphrase to unlock the luks-encrypted usb disk drive.
+        '''
+        if not self.is_qubes:
+            return
+
+        with TemporaryDirectory() as temp_dir:
+            self._run_disk_export(temp_dir, filepaths, passphrase)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1883,7 +1883,7 @@ class ExportDialog(QDialog):
         usb_form_layout = QVBoxLayout()
         self.insert_usb_form.setLayout(usb_form_layout)
         self.usb_error_message = SecureQLabel(_(
-            'Either the drive is not encrypted with VeraCrypt, or there is something else wrong'
+            'Either the drive is not luks-encrypted, or there is something else wrong'
             'with it. Please try another drive, or see your administrator for help.'))
         self.usb_error_message.setWordWrap(True)
         usb_instructions = SecureQLabel(_(
@@ -1928,11 +1928,18 @@ class ExportDialog(QDialog):
         passphrase_form_layout.addWidget(buttons, alignment=Qt.AlignRight)
         self.passphrase_error_message.hide()
 
+        # Starting export message
+        self.exporting_message = SecureQLabel(_('Exporting...'))
+        self.exporting_message.setWordWrap(True)
+
         layout.addWidget(self.starting_export_message)
+        layout.addWidget(self.exporting_message)
         layout.addWidget(self.generic_error)
         layout.addWidget(self.insert_usb_form)
         layout.addWidget(self.passphrase_form)
 
+        self.starting_export_message.show()
+        self.exporting_message.hide()
         self.generic_error.hide()
         self.insert_usb_form.hide()
         self.passphrase_form.hide()
@@ -1972,6 +1979,9 @@ class ExportDialog(QDialog):
     @pyqtSlot()
     def _on_unlock_disk_clicked(self):
         try:
+            self.passphrase_form.hide()
+            self.exporting_message.show()
+            QApplication.processEvents()
             passphrase = self.passphrase_field.text()
             self.controller.export_file_to_usb_drive(self.file_uuid, passphrase)
             self.close()
@@ -1990,6 +2000,7 @@ class ExportDialog(QDialog):
 
     def _request_passphrase(self, bad_passphrase: bool = False):
         self.starting_export_message.hide()
+        self.exporting_message.hide()
         self.passphrase_form.show()
         self.insert_usb_form.hide()
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1859,6 +1859,10 @@ class ExportDialog(QDialog):
         layout = QVBoxLayout(self)
         self.setLayout(layout)
 
+        # Starting export message
+        self.starting_export_message = SecureQLabel(_('Preparing export...'))
+        self.starting_export_message.setWordWrap(True)
+
         # Widget to show error messages that occur during an export
         self.generic_error = QWidget()
         self.generic_error.setObjectName('gener_error')
@@ -1921,6 +1925,7 @@ class ExportDialog(QDialog):
         passphrase_form_layout.addWidget(buttons, alignment=Qt.AlignRight)
         self.passphrase_error_message.hide()
 
+        layout.addWidget(self.starting_export_message)
         layout.addWidget(self.generic_error)
         layout.addWidget(self.insert_usb_form)
         layout.addWidget(self.passphrase_form)
@@ -1935,7 +1940,6 @@ class ExportDialog(QDialog):
         unlock_disk_button.clicked.connect(self._on_unlock_disk_clicked)
 
         self._export()
-
 
     def _export(self):
         try:
@@ -1958,28 +1962,11 @@ class ExportDialog(QDialog):
     @pyqtSlot()
     def _on_retry_export_button_clicked(self):
         try:
+            self.starting_export_message.hide()
             self.controller.run_export_preflight_checks()
             self._request_passphrase()
         except ExportError as e:
             self._update(e.status)
-
-    def _request_to_insert_usb_device(self, encryption_not_supported: bool = False):
-        self.passphrase_form.hide()
-        self.insert_usb_form.show()
-
-        if encryption_not_supported:
-            self.usb_error_message.show()
-        else:
-            self.usb_error_message.hide()
-
-    def _request_passphrase(self, bad_passphrase: bool = False):
-        self.passphrase_form.show()
-        self.insert_usb_form.hide()
-
-        if bad_passphrase:
-            self.passphrase_error_message.show()
-        else:
-            self.passphrase_error_message.hide()
 
     @pyqtSlot()
     def _on_unlock_disk_clicked(self):
@@ -1989,6 +1976,26 @@ class ExportDialog(QDialog):
             self.close()
         except ExportError as e:
             self._update(e.status)
+
+    def _request_to_insert_usb_device(self, encryption_not_supported: bool = False):
+        self.starting_export_message.hide()
+        self.passphrase_form.hide()
+        self.insert_usb_form.show()
+
+        if encryption_not_supported:
+            self.usb_error_message.show()
+        else:
+            self.usb_error_message.hide()
+
+    def _request_passphrase(self, bad_passphrase: bool = False):
+        self.starting_export_message.hide()
+        self.passphrase_form.show()
+        self.insert_usb_form.hide()
+
+        if bad_passphrase:
+            self.passphrase_error_message.show()
+        else:
+            self.passphrase_error_message.hide()
 
     def _update(self, status):
         if status == ExportStatus.USB_NOT_CONNECTED.value:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1785,11 +1785,6 @@ class FileWidget(QWidget):
         Called when the export button is clicked.
         """
         dialog = ExportDialog(self.controller, self.file.uuid)
-        frame_rect = self.frameGeometry()
-        dialog_rect = dialog.geometry()
-        x_center = (frame_rect.width() - dialog_rect.width()) / 2
-        y_center = (frame_rect.height() - dialog_rect.height()) / 2
-        dialog.move(x_center, y_center)
         dialog.exec()
 
     def _on_left_click(self):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1848,8 +1848,7 @@ class ExportDialog(QDialog):
 
         self.setObjectName('export_dialog')
         self.setStyleSheet(self.CSS)
-
-        self.setWindowTitle(_('Export'))
+        self.setWindowFlags(Qt.Popup)
 
         layout = QVBoxLayout(self)
         self.setLayout(layout)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -32,6 +32,7 @@ from PyQt5.QtWidgets import QListWidget, QLabel, QWidget, QListWidgetItem, QHBox
 
 from securedrop_client.db import Source, Message, File, Reply, User
 from securedrop_client.storage import source_exists
+from securedrop_client.export import ExportStatus, ExportError
 from securedrop_client.gui import SecureQLabel, SvgLabel, SvgPushButton, SvgToggleButton
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_icon, load_image
@@ -1715,7 +1716,7 @@ class FileWidget(QWidget):
         file_options_layout.addWidget(self.print_button)
 
         self.download_button.installEventFilter(self)
-        # self.export_button.installEventFilter(self)
+        self.export_button.clicked.connect(self._on_export_clicked)
         # self.print_button.installEventFilter(self)
 
         # File name or default string
@@ -1740,16 +1741,9 @@ class FileWidget(QWidget):
         if self.file.is_downloaded:
             self.download_button.hide()
             self.no_file_name.hide()
-            self.export_button.hide()  # Show once print is supported on the workstation client
+            self.export_button.show()
             self.print_button.hide()  # Show once print is supported on the workstation client
             self.file_name.show()
-
-            # Delete this block of code once print & export are supported on the workstation client
-            self.file_options.hide()
-            do_not_retain_space = QSizePolicy()
-            do_not_retain_space.setRetainSizeWhenHidden(False)
-            self.file_options.setSizePolicy(do_not_retain_space)
-
         else:
             self.export_button.hide()
             self.print_button.hide()
@@ -1781,15 +1775,22 @@ class FileWidget(QWidget):
                 self.file_name.setText(self.file.original_filename)
                 self.download_button.hide()
                 self.no_file_name.hide()
-                self.export_button.hide()  # Show once export is supported on the workstation client
+                self.export_button.show()
                 self.print_button.hide()  # Show once print is supported on the workstation client
                 self.file_name.show()
 
-                # Delete this block of code once print & export are supported on workstation client
-                self.file_options.hide()
-                do_not_retain_space = QSizePolicy()
-                do_not_retain_space.setRetainSizeWhenHidden(False)
-                self.file_options.setSizePolicy(do_not_retain_space)
+    @pyqtSlot()
+    def _on_export_clicked(self):
+        """
+        Called when the export button is clicked.
+        """
+        dialog = ExportDialog(self.controller, self.file.uuid)
+        frame_rect = self.frameGeometry()
+        dialog_rect = dialog.geometry()
+        x_center = (frame_rect.width() - dialog_rect.width()) / 2
+        y_center = (frame_rect.height() - dialog_rect.height()) / 2
+        dialog.move(x_center, y_center)
+        dialog.exec()
 
     def _on_left_click(self):
         """
@@ -1805,6 +1806,183 @@ class FileWidget(QWidget):
         else:
             # Download the file.
             self.controller.on_submission_download(File, self.file.uuid)
+
+
+class ExportDialog(QDialog):
+
+    CSS = '''
+    #export_dialog {
+        min-width: 830;
+        min-height: 330;
+        border: 1px solid #2a319d;
+    }
+    '''
+
+    CSS_FOR_DIALOG_WITH_ERROR = '''
+    #export_dialog {
+        min-width: 830;
+        min-height: 430;
+        border: 1px solid #2a319d;
+    }
+    '''
+
+    CSS = '''
+    #export_dialog {
+        min-width: 400;
+        max-width: 400;
+        min-height: 200;
+        max-height: 200;
+    }
+    #passphrase_label {
+        font-family: 'Montserrat';
+        font-weight: 500;
+        font-size: 13px;
+    }
+    #passphrase_form QLineEdit {
+        border-radius: 0px;
+        min-height: 30px;
+        margin: 0px 0px 10px 0px;
+    }
+    '''
+
+    def __init__(self, controller, file_uuid):
+        super().__init__()
+
+        self.controller = controller
+        self.file_uuid = file_uuid
+
+        self.setObjectName('export_dialog')
+        self.setStyleSheet(self.CSS)
+
+        self.setWindowTitle(_('Export'))
+
+        layout = QVBoxLayout(self)
+        self.setLayout(layout)
+
+        # Widget to show error messages that occur during an export
+        self.generic_error = QWidget()
+        self.generic_error.setObjectName('gener_error')
+        generic_error_layout = QHBoxLayout()
+        self.generic_error.setLayout(generic_error_layout)
+        self.error_status_code = SecureQLabel()
+        generic_error_message = SecureQLabel(_('See your administrator for help.'))
+        generic_error_message.setWordWrap(True)
+        generic_error_layout.addWidget(self.error_status_code)
+        generic_error_layout.addWidget(generic_error_message)
+
+        # Insert USB Device Form
+        self.insert_usb_form = QWidget()
+        self.insert_usb_form.setObjectName('insert_usb_form')
+        usb_form_layout = QVBoxLayout()
+        self.insert_usb_form.setLayout(usb_form_layout)
+        self.usb_error_message = SecureQLabel(_(
+            'Either the drive is not encrypted with VeraCrypt, or there is something else wrong'
+            'with it. Please try another drive, or see your administrator for help.'))
+        self.usb_error_message.setWordWrap(True)
+        usb_instructions = SecureQLabel(_(
+            'Please insert your encrypted drive into one of the USB ports marked EXTERNAL.'))
+        usb_instructions.setWordWrap(True)
+        buttons = QWidget()
+        buttons_layout = QHBoxLayout()
+        buttons.setLayout(buttons_layout)
+        usb_cancel_button = QPushButton(_('CANCEL'))
+        export_button = QPushButton(_('EXPORT'))
+        buttons_layout.addWidget(usb_cancel_button)
+        buttons_layout.addWidget(export_button)
+        usb_form_layout.addWidget(self.usb_error_message)
+        usb_form_layout.addWidget(usb_instructions)
+        usb_form_layout.addWidget(buttons, alignment=Qt.AlignRight)
+
+        # Passphrase Form
+        self.passphrase_form = QWidget()
+        self.passphrase_form.setObjectName('passphrase_form')
+        passphrase_form_layout = QVBoxLayout()
+        self.passphrase_form.setLayout(passphrase_form_layout)
+        self.passphrase_error_message = SecureQLabel(_(
+            'The passphrase provided did not work. Please try again.'))
+        self.passphrase_error_message.setWordWrap(True)
+        passphrase_instructions = SecureQLabel(_('Enter password for safe USB drive.'))
+        passphrase_instructions.setWordWrap(True)
+        passphrase_label = SecureQLabel(_('Passphrase'))
+        passphrase_label.setObjectName('passphrase_label')
+        self.passphrase_field = QLineEdit()
+        self.passphrase_field.setEchoMode(QLineEdit.Password)
+        buttons = QWidget()
+        buttons_layout = QHBoxLayout()
+        buttons.setLayout(buttons_layout)
+        passphrase_cancel_button = QPushButton(_('CANCEL'))
+        unlock_disk_button = QPushButton(_('SUBMIT'))
+        buttons_layout.addWidget(passphrase_cancel_button)
+        buttons_layout.addWidget(unlock_disk_button)
+        passphrase_form_layout.addWidget(self.passphrase_error_message)
+        passphrase_form_layout.addWidget(passphrase_instructions)
+        passphrase_form_layout.addWidget(passphrase_label)
+        passphrase_form_layout.addWidget(self.passphrase_field)
+        passphrase_form_layout.addWidget(buttons, alignment=Qt.AlignRight)
+        self.passphrase_error_message.hide()
+
+        layout.addWidget(self.generic_error)
+        layout.addWidget(self.insert_usb_form)
+        layout.addWidget(self.passphrase_form)
+
+        self.generic_error.hide()
+        self.insert_usb_form.hide()
+        self.passphrase_form.hide()
+
+        usb_cancel_button.clicked.connect(self.close)
+        passphrase_cancel_button.clicked.connect(self.close)
+        export_button.clicked.connect(self._export)
+        unlock_disk_button.clicked.connect(self._on_unlock_disk_clicked)
+
+        self._export()
+
+    @pyqtSlot()
+    def _export(self):
+        try:
+            self.controller.run_export_preflight_checks()
+            self._request_passphrase()
+        except ExportError as e:
+            self._update(e.status)
+
+    def _request_to_insert_usb_device(self, encryption_not_supported: bool = False):
+        self.passphrase_form.hide()
+        self.insert_usb_form.show()
+
+        if encryption_not_supported:
+            self.usb_error_message.show()
+        else:
+            self.usb_error_message.hide()
+
+    def _request_passphrase(self, bad_passphrase: bool = False):
+        self.passphrase_form.show()
+        self.insert_usb_form.hide()
+
+        if bad_passphrase:
+            self.passphrase_error_message.show()
+        else:
+            self.passphrase_error_message.hide()
+
+    @pyqtSlot()
+    def _on_unlock_disk_clicked(self):
+        try:
+            passphrase = self.passphrase_field.text()
+            self.controller.export_file_to_usb_drive(self.file_uuid, passphrase)
+            self.close()
+        except ExportError as e:
+            self._update(e.status)
+
+    def _update(self, status):
+        if status == ExportStatus.USB_NOT_CONNECTED.value:
+            self._request_to_insert_usb_device()
+        elif status == ExportStatus.BAD_PASSPHRASE.value:
+            self._request_passphrase(True)
+        elif status == ExportStatus.DISK_ENCRYPTION_NOT_SUPPORTED_ERROR.value:
+            self._request_to_insert_usb_device(True)
+        else:
+            self.error_status_code.setText(_(status))
+            self.generic_error.show()
+            self.passphrase_form.hide()
+            self.insert_usb_form.hide()
 
 
 class ConversationView(QWidget):

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -37,6 +37,7 @@ from securedrop_client.api_jobs.uploads import SendReplyJob, SendReplyJobError, 
     SendReplyJobTimeoutError
 from securedrop_client.api_jobs.updatestar import UpdateStarJob, UpdateStarJobException
 from securedrop_client.crypto import GpgHelper, CryptoError
+from securedrop_client.export import Export
 from securedrop_client.queue import ApiJobQueue
 from securedrop_client.utils import check_dir_permissions
 
@@ -177,6 +178,8 @@ class Controller(QObject):
         self.api_threads = {}  # type: Dict[str, Dict]
 
         self.gpg = GpgHelper(home, self.session_maker, proxy)
+
+        self.export = Export(self.qubes)
 
         self.sync_flag = os.path.join(home, 'sync_flag')
 
@@ -588,6 +591,14 @@ class Controller(QObject):
         else:  # pragma: no cover
             # Non Qubes OS. Just log the event for now.
             logger.info('Opening file "{}".'.format(original_filepath))
+
+    def run_export_preflight_checks(self):
+        self.export.run_preflight_checks()
+
+    def export_file_to_usb_drive(self, file_uuid: str, passphrase: str) -> None:
+        file = self.get_file(file_uuid)
+        filepath = os.path.join(self.data_dir, file.original_filename)
+        self.export.send_file_to_usb_device([filepath], passphrase)
 
     def on_submission_download(
         self,

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -179,7 +179,7 @@ class Controller(QObject):
 
         self.gpg = GpgHelper(home, self.session_maker, proxy)
 
-        self.export = Export(self.qubes)
+        self.export = Export()
 
         self.sync_flag = os.path.join(home, 'sync_flag')
 
@@ -593,12 +593,28 @@ class Controller(QObject):
             logger.info('Opening file "{}".'.format(original_filepath))
 
     def run_export_preflight_checks(self):
+        '''
+        Run preflight checks to make sure the Export VM is configured correctly and
+        '''
+        logger.debug('Running export preflight checks')
+
+        if not self.qubes:
+            return
+
         self.export.run_preflight_checks()
 
     def export_file_to_usb_drive(self, file_uuid: str, passphrase: str) -> None:
         file = self.get_file(file_uuid)
+
+        logger.debug('Exporting {}'.format(file.original_filename))
+
+        if not self.qubes:
+            return
+
         filepath = os.path.join(self.data_dir, file.original_filename)
         self.export.send_file_to_usb_device([filepath], passphrase)
+
+        logger.debug('Export successful')
 
     def on_submission_download(
         self,

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1444,7 +1444,7 @@ def test_FileWidget__on_export_clicked(mocker, session, source):
 
 def test_ExportDialog__export(mocker):
     """
-    Ensure export runs preflight checks and requests password.
+    Ensure happy path runs preflight checks and requests passphrase.
     """
     controller = mocker.MagicMock()
     export_dialog = ExportDialog(controller, 'mock_uuid')
@@ -1456,9 +1456,45 @@ def test_ExportDialog__export(mocker):
     export_dialog._request_passphrase.assert_called_with()
 
 
+def test_ExportDialog__export_request_to_insert_usb_device_on_CALLED_PROCESS_ERROR(mocker):
+    """
+    Ensure request to insert USB device on CALLED_PROCESS_ERROR.
+    """
+    controller = mocker.MagicMock()
+    called_process_error = ExportError(ExportStatus.CALLED_PROCESS_ERROR.value)
+    controller.run_export_preflight_checks = mocker.MagicMock(side_effect=called_process_error)
+    export_dialog = ExportDialog(controller, 'mock_uuid')
+    export_dialog._request_passphrase = mocker.MagicMock()
+    export_dialog._request_to_insert_usb_device = mocker.MagicMock()
+    export_dialog._update = mocker.MagicMock()
+
+    export_dialog._export()
+
+    export_dialog._request_passphrase.assert_not_called()
+    export_dialog._request_to_insert_usb_device.assert_called_once_with()
+    export_dialog._update.assert_not_called()
+
+
+def test_ExportDialog__export_request_to_insert_usb_device_on_USB_NOT_CONNECTED(mocker):
+    """
+    Ensure request to insert USB device on USB_NOT_CONNECTED.
+    """
+    controller = mocker.MagicMock()
+    usb_not_connected_error = ExportError(ExportStatus.USB_NOT_CONNECTED.value)
+    controller.run_export_preflight_checks = mocker.MagicMock(side_effect=usb_not_connected_error)
+    export_dialog = ExportDialog(controller, 'mock_uuid')
+    export_dialog._request_passphrase = mocker.MagicMock()
+    export_dialog._update = mocker.MagicMock()
+
+    export_dialog._export()
+
+    export_dialog._request_passphrase.assert_not_called()
+    export_dialog._update.assert_called_once_with('USB_NOT_CONNECTED')
+
+
 def test_ExportDialog__export_updates_on_ExportError(mocker):
     """
-    Ensure export runs update and does not ask for password when preflight checks error.
+    Ensure update is run for ExportError that is not USB_NOT_CONNECTED or CALLED_PROCESS_ERROR.
     """
     controller = mocker.MagicMock()
     controller.run_export_preflight_checks = mocker.MagicMock(side_effect=ExportError('mock'))
@@ -1469,6 +1505,74 @@ def test_ExportDialog__export_updates_on_ExportError(mocker):
     export_dialog._export()
 
     export_dialog._request_passphrase.assert_not_called()
+    export_dialog._update.assert_called_once_with('mock')
+
+
+def test_ExportDialog__on_retry_export_button_clicked(mocker):
+    """
+    Ensure happy path runs preflight checks and requests passphrase.
+    """
+    controller = mocker.MagicMock()
+    export_dialog = ExportDialog(controller, 'mock_uuid')
+    export_dialog._request_passphrase = mocker.MagicMock()
+
+    export_dialog._on_retry_export_button_clicked()
+
+    controller.run_export_preflight_checks.assert_called_with()
+    export_dialog._request_passphrase.assert_called_with()
+
+
+def test_ExportDialog__on_retry_export_button_clicked_USB_NOT_CONNECTED(mocker):
+    """
+    Ensure request to insert USB device on USB_NOT_CONNECTED.
+    """
+    controller = mocker.MagicMock()
+    usb_not_connected_error = ExportError(ExportStatus.USB_NOT_CONNECTED.value)
+    controller.run_export_preflight_checks = mocker.MagicMock(side_effect=usb_not_connected_error)
+    export_dialog = ExportDialog(controller, 'mock_uuid')
+    export_dialog._request_passphrase = mocker.MagicMock()
+    export_dialog._update = mocker.MagicMock()
+
+    export_dialog._on_retry_export_button_clicked()
+
+    export_dialog._request_passphrase.assert_not_called()
+    export_dialog._update.assert_called_once_with('USB_NOT_CONNECTED')
+
+
+def test_ExportDialog__on_retry_export_button_clicked_CALLED_PROCESS_ERROR(mocker):
+    """
+    Ensure update is run on CALLED_PROCESS_ERROR.
+    """
+    controller = mocker.MagicMock()
+    called_process_error = ExportError(ExportStatus.CALLED_PROCESS_ERROR.value)
+    controller.run_export_preflight_checks = mocker.MagicMock(side_effect=called_process_error)
+    export_dialog = ExportDialog(controller, 'mock_uuid')
+    export_dialog._request_passphrase = mocker.MagicMock()
+    export_dialog._request_to_insert_usb_device = mocker.MagicMock()
+    export_dialog._update = mocker.MagicMock()
+
+    export_dialog._on_retry_export_button_clicked()
+
+    export_dialog._request_passphrase.assert_not_called()
+    export_dialog._request_to_insert_usb_device.assert_not_called()
+    export_dialog._update.assert_called_once_with('CALLED_PROCESS_ERROR')
+
+
+def test_ExportDialog__on_retry_export_button_clicked_updates_on_ExportError(mocker):
+    """
+    Ensure update is run for ExportError that is not USB_NOT_CONNECTED.
+    """
+    controller = mocker.MagicMock()
+    controller.run_export_preflight_checks = mocker.MagicMock(side_effect=ExportError('mock'))
+    export_dialog = ExportDialog(controller, 'mock_uuid')
+    export_dialog._request_passphrase = mocker.MagicMock()
+    export_dialog._request_to_insert_usb_device = mocker.MagicMock()
+    export_dialog._update = mocker.MagicMock()
+
+    export_dialog._on_retry_export_button_clicked()
+
+    export_dialog._request_passphrase.assert_not_called()
+    export_dialog._request_to_insert_usb_device.assert_not_called()
     export_dialog._update.assert_called_once_with('mock')
 
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1442,7 +1442,7 @@ def test_FileWidget__on_export_clicked(mocker, session, source):
     _request_pass.assert_called_once_with()
 
 
-def test_ExportDialog__export(mocker):
+def test_ExportDialog_export(mocker):
     """
     Ensure happy path runs preflight checks and requests passphrase.
     """
@@ -1450,13 +1450,13 @@ def test_ExportDialog__export(mocker):
     export_dialog = ExportDialog(controller, 'mock_uuid')
     export_dialog._request_passphrase = mocker.MagicMock()
 
-    export_dialog._export()
+    export_dialog.export()
 
     controller.run_export_preflight_checks.assert_called_with()
     export_dialog._request_passphrase.assert_called_with()
 
 
-def test_ExportDialog__export_request_to_insert_usb_device_on_CALLED_PROCESS_ERROR(mocker):
+def test_ExportDialog_export_request_to_insert_usb_device_on_CALLED_PROCESS_ERROR(mocker):
     """
     Ensure request to insert USB device on CALLED_PROCESS_ERROR.
     """
@@ -1468,14 +1468,14 @@ def test_ExportDialog__export_request_to_insert_usb_device_on_CALLED_PROCESS_ERR
     export_dialog._request_to_insert_usb_device = mocker.MagicMock()
     export_dialog._update = mocker.MagicMock()
 
-    export_dialog._export()
+    export_dialog.export()
 
     export_dialog._request_passphrase.assert_not_called()
     export_dialog._request_to_insert_usb_device.assert_called_once_with()
     export_dialog._update.assert_not_called()
 
 
-def test_ExportDialog__export_request_to_insert_usb_device_on_USB_NOT_CONNECTED(mocker):
+def test_ExportDialog_export_request_to_insert_usb_device_on_USB_NOT_CONNECTED(mocker):
     """
     Ensure request to insert USB device on USB_NOT_CONNECTED.
     """
@@ -1486,13 +1486,13 @@ def test_ExportDialog__export_request_to_insert_usb_device_on_USB_NOT_CONNECTED(
     export_dialog._request_passphrase = mocker.MagicMock()
     export_dialog._update = mocker.MagicMock()
 
-    export_dialog._export()
+    export_dialog.export()
 
     export_dialog._request_passphrase.assert_not_called()
     export_dialog._update.assert_called_once_with('USB_NOT_CONNECTED')
 
 
-def test_ExportDialog__export_updates_on_ExportError(mocker):
+def test_ExportDialog_export_updates_on_ExportError(mocker):
     """
     Ensure update is run for ExportError that is not USB_NOT_CONNECTED or CALLED_PROCESS_ERROR.
     """
@@ -1502,7 +1502,7 @@ def test_ExportDialog__export_updates_on_ExportError(mocker):
     export_dialog._request_passphrase = mocker.MagicMock()
     export_dialog._update = mocker.MagicMock()
 
-    export_dialog._export()
+    export_dialog.export()
 
     export_dialog._request_passphrase.assert_not_called()
     export_dialog._update.assert_called_once_with('mock')
@@ -1670,6 +1670,23 @@ def test_ExportDialog__update_after_DISK_ENCRYPTION_NOT_SUPPORTED_ERROR(mocker):
     export_dialog._request_to_insert_usb_device = mocker.MagicMock()
     export_dialog._update(ExportStatus.DISK_ENCRYPTION_NOT_SUPPORTED_ERROR.value)
     export_dialog._request_to_insert_usb_device.assert_called_once_with(True)
+
+
+def test_ExportDialog__update_after_CALLED_PROCESS_ERROR_ERROR(mocker):
+    """
+    Ensure CALLED_PROCESS_ERROR shows generic 'contant admin' error with correct
+    error status code.
+    """
+    export_dialog = ExportDialog(mocker.MagicMock(), 'mock_uuid')
+    export_dialog._request_to_insert_usb_device = mocker.MagicMock()
+    export_dialog._request_passphrase = mocker.MagicMock()
+
+    export_dialog._update(ExportStatus.CALLED_PROCESS_ERROR.value)
+
+    assert not export_dialog.generic_error.isHidden()
+    assert export_dialog.error_status_code.text() == 'CALLED_PROCESS_ERROR'
+    export_dialog._request_to_insert_usb_device.assert_not_called()
+    export_dialog._request_passphrase.assert_not_called()
 
 
 def test_ConversationView_init(mocker, homedir):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -14,24 +14,12 @@ def test_send_file_to_usb_device(mocker):
     mock_temp_dir = mocker.MagicMock()
     mock_temp_dir.__enter__ = mocker.MagicMock(return_value='mock_temp_dir')
     mocker.patch('securedrop_client.export.TemporaryDirectory', return_value=mock_temp_dir)
-    export = Export(is_qubes=True)
+    export = Export()
     _run_disk_export = mocker.patch.object(export, '_run_disk_export')
 
     export.send_file_to_usb_device(['mock_filepath'], 'mock passphrase')
 
     _run_disk_export.assert_called_once_with('mock_temp_dir', ['mock_filepath'], 'mock passphrase')
-
-
-def test_send_file_to_usb_device_not_qubes(mocker):
-    '''
-    Ensure method returns without error and does not call qubes-only methods.
-    '''
-    export = Export(is_qubes=False)
-    _run_disk_export = mocker.patch.object(export, '_run_disk_export')
-
-    export.send_file_to_usb_device(['mock_filepath'], 'mock passphrase')
-
-    _run_disk_export.assert_not_called()
 
 
 def test_run_preflight_checks(mocker):
@@ -42,7 +30,7 @@ def test_run_preflight_checks(mocker):
     mock_temp_dir = mocker.MagicMock()
     mock_temp_dir.__enter__ = mocker.MagicMock(return_value='mock_temp_dir')
     mocker.patch('securedrop_client.export.TemporaryDirectory', return_value=mock_temp_dir)
-    export = Export(is_qubes=True)
+    export = Export()
     _run_usb_export = mocker.patch.object(export, '_run_usb_test')
     _run_disk_export = mocker.patch.object(export, '_run_disk_test')
 
@@ -52,27 +40,13 @@ def test_run_preflight_checks(mocker):
     _run_disk_export.assert_called_once_with('mock_temp_dir')
 
 
-def test_run_preflight_checks_not_qubes(mocker):
-    '''
-    Ensure method returns without error and does not call qubes-only methods.
-    '''
-    export = Export(is_qubes=False)
-    _run_usb_test = mocker.patch.object(export, '_run_usb_test')
-    _run_disk_test = mocker.patch.object(export, '_run_disk_test')
-
-    export.run_preflight_checks()
-
-    _run_usb_test.assert_not_called()
-    _run_disk_test.assert_not_called()
-
-
 def test__run_disk_export(mocker):
     '''
     Ensure _export_archive and _create_archive are called with the expected parameters,
     _export_archive is called with the return value of _create_archive, and
     _run_disk_test returns without error if '' is the ouput status of _export_archive.
     '''
-    export = Export(is_qubes=False)
+    export = Export()
     export._create_archive = mocker.MagicMock(return_value='mock_archive_path')
     export._export_archive = mocker.MagicMock(return_value='')
 
@@ -94,7 +68,7 @@ def test__run_disk_export_raises_ExportError_if_not_empty_string(mocker):
     '''
     Ensure ExportError is raised if _run_disk_test returns anything other than ''.
     '''
-    export = Export(is_qubes=True)
+    export = Export()
     export._create_archive = mocker.MagicMock(return_value='mock_archive_path')
     export._export_archive = mocker.MagicMock(return_value='SOMETHING_OTHER_THAN_EMPTY_STRING')
 
@@ -108,7 +82,7 @@ def test__run_disk_test(mocker):
     _export_archive is called with the return value of _create_archive, and
     _run_disk_test returns without error if 'USB_ENCRYPTED' is the ouput status of _export_archive.
     '''
-    export = Export(is_qubes=False)
+    export = Export()
     export._create_archive = mocker.MagicMock(return_value='mock_archive_path')
     export._export_archive = mocker.MagicMock(return_value='USB_ENCRYPTED')
 
@@ -123,7 +97,7 @@ def test__run_disk_test_raises_ExportError_if_not_USB_ENCRYPTED(mocker):
     '''
     Ensure ExportError is raised if _run_disk_test returns anything other than 'USB_ENCRYPTED'.
     '''
-    export = Export(is_qubes=True)
+    export = Export()
     export._create_archive = mocker.MagicMock(return_value='mock_archive_path')
     export._export_archive = mocker.MagicMock(return_value='SOMETHING_OTHER_THAN_USB_ENCRYPTED')
 
@@ -137,7 +111,7 @@ def test__run_usb_test(mocker):
     _export_archive is called with the return value of _create_archive, and
     _run_disk_test returns without error if 'USB_CONNECTED' is the return value of _export_archive.
     '''
-    export = Export(is_qubes=False)
+    export = Export()
     export._create_archive = mocker.MagicMock(return_value='mock_archive_path')
     export._export_archive = mocker.MagicMock(return_value='USB_CONNECTED')
 
@@ -152,7 +126,7 @@ def test__run_usb_test_raises_ExportError_if_not_USB_CONNECTED(mocker):
     '''
     Ensure ExportError is raised if _run_disk_test returns anything other than 'USB_CONNECTED'.
     '''
-    export = Export(is_qubes=True)
+    export = Export()
     export._create_archive = mocker.MagicMock(return_value='mock_archive_path')
     export._export_archive = mocker.MagicMock(return_value='SOMETHING_OTHER_THAN_USB_CONNECTED')
 
@@ -164,7 +138,7 @@ def test__create_archive(mocker):
     '''
     Ensure _create_archive creates an archive in the supplied directory.
     '''
-    export = Export(is_qubes=True)
+    export = Export()
     archive_path = None
     with TemporaryDirectory() as temp_dir:
         archive_path = export._create_archive(temp_dir, 'mock.sd-export', {})
@@ -175,7 +149,7 @@ def test__create_archive(mocker):
 
 
 def test__create_archive_with_an_export_file(mocker):
-    export = Export(is_qubes=True)
+    export = Export()
     archive_path = None
     with TemporaryDirectory() as temp_dir, NamedTemporaryFile() as export_file:
         archive_path = export._create_archive(temp_dir, 'mock.sd-export', {}, [export_file.name])
@@ -189,7 +163,7 @@ def test__create_archive_with_multiple_export_files(mocker):
     '''
     Ensure an archive
     '''
-    export = Export(is_qubes=True)
+    export = Export()
     archive_path = None
     with TemporaryDirectory() as temp_dir, \
         NamedTemporaryFile() as export_file_one, \
@@ -207,7 +181,7 @@ def test__export_archive(mocker):
     Ensure the subprocess call returns the expected output.
     '''
     mocker.patch('subprocess.check_output', return_value=b'mock')
-    export = Export(is_qubes=True)
+    export = Export()
     status = export._export_archive('mock.sd-export')
 
     assert status == 'mock'
@@ -220,7 +194,7 @@ def test__export_archive_does_not_raise_ExportError_when_CalledProcessError(mock
     mock_error = subprocess.CalledProcessError('mock_cmd', 123)
     mocker.patch('subprocess.check_output', side_effect=mock_error)
 
-    export = Export(is_qubes=True)
+    export = Export()
 
     with pytest.raises(ExportError, match='CALLED_PROCESS_ERROR'):
         export._export_archive('mock.sd-export')
@@ -230,10 +204,10 @@ def test__export_archive_with_evil_command(mocker):
     '''
     Ensure shell command is shell-escaped.
     '''
-    export = Export(is_qubes=False)
+    export = Export()
     check_output = mocker.patch('subprocess.check_output', return_value=b'')
 
     export._export_archive('somefile; rm -rf ~')
 
     check_output.assert_called_once_with(
-        ['qvm-open-in-vm', 'sd-export-usb', "'somefile; rm -rf ~'"], stderr=-2)
+        ['qvm-open-in-vm', 'sd-export-usb', "'somefile; rm -rf ~'", '--view-only'], stderr=-2)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,248 @@
+import os
+import pytest
+import subprocess
+from tempfile import TemporaryDirectory, NamedTemporaryFile
+
+from securedrop_client.export import Export, ExportError
+
+
+def test_send_file_to_usb_device(mocker):
+    '''
+    Ensure TemporaryDirectory is used when creating and sending the archive containing the export
+    file.
+    '''
+    mock_temp_dir = mocker.MagicMock()
+    mock_temp_dir.__enter__ = mocker.MagicMock(return_value='mock_temp_dir')
+    mocker.patch('securedrop_client.export.TemporaryDirectory', return_value=mock_temp_dir)
+    export = Export(is_qubes=True)
+    _run_disk_export = mocker.patch.object(export, '_run_disk_export')
+
+    export.send_file_to_usb_device(['mock_filepath'], 'mock passphrase')
+
+    _run_disk_export.assert_called_once_with('mock_temp_dir', ['mock_filepath'], 'mock passphrase')
+
+
+def test_send_file_to_usb_device_not_qubes(mocker):
+    '''
+    Ensure method returns without error and does not call qubes-only methods.
+    '''
+    export = Export(is_qubes=False)
+    _run_disk_export = mocker.patch.object(export, '_run_disk_export')
+
+    export.send_file_to_usb_device(['mock_filepath'], 'mock passphrase')
+
+    _run_disk_export.assert_not_called()
+
+
+def test_run_preflight_checks(mocker):
+    '''
+    Ensure TemporaryDirectory is used when creating and sending the archives during the preflight
+    checks.
+    '''
+    mock_temp_dir = mocker.MagicMock()
+    mock_temp_dir.__enter__ = mocker.MagicMock(return_value='mock_temp_dir')
+    mocker.patch('securedrop_client.export.TemporaryDirectory', return_value=mock_temp_dir)
+    export = Export(is_qubes=True)
+    _run_usb_export = mocker.patch.object(export, '_run_usb_test')
+    _run_disk_export = mocker.patch.object(export, '_run_disk_test')
+
+    export.run_preflight_checks()
+
+    _run_usb_export.assert_called_once_with('mock_temp_dir')
+    _run_disk_export.assert_called_once_with('mock_temp_dir')
+
+
+def test_run_preflight_checks_not_qubes(mocker):
+    '''
+    Ensure method returns without error and does not call qubes-only methods.
+    '''
+    export = Export(is_qubes=False)
+    _run_usb_test = mocker.patch.object(export, '_run_usb_test')
+    _run_disk_test = mocker.patch.object(export, '_run_disk_test')
+
+    export.run_preflight_checks()
+
+    _run_usb_test.assert_not_called()
+    _run_disk_test.assert_not_called()
+
+
+def test__run_disk_export(mocker):
+    '''
+    Ensure _export_archive and _create_archive are called with the expected parameters,
+    _export_archive is called with the return value of _create_archive, and
+    _run_disk_test returns without error if '' is the ouput status of _export_archive.
+    '''
+    export = Export(is_qubes=False)
+    export._create_archive = mocker.MagicMock(return_value='mock_archive_path')
+    export._export_archive = mocker.MagicMock(return_value='')
+
+    export._run_disk_export('mock_archive_dir', ['mock_filepath'], 'mock_passphrase')
+
+    export._export_archive.assert_called_once_with('mock_archive_path')
+    export._create_archive.assert_called_once_with(
+        'mock_archive_dir',
+        'archive.sd-export',
+        {
+            'encryption_key': 'mock_passphrase',
+            'device': 'disk',
+            'encryption_method': 'luks'
+        },
+        ['mock_filepath'])
+
+
+def test__run_disk_export_raises_ExportError_if_not_empty_string(mocker):
+    '''
+    Ensure ExportError is raised if _run_disk_test returns anything other than ''.
+    '''
+    export = Export(is_qubes=True)
+    export._create_archive = mocker.MagicMock(return_value='mock_archive_path')
+    export._export_archive = mocker.MagicMock(return_value='SOMETHING_OTHER_THAN_EMPTY_STRING')
+
+    with pytest.raises(ExportError):
+        export._run_disk_export('mock_archive_dir', ['mock_filepath'], 'mock_passphrase')
+
+
+def test__run_disk_export_with_evil_passphrase(mocker):
+    '''
+    Ensure passphrase is shell-escaped.
+    '''
+    export = Export(is_qubes=False)
+    export._create_archive = mocker.MagicMock(return_value='mock_archive_path')
+    export._export_archive = mocker.MagicMock(return_value='')
+
+    evil_passphrase = 'somefile; rm -rf ~'
+    export._run_disk_export('mock_archive_dir', ['mock_filepath'], evil_passphrase)
+
+    export._create_archive.assert_called_once_with(
+        'mock_archive_dir',
+        'archive.sd-export',
+        {
+            'encryption_key': "'somefile; rm -rf ~'",
+            'device': 'disk',
+            'encryption_method': 'luks'
+        },
+        ['mock_filepath'])
+
+
+def test__run_disk_test(mocker):
+    '''
+    Ensure _export_archive and _create_archive are called with the expected parameters,
+    _export_archive is called with the return value of _create_archive, and
+    _run_disk_test returns without error if 'USB_ENCRYPTED' is the ouput status of _export_archive.
+    '''
+    export = Export(is_qubes=False)
+    export._create_archive = mocker.MagicMock(return_value='mock_archive_path')
+    export._export_archive = mocker.MagicMock(return_value='USB_ENCRYPTED')
+
+    export._run_disk_test('mock_archive_dir')
+
+    export._export_archive.assert_called_once_with('mock_archive_path')
+    export._create_archive.assert_called_once_with(
+        'mock_archive_dir', 'disk-test.sd-export', {'device': 'disk-test'})
+
+
+def test__run_disk_test_raises_ExportError_if_not_USB_ENCRYPTED(mocker):
+    '''
+    Ensure ExportError is raised if _run_disk_test returns anything other than 'USB_ENCRYPTED'.
+    '''
+    export = Export(is_qubes=True)
+    export._create_archive = mocker.MagicMock(return_value='mock_archive_path')
+    export._export_archive = mocker.MagicMock(return_value='SOMETHING_OTHER_THAN_USB_ENCRYPTED')
+
+    with pytest.raises(ExportError):
+        export._run_disk_test('mock_archive_dir')
+
+
+def test__run_usb_test(mocker):
+    '''
+    Ensure _export_archive and _create_archive are called with the expected parameters,
+    _export_archive is called with the return value of _create_archive, and
+    _run_disk_test returns without error if 'USB_CONNECTED' is the return value of _export_archive.
+    '''
+    export = Export(is_qubes=False)
+    export._create_archive = mocker.MagicMock(return_value='mock_archive_path')
+    export._export_archive = mocker.MagicMock(return_value='USB_CONNECTED')
+
+    export._run_usb_test('mock_archive_dir')
+
+    export._export_archive.assert_called_once_with('mock_archive_path')
+    export._create_archive.assert_called_once_with(
+        'mock_archive_dir', 'usb-test.sd-export', {'device': 'usb-test'})
+
+
+def test__run_usb_test_raises_ExportError_if_not_USB_CONNECTED(mocker):
+    '''
+    Ensure ExportError is raised if _run_disk_test returns anything other than 'USB_CONNECTED'.
+    '''
+    export = Export(is_qubes=True)
+    export._create_archive = mocker.MagicMock(return_value='mock_archive_path')
+    export._export_archive = mocker.MagicMock(return_value='SOMETHING_OTHER_THAN_USB_CONNECTED')
+
+    with pytest.raises(ExportError):
+        export._run_usb_test('mock_archive_dir')
+
+
+def test__create_archive(mocker):
+    '''
+    Ensure _create_archive creates an archive in the supplied directory.
+    '''
+    export = Export(is_qubes=True)
+    archive_path = None
+    with TemporaryDirectory() as temp_dir:
+        archive_path = export._create_archive(temp_dir, 'mock.sd-export', {})
+        assert archive_path == os.path.join(temp_dir, 'mock.sd-export')
+        assert os.path.exists(archive_path)  # sanity check
+
+    assert not os.path.exists(archive_path)
+
+
+def test__create_archive_with_an_export_file(mocker):
+    export = Export(is_qubes=True)
+    archive_path = None
+    with TemporaryDirectory() as temp_dir, NamedTemporaryFile() as export_file:
+        archive_path = export._create_archive(temp_dir, 'mock.sd-export', {}, [export_file.name])
+        assert archive_path == os.path.join(temp_dir, 'mock.sd-export')
+        assert os.path.exists(archive_path)  # sanity check
+
+    assert not os.path.exists(archive_path)
+
+
+def test__create_archive_with_multiple_export_files(mocker):
+    '''
+    Ensure an archive
+    '''
+    export = Export(is_qubes=True)
+    archive_path = None
+    with TemporaryDirectory() as temp_dir, \
+        NamedTemporaryFile() as export_file_one, \
+        NamedTemporaryFile() as export_file_two:  # noqa
+        archive_path = export._create_archive(
+            temp_dir, 'mock.sd-export', {}, [export_file_one.name, export_file_two.name])
+        assert archive_path == os.path.join(temp_dir, 'mock.sd-export')
+        assert os.path.exists(archive_path)  # sanity check
+
+    assert not os.path.exists(archive_path)
+
+
+def test__export_archive(mocker):
+    '''
+    Ensure the subprocess call returns the expected output.
+    '''
+    mocker.patch('subprocess.check_output', return_value=b'mock')
+    export = Export(is_qubes=True)
+    status = export._export_archive('mock.sd-export')
+
+    assert status == 'mock'
+
+
+def test__export_archive_does_not_raise_ExportError_when_CalledProcessError(mocker):
+    '''
+    Ensure ExportError is raised if a CalledProcessError is encountered.
+    '''
+    mock_error = subprocess.CalledProcessError('mock_cmd', 123)
+    mocker.patch('subprocess.check_output', side_effect=mock_error)
+
+    export = Export(is_qubes=True)
+
+    with pytest.raises(ExportError, match='CALLED_PROCESS_ERROR'):
+        export._export_archive('mock.sd-export')

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1414,3 +1414,27 @@ def test_Controller_call_update_star_success(homedir, config, mocker, session_ma
         co.on_update_star_success, type=Qt.QueuedConnection)
     mock_failure_signal.connect.assert_called_once_with(
         co.on_update_star_failure, type=Qt.QueuedConnection)
+
+
+def test_Controller_run_export_preflight_checks(homedir, mocker):
+    co = Controller('http://localhost', mocker.MagicMock(), mocker.MagicMock(), homedir)
+    co.export = mocker.MagicMock()
+
+    co.run_export_preflight_checks()
+
+    co.export.run_preflight_checks.assert_called_once_with()
+
+
+def test_Controller_export_file_to_usb_drive(homedir, mocker, session):
+
+    co = Controller('http://localhost', mocker.MagicMock(), mocker.MagicMock(), homedir)
+    co.export = mocker.MagicMock()
+    file = factory.File(source=factory.Source(), original_filename='mock_filename')
+    session.add(file)
+    session.commit()
+    mocker.patch('securedrop_client.logic.Controller.get_file', return_value=file)
+
+    co.export_file_to_usb_drive(file.uuid, 'mock passphrase')
+
+    co.export.send_file_to_usb_device.assert_called_once_with(
+        [os.path.join(co.data_dir, 'mock_filename')], 'mock passphrase')

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1417,16 +1417,30 @@ def test_Controller_call_update_star_success(homedir, config, mocker, session_ma
 
 
 def test_Controller_run_export_preflight_checks(homedir, mocker):
+    debug_logger = mocker.patch('securedrop_client.logic.logger.debug')
     co = Controller('http://localhost', mocker.MagicMock(), mocker.MagicMock(), homedir)
     co.export = mocker.MagicMock()
 
     co.run_export_preflight_checks()
 
     co.export.run_preflight_checks.assert_called_once_with()
+    debug_logger.assert_called_once_with('Running export preflight checks')
+
+
+def test_Controller_run_export_preflight_checks_not_qubes(homedir, mocker):
+    debug_logger = mocker.patch('securedrop_client.logic.logger.debug')
+    co = Controller('http://localhost', mocker.MagicMock(), mocker.MagicMock(), homedir)
+    co.qubes = False
+    co.export = mocker.MagicMock()
+
+    co.run_export_preflight_checks()
+
+    co.export.run_preflight_checks.assert_not_called()
+    debug_logger.assert_called_once_with('Running export preflight checks')
 
 
 def test_Controller_export_file_to_usb_drive(homedir, mocker, session):
-
+    debug_logger = mocker.patch('securedrop_client.logic.logger.debug')
     co = Controller('http://localhost', mocker.MagicMock(), mocker.MagicMock(), homedir)
     co.export = mocker.MagicMock()
     file = factory.File(source=factory.Source(), original_filename='mock_filename')
@@ -1438,3 +1452,21 @@ def test_Controller_export_file_to_usb_drive(homedir, mocker, session):
 
     co.export.send_file_to_usb_device.assert_called_once_with(
         [os.path.join(co.data_dir, 'mock_filename')], 'mock passphrase')
+    debug_logger.call_args_list[0][0][0] == 'Exporting {}'.format(file.original_filename)
+    debug_logger.call_args_list[1][0][0] == 'Export successful'
+
+
+def test_Controller_export_file_to_usb_drive_not_qubes(homedir, mocker, session):
+    debug_logger = mocker.patch('securedrop_client.logic.logger.debug')
+    co = Controller('http://localhost', mocker.MagicMock(), mocker.MagicMock(), homedir)
+    co.qubes = False
+    co.export = mocker.MagicMock()
+    file = factory.File(source=factory.Source(), original_filename='mock_filename')
+    session.add(file)
+    session.commit()
+    mocker.patch('securedrop_client.logic.Controller.get_file', return_value=file)
+
+    co.export_file_to_usb_drive(file.uuid, 'mock passphrase')
+
+    co.export.send_file_to_usb_device.assert_not_called()
+    debug_logger.call_args_list[0][0][0] == 'Exporting {}'.format(file.original_filename)


### PR DESCRIPTION
# Description

Adds export functionality to the client.

# Test Plan

From Qubes:

1. Start the client and make sure the Export VM is running and configured correctly
2. Plug in your luks-encrypted transfer device and click Export next to the file you want to export
3. Type in your passphrase and click Submit
4. Once the transfer is successful, you will see a SecureDrop Qubes notification saying so
5. Check you transfer device for the file

Test this with the wrong password and without a transfer device plugged in. If you see any strange behavior, first check the known issues in the securedrop-export repo to see if it's already documented.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes