### PR TITLE
close #360 fix db warnings upon source deletion

### DIFF
--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -104,18 +104,16 @@ def update_local_storage(session: Session,
     with this data.
     """
 
-    local_sources = get_local_sources(session)
-    local_files = get_local_files(session)
-    local_messages = get_local_messages(session)
-    local_replies = get_local_replies(session)
-
     remote_messages = [x for x in remote_submissions if x.filename.endswith('msg.gpg')]
     remote_files = [x for x in remote_submissions if not x.filename.endswith('msg.gpg')]
 
-    update_sources(remote_sources, local_sources, session, data_dir)
-    update_files(remote_files, local_files, session, data_dir)
-    update_messages(remote_messages, local_messages, session, data_dir)
-    update_replies(remote_replies, local_replies, session, data_dir)
+    # The following update_* functions may change the database state.
+    # Because of that, each get_local_* function needs to be called just before
+    # its respective update_* function.
+    update_sources(remote_sources, get_local_sources(session), session, data_dir)
+    update_files(remote_files, get_local_files(session), session, data_dir)
+    update_messages(remote_messages, get_local_messages(session), session, data_dir)
+    update_replies(remote_replies, get_local_replies(session), session, data_dir)
 
 
 def update_sources(remote_sources: List[SDKSource],


### PR DESCRIPTION
Fixes database warnings about double deletion

# Description
warnings were caused by double deletion of messages
  - once upon updating the sources
  - another upon updating files, messages and replies

The bug was in `update_local_storage()` in the file `securedrop_client/storage.py`. Bellow is a copy of the buggy version.

```python
def update_local_storage(session: Session,
                         remote_sources: List[SDKSource],
                         remote_submissions: List[SDKSubmission],
                         remote_replies: List[SDKReply],
                         data_dir: str) -> None:

    local_sources = get_local_sources(session)
    local_files = get_local_files(session)
    local_messages = get_local_messages(session)
    local_replies = get_local_replies(session)

    remote_messages = [x for x in remote_submissions if x.filename.endswith('msg.gpg')]
    remote_files = [x for x in remote_submissions if not x.filename.endswith('msg.gpg')]

    update_sources(remote_sources, local_sources, session, data_dir)
    update_files(remote_files, local_files, session, data_dir)
    update_messages(remote_messages, local_messages, session, data_dir)
    update_replies(remote_replies, local_replies, session, data_dir)
```

When a source was deleted all of the files, messages and replies were deleted from the db as well since they are deleted in cascade with the source according to `securedrop_client/db.py`.

But because `local_{sources,files,messages,replies}` are all fetched at once before the execution of the `update_*` functions they would try to delete lines in the table that were already deleted, thus the warning `SAWarning: DELETE statement on table ....`

Fixes #360 and possibly #545 

# Test Plan
1. delete source
2. check terminal of sd-client to see that there are no ` SAWarning: DELETE statement on table ...` warnings

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

# Comments
If you can make the explanation comment on the code more concise, feel free to change it.