### PR TITLE
Updates CI to run on Buster for Debian packaging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,42 @@ common-steps:
         source .venv/bin/activate
         make bandit
 
+  - &install_packaging_dependencies
+    run:
+      name: Install Debian packaging dependencies and download wheels
+      command: |
+        mkdir ~/packaging && cd ~/packaging
+        git clone https://github.com/freedomofpress/securedrop-debian-packaging.git
+        cd securedrop-debian-packaging
+        make install-deps && make fetch-wheels
+        PKG_DIR=~/project make requirements
+
+  - &verify_requirements
+    run:
+      name: Ensure that build-requirements.txt and requirements.txt are in sync.
+      command: |
+        cd ~/project
+        # Return 1 if unstaged changes exist (after `make requirements` in the
+        # previous run step), else return 0.
+        git diff --quiet
+
+  - &make_source_tarball
+    run:
+      name: Tag and make source tarball
+      command: |
+        cd ~/project
+        ./update_version.sh 1000.0  # Dummy version number, doesn't matter what we put here
+        python3 setup.py sdist
+
+  - &build_debian_package
+    run:
+      name: Build debian package
+      command: |
+        cd ~/packaging/securedrop-debian-packaging
+        export PKG_VERSION=1000.0
+        export PKG_PATH=/home/circleci/project/dist/securedrop-client-$PKG_VERSION.tar.gz
+        make securedrop-client
+
 version: 2
 jobs:
   build-stretch:
@@ -34,38 +70,20 @@ jobs:
       - image: circleci/python:3.5-stretch
     steps:
       - checkout
+      - *install_packaging_dependencies
+      - *verify_requirements
+      - *make_source_tarball
+      - *build_debian_package
 
-      - run:
-          name: Install Debian packaging dependencies and download wheels
-          command: |
-            mkdir ~/packaging && cd ~/packaging
-            git clone https://github.com/freedomofpress/securedrop-debian-packaging.git
-            cd securedrop-debian-packaging
-            make install-deps && make fetch-wheels
-            PKG_DIR=~/project make requirements
-
-      - run:
-          name: Ensure that build-requirements.txt and requirements.txt are in sync.
-          command: |
-            cd ~/project
-            # Return 1 if unstaged changes exist (after `make requirements` in the 
-            # previous run step), else return 0.
-            git diff --quiet
-
-      - run:
-          name: Tag and make source tarball
-          command: |
-            cd ~/project
-            ./update_version.sh 1000.0  # Dummy version number, doesn't matter what we put here
-            python3 setup.py sdist
-
-      - run:
-          name: Build debian package
-          command: |
-            cd ~/packaging/securedrop-debian-packaging
-            export PKG_VERSION=1000.0
-            export PKG_PATH=~/project/dist/securedrop-client-$PKG_VERSION.tar.gz
-            make securedrop-client
+  build-buster:
+    docker:
+      - image: circleci/python:3.7-buster
+    steps:
+      - checkout
+      - *install_packaging_dependencies
+      - *verify_requirements
+      - *make_source_tarball
+      - *build_debian_package
 
   test-stretch:
     docker:
@@ -94,3 +112,4 @@ workflows:
       - test-stretch
       - build-stretch
       - test-buster
+      - build-buster


### PR DESCRIPTION
# Description

Fixes #527

Before this https://github.com/freedomofpress/securedrop-debian-packaging/pull/89 needs to get merged. Then we will have to kick the CI for rebuild.

# Test Plan

- Get the branch from https://github.com/freedomofpress/securedrop-debian-packaging/pull/89 and then try to build the package.

```
./update_version.sh 1000.0  # Dummy version number, doesn't matter what we put here python3 setup.py sdist
cd ../securedrop-debian-packaging
export PKG_VERSION=1000.0
export PKG_PATH=/home/circleci/project/dist/securedrop-client-$PKG_VERSION.tar.gz
make securedrop-client
```
