### PR TITLE
Use queue for source deletion

### DIFF
--- a/securedrop_client/api_jobs/sources.py
+++ b/securedrop_client/api_jobs/sources.py
@@ -1,0 +1,44 @@
+import logging
+import sdclientapi
+
+from sdclientapi import API
+from sqlalchemy.orm.session import Session
+
+from securedrop_client.api_jobs.base import ApiJob
+
+logger = logging.getLogger(__name__)
+
+
+class DeleteSourceJob(ApiJob):
+    def __init__(self, source_uuid: str) -> None:
+        super().__init__()
+        self.source_uuid = source_uuid
+
+    def call_api(self, api_client: API, session: Session) -> str:
+        '''
+        Override ApiJob.
+
+        Delete a source on the server
+        '''
+        try:
+            source_sdk_object = sdclientapi.Source(uuid=self.source_uuid)
+
+            # TODO: After
+            # https://github.com/freedomofpress/securedrop-client/issues/648
+            # is merged, we will want to pass the default request
+            # timeout instead of setting it on the api object
+            # directly.
+            api_client.default_request_timeout = 5
+            api_client.delete_source(source_sdk_object)
+
+            return self.source_uuid
+        except Exception as e:
+            error_message = "Failed to delete source {uuid} due to {exception}".format(
+                uuid=self.source_uuid, exception=repr(e))
+            raise DeleteSourceJobException(error_message, self.source_uuid)
+
+
+class DeleteSourceJobException(Exception):
+    def __init__(self, message: str, source_uuid: str):
+        super().__init__(message)
+        self.source_uuid = source_uuid

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -11,6 +11,7 @@ from securedrop_client.api_jobs.base import ApiJob, ApiInaccessibleError, DEFAUL
     PauseQueueJob
 from securedrop_client.api_jobs.downloads import (FileDownloadJob, MessageDownloadJob,
                                                   ReplyDownloadJob, MetadataSyncJob)
+from securedrop_client.api_jobs.sources import DeleteSourceJob
 from securedrop_client.api_jobs.uploads import SendReplyJob
 from securedrop_client.api_jobs.updatestar import UpdateStarJob
 
@@ -45,7 +46,7 @@ class RunnableQueue(QObject):
         FileDownloadJob: 13,  # File downloads processed in separate queue
         MessageDownloadJob: 13,
         ReplyDownloadJob: 13,
-        # DeletionJob: 14,  # Not yet implemented
+        DeleteSourceJob: 14,
         SendReplyJob: 15,
         UpdateStarJob: 16,
         # FlagJob: 16,  # Not yet implemented

--- a/tests/api_jobs/test_sources.py
+++ b/tests/api_jobs/test_sources.py
@@ -1,0 +1,45 @@
+import pytest
+
+from securedrop_client.api_jobs.sources import DeleteSourceJob, DeleteSourceJobException
+from tests import factory
+
+
+def test_delete_source_job(homedir, mocker, session, session_maker):
+    '''
+    Test DeleteSourceJob construction and operation.
+    '''
+    source = factory.Source()
+    session.add(source)
+    session.commit()
+
+    api_client = mocker.MagicMock()
+    api_client.delete_source = mocker.MagicMock()
+
+    mock_sdk_source = mocker.Mock()
+    mock_source_init = mocker.patch(
+        'securedrop_client.logic.sdclientapi.Source',
+        return_value=mock_sdk_source
+    )
+
+    job = DeleteSourceJob(source.uuid)
+    job.call_api(api_client, session)
+
+    mock_source_init.assert_called_once_with(uuid=source.uuid)
+    api_client.delete_source.assert_called_once_with(mock_sdk_source)
+
+
+def test_failure_to_delete(homedir, mocker, session, session_maker):
+    '''
+    Check failure of a DeleteSourceJob.
+    '''
+    source = factory.Source()
+    session.add(source)
+    session.commit()
+
+    api_client = mocker.MagicMock()
+    api_client.delete_source = mocker.MagicMock()
+    api_client.delete_source.side_effect = Exception
+
+    job = DeleteSourceJob(source.uuid)
+    with pytest.raises(DeleteSourceJobException):
+        job.call_api(api_client, session)


### PR DESCRIPTION
# Description

Add `api_jobs/sources.py` containing `DeleteSourceJob`, add its priority to `queue.JOB_PRIORITIES`, and use it in `logic.delete_source`. Add tests.

Fixes #402.

# Test Plan

- Run `make dev` in your `securedrop` working copy
- Check out this branch in your `securedrop-client` working copy
- Run the client with `run.sh`
- Delete a source. 

# Checklist

 - [x] I have tested these changes in the appropriate Qubes environment
