### PR TITLE
Hover polish for file download clickables. Fixes #591.

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1741,7 +1741,10 @@ class FileWidget(QWidget):
         font-family: 'Source Sans Pro';
         font-weight: 500;
         font-size: 13px;
-        color: #0065db;
+        color: #2A319D;
+    }
+    QPushButton#export_print:hover {
+        color: #05a6fe;
     }
     QPushButton#download_button {
         border: none;
@@ -1833,11 +1836,13 @@ class FileWidget(QWidget):
         self.export_button = QPushButton(_('EXPORT'))
         self.export_button.setObjectName('export_print')
         self.export_button.setFont(file_buttons_font)
+        self.middot = QLabel("·")
         self.print_button = QPushButton(_('PRINT'))
         self.print_button.setObjectName('export_print')
         self.print_button.setFont(file_buttons_font)
         file_options_layout.addWidget(self.download_button)
         file_options_layout.addWidget(self.export_button)
+        file_options_layout.addWidget(self.middot)
         file_options_layout.addWidget(self.print_button)
 
         self.download_button.installEventFilter(self)
@@ -1867,10 +1872,12 @@ class FileWidget(QWidget):
             self.download_button.hide()
             self.no_file_name.hide()
             self.export_button.show()
+            self.middot.show()
             self.print_button.show()
             self.file_name.show()
         else:
             self.export_button.hide()
+            self.middot.hide()
             self.print_button.hide()
             self.file_name.hide()
             self.download_button.show()
@@ -1901,6 +1908,7 @@ class FileWidget(QWidget):
                 self.download_button.hide()
                 self.no_file_name.hide()
                 self.export_button.show()
+                self.middot.show()
                 self.print_button.show()
                 self.file_name.show()
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1279,6 +1279,7 @@ def test_FileWidget_init_file_not_downloaded(mocker, source, session):
     assert not fw.download_button.isHidden()
     assert not fw.no_file_name.isHidden()
     assert fw.export_button.isHidden()
+    assert fw.middot.isHidden()
     assert fw.print_button.isHidden()
     assert fw.file_name.isHidden()
 
@@ -1301,6 +1302,7 @@ def test_FileWidget_init_file_downloaded(mocker, source, session):
     assert fw.download_button.isHidden()
     assert fw.no_file_name.isHidden()
     assert not fw.export_button.isHidden()
+    assert not fw.middot.isHidden()
     assert not fw.print_button.isHidden()
     assert not fw.file_name.isHidden()
 
@@ -1409,6 +1411,7 @@ def test_FileWidget_on_file_download_updates_items_when_uuid_matches(mocker, sou
 
     assert fw.download_button.isHidden()
     assert not fw.export_button.isHidden()
+    assert not fw.middot.isHidden()
     assert not fw.print_button.isHidden()
     assert fw.no_file_name.isHidden()
     assert not fw.file_name.isHidden()
@@ -1436,6 +1439,7 @@ def test_FileWidget_on_file_download_updates_items_when_uuid_does_not_match(
     fw.clear.assert_not_called()
     assert fw.download_button.isHidden()
     assert not fw.export_button.isHidden()
+    assert not fw.middot.isHidden()
     assert not fw.print_button.isHidden()
     assert fw.no_file_name.isHidden()
     assert not fw.file_name.isHidden()


### PR DESCRIPTION
# Description

Fixes #591 . Getting the middot in there was fun. In the end I just copied and pasted an actual middot into a Python string. Was expecting Qt to have something like this already built in. 

# Test Plan

Unit tests updated. Checked with eyeball Mk1 ~ see enclosed screenie.

![sd_screenie](https://user-images.githubusercontent.com/37602/71817033-7d085f00-307c-11ea-8182-d52e50ac561a.png)


# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes