### PR TITLE
Submit login form if user presses [Enter] or [Return]

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1410,15 +1410,14 @@ class LoginDialog(QDialog):
 
     def keyPressEvent(self, event):
         """
-        Override default QDialog behavior that closes the dialog window when the Esc key is pressed.
-        Instead, ignore the event.
+        Cutomize keyboard behavior in the login dialog.
+
+        - [Esc] should not close the dialog
+        - [Enter] or [Return] should attempt to submit the form
         """
         if event.key() == Qt.Key_Escape:
             event.ignore()
 
-        """
-        Pressing return or enter should attempt to submit the login form.
-        """
         if event.key() == Qt.Key_Enter or event.key() == Qt.Key_Return:
             self.validate()
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1416,6 +1416,12 @@ class LoginDialog(QDialog):
         if event.key() == Qt.Key_Escape:
             event.ignore()
 
+        """
+        Pressing return or enter should attempt to submit the login form.
+        """
+        if event.key() == Qt.Key_Enter or event.key() == Qt.Key_Return:
+            self.validate()
+
     def setup(self, controller):
         self.controller = controller
         self.offline_mode.clicked.connect(self.controller.login_offline_mode)

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -2,6 +2,7 @@
 Make sure the UI widgets are configured correctly and work as expected.
 """
 import html
+import pytest
 
 from PyQt5.QtCore import Qt, QEvent
 from PyQt5.QtGui import QFocusEvent
@@ -1068,7 +1069,7 @@ def test_LoginDialog_validate_input_ok(mocker):
     mock_controller.login.assert_called_once_with('foo', 'nicelongpassword', '123456')
 
 
-def test_LoginDialog_keyPressEvent(mocker):
+def test_LoginDialog_escapeKeyPressEvent(mocker):
     """
     Ensure we don't hide the login dialog when Esc key is pressed.
     """
@@ -1079,6 +1080,23 @@ def test_LoginDialog_keyPressEvent(mocker):
     ld.keyPressEvent(event)
 
     event.ignore.assert_called_once_with()
+
+
+@pytest.mark.parametrize("qt_key", [Qt.Key_Enter, Qt.Key_Return])
+def test_LoginDialog_submitKeyPressEvent(mocker, qt_key):
+    """
+    Ensure we submit the form when the user presses [Enter] or [Return]
+    """
+
+    ld = LoginDialog(None)
+    event = mocker.MagicMock()
+    event.key = mocker.MagicMock(return_value=qt_key)
+
+    ld.validate = mocker.MagicMock()
+
+    ld.keyPressEvent(event)
+
+    ld.validate.assert_called_once_with()
 
 
 def test_LoginDialog_closeEvent_exits(mocker):


### PR DESCRIPTION
Towards #274

# Status

Ready for review

# Test Plan

Keyboard use works in success case:
1. Provide complete credentials and log in by pressing [Enter] or [Return]
2. Confirm that you are successfully logged in

Keyboard use works in error case:
1. Provide incomplete or incorrect credentials and attempt to log in by pressing [Enter] or [Return]
2. Confirm that you see the expected error message

Clicking button still works:
1. Verify the above behavior by clicking "Sign in" instead of pressing [Enter] or [Return]
2. Confirm that the behavior is unchanged

# Checklist

- [x]  I have tested these changes in the appropriate Qubes environment