### PR TITLE
Replybox richtext placeholder with modified behavior

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2374,6 +2374,9 @@ class ReplyTextEdit(QPlainTextEdit):
         font-size: 18px;
         color: #404040;
     }
+    #reply_placeholder::disabled {
+        color: rgba(42, 49, 157, 0.6);
+    }
     '''
 
     def __init__(self, source, controller):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2326,14 +2326,12 @@ class ReplyBoxWidget(QWidget):
         self.controller.authentication_state.connect(self._on_authentication_changed)
 
     def enable(self):
-        self.text_edit.clear()
-        self.text_edit.setEnabled(True)
+        self.text_edit.set_logged_in()
         self.replybox.setEnabled(True)
         self.send_button.show()
 
     def disable(self):
-        self.text_edit.setPlainText(_('You need to log in to send replies.'))
-        self.text_edit.setEnabled(False)
+        self.text_edit.set_logged_out()
         self.replybox.setEnabled(False)
         self.send_button.hide()
 
@@ -2386,14 +2384,11 @@ class ReplyTextEdit(QPlainTextEdit):
         self.setObjectName('reply_textedit')
         self.setStyleSheet(self.CSS)
 
-        formatted_source_name = "<strong><font color=\"#24276d\">%s</font></strong>" % \
-                                self.source.journalist_designation
-        formatted_placeholder = _("Compose a reply to ") + formatted_source_name
-
-        self.placeholder = QLabel(formatted_placeholder)
+        self.placeholder = QLabel()
         self.placeholder.setObjectName("reply_placeholder")
         self.placeholder.setParent(self)
         self.placeholder.move(QPoint(3, 4))  # make label match text below
+        self.set_logged_in()
 
     def focusInEvent(self, e):
         # override default behavior: when reply text box is focused, the placeholder
@@ -2407,7 +2402,20 @@ class ReplyTextEdit(QPlainTextEdit):
             self.placeholder.show()
         super(ReplyTextEdit, self).focusOutEvent(e)
 
-    def setPlainText(self, text):
+    def set_logged_in(self):
+        source_name = "<strong><font color=\"#24276d\">%s</font></strong>" % \
+                                self.source.journalist_designation
+        placeholder = _("Compose a reply to ") + source_name
+        self.placeholder.setText(placeholder)
+        self.setEnabled(True)
+
+    def set_logged_out(self):
+        text = "<strong><font color=\"#2a319d\">" + _("Sign in") + " </font></strong>" + \
+            _("to compose or send a reply.")
+        self.placeholder.setText(text)
+        self.setEnabled(False)
+
+    def setText(self, text):
         if text == "":
             self.placeholder.show()
         else:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2345,7 +2345,7 @@ class ReplyBoxWidget(QWidget):
             reply_uuid = str(uuid4())
             self.controller.send_reply(self.source.uuid, reply_uuid, reply_text)
             self.reply_sent.emit(self.source.uuid, reply_uuid, reply_text)
-            self.text_edit.clear()
+            self.text_edit.setText('')
 
     def _on_authentication_changed(self, authenticated: bool) -> None:
         if authenticated:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2414,7 +2414,7 @@ class ReplyTextEdit(QPlainTextEdit):
 
     def set_logged_out(self):
         text = "<strong><font color=\"#2a319d\">" + _("Sign in") + " </font></strong>" + \
-            _("to compose or send a reply.")
+            _("to compose or send a reply")
         self.placeholder.setText(text)
         self.setEnabled(False)
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -2374,6 +2374,35 @@ def test_ReplyBoxWidget_disable(mocker):
     rb.send_button.hide.assert_called_once_with()
 
 
+def test_ReplyTextEdit_set_logged_out(mocker):
+    """
+    Checks the placeholder text for reply box is correct for offline mode
+    """
+    source = mocker.MagicMock()
+    controller = mocker.MagicMock()
+    rt = ReplyTextEdit(source, controller)
+
+    rt.set_logged_out()
+
+    assert 'Sign in' in rt.placeholder.text()
+    assert 'to compose or send a reply.' in rt.placeholder.text()
+
+
+def test_ReplyTextEdit_set_logged_in(mocker):
+    """
+    Checks the placeholder text for reply box is correct for online mode
+    """
+    source = mocker.MagicMock()
+    source.journalist_designation = 'journalist designation'
+    controller = mocker.MagicMock()
+    rt = ReplyTextEdit(source, controller)
+
+    rt.set_logged_in()
+
+    assert 'Compose a reply to' in rt.placeholder.text()
+    assert source.journalist_designation in rt.placeholder.text()
+
+
 def test_update_conversation_maintains_old_items(mocker, session):
     """
     Calling update_conversation deletes and adds old items back to layout

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -2373,6 +2373,45 @@ def test_ReplyBoxWidget_disable(mocker):
     rb.text_edit.set_logged_out.assert_called_once_with()
     rb.send_button.hide.assert_called_once_with()
 
+def test_ReplyTextEdit_focus_change_no_text(mocker):
+    """
+    Tests if placeholder text in reply box disappears when it's focused (clicked)
+    and reappears when it's no longer on focus
+    """
+    source = mocker.MagicMock()
+    controller = mocker.MagicMock()
+    rt = ReplyTextEdit(source, controller)
+    rt.placeholder = mocker.MagicMock()
+
+    rt.setFocus()
+    assert rt.placeholder.hide.assert_called_once_with()
+    assert rt.text() == ''
+
+    rt.clearFocus()
+    assert rt.placeholder.show.assert_called_once_with()
+    assert rt.text() == ''
+
+
+def test_ReplyTextEdit_focus_change_with_text_typed(mocker):
+    """
+    Tests if placeholder text in reply box disappears when it's focused and does
+    not reappear when text has been typed and it becomes out of focus again
+    """
+    source = mocker.MagicMock()
+    controller = mocker.MagicMock()
+    rt = ReplyTextEdit(source, controller)
+
+    assert rt.placeholder.hide.assert_called_once_with()
+
+    rt.setFocus()
+
+    reply_text = mocker.MagicMock()
+    rt.setText(reply_text)
+
+    rt.clearFocus()
+    assert rt.placeholder.show.assert_not_called()
+    assert rt.text() == reply_text
+
 
 def test_ReplyTextEdit_set_logged_out(mocker):
     """

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -3,7 +3,7 @@ Make sure the UI widgets are configured correctly and work as expected.
 """
 import html
 
-from PyQt5.QtWidgets import QWidget, QApplication, QVBoxLayout, QMessageBox, QMainWindow, QTextEdit
+from PyQt5.QtWidgets import QWidget, QApplication, QVBoxLayout, QMessageBox, QMainWindow
 from PyQt5.QtCore import Qt, QEvent
 from sqlalchemy.orm import scoped_session, sessionmaker
 
@@ -14,8 +14,8 @@ from securedrop_client.gui.widgets import MainView, SourceList, SourceWidget, Lo
     SpeechBubble, MessageWidget, ReplyWidget, FileWidget, ConversationView, \
     DeleteSourceMessageBox, DeleteSourceAction, SourceMenu, TopPane, LeftPane, RefreshButton, \
     ErrorStatusBar, ActivityStatusBar, UserProfile, UserButton, UserMenu, LoginButton, \
-    ReplyBoxWidget, SourceConversationWrapper, StarToggleButton, LoginOfflineLink, LoginErrorBar, \
-    EmptyConversationView, ExportDialog
+    ReplyBoxWidget, ReplyTextEdit, SourceConversationWrapper, StarToggleButton, LoginOfflineLink, \
+    LoginErrorBar, EmptyConversationView, ExportDialog
 
 
 app = QApplication([])
@@ -2233,7 +2233,8 @@ def test_ReplyBoxWidget_send_reply(mocker):
     on_reply_sent_fn = mocker.MagicMock()
     scw.conversation_view.on_reply_sent = on_reply_sent_fn
     scw.reply_box.reply_sent = mocker.MagicMock()
-    scw.reply_box.text_edit = QTextEdit('Alles für Alle')
+    scw.reply_box.text_edit = ReplyTextEdit(source, controller)
+    scw.reply_box.text_edit.setPlainText('Alles für Alle')
 
     scw.reply_box.send_reply()
 
@@ -2249,7 +2250,7 @@ def test_ReplyBoxWidget_send_reply_does_not_send_empty_string(mocker):
     source = mocker.MagicMock()
     controller = mocker.MagicMock()
     rb = ReplyBoxWidget(source, controller)
-    rb.text_edit = QTextEdit()
+    rb.text_edit = ReplyTextEdit(source, controller)
     assert not rb.text_edit.toPlainText()
 
     rb.send_reply()
@@ -2347,13 +2348,14 @@ def test_ReplyBoxWidget_enable(mocker):
     source = mocker.MagicMock()
     controller = mocker.MagicMock()
     rb = ReplyBoxWidget(source, controller)
-    rb.text_edit = QTextEdit()
+    rb.text_edit = ReplyTextEdit(source, controller)
+    rb.text_edit.set_logged_in = mocker.MagicMock()
     rb.send_button = mocker.MagicMock()
 
     rb.enable()
 
-    assert rb.text_edit.isEnabled()
     assert rb.text_edit.toPlainText() == ''
+    rb.text_edit.set_logged_in.assert_called_once_with()
     rb.send_button.show.assert_called_once_with()
 
 
@@ -2361,13 +2363,14 @@ def test_ReplyBoxWidget_disable(mocker):
     source = mocker.MagicMock()
     controller = mocker.MagicMock()
     rb = ReplyBoxWidget(source, controller)
-    rb.text_edit = QTextEdit()
+    rb.text_edit = ReplyTextEdit(source, controller)
+    rb.text_edit.set_logged_out = mocker.MagicMock()
     rb.send_button = mocker.MagicMock()
 
     rb.disable()
 
-    assert not rb.text_edit.isEnabled()
-    assert rb.text_edit.toPlainText() == 'You need to log in to send replies.'
+    assert rb.text_edit.toPlainText() == ''
+    rb.text_edit.set_logged_out.assert_called_once_with()
     rb.send_button.hide.assert_called_once_with()
 
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -2189,31 +2189,11 @@ def test_ReplyBoxWidget_placeholder_show_currently_selected_source(mocker):
     designation for the correct source. #sanity-check
     """
     controller = mocker.MagicMock()
-    sl = SourceList()
-    sl.setup(controller)
+    source = factory.Source()
+    source.journalist_designation = "source name"
 
-    source_1 = factory.Source()
-    source_1.journalist_designation = "source one"
-    source_2 = factory.Source()
-    source_2.journalist_designation = "source two"
-
-    # add sources to sources list
-    sl.update([source_1, source_2])
-
-    source_1_item = sl.item(0)
-    source_2_item = sl.item(1)
-
-    # select source 1
-    sl.setCurrentItem(source_1_item)
-    assert sl.currentItem() == source_1_item
-
-    # select source other source
-    sl.setCurrentItem(source_2_item)
-    assert sl.currentItem() == source_2_item
-
-    selected_source = sl.itemWidget(sl.currentItem()).source
-    rb = ReplyBoxWidget(selected_source, controller)
-    assert rb.text_edit.placeholderText().find(source_2.journalist_designation) != -1
+    rb = ReplyBoxWidget(source, controller)
+    assert rb.text_edit.placeholder.text().find(source.journalist_designation) != -1
 
 
 def test_ReplyBoxWidget_send_reply(mocker):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -2215,13 +2215,31 @@ def test_ReplyBoxWidget_send_reply(mocker):
     scw.conversation_view.on_reply_sent = on_reply_sent_fn
     scw.reply_box.reply_sent = mocker.MagicMock()
     scw.reply_box.text_edit = ReplyTextEdit(source, controller)
+    scw.reply_box.text_edit.setText = mocker.MagicMock()
     scw.reply_box.text_edit.setPlainText('Alles für Alle')
 
     scw.reply_box.send_reply()
 
     scw.reply_box.reply_sent.emit.assert_called_once_with('abc123', '456xyz', 'Alles für Alle')
-    assert scw.reply_box.text_edit.toPlainText() == ''
+    scw.reply_box.text_edit.setText.assert_called_once_with('')
     controller.send_reply.assert_called_once_with('abc123', '456xyz', 'Alles für Alle')
+
+
+def test_ReplyBoxWidget_send_reply_calls_setText_after_send(mocker):
+    """
+    Ensure sending a reply from the reply box emits signal, clears text box, and sends the reply
+    details to the controller.
+    """
+    source = factory.Source()
+    controller = mocker.MagicMock()
+    rb = ReplyBoxWidget(source, controller)
+    rb.text_edit = ReplyTextEdit(source, controller)
+    setText = mocker.patch.object(rb.text_edit, 'setText')
+    rb.text_edit.setPlainText('Alles für Alle')
+
+    rb.send_reply()
+
+    setText.assert_called_once_with('')
 
 
 def test_ReplyBoxWidget_send_reply_does_not_send_empty_string(mocker):


### PR DESCRIPTION
The commit is fully functional. I just have some questions regarding tests.

# Description
Tweaks reply box according to #594:
  - placeholder It should be removed as soon as soon as textbox is active. 
  - added formatting to placeholder: "Compose a reply to **[source name]**" (with color)

Fixes #594

![reply](https://user-images.githubusercontent.com/47065258/67717439-9ed2cf00-f9c5-11e9-833f-2d30325972f9.png)


# Test Plan
1. Login to client
2. Check the reply box has text `Compose a message to [source name]`
3. Click on text box and verify placeholder is cleared
4. Click outside text box and verify that the placeholder comes back
5. Log out and check appropriate behavior (placeholder with other text)

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

# Comments
The implementation uses a `QLabel` to act as a fake placeholder. Another alternative was to use the `QTextEdit.setPlaceholderText()`, given the constraints that:
- Reply box should not accept rich text (#539) -> making it a `PlainTextEdit` solves it
- `QTextEdit.setPlaceholderText()` does NOT allow html as input
- `QTextEdit.setText()` allows for html but for some reason it does not work if we wanted to set it as a "placeholder" (meaning that we cannot setText as soon as the text box is created)
