### PR TITLE
add failure message for replies

### DIFF
--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1168,9 +1168,6 @@ def test_SpeechBubble_init(mocker):
     Check the speech bubble is configured correctly (there's a label containing
     the passed in text).
     """
-    mock_label = mocker.patch('securedrop_client.gui.widgets.SecureQLabel')
-    mocker.patch('securedrop_client.gui.widgets.QVBoxLayout')
-    mocker.patch('securedrop_client.gui.widgets.SpeechBubble.setLayout')
     mock_signal = mocker.Mock()
     mock_connect = mocker.Mock()
     mock_signal.connect = mock_connect
@@ -1178,7 +1175,7 @@ def test_SpeechBubble_init(mocker):
     sb = SpeechBubble('mock id', 'hello', mock_signal)
     ss = sb.styleSheet()
 
-    mock_label.assert_called_once_with('hello')
+    sb.message.text() == 'hello'
     assert mock_connect.called
     assert 'background-color' in ss
 
@@ -1187,8 +1184,6 @@ def test_SpeechBubble_update_text(mocker):
     """
     Check that the calling the slot updates the text.
     """
-    mocker.patch('securedrop_client.gui.widgets.QVBoxLayout')
-    mocker.patch('securedrop_client.gui.widgets.SpeechBubble.setLayout')
     mock_signal = mocker.MagicMock()
 
     msg_id = 'abc123'
@@ -2482,16 +2477,21 @@ def test_ReplyWidget_success_failure_slots(mocker):
     # check the success slog
     mock_logger = mocker.patch('securedrop_client.gui.widgets.logger')
     widget._on_reply_success(msg_id + "x")
+    assert widget.error.isHidden()
     assert not mock_logger.debug.called
     widget._on_reply_success(msg_id)
+    assert widget.error.isHidden()
     assert mock_logger.debug.called
     mock_logger.reset_mock()
 
-    # check the failure slot
+    # check the failure slot where message id does not match
     mock_logger = mocker.patch('securedrop_client.gui.widgets.logger')
     widget._on_reply_failure(msg_id + "x")
+    assert widget.error.isHidden()
     assert not mock_logger.debug.called
+    # check the failure slot where message id matches
     widget._on_reply_failure(msg_id)
+    assert not widget.error.isHidden()
     assert mock_logger.debug.called
 
 


### PR DESCRIPTION
# Description

Resolves https://github.com/freedomofpress/securedrop-client/issues/638

# Test Plan

1. apply diff to cause some replies to fail:

```
diff --git a/securedrop/journalist_app/api.py b/securedrop/journalist_app/api.py
index aa776d520..8eb8f26c8 100644
--- a/securedrop/journalist_app/api.py
+++ b/securedrop/journalist_app/api.py
@@ -230,6 +230,13 @@ def make_blueprint(config):
                 {'replies': [reply.to_json() for
                              reply in source.replies]}), 200
         elif request.method == 'POST':
+            import time
+            time.sleep(2)
+
+            import random
+            fail_early = random.choice([True, False])
+            if fail_early:
+                abort(409, 'That UUID is already in use.')
             source = get_or_404(Source, source_uuid,
                                 column=Source.uuid)
             if request.json is None:
```

2. send some replies and see "Failed to send" message with error icon
![failed_to_send](https://user-images.githubusercontent.com/4522213/70936160-9e82a780-1ff6-11ea-9fce-1a708128f5b2.png)

3. close and reopen the client to see that replies which fail continue to show error message.

 - [x] These changes should not need testing in Qubes