### PR TITLE
Add mention of possible requirement for sqlite3 command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ pip install --require-hashes -r dev-requirements.txt
 Please install system libraries for PyQt rather than using PyPI-managed libraries- this makes packaging possible later. On Debian, `apt install python3-pyqt5 python3-pyqt5.qtsvg` will install what you need.
 
 In order to run the test suite you should also install the `xvfb` package (to
-make the `xvfb-run` command available): `apt install xvfb`.
+make the `xvfb-run` command available): `apt install xvfb`. You may also need
+to install the `sqlite3` command: `apt install sqlite3`.
 
 ### OSX
 


### PR DESCRIPTION
# Description

The test suite fails on a clean install of the dev environment on an Ubuntu based machine and requires the installation of the `sqlite3` command. This PR ensures such a requirement is addressed in the appropriate place in the README.

# Test Plan

N/A

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes