### PR TITLE
Adjust download size scaling factor (part 1)

### DIFF
--- a/securedrop_client/api_jobs/downloads.py
+++ b/securedrop_client/api_jobs/downloads.py
@@ -65,16 +65,17 @@ class DownloadJob(ApiJob):
 
         * As you might expect, this method returns timeouts that are larger than the expected
           download time, which is why the rates below are slower than what you see above with the
-          Tor metrics.
+          Tor metrics, e.g. instead of setting SMALL_FILE_DOWNLOAD_TIMEOUT_BYTES_PER_SECOND to
+          12800 bytes/second, we set it to 10000 bytes per second.
 
         * Minimum timeout allowed is 3 seconds.
         '''
         SMALL_FILE_DOWNLOAD_TIMEOUT_BYTES_PER_SECOND = 10000.0
         DOWNLOAD_TIMEOUT_BYTES_PER_SECOND = 100000.0
-        ONE_MIBIBYTE = 1049000
+        ONE_MEGABYTE = 1000000
         MINIMUM_TIMEOUT = 3
 
-        if size_in_bytes < ONE_MIBIBYTE:
+        if size_in_bytes < ONE_MEGABYTE:
             timeout = math.ceil(size_in_bytes / SMALL_FILE_DOWNLOAD_TIMEOUT_BYTES_PER_SECOND)
             return max(MINIMUM_TIMEOUT, timeout)
 

--- a/securedrop_client/api_jobs/downloads.py
+++ b/securedrop_client/api_jobs/downloads.py
@@ -46,8 +46,7 @@ class DownloadJob(ApiJob):
         '''
         Return a realistic timeout in seconds for a file, message, or reply based on its size.
 
-        This simply scales the timeouts per file so that in general it increases as the file size
-        increases.
+        This simply scales the timeouts per file so that it increases as the file size increases.
 
         Note that:
 
@@ -65,22 +64,16 @@ class DownloadJob(ApiJob):
 
         * As you might expect, this method returns timeouts that are larger than the expected
           download time, which is why the rates below are slower than what you see above with the
-          Tor metrics, e.g. instead of setting SMALL_FILE_DOWNLOAD_TIMEOUT_BYTES_PER_SECOND to
-          12800 bytes/second, we set it to 10000 bytes per second.
+          Tor metrics, e.g. instead of setting TIMEOUT_BYTES_PER_SECOND to 139867 bytes/second, we
+          set it to 100000 bytes/second.
 
-        * Minimum timeout allowed is 3 seconds.
+        * Minimum timeout allowed is 25 seconds
         '''
-        SMALL_FILE_DOWNLOAD_TIMEOUT_BYTES_PER_SECOND = 10000.0
-        DOWNLOAD_TIMEOUT_BYTES_PER_SECOND = 100000.0
-        ONE_MEGABYTE = 1000000
-        MINIMUM_TIMEOUT = 3
-
-        if size_in_bytes < ONE_MEGABYTE:
-            timeout = math.ceil(size_in_bytes / SMALL_FILE_DOWNLOAD_TIMEOUT_BYTES_PER_SECOND)
-            return max(MINIMUM_TIMEOUT, timeout)
-
-        timeout = math.ceil(size_in_bytes / DOWNLOAD_TIMEOUT_BYTES_PER_SECOND)
-        return max(MINIMUM_TIMEOUT, timeout)
+        TIMEOUT_BYTES_PER_SECOND = 100000.0
+        TIMEOUT_ADJUSTMENT_FACTOR = 1.5
+        TIMEOUT_BASE = 25
+        timeout = math.ceil((size_in_bytes / TIMEOUT_BYTES_PER_SECOND) * TIMEOUT_ADJUSTMENT_FACTOR)
+        return timeout + TIMEOUT_BASE
 
     def call_download_api(self, api: API,
                           db_object: Union[File, Message, Reply]) -> Tuple[str, str]:

--- a/securedrop_client/api_jobs/downloads.py
+++ b/securedrop_client/api_jobs/downloads.py
@@ -66,15 +66,20 @@ class DownloadJob(ApiJob):
         * As you might expect, this method returns timeouts that are larger than the expected
           download time, which is why the rates below are slower than what you see above with the
           Tor metrics.
+
+        * Minimum timeout allowed is 3 seconds.
         '''
         SMALL_FILE_DOWNLOAD_TIMEOUT_BYTES_PER_SECOND = 10000.0
         DOWNLOAD_TIMEOUT_BYTES_PER_SECOND = 100000.0
         ONE_MIBIBYTE = 1049000
+        MINIMUM_TIMEOUT = 3
 
         if size_in_bytes < ONE_MIBIBYTE:
-            return math.ceil(size_in_bytes / SMALL_FILE_DOWNLOAD_TIMEOUT_BYTES_PER_SECOND)
+            timeout = math.ceil(size_in_bytes / SMALL_FILE_DOWNLOAD_TIMEOUT_BYTES_PER_SECOND)
+            return max(MINIMUM_TIMEOUT, timeout)
 
-        return math.ceil(size_in_bytes / DOWNLOAD_TIMEOUT_BYTES_PER_SECOND)
+        timeout = math.ceil(size_in_bytes / DOWNLOAD_TIMEOUT_BYTES_PER_SECOND)
+        return max(MINIMUM_TIMEOUT, timeout)
 
     def call_download_api(self, api: API,
                           db_object: Union[File, Message, Reply]) -> Tuple[str, str]:

--- a/tests/api_jobs/test_downloads.py
+++ b/tests/api_jobs/test_downloads.py
@@ -537,8 +537,9 @@ def test_timeout_length_of_file_downloads(mocker, homedir, session, session_make
 
     # ceil(file_size / 10000 bytes/sec) is expected for file sizes less than 1MiB
     # ceil(file_size / 100000 bytes/sec) is expected for file sizes greater than or equal to 1MiB
-    assert one_byte_file_timeout == 1
-    assert one_KiB_file_timeout == 1
+    # minimum timeout is 3 seconds
+    assert one_byte_file_timeout == 3
+    assert one_KiB_file_timeout == 3
     assert fifty_KiB_file_timeout == 6
     assert half_MiB_file_timeout == 53
     assert one_MiB_file_timeout == 11

--- a/tests/api_jobs/test_downloads.py
+++ b/tests/api_jobs/test_downloads.py
@@ -535,8 +535,8 @@ def test_timeout_length_of_file_downloads(mocker, homedir, session, session_make
     one_MiB_file_timeout = one_MiB_file_job._get_realistic_timeout(one_MiB_file.size)
     five_MiB_file_timeout = five_MiB_file_job._get_realistic_timeout(five_MiB_file.size)
 
-    # ceil(file_size / 10000 bytes/sec) is expected for file sizes less than 1MiB
-    # ceil(file_size / 100000 bytes/sec) is expected for file sizes greater than or equal to 1MiB
+    # ceil(file_size / 10000 bytes/sec) is expected for file sizes less than 1MB
+    # ceil(file_size / 100000 bytes/sec) is expected for file sizes greater than or equal to 1MB
     # minimum timeout is 3 seconds
     assert one_byte_file_timeout == 3
     assert one_KiB_file_timeout == 3


### PR DESCRIPTION
# Description

This is a quick adjustment to our timeout estimation function that scales the timeouts per file so that in general it increases as the file size increases.

It turns out that we could only download very small files due to a scaling bug which added 7.5 seconds to the timeout for every single byte in the file. This change makes it so that timeout is calculated by dividing the size of the file by the estimated download rate, which we get from Tor metrics: https://metrics.torproject.org/torperf.html?start=2019-05-02&end=2019-07-31&server=onion

Couple notes:

* This is not a final solution. This is a quick fix to make it so that most of the time our download timeouts are pretty good and we can download files. It does not account for unexpected network latency issues. This will be addressed in a followup PR that will ramp up the timeout value each time the download job is retried, up to a certain cap of number of retry attempts.

* The download speed is slower per byte for files ~50KiB due to overhead and other possible factors. This is based on the metrics provided in the link above. Our scaling function takes this into account by simply changing the rate of the download speed to a slower rate if the file is less than 1MiB. You can see how this is reflected in the test assertions I added. 

* As you might expect, a timeout is larger than the expected download time, which is why the rates we use are slower than the rates reported by Tor.

~* I'm leaving https://github.com/freedomofpress/securedrop-client/issues/546 open until the ramp-up timeout implementation and/or range requests are added.~

Actually, this does fix the bug that prevented us from downloading large files, but I want to make sure we add the ramping up/ range requests soonish...

Fixes https://github.com/freedomofpress/securedrop-client/issues/546

# Test Plan

* Download files of all sizes.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes