### PR TITLE
app: move export calls to separate thread

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1858,6 +1858,7 @@ class ExportDialog(QDialog):
         self.setObjectName('export_dialog')
         self.setStyleSheet(self.CSS)
         self.setWindowFlags(Qt.Popup)
+        self.setWindowModality(Qt.WindowModal)
 
         layout = QVBoxLayout(self)
         self.setLayout(layout)


### PR DESCRIPTION
# Description

Fixes #561

# Test Plan

Also for testing I've added some debug lines (which are worth leaving in) to demonstrate these export actions are running in the right thread (`export_thread`), logs from a test run just now: 

```
2019-10-10 11:14:24,538 - securedrop_client.api_jobs.downloads:130(_download) INFO: File downloaded: 2-somber_junction-doc.gz.gpg
2019-10-10 11:14:24,588 - securedrop_client.api_jobs.downloads:147(_decrypt) INFO: File decrypted: 2-somber_junction-doc.gz.gpg
2019-10-10 11:14:24,980 - securedrop_client.logic:617(run_export_preflight_checks) DEBUG: Calling export preflight checks from thread 140735889998720
2019-10-10 11:14:24,981 - securedrop_client.export:237(run_preflight_checks) DEBUG: beginning preflight checks in thread 123145349275648
2019-10-10 11:14:29,982 - securedrop_client.export:239(run_preflight_checks) DEBUG: completed preflight checks: success
2019-10-10 11:14:29,983 - securedrop_client.gui.widgets:2000(_request_passphrase) DEBUG: requesting passphrase...
2019-10-10 11:14:31,129 - securedrop_client.logic:636(export_file_to_usb_drive) DEBUG: Exporting 3-banned_sinker-msg from thread 140735889998720
2019-10-10 11:14:31,130 - securedrop_client.export:258(send_file_to_usb_device) DEBUG: beginning export from thread 123145349275648
2019-10-10 11:14:36,134 - securedrop_client.export:262(send_file_to_usb_device) DEBUG: Export successful
```

(GUI thread is 140735889998720, export thread is 123145349275648)

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment - what I've tested here is the USB_NO_SUPPORTED_ENCRYPTION case
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes