### PR TITLE
Add print integration

### DIFF
--- a/securedrop_client/export.py
+++ b/securedrop_client/export.py
@@ -83,6 +83,7 @@ class Export(QObject):
     begin_print = pyqtSignal(list)
     print_call_failure = pyqtSignal(object)
     print_call_success = pyqtSignal()
+    export_completed = pyqtSignal(list)
 
     def __init__(self) -> None:
         super().__init__()
@@ -282,10 +283,7 @@ class Export(QObject):
                 logger.error(e)
                 self.export_usb_call_failure.emit(e)
 
-        # Export is finished, now remove files created when export began
-        for filepath in filepaths:
-            if os.path.exists(filepath):
-                os.remove(filepath)
+        self.export_completed.emit(filepaths)
 
     @pyqtSlot(list)
     def print(self, filepaths: List[str]) -> None:
@@ -306,7 +304,4 @@ class Export(QObject):
                 logger.error(e)
                 self.print_call_failure.emit(e)
 
-        # Print is finished, now remove files created when print began
-        for filepath in filepaths:
-            if os.path.exists(filepath):
-                os.remove(filepath)
+        self.export_completed.emit(filepaths)

--- a/securedrop_client/export.py
+++ b/securedrop_client/export.py
@@ -35,6 +35,8 @@ class ExportStatus(Enum):
     DISK_ENCRYPTION_NOT_SUPPORTED_ERROR = 'USB_ENCRYPTION_NOT_SUPPORTED'
     ERROR_USB_CONFIGURATION = 'ERROR_USB_CONFIGURATION'
     UNEXPECTED_RETURN_STATUS = 'UNEXPECTED_RETURN_STATUS'
+    PRINTER_NOT_FOUND = 'ERROR_PRINTER_NOT_FOUND'
+    MISSING_PRINTER_URI = 'ERROR_MISSING_PRINTER_URI'
 
 
 class Export(QObject):
@@ -58,6 +60,11 @@ class Export(QObject):
         'device': 'disk-test'
     }
 
+    PRINT_FN = 'print_archive.sd-export'
+    PRINT_METADATA = {
+        'device': 'printer',
+    }
+
     DISK_FN = 'archive.sd-export'
     DISK_METADATA = {
         'device': 'disk',
@@ -73,14 +80,16 @@ class Export(QObject):
     begin_preflight_check = pyqtSignal()
     export_usb_call_failure = pyqtSignal(object)
     export_usb_call_success = pyqtSignal()
+    begin_print = pyqtSignal(list)
+    print_call_failure = pyqtSignal(object)
+    print_call_success = pyqtSignal()
 
     def __init__(self) -> None:
         super().__init__()
 
-        self.begin_preflight_check.connect(self.run_preflight_checks,
-                                           type=Qt.QueuedConnection)
-        self.begin_usb_export.connect(self.send_file_to_usb_device,
-                                      type=Qt.QueuedConnection)
+        self.begin_preflight_check.connect(self.run_preflight_checks, type=Qt.QueuedConnection)
+        self.begin_usb_export.connect(self.send_file_to_usb_device, type=Qt.QueuedConnection)
+        self.begin_print.connect(self.print, type=Qt.QueuedConnection)
 
     def _export_archive(cls, archive_path: str) -> str:
         '''
@@ -222,6 +231,20 @@ class Export(QObject):
         if status:
             raise ExportError(status)
 
+    def _run_print(self, archive_dir: str, filepaths: List[str]) -> None:
+        '''
+        Create "printer" archive to send to Export VM.
+
+        Args:
+            archive_dir (str): The path to the directory in which to create the archive.
+
+        '''
+        metadata = self.PRINT_METADATA.copy()
+        archive_path = self._create_archive(archive_dir, self.PRINT_FN, metadata, filepaths)
+        status = self._export_archive(archive_path)
+        if status:
+            raise ExportError(status)
+
     @pyqtSlot()
     def run_preflight_checks(self) -> None:
         '''
@@ -259,7 +282,31 @@ class Export(QObject):
                 logger.error(e)
                 self.export_usb_call_failure.emit(e)
 
-        # Export is finished, now remov files created when export began
+        # Export is finished, now remove files created when export began
+        for filepath in filepaths:
+            if os.path.exists(filepath):
+                os.remove(filepath)
+
+    @pyqtSlot(list)
+    def print(self, filepaths: List[str]) -> None:
+        '''
+        Print the file to the printer attached to the Export VM.
+
+        Args:
+            filepath: The path of file to export.
+        '''
+        with TemporaryDirectory() as temp_dir:
+            try:
+                logger.debug('beginning printer from thread {}'.format(
+                    threading.current_thread().ident))
+                self._run_print(temp_dir, filepaths)
+                self.print_call_success.emit()
+                logger.debug('Print successful')
+            except ExportError as e:
+                logger.error(e)
+                self.print_call_failure.emit(e)
+
+        # Print is finished, now remove files created when print began
         for filepath in filepaths:
             if os.path.exists(filepath):
                 os.remove(filepath)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1862,7 +1862,7 @@ class FileWidget(QWidget):
                 self.download_button.hide()
                 self.no_file_name.hide()
                 self.export_button.show()
-                self.print_button.hide()  # Show once print is supported on the workstation client
+                self.print_button.show()
                 self.file_name.show()
 
     @pyqtSlot()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -29,7 +29,7 @@ from PyQt5.QtCore import Qt, pyqtSlot, pyqtSignal, QEvent, QTimer, QSize, pyqtBo
 from PyQt5.QtGui import QIcon, QPalette, QBrush, QColor, QFont, QLinearGradient
 from PyQt5.QtWidgets import QListWidget, QLabel, QWidget, QListWidgetItem, QHBoxLayout, \
     QPushButton, QVBoxLayout, QLineEdit, QScrollArea, QDialog, QAction, QMenu, QMessageBox, \
-    QToolButton, QSizePolicy, QPlainTextEdit, QStatusBar, QGraphicsDropShadowEffect, QApplication
+    QToolButton, QSizePolicy, QPlainTextEdit, QStatusBar, QGraphicsDropShadowEffect
 
 from securedrop_client.db import DraftReply, Source, Message, File, Reply, User
 from securedrop_client.storage import source_exists
@@ -1875,14 +1875,7 @@ class FileWidget(QWidget):
             return
 
         dialog = ExportDialog(self.controller, self.file.uuid)
-        # The underlying function of the `export` method makes a blocking call that can potentially
-        # take a long time to run (if the Export VM is not already running and needs to start, this
-        # can take 15 or more seconds). Calling `QApplication.processEvents` ensures that the `show`
-        # event is processed before the blocking call so that the user can see the dialog with a
-        # message to wait before the blocking call. We also call `exec` afterwards in order to give
-        # control to the dialog for the rest of the export process.
         dialog.show()
-        QApplication.processEvents()
         dialog.export()
         dialog.exec()
 
@@ -1896,14 +1889,7 @@ class FileWidget(QWidget):
             return
 
         dialog = PrintDialog(self.controller, self.file.uuid)
-        # The underlying function of the `export` method makes a blocking call that can potentially
-        # take a long time to run (if the Export VM is not already running and needs to start, this
-        # can take 15 or more seconds). Calling `QApplication.processEvents` ensures that the `show`
-        # event is processed before the blocking call so that the user can see the dialog with a
-        # message to wait before the blocking call. We also call `exec` afterwards in order to give
-        # control to the dialog for the rest of the export process.
         dialog.show()
-        QApplication.processEvents()
         dialog.print()
         dialog.exec()
 
@@ -2036,8 +2022,6 @@ class PrintDialog(QDialog):
     def _update(self, status):
         logger.debug('updating status... ')
         if status == ExportStatus.PRINTER_NOT_FOUND.value:
-            self._request_to_insert_usb_device()
-        elif status == ExportStatus.MISSING_PRINTER_URI.value:
             self._request_to_insert_usb_device()
         else:
             self.error_status_code.setText(_(status))

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1802,7 +1802,7 @@ class FileWidget(QWidget):
 
         self.download_button.installEventFilter(self)
         self.export_button.clicked.connect(self._on_export_clicked)
-        # self.print_button.installEventFilter(self)
+        self.print_button.clicked.connect(self._on_print_clicked)
 
         # File name or default string
         self.file_name = SecureQLabel(self.file.original_filename)
@@ -1885,6 +1885,27 @@ class FileWidget(QWidget):
         dialog.export()
         dialog.exec()
 
+    @pyqtSlot()
+    def _on_print_clicked(self):
+        """
+        Called when the print button is clicked.
+        """
+        if not self.controller.downloaded_file_exists(self.file.uuid):
+            self.controller.sync_api()
+            return
+
+        dialog = PrintDialog(self.controller, self.file.uuid)
+        # The underlying function of the `export` method makes a blocking call that can potentially
+        # take a long time to run (if the Export VM is not already running and needs to start, this
+        # can take 15 or more seconds). Calling `QApplication.processEvents` ensures that the `show`
+        # event is processed before the blocking call so that the user can see the dialog with a
+        # message to wait before the blocking call. We also call `exec` afterwards in order to give
+        # control to the dialog for the rest of the export process.
+        dialog.show()
+        QApplication.processEvents()
+        dialog.export()
+        dialog.exec()
+
     def _on_left_click(self):
         """
         Handle a completed click via the program logic. The download state
@@ -1899,6 +1920,126 @@ class FileWidget(QWidget):
         else:
             # Download the file.
             self.controller.on_submission_download(File, self.file.uuid)
+
+
+class PrintDialog(QDialog):
+
+    CSS_FOR_DIALOG_WITH_ERROR = '''
+    #print_dialog {
+        min-width: 830;
+        min-height: 430;
+        border: 1px solid #2a319d;
+    }
+    '''
+
+    CSS = '''
+    #print_dialog {
+        min-width: 400;
+        max-width: 400;
+        min-height: 200;
+        max-height: 200;
+    }
+    '''
+
+    def __init__(self, controller, file_uuid):
+        super().__init__()
+
+        self.controller = controller
+        self.file_uuid = file_uuid
+
+        self.setObjectName('print_dialog')
+        self.setStyleSheet(self.CSS)
+        self.setWindowFlags(Qt.Popup)
+        self.setWindowModality(Qt.WindowModal)
+
+        layout = QVBoxLayout(self)
+        self.setLayout(layout)
+
+        # Opening VM message
+        self.starting_message = SecureQLabel(_('Preparing print...'))
+        self.starting_message.setWordWrap(True)
+
+        # Widget to show error messages that occur during print
+        self.generic_error = QWidget()
+        self.generic_error.setObjectName('generic_error')
+        generic_error_layout = QHBoxLayout()
+        self.generic_error.setLayout(generic_error_layout)
+        self.error_status_code = SecureQLabel()
+        generic_error_message = SecureQLabel(_('See your administrator for help.'))
+        generic_error_message.setWordWrap(True)
+        generic_error_layout.addWidget(self.error_status_code)
+        generic_error_layout.addWidget(generic_error_message)
+
+        # Insert USB Device Form
+        self.insert_usb_form = QWidget()
+        self.insert_usb_form.setObjectName('insert_usb_form')
+        usb_form_layout = QVBoxLayout()
+        self.insert_usb_form.setLayout(usb_form_layout)
+        self.usb_error_message = SecureQLabel(_(
+            'Please try reconnecting your printer, or see your administrator for help.'))
+        self.usb_error_message.setWordWrap(True)
+        usb_instructions = SecureQLabel(_('Please connect your printer to a USB port.'))
+        usb_instructions.setWordWrap(True)
+        buttons = QWidget()
+        buttons_layout = QHBoxLayout()
+        buttons.setLayout(buttons_layout)
+        cancel_button = QPushButton(_('CANCEL'))
+        retry_button = QPushButton(_('CONTINUE'))
+        buttons_layout.addWidget(cancel_button)
+        buttons_layout.addWidget(retry_button)
+        usb_form_layout.addWidget(self.usb_error_message)
+        usb_form_layout.addWidget(usb_instructions)
+        usb_form_layout.addWidget(buttons, alignment=Qt.AlignRight)
+
+        # Printing message
+        self.printing_message = SecureQLabel(_('Printing...'))
+        self.printing_message.setWordWrap(True)
+
+        layout.addWidget(self.starting_message)
+        layout.addWidget(self.printing_message)
+        layout.addWidget(self.generic_error)
+        layout.addWidget(self.insert_usb_form)
+
+        self.starting_message.show()
+        self.printing_message.hide()
+        self.generic_error.hide()
+        self.insert_usb_form.hide()
+
+        cancel_button.clicked.connect(self.close)
+        retry_button.clicked.connect(self._on_retry_button_clicked)
+
+        self.controller.export.print_call_failure.connect(
+            self._on_print_failure, type=Qt.QueuedConnection)
+        self.controller.export.print_call_success.connect(
+            self._on_print_success, type=Qt.QueuedConnection)
+
+    def print(self):
+        self.printing_message.show()
+        self.controller.print_file(self.file_uuid)
+
+    @pyqtSlot()
+    def _on_retry_button_clicked(self):
+        self.print()
+
+    @pyqtSlot()
+    def _on_print_success(self):
+        self.close()
+
+    @pyqtSlot(object)
+    def _on_print_failure(self, status):
+        self._update(status)
+
+    def _update(self, status):
+        logger.debug('updating status... ')
+        if status == PrintStatus.PRINTER_NOT_FOUND.value:
+            self._request_to_insert_usb_device()
+        elif status == PrintStatus.MISSING_PRINTER_URI.value:
+            self._request_to_insert_usb_device()
+        else:
+            self.error_status_code.setText(_(status))
+            self.generic_error.show()
+            self.starting_message.hide()
+            self.insert_usb_form.hide()
 
 
 class ExportDialog(QDialog):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1413,6 +1413,8 @@ def test_FileWidget_on_file_download_updates_items_when_uuid_matches(mocker, sou
     fw._on_file_downloaded(file.uuid)
 
     assert fw.download_button.isHidden()
+    assert not fw.export_button.isHidden()
+    assert not fw.print_button.isHidden()
     assert fw.no_file_name.isHidden()
     assert not fw.file_name.isHidden()
 
@@ -1437,6 +1439,11 @@ def test_FileWidget_on_file_download_updates_items_when_uuid_does_not_match(
     fw._on_file_downloaded('not a matching uuid')
 
     fw.clear.assert_not_called()
+    assert fw.download_button.isHidden()
+    assert not fw.export_button.isHidden()
+    assert not fw.print_button.isHidden()
+    assert fw.no_file_name.isHidden()
+    assert not fw.file_name.isHidden()
 
 
 def test_FileWidget__on_export_clicked(mocker, session, source):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1492,7 +1492,7 @@ def test_FileWidget__on_export_clicked_missing_file(mocker, session, source):
 
 def test_FileWidget__on_print_clicked(mocker, session, source):
     """
-    Ensure preflight checks start when the EXPORT button is clicked and that password is requested
+    Ensure print_file is called when the PRINT button is clicked
     """
     file = factory.File(source=source['source'], is_downloaded=True)
     session.add(file)
@@ -1764,7 +1764,7 @@ def test_ExportDialog__update_after_CALLED_PROCESS_ERROR(mocker):
 
 def test_PrintDialog__on_retry_button_clicked(mocker):
     """
-    Ensure happy path runs preflight checks.
+    Ensure happy path prints the file.
     """
     controller = mocker.MagicMock()
     dialog = PrintDialog(controller, 'mock_uuid')

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -17,17 +17,16 @@ def test_print(mocker):
     export = Export()
     export.print_call_success = mocker.MagicMock()
     export.print_call_success.emit = mocker.MagicMock()
+    export.export_completed = mocker.MagicMock()
+    export.export_completed.emit = mocker.MagicMock()
     _run_print = mocker.patch.object(export, '_run_print')
     mocker.patch('os.path.exists', return_value=True)
-    os_remove = mocker.patch('os.remove')
 
     export.print(['path1', 'path2'])
 
     _run_print.assert_called_once_with('mock_temp_dir', ['path1', 'path2'])
     export.print_call_success.emit.assert_called_once_with()
-    assert os_remove.call_count == 2
-    assert os_remove.call_args_list[0][0][0] == 'path1'
-    assert os_remove.call_args_list[1][0][0] == 'path2'
+    export.export_completed.emit.assert_called_once_with(['path1', 'path2'])
 
 
 def test_print_error(mocker):
@@ -41,18 +40,17 @@ def test_print_error(mocker):
     export = Export()
     export.print_call_failure = mocker.MagicMock()
     export.print_call_failure.emit = mocker.MagicMock()
+    export.export_completed = mocker.MagicMock()
+    export.export_completed.emit = mocker.MagicMock()
     error = ExportError('[mock_filepath]')
     _run_print = mocker.patch.object(export, '_run_print', side_effect=error)
     mocker.patch('os.path.exists', return_value=True)
-    os_remove = mocker.patch('os.remove')
 
     export.print(['path1', 'path2'])
 
     _run_print.assert_called_once_with('mock_temp_dir', ['path1', 'path2'])
     export.print_call_failure.emit.assert_called_once_with(error)
-    assert os_remove.call_count == 2
-    assert os_remove.call_args_list[0][0][0] == 'path1'
-    assert os_remove.call_args_list[1][0][0] == 'path2'
+    export.export_completed.emit.assert_called_once_with(['path1', 'path2'])
 
 
 def test__run_print(mocker):
@@ -99,17 +97,16 @@ def test_send_file_to_usb_device(mocker):
     export = Export()
     export.export_usb_call_success = mocker.MagicMock()
     export.export_usb_call_success.emit = mocker.MagicMock()
+    export.export_completed = mocker.MagicMock()
+    export.export_completed.emit = mocker.MagicMock()
     _run_disk_export = mocker.patch.object(export, '_run_disk_export')
     mocker.patch('os.path.exists', return_value=True)
-    os_remove = mocker.patch('os.remove')
 
     export.send_file_to_usb_device(['path1', 'path2'], 'mock passphrase')
 
     _run_disk_export.assert_called_once_with('mock_temp_dir', ['path1', 'path2'], 'mock passphrase')
     export.export_usb_call_success.emit.assert_called_once_with()
-    assert os_remove.call_count == 2
-    assert os_remove.call_args_list[0][0][0] == 'path1'
-    assert os_remove.call_args_list[1][0][0] == 'path2'
+    export.export_completed.emit.assert_called_once_with(['path1', 'path2'])
 
 
 def test_send_file_to_usb_device_error(mocker):
@@ -123,18 +120,17 @@ def test_send_file_to_usb_device_error(mocker):
     export = Export()
     export.export_usb_call_failure = mocker.MagicMock()
     export.export_usb_call_failure.emit = mocker.MagicMock()
+    export.export_completed = mocker.MagicMock()
+    export.export_completed.emit = mocker.MagicMock()
     error = ExportError('[mock_filepath]')
     _run_disk_export = mocker.patch.object(export, '_run_disk_export', side_effect=error)
     mocker.patch('os.path.exists', return_value=True)
-    os_remove = mocker.patch('os.remove')
 
     export.send_file_to_usb_device(['path1', 'path2'], 'mock passphrase')
 
     _run_disk_export.assert_called_once_with('mock_temp_dir', ['path1', 'path2'], 'mock passphrase')
     export.export_usb_call_failure.emit.assert_called_once_with(error)
-    assert os_remove.call_count == 2
-    assert os_remove.call_args_list[0][0][0] == 'path1'
-    assert os_remove.call_args_list[1][0][0] == 'path2'
+    export.export_completed.emit.assert_called_once_with(['path1', 'path2'])
 
 
 def test_run_preflight_checks(mocker):

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -12,7 +12,6 @@ from tests import factory
 
 from securedrop_client import storage, db
 from securedrop_client.crypto import CryptoError
-from securedrop_client.export import Export
 from securedrop_client.logic import APICallRunner, Controller
 from securedrop_client.api_jobs.downloads import DownloadChecksumMismatchException
 from securedrop_client.api_jobs.uploads import SendReplyJobError

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -273,7 +273,7 @@ def test_ApiJobQueue_pause_queues(mocker):
 
     job_queue.on_queue_paused()
 
-    job_queue.paused.emit()
+    job_queue.paused.emit.assert_called_once_with()
 
 
 def test_ApiJobQueue_resume_queues_emits_resume_signal(mocker):


### PR DESCRIPTION
# Description

Resolves https://github.com/freedomofpress/securedrop-client/issues/477
Resolves #632

# Test Plan

If you have an HP LaserJet printer like me, then update the export script with this change: https://github.com/freedomofpress/securedrop-export/tree/laserjet-printers.

#### Test `ERROR_PRINTER_NOT_FOUND`:

1. Do not attach the printer to the Export VM
2. Print a document and see message to plug in printer

#### Test `ERROR_PRINTER_NOT_SUPPORTED`

1. Plug in an unsupported printer or modify the export script to expect a dummy uri so that this check does not pass: https://github.com/freedomofpress/securedrop-export/blob/312f9f8ac5d8b2bdde66671d51ac4f075639885b/securedrop_export/export.py#L353
2. Print a document and see error message to contact admin.

#### Test `ERROR_PRINTER_DRIVER_UNAVAILABLE`
1. Move /usr/share/cups/drv/brlaser.drv to /usr/share/cups/drv/brlaser.drv.bak so it's not found
2. Print a document and see error message to contact admin.

#### Test `ERROR_PRINT`
1. Send a corrupt doc file to SD instance so that `unoconv -o converted_path /tmp/tmp123/export_data/hello.doc.pdf /tmp/tmp123/export_data/hello.doc` fails
2. Print corrupt doc file and see error message to contact admin.

# Checklist

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes