### PR TITLE
move metadata sync to api queue

### DIFF
--- a/securedrop_client/api_jobs/downloads.py
+++ b/securedrop_client/api_jobs/downloads.py
@@ -64,7 +64,10 @@ class MetadataSyncJob(ApiJob):
                 pub_key = source.key.get('public', None)
                 fingerprint = source.key.get('fingerprint', None)
                 if not pub_key or not fingerprint:
-                    continue
+                    # The below line needs to be excluded from the coverage computation
+                    # as it will show as uncovered due to a cpython compiler optimziation.
+                    # See: https://bugs.python.org/issue2506
+                    continue  # pragma: no cover
                 try:
                     self.gpg.import_key(source.uuid, pub_key, fingerprint)
                 except CryptoError:

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -33,11 +33,11 @@ from sqlalchemy.orm.session import sessionmaker
 from securedrop_client import storage
 from securedrop_client import db
 from securedrop_client.api_jobs.downloads import FileDownloadJob, MessageDownloadJob, \
-    ReplyDownloadJob, DownloadChecksumMismatchException
+    ReplyDownloadJob, DownloadChecksumMismatchException, MetadataSyncJob
 from securedrop_client.api_jobs.uploads import SendReplyJob, SendReplyJobError, \
     SendReplyJobTimeoutError
 from securedrop_client.api_jobs.updatestar import UpdateStarJob, UpdateStarJobException
-from securedrop_client.crypto import GpgHelper, CryptoError
+from securedrop_client.crypto import GpgHelper
 from securedrop_client.export import Export
 from securedrop_client.queue import ApiJobQueue
 from securedrop_client.utils import check_dir_permissions
@@ -326,8 +326,8 @@ class Controller(QObject):
             self.session)
         self.gui.show_main_window(user)
         self.update_sources()
-        self.sync_api()
         self.api_job_queue.login(self.api)
+        self.sync_api()
         self.is_authenticated = True
         self.resume_queues()
 
@@ -371,11 +371,14 @@ class Controller(QObject):
 
         if self.authenticated():
             logger.debug("You are authenticated, going to make your call")
-            self.call_api(storage.get_remote_data,
-                          self.on_sync_success,
-                          self.on_sync_failure,
-                          self.api)
-            logger.debug("In sync_api, after call to call_api, on "
+
+            job = MetadataSyncJob(self.data_dir, self.gpg)
+
+            job.success_signal.connect(self.on_sync_success, type=Qt.QueuedConnection)
+            job.failure_signal.connect(self.on_sync_failure, type=Qt.QueuedConnection)
+            self.api_job_queue.enqueue(job)
+
+            logger.debug("In sync_api, after call to submit job to queue, on "
                          "thread {}".format(self.thread().currentThreadId()))
 
     def last_sync(self):
@@ -388,37 +391,17 @@ class Controller(QObject):
         except Exception:
             return None
 
-    def on_sync_success(self, result) -> None:
+    def on_sync_success(self) -> None:
         """
-        Called when syncronisation of data via the API succeeds.
+        Called when syncronisation of data via the API queue succeeds.
 
-            * Update db with new metadata
             * Set last sync flag
-            * Import keys into keyring
             * Display the last sync time and updated list of sources in GUI
             * Download new messages and replies
             * Update missing files so that they can be re-downloaded
         """
-        remote_sources, remote_submissions, remote_replies = result
-        storage.update_local_storage(self.session,
-                                     remote_sources,
-                                     remote_submissions,
-                                     remote_replies,
-                                     self.data_dir)
-
         with open(self.sync_flag, 'w') as f:
             f.write(arrow.now().format())
-
-        for source in remote_sources:
-            if source.key and source.key.get('type', None) == 'PGP':
-                pub_key = source.key.get('public', None)
-                fingerprint = source.key.get('fingerprint', None)
-                if not pub_key or not fingerprint:
-                    continue
-                try:
-                    self.gpg.import_key(source.uuid, pub_key, fingerprint)
-                except CryptoError:
-                    logger.warning('Failed to import key for source {}'.format(source.uuid))
 
         storage.update_missing_files(self.data_dir, self.session)
         self.update_sources()
@@ -428,7 +411,7 @@ class Controller(QObject):
 
     def on_sync_failure(self, result: Exception) -> None:
         """
-        Called when syncronisation of data via the API fails.
+        Called when syncronisation of data via the API queue fails.
         """
         self.gui.update_error_status(
             _('The SecureDrop server cannot be reached.'),

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -10,7 +10,7 @@ from typing import Optional, Tuple  # noqa: F401
 from securedrop_client.api_jobs.base import ApiJob, ApiInaccessibleError, DEFAULT_NUM_ATTEMPTS, \
     PauseQueueJob
 from securedrop_client.api_jobs.downloads import (FileDownloadJob, MessageDownloadJob,
-                                                  ReplyDownloadJob)
+                                                  ReplyDownloadJob, MetadataSyncJob)
 from securedrop_client.api_jobs.uploads import SendReplyJob
 from securedrop_client.api_jobs.updatestar import UpdateStarJob
 
@@ -41,7 +41,7 @@ class RunnableQueue(QObject):
     JOB_PRIORITIES = {
         # TokenInvalidationJob: 10,  # Not yet implemented
         PauseQueueJob: 11,
-        # MetadataSyncJob: 12,  # Not yet implemented
+        MetadataSyncJob: 12,
         FileDownloadJob: 13,  # File downloads processed in separate queue
         MessageDownloadJob: 13,
         ReplyDownloadJob: 13,


### PR DESCRIPTION
# Description

Fixes #461 
Fixes #489 (between this change and the pending reply change we should not see that bug any more)

This PR implements the `MetadataSyncJob`. A couple notes:
 * I left in `on_sync_failure` which is what is creating the "The SecureDrop server cannot be reached" messages so we can observe over the coming days/weeks how often this is failing (if we still see failures, we can bump up the number of automatic tries in the queue)
 * I hit an upstream `cpython` bug where a line is incorrectly showing as uncovered, see full explanation in and relevant links in e0370803aeb131941adea40af9b5bf0b85a047df

# Test Plan

0. Open client
1. Check client populates with messages/replies/etc.
2. Send a message as a new source
3. Click sync, check the new message appears

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes (just moves things around, doesn't change any qubes-specific logic)