### PR TITLE
update user uuid ref

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -734,7 +734,7 @@ class Controller(QObject):
             uuid=reply_uuid,
             timestamp=datetime.utcnow(),
             source_id=source.id,
-            journalist_id=self.user.uuid,
+            journalist_id=self.api.token_journalist_uuid,
             file_counter=source.interaction_count,
             content=message,
             send_status_id=reply_status.id,

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1306,6 +1306,8 @@ def test_Controller_send_reply_success(homedir, config, mocker, session_maker, s
     mock_gui = mocker.MagicMock()
     co = Controller('http://localhost', mock_gui, session_maker, homedir)
     co.user = factory.User()
+    co.api = mocker.MagicMock()
+    co.api.token_journalist_uuid = co.user.uuid
 
     mock_success_signal = mocker.MagicMock()
     mock_failure_signal = mocker.MagicMock()
@@ -1317,17 +1319,14 @@ def test_Controller_send_reply_success(homedir, config, mocker, session_maker, s
 
     source = factory.Source()
     session.add(source)
-    msg_uuid = 'xyz456'
     session.commit()
 
-    msg = 'wat'
-
-    co.send_reply(source.uuid, msg_uuid, msg)
+    co.send_reply(source.uuid, 'mock_user_uuid', 'mock_msg')
 
     mock_job_cls.assert_called_once_with(
         source.uuid,
-        msg_uuid,
-        msg,
+        'mock_user_uuid',
+        'mock_msg',
         co.gpg,
     )
 


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/622

# Test Plan

1. Manual functional test: send a reply from a source
2. Log out and make sure you can't send a reply (otherwise we would see an error when trying to access `self.api.token_journalist_uuid`

# Checklist

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes