### PR TITLE
Export VM no longer requires device to boot

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2289,18 +2289,7 @@ class ExportDialog(QDialog):
 
     @pyqtSlot(object)
     def _on_preflight_check_call_failure(self, error: ExportError):
-        # The first time we see a CALLED_PROCESS_ERROR, tell the user to insert the USB device
-        # in case the issue is that the Export VM cannot start due to a USB device being
-        # unavailable for attachment. According to the Qubes docs:
-        #
-        #   "If the device is unavailable (physically missing or sourceVM not started), booting
-        #    the targetVM fails."
-        #
-        # For information, see https://www.qubes-os.org/doc/device-handling
-        if error.status == ExportStatus.CALLED_PROCESS_ERROR.value:
-            self._request_to_insert_usb_device()
-        else:
-            self._update(error.status)
+        self._update(error.status)
 
     @pyqtSlot(object)
     def _on_export_usb_call_failure(self, error: ExportError):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1556,9 +1556,9 @@ def test_ExportDialog_export(mocker):
     controller.run_export_preflight_checks.assert_called_with()
 
 
-def test_ExportDialog_pre_flight_request_to_insert_usb_device_on_CALLED_PROCESS_ERROR(mocker):
+def test_ExportDialog_pre_flight_updates_dialog_on_CALLED_PROCESS_ERROR(mocker):
     """
-    Ensure request to insert USB device on CALLED_PROCESS_ERROR during pre-flight.
+    Ensure CALLED_PROCESS_ERROR during pre-flight updates the dialog with the status code.
     """
     controller = mocker.MagicMock()
     called_process_error = ExportError(ExportStatus.CALLED_PROCESS_ERROR.value)
@@ -1571,13 +1571,13 @@ def test_ExportDialog_pre_flight_request_to_insert_usb_device_on_CALLED_PROCESS_
     export_dialog._on_preflight_check_call_failure(called_process_error)
 
     export_dialog._request_passphrase.assert_not_called()
-    export_dialog._request_to_insert_usb_device.assert_called_once_with()
-    export_dialog._update.assert_not_called()
+    export_dialog._request_to_insert_usb_device.assert_not_called()
+    export_dialog._update.assert_called_once_with(called_process_error.status)
 
 
-def test_ExportDialog_export_request_to_insert_usb_device_on_CALLED_PROCESS_ERROR(mocker):
+def test_ExportDialog_export_updates_dialog_on_CALLED_PROCESS_ERROR(mocker):
     """
-    Ensure request to insert USB device on CALLED_PROCESS_ERROR during export.
+    Ensure CALLED_PROCESS_ERROR during export updates the dialog with the status code.
     """
     controller = mocker.MagicMock()
     called_process_error = ExportError(ExportStatus.CALLED_PROCESS_ERROR.value)


### PR DESCRIPTION
# Description

Now that we no longer use [persistent attachement in Qubes for the Export VM](https://github.com/freedomofpress/securedrop-workstation/pull/323), we no longer need the workaround to ask the user to insert their drive if we see an error that might have been from the VM not booting.
