### PR TITLE
Add shortcuts for sending replies. Fixes # 606.

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -26,7 +26,7 @@ from typing import Dict, List, Union  # noqa: F401
 from uuid import uuid4
 from PyQt5.QtCore import Qt, pyqtSlot, pyqtSignal, QEvent, QTimer, QSize, pyqtBoundSignal, \
     QObject, QPoint
-from PyQt5.QtGui import QIcon, QPalette, QBrush, QColor, QFont, QLinearGradient
+from PyQt5.QtGui import QIcon, QPalette, QBrush, QColor, QFont, QLinearGradient, QKeySequence
 from PyQt5.QtWidgets import QListWidget, QLabel, QWidget, QListWidgetItem, QHBoxLayout, \
     QPushButton, QVBoxLayout, QLineEdit, QScrollArea, QDialog, QAction, QMenu, QMessageBox, \
     QToolButton, QSizePolicy, QPlainTextEdit, QStatusBar, QGraphicsDropShadowEffect
@@ -2553,6 +2553,11 @@ class ReplyBoxWidget(QWidget):
         button_icon = QIcon(button_pixmap)
         self.send_button.setIcon(button_icon)
         self.send_button.setIconSize(QSize(56.5, 47))
+        self.send_button.setShortcut(QKeySequence("Ctrl+Return"))
+        self.send_button.setDefault(True)
+
+        # Ensure TAB order from text edit -> send button
+        self.setTabOrder(self.text_edit, self.send_button)
 
         # Add widgets to replybox
         replybox_layout.addWidget(self.text_edit)
@@ -2632,6 +2637,8 @@ class ReplyTextEdit(QPlainTextEdit):
 
         self.setObjectName('reply_textedit')
         self.setStyleSheet(self.CSS)
+
+        self.setTabChangesFocus(True)  # Needed so we can TAB to send button.
 
         self.placeholder = QLabel()
         self.placeholder.setObjectName("reply_placeholder")

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -2363,6 +2363,8 @@ def test_ReplyBoxWidget_init(mocker):
     rb = ReplyBoxWidget(mocker.MagicMock(), mocker.MagicMock())
     assert rb.text_edit.isEnabled()
     assert not rb.send_button.isHidden()
+    assert rb.send_button.isDefault() is True  # Needed for "Enter" to work.
+    assert rb.send_button.shortcut().toString() == "Ctrl+Return"
 
 
 def test_ReplyBoxWidget_init_no_auth(mocker):


### PR DESCRIPTION
# Description

Fixes #606. Implements the following functionality:

* Pressing `CTRL+ENTER` while focused in the text area will send the message.
* Pressing `TAB` while in the text area will move focus to the send button (airplane).
* Pressing either `ENTER` or `SPACE` while the send button is highlighted causes it to be activated so the message is sent.

*NOTE*: Please see the GIF of a demo below and see how the scrolling of the messages jumps around. Is this expected. My feeling is you should always see the newest message (at the bottom of the message area) rather than the strange behaviour seen in this GIF.

![sd-demo](https://user-images.githubusercontent.com/37602/71829210-04b19600-309c-11ea-8b06-b644355b1ef4.gif)


# Test Plan

Minor additions to the unit test suite to ensure the updated state of the UI is configured correctly.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes