### PR TITLE
ci: ensure that requirements files are in sync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,14 @@ jobs:
             PKG_DIR=~/project make requirements
 
       - run:
+          name: Ensure that build-requirements.txt and requirements.txt are in sync.
+          command: |
+            cd ~/project
+            # Return 1 if unstaged changes exist (after `make requirements` in the 
+            # previous run step), else return 0.
+            git diff --quiet
+
+      - run:
           name: Tag and make source tarball
           command: |
             cd ~/project


### PR DESCRIPTION
# Description

Fix ported from freedomofpress/securedrop-proxy#48, we use similar logic here in our build job so we should add the fix here also. See that PR for more details, but in short this PR ensures that diffs that update `build-requirements.txt` without updating `requirements.txt` fail CI.

# Checklist

CI only