### PR TITLE
Fix scroll to bottom issue in #61.

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2392,11 +2392,7 @@ class ConversationView(QWidget):
         Handler called when a new item is added to the conversation. Ensures
         it's scrolled to the bottom and thus visible.
         """
-        current_val = self.scroll.verticalScrollBar().value()
-        viewport_height = self.scroll.viewport().height()
-
-        if current_val + viewport_height > max_val:
-            self.scroll.verticalScrollBar().setValue(max_val)
+        self.scroll.verticalScrollBar().setValue(max_val)
 
     def add_message(self, message: Message) -> None:
         """

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1914,25 +1914,6 @@ def test_ConversationView_update_conversation_position_follow(mocker, homedir):
     cv.scroll.verticalScrollBar().setValue.assert_called_once_with(6000)
 
 
-def test_ConversationView_update_conversation_position_stay_fixed(mocker, homedir):
-    """
-    Check the signal handler does not change the conversation position when
-    journalist is reading older messages
-    """
-    mocked_source = mocker.MagicMock()
-    mocked_controller = mocker.MagicMock()
-
-    cv = ConversationView(mocked_source, mocked_controller)
-
-    cv.scroll.verticalScrollBar().value = mocker.MagicMock(return_value=5500)
-    cv.scroll.viewport().height = mocker.MagicMock(return_value=500)
-    cv.scroll.verticalScrollBar().setValue = mocker.MagicMock()
-
-    cv.update_conversation_position(0, 6000)
-
-    cv.scroll.verticalScrollBar().setValue.assert_not_called()
-
-
 def test_ConversationView_add_message(mocker, session, source):
     """
     Adding a message results in a new MessageWidget added to the layout.


### PR DESCRIPTION
# Description

Fixes #61.

I've undone some changes that were applied to the original code which ensured that when new messages were added the pane would scroll to the bottom. I'm unsure why this code would have been added. AFAICT, when a new message is added to the pane, you should be able to see it!

Before merging, I'd like to explore what problems **I** may be re-introducing by removing this code (and associated test). The comment in the test appears to suggest that the code was added to avoid scrolling if the journalist was reading an older message. I feel these requirements are mutually exclusive, IYSWIM, so some sort of UX decision / discussion should probably happen (pinging @ninavizz).

# Test Plan

This is removal of code and an associated unit test. Further UX discussion is required and I expect further revisions to the code to reflect the outcome of such discussions.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes