### PR TITLE
close #331 fix bug of sources disappearing from source list

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -834,14 +834,16 @@ class SourceList(QListWidget):
     Displays the list of sources.
     """
 
+    # Thick 500px border in QListView::item:selected is a workaround.
+    # See https://github.com/freedomofpress/securedrop-client/issues/331
     CSS = '''
     QListView {
         border: none;
-        show-decoration-selected: 0;
+        show-decoration-selected: 1;
         border-right: 3px solid #f3f5f9;
     }
     QListView::item:selected {
-        background: #f3f5f9;
+        border: 500px solid #f3f5f9;
     }
     '''
 


### PR DESCRIPTION
# Description
Fixes #331 where the bottom source was disappearing from the source list when the window
was maximized.

It was achieved with the workaround of doing the styling in the border instead of in the background and making the border very large so that the default style is shrinked until it no longer exists. See #331 for discussion.

# Test Plan
1. log in
2. maximise window
3. check that bottom source is still there and color and styling is correct
4. repeat 2, 3 several times as the original bug seemed to be a bit random

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

(I don't know if this is qubes-specific or not)