### PR TITLE
bugfix: populate source list immediately upon login (#577)

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -325,6 +325,7 @@ class Controller(QObject):
             self.api.journalist_last_name,
             self.session)
         self.gui.show_main_window(user)
+        self.update_sources()
         self.sync_api()
         self.api_job_queue.login(self.api)
         self.is_authenticated = True

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -196,6 +196,7 @@ def test_Controller_on_authenticate_success(homedir, config, mocker, session_mak
     mock_api_job_queue = mocker.patch("securedrop_client.logic.ApiJobQueue")
     co = Controller('http://localhost', mock_gui, session_maker, homedir)
     co.sync_api = mocker.MagicMock()
+    co.update_sources = mocker.MagicMock()
     co.session.add(user)
     co.session.commit()
     co.api = mocker.MagicMock()
@@ -211,6 +212,7 @@ def test_Controller_on_authenticate_success(homedir, config, mocker, session_mak
     co.sync_api.assert_called_once_with()
     assert co.is_authenticated
     assert mock_api_job_queue.called
+    co.update_sources.assert_called_once_with()
     login.assert_called_with(co.api)
     co.resume_queues.assert_called_once_with()
 


### PR DESCRIPTION
# Description

Closes #577

I investigated what was going on with #577, turns out it's a fast fix:
the controller's `update_sources()` method is used to display in the
source list whatever is contained in local storage. If we wait until
after `sync_api` is called _before_ calling it (what we're doing on `master`),
there will be a delay of potentially several seconds until the round-trip 
to the SecureDrop server completes. In this commit we just call the 
`update_sources()` method immediately upon login.

# Test Plan

0. Reproduce #577, i.e. confirm the the source list populates slowly (will only happen if you're going over tor)
1. Check out this branch and login
2. Confirm the source list appears populated immediately upon login

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes