### PR TITLE
app: skip round trip to user endpoint during login (fix #575)

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -318,12 +318,15 @@ class Controller(QObject):
         """
         logger.info('{} successfully logged in'.format(self.api.username))
         self.gui.hide_login()
+        user = storage.update_and_get_user(
+            self.api.token_journalist_uuid,
+            self.api.username,
+            self.api.journalist_first_name,
+            self.api.journalist_last_name,
+            self.session)
+        self.gui.show_main_window(user)
         self.sync_api()
-        self.call_api(self.api.get_current_user,
-                      self.on_get_current_user_success,
-                      self.on_get_current_user_failure)
         self.api_job_queue.login(self.api)
-
         self.is_authenticated = True
         self.resume_queues()
 
@@ -333,20 +336,6 @@ class Controller(QObject):
         error = _('There was a problem signing in. '
                   'Please verify your credentials and try again.')
         self.gui.show_login_error(error=error)
-
-    def on_get_current_user_success(self, result) -> None:
-        user = storage.update_and_get_user(
-            result['uuid'],
-            result['username'],
-            result['first_name'],
-            result['last_name'],
-            self.session)
-        self.user = user
-        self.gui.show_main_window(self.user)
-
-    def on_get_current_user_failure(self, result: Exception) -> None:
-        self.api = None
-        self.gui.show_login_error(error=_('Could not find your account.'))
 
     def login_offline_mode(self):
         """

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -22,6 +22,8 @@ def User(**attrs):
     defaults = dict(
         uuid='user-uuid-{}'.format(USER_COUNT),
         username='test-user-id-{}'.format(USER_COUNT),
+        firstname='slim',
+        lastname='shady'
     )
 
     defaults.update(attrs)


### PR DESCRIPTION
# Description

Fixes #575 following option 1 presented in the bottom of that ticket: avoiding the round-trip to the /user endpoint by presenting everything we need at login time in the response to the /token endpoint

⚠️ This is marked as "Draft" until the corresponding SDK changes are merged and released

# Test Plan

0. Apply small server diff: https://github.com/freedomofpress/securedrop/compare/api-journo-names
1. Merge SDK change - or simply apply it during review of this PR via `pip install -e git+https://github.com/freedomofpress/securedrop-sdk.git@token-endpoint-journo-names#egg=securedrop-sdk`
2. Confirm that login still works, and verify in the diff that there is now no second call to the server prior to the main window being displayed

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes