### PR TITLE
Handle missing files during an export and open

### DIFF
--- a/securedrop_client/export.py
+++ b/securedrop_client/export.py
@@ -256,4 +256,5 @@ class Export(QObject):
                 logger.debug('Export successful')
                 self.export_usb_call_success.emit(filepaths)
             except ExportError as e:
-                self.export_usb_call_failure.emit(e.status)
+                logger.error(e)
+                self.export_usb_call_failure.emit(filepaths)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1975,12 +1975,12 @@ class ExportDialog(QDialog):
             self._on_export_success, type=Qt.QueuedConnection)
 
     def export(self):
-        self.controller.run_export_preflight_checks()
+        self.controller.run_export_preflight_checks(self.file_uuid)
 
     @pyqtSlot()
     def _on_retry_export_button_clicked(self):
         self.starting_export_message.hide()
-        self.controller.run_export_preflight_checks()
+        self.controller.run_export_preflight_checks(self.file_uuid)
 
     @pyqtSlot()
     def _on_unlock_disk_clicked(self):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1799,6 +1799,10 @@ class FileWidget(QWidget):
         """
         Called when the export button is clicked.
         """
+        if not self.controller.downloaded_file_exists(self.file.uuid):
+            self.controller.sync_api()
+            return
+
         dialog = ExportDialog(self.controller, self.file.uuid)
         # The underlying function of the `export` method makes a blocking call that can potentially
         # take a long time to run (if the Export VM is not already running and needs to start, this
@@ -1975,12 +1979,12 @@ class ExportDialog(QDialog):
             self._on_export_success, type=Qt.QueuedConnection)
 
     def export(self):
-        self.controller.run_export_preflight_checks(self.file_uuid)
+        self.controller.run_export_preflight_checks()
 
     @pyqtSlot()
     def _on_retry_export_button_clicked(self):
         self.starting_export_message.hide()
-        self.controller.run_export_preflight_checks(self.file_uuid)
+        self.controller.run_export_preflight_checks()
 
     @pyqtSlot()
     def _on_unlock_disk_clicked(self):

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -181,6 +181,7 @@ class Controller(QObject):
 
         self.export = Export()
         self.export.export_usb_call_success.connect(self.on_export_usb_call_success)
+        self.export.export_usb_call_failure.connect(self.on_export_usb_call_failure)
 
         self.sync_flag = os.path.join(home, 'sync_flag')
 
@@ -668,6 +669,14 @@ class Controller(QObject):
         self.export.begin_usb_export.emit([path_to_file_with_original_name], passphrase)
 
     def on_export_usb_call_success(self, filepaths: List[str]):
+        '''
+        Clean export files that are hard links to the file on disk.
+        '''
+        for filepath in filepaths:
+            if os.path.exists(filepath):
+                os.remove(filepath)
+
+    def on_export_usb_call_failure(self, filepaths: List[str]):
         '''
         Clean export files that are hard links to the file on disk.
         '''

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -592,7 +592,7 @@ class Controller(QObject):
         filepath = os.path.join(self.data_dir, fn_no_ext)
         if not os.path.exists(filepath):
             msg = _('Could not export {}. File does not exist.'.format(file.original_filename))
-            storage.mark_as_not_downloaded(file_uuid)
+            storage.mark_as_not_downloaded(file_uuid, self.session)
             self.sync_api()
             logger.debug(msg)
             self.gui.update_error_status(msg)
@@ -641,7 +641,7 @@ class Controller(QObject):
         filepath = os.path.join(self.data_dir, fn_no_ext)
         if not os.path.exists(filepath):
             msg = _('Could not export {}. File does not exist.'.format(file.original_filename))
-            storage.mark_as_not_downloaded(file_uuid)
+            storage.mark_as_not_downloaded(file_uuid, self.session)
             self.sync_api()
             logger.debug(msg)
             self.gui.update_error_status(msg)

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -21,7 +21,6 @@ import inspect
 import logging
 import os
 import sdclientapi
-import threading
 import uuid
 from typing import Dict, Tuple, Union, Any, List, Type  # noqa: F401
 
@@ -591,7 +590,7 @@ class Controller(QObject):
         fn_no_ext, dummy = os.path.splitext(os.path.splitext(file.filename)[0])
         filepath = os.path.join(self.data_dir, fn_no_ext)
         if not os.path.exists(filepath):
-            msg = _('Could not export {}. File does not exist.'.format(file.original_filename))
+            msg = _('Could not open {}. File does not exist.'.format(file.original_filename))
             storage.mark_as_not_downloaded(file_uuid, self.session)
             self.sync_api()
             logger.debug(msg)

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -637,7 +637,7 @@ class Controller(QObject):
         file = self.get_file(file_uuid)
         logger.info('Exporting file {}'.format(file.original_filename))
 
-        fn_no_ext, _ = os.path.splitext(os.path.splitext(file.filename)[0])
+        fn_no_ext, dummy = os.path.splitext(os.path.splitext(file.filename)[0])
         filepath = os.path.join(self.data_dir, fn_no_ext)
         if not os.path.exists(filepath):
             msg = _('Could not export {}. File does not exist.'.format(file.original_filename))

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -366,6 +366,17 @@ def find_new_replies(session: Session) -> List[Reply]:
             Reply.is_decrypted == None)).all()  # noqa: E711
 
 
+def mark_as_not_downloaded(uuid: str, session: Session) -> None:
+    """
+    Mark File as not downloaded in the database.
+    """
+    db_obj = session.query(File).filter_by(uuid=uuid).one()
+    db_obj.is_downloaded = False
+    db_obj.is_decrypted = None
+    session.add(db_obj)
+    session.commit()
+
+
 def mark_as_downloaded(
     model_type: Union[Type[File], Type[Message], Type[Reply]],
     uuid: str,

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1437,7 +1437,7 @@ def test_FileWidget__on_export_clicked(mocker, session, source):
 
     fw._on_export_clicked()
 
-    controller.run_export_preflight_checks.assert_called_once_with()
+    controller.run_export_preflight_checks.assert_called_once_with(file.uuid)
 
 
 def test_ExportDialog_export(mocker):
@@ -1450,7 +1450,7 @@ def test_ExportDialog_export(mocker):
 
     export_dialog.export()
 
-    controller.run_export_preflight_checks.assert_called_with()
+    controller.run_export_preflight_checks.assert_called_with('mock_uuid')
 
 
 def test_ExportDialog_pre_flight_request_to_insert_usb_device_on_CALLED_PROCESS_ERROR(mocker):
@@ -1500,7 +1500,7 @@ def test_ExportDialog__on_retry_export_button_clicked(mocker):
 
     export_dialog._on_retry_export_button_clicked()
 
-    controller.run_export_preflight_checks.assert_called_with()
+    controller.run_export_preflight_checks.assert_called_with('mock_uuid')
 
 
 def test_ExportDialog__update_export_button_clicked_USB_NOT_CONNECTED(mocker):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1434,10 +1434,40 @@ def test_FileWidget__on_export_clicked(mocker, session, source):
     fw.update = mocker.MagicMock()
     mocker.patch('securedrop_client.gui.widgets.QDialog.exec')
     controller.run_export_preflight_checks = mocker.MagicMock()
+    controller.downloaded_file_exists = mocker.MagicMock(return_value=True)
 
     fw._on_export_clicked()
 
-    controller.run_export_preflight_checks.assert_called_once_with(file.uuid)
+    controller.run_export_preflight_checks.assert_called_once_with()
+
+    # Also assert that the dialog is initialized
+    dialog = mocker.patch('securedrop_client.gui.widgets.ExportDialog')
+    fw._on_export_clicked()
+    dialog.assert_called_once_with(controller, file.uuid)
+
+
+def test_FileWidget__on_export_clicked_missing_file(mocker, session, source):
+    """
+    Ensure dialog does not open when the EXPORT button is clicked yet the file to export is missing
+    """
+    file = factory.File(source=source['source'], is_downloaded=True)
+    session.add(file)
+    session.commit()
+
+    get_file = mocker.MagicMock(return_value=file)
+    controller = mocker.MagicMock(get_file=get_file)
+
+    fw = FileWidget(file.uuid, controller, mocker.MagicMock())
+    fw.update = mocker.MagicMock()
+    mocker.patch('securedrop_client.gui.widgets.QDialog.exec')
+    controller.run_export_preflight_checks = mocker.MagicMock()
+    controller.downloaded_file_exists = mocker.MagicMock(return_value=False)
+    dialog = mocker.patch('securedrop_client.gui.widgets.ExportDialog')
+
+    fw._on_export_clicked()
+
+    controller.run_export_preflight_checks.assert_not_called()
+    dialog.assert_not_called()
 
 
 def test_ExportDialog_export(mocker):
@@ -1450,7 +1480,7 @@ def test_ExportDialog_export(mocker):
 
     export_dialog.export()
 
-    controller.run_export_preflight_checks.assert_called_with('mock_uuid')
+    controller.run_export_preflight_checks.assert_called_with()
 
 
 def test_ExportDialog_pre_flight_request_to_insert_usb_device_on_CALLED_PROCESS_ERROR(mocker):
@@ -1500,7 +1530,7 @@ def test_ExportDialog__on_retry_export_button_clicked(mocker):
 
     export_dialog._on_retry_export_button_clicked()
 
-    controller.run_export_preflight_checks.assert_called_with('mock_uuid')
+    controller.run_export_preflight_checks.assert_called_with()
 
 
 def test_ExportDialog__update_export_button_clicked_USB_NOT_CONNECTED(mocker):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -36,13 +36,13 @@ def test_send_file_to_usb_device_error(mocker):
     export = Export()
     export.export_usb_call_failure = mocker.MagicMock()
     export.export_usb_call_failure.emit = mocker.MagicMock()
-    error = ExportError('bang')
+    error = ExportError('[mock_filepath]')
     _run_disk_export = mocker.patch.object(export, '_run_disk_export', side_effect=error)
 
     export.send_file_to_usb_device(['mock_filepath'], 'mock passphrase')
 
     _run_disk_export.assert_called_once_with('mock_temp_dir', ['mock_filepath'], 'mock passphrase')
-    export.export_usb_call_failure.emit.assert_called_once_with(error.status)
+    export.export_usb_call_failure.emit.assert_called_once_with(['mock_filepath'])
 
 
 def test_run_preflight_checks(mocker):

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1762,6 +1762,18 @@ def test_on_export_usb_call_success(mocker, homedir):
     assert os_remove.call_args_list[1][0][0] == 'mock_filepath_2'
 
 
+def test_on_export_usb_call_failure(mocker, homedir):
+    co = Controller('http://localhost', mocker.MagicMock(), mocker.MagicMock(), homedir)
+    mocker.patch('os.path.exists', return_value=True)
+    os_remove = mocker.patch('os.remove')
+
+    co.on_export_usb_call_failure(['mock_filepath_1', 'mock_filepath_2'])
+
+    assert os_remove.call_count == 2
+    assert os_remove.call_args_list[0][0][0] == 'mock_filepath_1'
+    assert os_remove.call_args_list[1][0][0] == 'mock_filepath_2'
+
+
 def test_get_file(mocker, session, homedir):
     co = Controller('http://localhost', mocker.MagicMock(), mocker.MagicMock(), homedir)
     storage = mocker.patch('securedrop_client.logic.storage')


### PR DESCRIPTION
# Description

Tells the user that the file they're trying to export is missing from the file system. Next step is to show a Download link once again for the file that no longer exists on the filesystem, captured in this issue: https://github.com/freedomofpress/securedrop-client/issues/565