### PR TITLE
health checker/ auto-retry bg sync + adjusted timeouts

### DIFF
--- a/securedrop_client/api_jobs/downloads.py
+++ b/securedrop_client/api_jobs/downloads.py
@@ -51,7 +51,7 @@ class MetadataSyncJob(ApiJob):
         '''
 
         # TODO: Once https://github.com/freedomofpress/securedrop-client/issues/648, we will want to
-        # pass the default request timeout to download_reply instead of setting it on the api object
+        # pass the default request timeout to api calls instead of setting it on the api object
         # directly.
         api_client.default_request_timeout = 20
         remote_sources, remote_submissions, remote_replies = \

--- a/securedrop_client/api_jobs/downloads.py
+++ b/securedrop_client/api_jobs/downloads.py
@@ -50,6 +50,10 @@ class MetadataSyncJob(ApiJob):
         jobs.
         '''
 
+        # TODO: Once https://github.com/freedomofpress/securedrop-client/issues/648, we will want to
+        # pass the default request timeout to download_reply instead of setting it on the api object
+        # directly.
+        api_client.default_request_timeout = 20
         remote_sources, remote_submissions, remote_replies = \
             get_remote_data(api_client)
 
@@ -87,7 +91,7 @@ class DownloadJob(ApiJob):
 
     def _get_realistic_timeout(self, size_in_bytes: int) -> int:
         '''
-        Return a realistic timeout in seconds for a file, message, or reply based on its size.
+        Return a realistic timeout in seconds based on the size of the download.
 
         This simply scales the timeouts per file so that it increases as the file size increases.
 
@@ -260,6 +264,11 @@ class ReplyDownloadJob(DownloadJob):
         '''
         sdk_object = SdkReply(uuid=db_object.uuid, filename=db_object.filename)
         sdk_object.source_uuid = db_object.source.uuid
+
+        # TODO: Once https://github.com/freedomofpress/securedrop-sdk/issues/108 is implemented, we
+        # will want to pass the default request timeout to download_reply instead of setting it on
+        # the api object directly.
+        api.default_request_timeout = 20
         return api.download_reply(sdk_object)
 
     def call_decrypt(self, filepath: str, session: Session = None) -> str:

--- a/securedrop_client/api_jobs/updatestar.py
+++ b/securedrop_client/api_jobs/updatestar.py
@@ -24,6 +24,10 @@ class UpdateStarJob(ApiJob):
         try:
             source_sdk_object = sdclientapi.Source(uuid=self.source_uuid)
 
+            # TODO: Once https://github.com/freedomofpress/securedrop-client/issues/648, we will
+            # want to pass the default request timeout to download_reply instead of setting it on
+            # the api object directly.
+            api_client.default_request_timeout = 5
             if self.star_status:
                 api_client.remove_star(source_sdk_object)
             else:

--- a/securedrop_client/api_jobs/updatestar.py
+++ b/securedrop_client/api_jobs/updatestar.py
@@ -25,8 +25,8 @@ class UpdateStarJob(ApiJob):
             source_sdk_object = sdclientapi.Source(uuid=self.source_uuid)
 
             # TODO: Once https://github.com/freedomofpress/securedrop-client/issues/648, we will
-            # want to pass the default request timeout to download_reply instead of setting it on
-            # the api object directly.
+            # want to pass the default request timeout to remove_star and add_star instead of
+            # setting it on the api object directly.
             api_client.default_request_timeout = 5
             if self.star_status:
                 api_client.remove_star(source_sdk_object)

--- a/securedrop_client/api_jobs/uploads.py
+++ b/securedrop_client/api_jobs/uploads.py
@@ -92,6 +92,11 @@ class SendReplyJob(ApiJob):
 
     def _make_call(self, encrypted_reply: str, api_client: API) -> sdclientapi.Reply:
         sdk_source = sdclientapi.Source(uuid=self.source_uuid)
+
+        # TODO: Once https://github.com/freedomofpress/securedrop-client/issues/648, we will want to
+        # pass the default request timeout to download_reply instead of setting it on the api object
+        # directly.
+        api_client.default_request_timeout = 5
         return api_client.reply_source(sdk_source, encrypted_reply, self.reply_uuid)
 
 

--- a/securedrop_client/api_jobs/uploads.py
+++ b/securedrop_client/api_jobs/uploads.py
@@ -94,7 +94,7 @@ class SendReplyJob(ApiJob):
         sdk_source = sdclientapi.Source(uuid=self.source_uuid)
 
         # TODO: Once https://github.com/freedomofpress/securedrop-client/issues/648, we will want to
-        # pass the default request timeout to download_reply instead of setting it on the api object
+        # pass the default request timeout to reply_source instead of setting it on the api object
         # directly.
         api_client.default_request_timeout = 5
         return api_client.reply_source(sdk_source, encrypted_reply, self.reply_uuid)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -231,7 +231,7 @@ class RefreshButton(SvgPushButton):
         self.controller.sync_events.connect(self._on_refresh_complete)
 
     def _on_clicked(self):
-        self.controller.sync_api()
+        self.controller.sync_api(manual_refresh=True)
         # This is a temporary solution for showing the icon as active for the entire duration of a
         # refresh, rather than for just the duration of a click. The icon image will be replaced
         # when the controller tells us the refresh has finished. A cleaner solution would be to

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -306,9 +306,12 @@ class Controller(QObject):
         """
         Given a username, password and time based one-time-passcode (TOTP),
         create a new instance representing the SecureDrop api and authenticate.
+
+        Default to 60 seconds until we implement a better request timeout strategy.
         """
         storage.mark_all_pending_drafts_as_failed(self.session)
-        self.api = sdclientapi.API(self.hostname, username, password, totp, self.proxy)
+        self.api = sdclientapi.API(
+            self.hostname, username, password, totp, self.proxy, default_request_timeout=60)
         self.call_api(self.api.authenticate,
                       self.on_authenticate_success,
                       self.on_authenticate_failure)

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -417,7 +417,7 @@ class Controller(QObject):
             * Download new messages and replies
             * Update missing files so that they can be re-downloaded
         """
-        self.set_status('')  # remove any permanent error status message
+        self.gui.clear_error_status()  # remove any permanent error status message
 
         with open(self.sync_flag, 'w') as f:
             f.write(arrow.now().format())
@@ -470,6 +470,7 @@ class Controller(QObject):
         """
         After we star a source, we should sync the API such that the local database is updated.
         """
+        self.gui.clear_error_status()  # remove any permanent error status message
         self.sync_api()  # Syncing the API also updates the source list UI
 
     def on_update_star_failure(self, result: UpdateStarJobException) -> None:
@@ -550,6 +551,7 @@ class Controller(QObject):
         """
         Called when a message has downloaded.
         """
+        self.gui.clear_error_status()  # remove any permanent error status message
         message = storage.get_message(self.session, uuid)
         self.message_ready.emit(message.uuid, message.content)
 
@@ -573,6 +575,7 @@ class Controller(QObject):
         """
         Called when a reply has downloaded.
         """
+        self.gui.clear_error_status()  # remove any permanent error status message
         reply = storage.get_reply(self.session, uuid)
         self.reply_ready.emit(reply.uuid, reply.content)
 
@@ -745,6 +748,7 @@ class Controller(QObject):
         """
         Handler for when a source deletion succeeds.
         """
+        self.gui.clear_error_status()  # remove any permanent error status message
         self.sync_api()
 
     def on_delete_source_failure(self, result: Exception) -> None:
@@ -801,6 +805,7 @@ class Controller(QObject):
 
     def on_reply_success(self, reply_uuid: str) -> None:
         logger.debug('{} sent successfully'.format(reply_uuid))
+        self.gui.clear_error_status()  # remove any permanent error status message
         self.reply_succeeded.emit(reply_uuid)
         self.sync_api()
 
@@ -818,6 +823,7 @@ class Controller(QObject):
 
     def on_logout_success(self, result) -> None:
         logging.info('Client logout successful')
+        self.gui.clear_error_status()  # remove any permanent error status message
 
     def on_logout_failure(self, result: Exception) -> None:
         logging.info('Client logout failure')

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -729,6 +729,7 @@ class Controller(QObject):
         """
         Called when a file has downloaded.
         """
+        self.gui.clear_error_status()  # remove any permanent error status message
         self.file_ready.emit(result)
 
     def on_file_download_failure(self, exception: Exception) -> None:

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -159,13 +159,12 @@ class ApiJobQueue(QObject):
     def login(self, api_client: API) -> None:
         logger.debug('Passing API token to queues')
 
-        # Setting realistic (shorter) timeout for general requests so that user feedback is faster.
-        # General requests includes:
-        #       FileDownloadJob
-        #       MessageDownloadJob
-        #       ReplyDownloadJo
-        #       SendReplyJob
-        #       UpdateStarJob
+        # Setting shorter default timeout so that user feedback is faster. For download jobs, this
+        # timeout is adjusted to be more realistic depending on file size.
+        #
+        # Currently ReplyDownloadJobs do not use adjusted timeouts because it is dependent on adding
+        # an optional timeout parameter to the download_reply securedrop-sdk method, see:
+        # https://github.com/freedomofpress/securedrop-sdk/issues/108
         api_client.default_request_timeout = 5
 
         self.main_queue.api_client = api_client

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -158,15 +158,6 @@ class ApiJobQueue(QObject):
 
     def login(self, api_client: API) -> None:
         logger.debug('Passing API token to queues')
-
-        # Setting shorter default timeout so that user feedback is faster. For download jobs, this
-        # timeout is adjusted to be more realistic depending on file size.
-        #
-        # Currently ReplyDownloadJobs do not use adjusted timeouts because it is dependent on adding
-        # an optional timeout parameter to the download_reply securedrop-sdk method, see:
-        # https://github.com/freedomofpress/securedrop-sdk/issues/108
-        api_client.default_request_timeout = 5
-
         self.main_queue.api_client = api_client
         self.download_file_queue.api_client = api_client
         self.start_queues()

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -136,13 +136,12 @@ class ApiJobQueue(QObject):
 
     def __init__(self, api_client: API, session_maker: scoped_session) -> None:
         super().__init__(None)
-        self.api_client = api_client
 
         self.main_thread = QThread()
         self.download_file_thread = QThread()
 
-        self.main_queue = RunnableQueue(self.api_client, session_maker)
-        self.download_file_queue = RunnableQueue(self.api_client, session_maker)
+        self.main_queue = RunnableQueue(api_client, session_maker)
+        self.download_file_queue = RunnableQueue(api_client, session_maker)
 
         self.main_queue.moveToThread(self.main_thread)
         self.download_file_queue.moveToThread(self.download_file_thread)
@@ -159,11 +158,6 @@ class ApiJobQueue(QObject):
 
     def login(self, api_client: API) -> None:
         logger.debug('Passing API token to queues')
-
-        # Setting realistic (shorter) timeout for general requests so that user feedback
-        # is faster
-        api_client.default_request_timeout = 5
-
         self.main_queue.api_client = api_client
         self.download_file_queue.api_client = api_client
         self.start_queues()

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -158,6 +158,16 @@ class ApiJobQueue(QObject):
 
     def login(self, api_client: API) -> None:
         logger.debug('Passing API token to queues')
+
+        # Setting realistic (shorter) timeout for general requests so that user feedback is faster.
+        # General requests includes:
+        #       FileDownloadJob
+        #       MessageDownloadJob
+        #       ReplyDownloadJo
+        #       SendReplyJob
+        #       UpdateStarJob
+        api_client.default_request_timeout = 5
+
         self.main_queue.api_client = api_client
         self.download_file_queue.api_client = api_client
         self.start_queues()

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -77,15 +77,10 @@ def get_remote_data(api: API) -> Tuple[List[SDKSource], List[SDKSubmission], Lis
     (remote_sources, remote_submissions, remote_replies)
     """
     remote_submissions = []  # type: List[SDKSubmission]
-    try:
-        remote_sources = api.get_sources()
-        for source in remote_sources:
-            remote_submissions.extend(api.get_submissions(source))
-        remote_replies = api.get_all_replies()
-    except Exception as ex:
-        # Log any errors but allow the caller to handle the exception.
-        logger.error(ex)
-        raise(ex)
+    remote_sources = api.get_sources()
+    for source in remote_sources:
+        remote_submissions.extend(api.get_submissions(source))
+    remote_replies = api.get_all_replies()
 
     logger.info('Fetched {} remote sources.'.format(len(remote_sources)))
     logger.info('Fetched {} remote submissions.'.format(

--- a/tests/api_jobs/test_downloads.py
+++ b/tests/api_jobs/test_downloads.py
@@ -38,7 +38,9 @@ def test_MetadataSyncJob_success(mocker, homedir, session, session_maker):
         'securedrop_client.api_jobs.downloads.get_remote_data',
         return_value=([mock_source], 'submissions', 'replies'))
 
-    api_client = 'foo'
+    api_client = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
 
     mocker.patch(
         'securedrop_client.api_jobs.downloads.update_local_storage',
@@ -73,7 +75,8 @@ def test_MetadataSyncJob_success_with_key_import_fail(mocker, homedir, session, 
         'securedrop_client.api_jobs.downloads.get_remote_data',
         return_value=([mock_source], 'submissions', 'replies'))
 
-    api_client = 'foo'
+    api_client = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
 
     mocker.patch(
         'securedrop_client.api_jobs.downloads.update_local_storage',
@@ -107,7 +110,8 @@ def test_MetadataSyncJob_success_with_missing_key(mocker, homedir, session, sess
         'securedrop_client.api_jobs.downloads.get_remote_data',
         return_value=([mock_source], 'submissions', 'replies'))
 
-    api_client = 'foo'
+    api_client = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
 
     mocker.patch(
         'securedrop_client.api_jobs.downloads.update_local_storage',
@@ -149,6 +153,7 @@ def test_ReplyDownloadJob_no_download_or_decrypt(mocker, homedir, session, sessi
     mocker.patch.object(job_1.gpg, 'decrypt_submission_or_reply')
     mocker.patch.object(job_2.gpg, 'decrypt_submission_or_reply')
     api_client = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
     path = os.path.join(homedir, 'data')
     api_client.download_submission = mocker.MagicMock(return_value=('', path))
 
@@ -194,6 +199,7 @@ def test_ReplyDownloadJob_message_already_downloaded(mocker, homedir, session, s
     job = ReplyDownloadJob(reply.uuid, homedir, gpg)
     mocker.patch.object(job.gpg, 'decrypt_submission_or_reply')
     api_client = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
     download_fn = mocker.patch.object(api_client, 'download_reply')
 
     return_uuid = job.call_api(api_client, session)
@@ -216,6 +222,7 @@ def test_ReplyDownloadJob_happiest_path(mocker, homedir, session, session_maker)
     job = ReplyDownloadJob(reply.uuid, homedir, gpg)
     mocker.patch.object(job.gpg, 'decrypt_submission_or_reply')
     api_client = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
     data_dir = os.path.join(homedir, 'data')
     api_client.download_reply = mocker.MagicMock(return_value=('', data_dir))
 
@@ -244,6 +251,7 @@ def test_MessageDownloadJob_no_download_or_decrypt(mocker, homedir, session, ses
     mocker.patch.object(job_1.gpg, 'decrypt_submission_or_reply')
     mocker.patch.object(job_2.gpg, 'decrypt_submission_or_reply')
     api_client = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
     path = os.path.join(homedir, 'data')
     api_client.download_submission = mocker.MagicMock(return_value=('', path))
 
@@ -269,6 +277,7 @@ def test_MessageDownloadJob_message_already_decrypted(mocker, homedir, session, 
     job = MessageDownloadJob(message.uuid, homedir, gpg)
     decrypt_fn = mocker.patch.object(job.gpg, 'decrypt_submission_or_reply')
     api_client = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
     download_fn = mocker.patch.object(api_client, 'download_submission')
 
     return_uuid = job.call_api(api_client, session)
@@ -289,6 +298,7 @@ def test_MessageDownloadJob_message_already_downloaded(mocker, homedir, session,
     job = MessageDownloadJob(message.uuid, homedir, gpg)
     mocker.patch.object(job.gpg, 'decrypt_submission_or_reply')
     api_client = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
     download_fn = mocker.patch.object(api_client, 'download_submission')
 
     return_uuid = job.call_api(api_client, session)
@@ -311,6 +321,7 @@ def test_MessageDownloadJob_happiest_path(mocker, homedir, session, session_make
     job = MessageDownloadJob(message.uuid, homedir, gpg)
     mocker.patch.object(job.gpg, 'decrypt_submission_or_reply')
     api_client = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
     data_dir = os.path.join(homedir, 'data')
     api_client.download_submission = mocker.MagicMock(return_value=('', data_dir))
 
@@ -332,6 +343,7 @@ def test_MessageDownloadJob_with_base_error(mocker, homedir, session, session_ma
     gpg = GpgHelper(homedir, session_maker, is_qubes=False)
     job = MessageDownloadJob(message.uuid, homedir, gpg)
     api_client = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
     mocker.patch.object(api_client, 'download_submission', side_effect=BaseError)
     decrypt_fn = mocker.patch.object(job.gpg, 'decrypt_submission_or_reply')
 
@@ -357,7 +369,7 @@ def test_MessageDownloadJob_with_crypto_error(mocker, homedir, session, session_
     job = MessageDownloadJob(message.uuid, homedir, gpg)
     mocker.patch.object(job.gpg, 'decrypt_submission_or_reply', side_effect=CryptoError)
     api_client = mocker.MagicMock()
-    api_client = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
     path = os.path.join(homedir, 'data')
     api_client.download_submission = mocker.MagicMock(return_value=('', path))
 
@@ -380,6 +392,7 @@ def test_FileDownloadJob_message_already_decrypted(mocker, homedir, session, ses
     job = FileDownloadJob(file_.uuid, homedir, gpg)
     decrypt_fn = mocker.patch.object(job.gpg, 'decrypt_submission_or_reply')
     api_client = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
     download_fn = mocker.patch.object(api_client, 'download_submission')
 
     return_uuid = job.call_api(api_client, session)
@@ -400,6 +413,7 @@ def test_FileDownloadJob_message_already_downloaded(mocker, homedir, session, se
     job = FileDownloadJob(file_.uuid, os.path.join(homedir, 'data'), gpg)
     patch_decrypt(mocker, homedir, gpg, file_.filename)
     api_client = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
     download_fn = mocker.patch.object(api_client, 'download_submission')
 
     return_uuid = job.call_api(api_client, session)
@@ -429,6 +443,7 @@ def test_FileDownloadJob_happy_path_no_etag(mocker, homedir, session, session_ma
         return ('', full_path)
 
     api_client = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
     api_client.download_submission = fake_download
 
     job = FileDownloadJob(
@@ -471,6 +486,7 @@ def test_FileDownloadJob_happy_path_sha256_etag(mocker, homedir, session, sessio
                 full_path)
 
     api_client = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
     api_client.download_submission = fake_download
 
     job = FileDownloadJob(
@@ -506,6 +522,7 @@ def test_FileDownloadJob_bad_sha256_etag(mocker, homedir, session, session_maker
                 full_path)
 
     api_client = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
     api_client.download_submission = fake_download
 
     job = FileDownloadJob(
@@ -538,6 +555,7 @@ def test_FileDownloadJob_happy_path_unknown_etag(mocker, homedir, session, sessi
                 full_path)
 
     api_client = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
     api_client.download_submission = fake_download
 
     job = FileDownloadJob(
@@ -581,6 +599,7 @@ def test_FileDownloadJob_decryption_error(mocker, homedir, session, session_make
                 full_path)
 
     api_client = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
     api_client.download_submission = fake_download
 
     job = FileDownloadJob(

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -168,14 +168,14 @@ def test_RefreshButton_setup(mocker):
 
 def test_RefreshButton_on_clicked(mocker):
     """
-    When refresh button is clicked, sync_api should be called.
+    When refresh button is clicked, sync_api should be called with manual_refresh set to True.
     """
     rb = RefreshButton()
     rb.controller = mocker.MagicMock()
 
     rb._on_clicked()
 
-    rb.controller.sync_api.assert_called_once_with()
+    rb.controller.sync_api.assert_called_once_with(manual_refresh=True)
 
 
 def test_RefreshButton_on_refresh_complete(mocker):


### PR DESCRIPTION
# Description

Resolves https://github.com/freedomofpress/securedrop-client/issues/610
Resolves #181

* we no longer ask the user to manually refresh if a bg sync job fails, instead we auto retry in the background (this is what resolves #610)
* adds a `manual_refresh` option to `sync_api` so that if a user clicks the refresh icon and the sync fails, we show an error in the status bar with a retry link
* bumps the default timeout to 60 seconds used for login and delete (this is what resolves #181)
* queue jobs still use a default of 5 seconds for timeouts, so if the server cannot be reached, we will show the error immediately to the user if they click on the refresh icon

 - [x] I have tested these changes in the appropriate Qubes environment