### PR TITLE
add changeable log levels

### DIFF
--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -37,7 +37,7 @@ from securedrop_client.utils import safe_mkdir
 
 DEFAULT_SDC_HOME = '~/.securedrop_client'
 ENCODING = 'utf-8'
-
+LOGLEVEL = os.environ.get('LOGLEVEL', 'info').upper()
 
 def init(sdc_home: str) -> None:
     safe_mkdir(sdc_home)
@@ -97,7 +97,7 @@ def configure_logging(sdc_home: str) -> None:
 
     # set up primary log
     log = logging.getLogger()
-    log.setLevel(logging.DEBUG)
+    log.setLevel(LOGLEVEL)
     log.addHandler(handler)
 
     # override excepthook to capture a log of catastrophic failures.


### PR DESCRIPTION
# Description

Makes it so we can change log levels for each client run and now default to INFO level.

# Test Plan

1. `tail -f $HOMEDIR/logs/client.log`
2. `./run.sh`
See only info and error logs.
3. Ctrl+C
4. `LOGLEVEL=debug ./run.sh`
See debug logs and up.
