### PR TITLE
ci + test: buster, python 3.7 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,35 @@
+---
+common-steps:
+  - &run_tests
+    run:
+      name: Install requirements and run tests
+      command: |
+        set -e
+        virtualenv .venv
+        source .venv/bin/activate
+        pip install --require-hashes -r dev-requirements.txt
+        export PYTHONPATH=$PYTHONPATH:.  # so alembic can get to Base metadata
+        make check --keep-going
+
+  - &check_python_dependencies_for_vulns
+    run:
+      name: Check Python dependencies for known vulnerabilities
+      command: |
+        set -e
+        source .venv/bin/activate
+        make safety
+
+  - &run_static_analysis
+    run:
+      name: Run static analysis on source code to find security issues
+      command: |
+        set -e
+        source .venv/bin/activate
+        make bandit
+
 version: 2
 jobs:
-  build:
+  build-stretch:
     docker:
       - image: circleci/python:3.5-stretch
     steps:
@@ -30,41 +59,30 @@ jobs:
             export PKG_PATH=~/project/dist/securedrop-client-$PKG_VERSION.tar.gz
             make securedrop-client
 
-  test:
+  test-stretch:
     docker:
-      - image: circleci/python:3.5
+      - image: circleci/python:3.5-stretch
     steps:
       - checkout
-
       - run: sudo apt-get install -y sqlite3 libqt5x11extras5
+      - *run_tests
+      - *check_python_dependencies_for_vulns
+      - *run_static_analysis
 
-      - run:
-          name: Install requirements and run tests
-          command: |
-            set -e
-            virtualenv .venv
-            source .venv/bin/activate
-            pip install --require-hashes -r dev-requirements.txt
-            export PYTHONPATH=$PYTHONPATH:.  # so alembic can get to Base metadata
-            make check --keep-going
-
-      - run:
-          name: Check Python dependencies for known vulnerabilities
-          command: |
-            set -e
-            source .venv/bin/activate
-            make safety
-
-      - run:
-          name: Run static analysis on source code to find security issues
-          command: |
-            set -e
-            source .venv/bin/activate
-            make bandit
+  test-buster:
+    docker:
+      - image: circleci/python:3.7-buster
+    steps:
+      - checkout
+      - run: sudo apt-get install -y sqlite3 libqt5x11extras5
+      - *run_tests
+      - *check_python_dependencies_for_vulns
+      - *run_static_analysis
 
 workflows:
   version: 2
   securedrop_client_ci:
     jobs:
-      - test
-      - build
+      - test-stretch
+      - build-stretch
+      - test-buster

--- a/securedrop_client/utils.py
+++ b/securedrop_client/utils.py
@@ -6,14 +6,22 @@ def safe_mkdir(sdc_home: str, relative_path: str = None) -> None:
     '''
     Safely create directories while checking permissions along the way.
     '''
+
+    if relative_path:
+        full_path = os.path.join(sdc_home, relative_path)
+    else:
+        full_path = sdc_home
+
+    if not full_path == os.path.abspath(full_path):
+        raise ValueError('Path is not absolute: {}'.format(full_path))
+
+    if not os.path.exists(sdc_home):
+        os.makedirs(sdc_home, 0o700)
+
     check_dir_permissions(sdc_home)
 
     if not relative_path:
         return
-
-    full_path = os.path.join(sdc_home, relative_path)
-    if not full_path == os.path.abspath(full_path):
-        raise ValueError('Path is not absolute: {}'.format(full_path))
 
     path_components = split_path(relative_path)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -39,7 +39,6 @@ def test_configure_logging(homedir, mocker):
     expected (rotating logs) manner.
     """
     mock_log_conf = mocker.patch('securedrop_client.app.TimedRotatingFileHandler')
-    mocker.patch('securedrop_client.app.os.path.exists', return_value=False)
     mock_logging = mocker.patch('securedrop_client.app.logging')
     mock_log_file = os.path.join(homedir, 'logs', 'client.log')
     configure_logging(homedir)
@@ -120,6 +119,8 @@ def test_start_app(homedir, mocker):
     mocker.patch('securedrop_client.app.configure_logging')
     mock_app = mocker.patch('securedrop_client.app.QApplication')
     mock_win = mocker.patch('securedrop_client.app.Window')
+    mocker.patch('securedrop_client.resources.path',
+                 return_value=mock_args.sdc_home + 'dummy.jpg')
     mock_controller = mocker.patch('securedrop_client.app.Controller')
     mocker.patch('securedrop_client.app.prevent_second_instance')
     mocker.patch('securedrop_client.app.sys')
@@ -172,12 +173,12 @@ def test_create_app_dir_permissions(tmpdir, mocker):
     for idx, case in enumerate(PERMISSIONS_CASES):
         mock_session_maker = mocker.MagicMock()
         mock_args = mocker.MagicMock()
+        sdc_home = os.path.join(str(tmpdir), 'case-{}'.format(idx))
+        mock_args.sdc_home = sdc_home
         mock_qt_args = mocker.MagicMock()
 
-        sdc_home = os.path.join(str(tmpdir), 'case-{}'.format(idx))
-
         # optionally create the dir
-        if case['home_perms'] is not None:
+        if case['home_perms']:
             os.mkdir(sdc_home, case['home_perms'])
 
         mock_args.sdc_home = sdc_home
@@ -191,6 +192,8 @@ def test_create_app_dir_permissions(tmpdir, mocker):
         mocker.patch('securedrop_client.app.Window')
         mocker.patch('securedrop_client.app.Controller')
         mocker.patch('securedrop_client.app.sys')
+        mocker.patch('securedrop_client.resources.path',
+                     return_value=sdc_home + 'dummy.jpg')
         mocker.patch('securedrop_client.app.prevent_second_instance')
         mocker.patch('securedrop_client.app.make_session_maker', return_value=mock_session_maker)
 


### PR DESCRIPTION
# Description

towards #527

add buster test job (build job we can't add until we update our pip mirror) and gets tests passing on buster / python 3.7.

the one application change here is to ensure that calling `safe_mkdir(sdc_home)` directly actually creates `sdc_home` - previously it would just return without creating the directory.

# Testing

1. Make a python 3.7 virtualenv
2. Ensure you can start the application
3. New CI job should also pass

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes