### PR TITLE
Work around (not bug fix) for issue #684.

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2647,7 +2647,11 @@ class ReplyTextEdit(QPlainTextEdit):
         self.setStyleSheet(self.CSS)
 
         self.setTabChangesFocus(True)  # Needed so we can TAB to send button.
-        self.placeholder = None
+
+        self.placeholder = QLabel()
+        self.placeholder.setObjectName("reply_placeholder")
+        self.placeholder.setParent(self)
+        self.placeholder.move(QPoint(3, 4))  # make label match text below
         self.set_logged_in()
 
     def focusInEvent(self, e):
@@ -2662,37 +2666,20 @@ class ReplyTextEdit(QPlainTextEdit):
             self.placeholder.show()
         super(ReplyTextEdit, self).focusOutEvent(e)
 
-    def set_placeholder(self, message):
-        """
-        See #684 for context. Sometimes, the placeholder widget wasn't
-        repainted correctly by Qt when the setText method was used (the text
-        appeared truncated). Therefore, each time the placeholder text
-        is set by this method, the old placeholder is hidden then
-        self.placeholder is re-assigned to new placeholder (with the correct
-        dimensions). At the end of this method the old (now hidden placeholder)
-        goes out of scope and is garbage collected by Python.
-        """
-        if self.placeholder:
-            self.placeholder.hide()
-        self.placeholder = QLabel()
-        self.placeholder.setObjectName("reply_placeholder")
-        self.placeholder.setParent(self)
-        self.placeholder.move(QPoint(3, 4))  # make label match text below
-        self.placeholder.setText(message)
-        self.placeholder.show()
-
     def set_logged_in(self):
         self.setEnabled(True)
         source_name = "<strong><font color=\"#24276d\">{}</font></strong>".format(
             self.source.journalist_designation
         )
         placeholder = _("Compose a reply to ") + source_name
-        self.set_placeholder(placeholder)
+        self.placeholder.setText(placeholder)
+        self.placeholder.adjustSize()
 
     def set_logged_out(self):
         text = "<strong><font color=\"#2a319d\">" + _("Sign in") + " </font></strong>" + \
             _("to compose or send a reply")
-        self.set_placeholder(text)
+        self.placeholder.setText(text)
+        self.placeholder.adjustSize()
         self.setEnabled(False)
 
     def setText(self, text):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -2678,24 +2678,6 @@ def test_ReplyTextEdit_set_logged_in(mocker):
     assert source.journalist_designation in rt.placeholder.text()
 
 
-def test_ReplyTextEdit_set_placeholder(mocker):
-    """
-    Checks the placeholder text is updated.
-    """
-    source = mocker.MagicMock()
-    source.journalist_designation = 'journalist designation'
-    controller = mocker.MagicMock()
-    rt = ReplyTextEdit(source, controller)
-    mock_old_placeholder = mocker.MagicMock()
-    rt.placeholder = mock_old_placeholder
-    rt.set_placeholder("Hello, World!")
-    # The old placeholder is hidden and replaced with a new QLabel with the
-    # expected text.
-    mock_old_placeholder.hide.assert_called_once_with()
-    assert rt.placeholder is not mock_old_placeholder
-    assert rt.placeholder.text() == "Hello, World!"
-
-
 def test_update_conversation_maintains_old_items(mocker, session):
     """
     Calling update_conversation deletes and adds old items back to layout

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -2678,6 +2678,24 @@ def test_ReplyTextEdit_set_logged_in(mocker):
     assert source.journalist_designation in rt.placeholder.text()
 
 
+def test_ReplyTextEdit_set_placeholder(mocker):
+    """
+    Checks the placeholder text is updated.
+    """
+    source = mocker.MagicMock()
+    source.journalist_designation = 'journalist designation'
+    controller = mocker.MagicMock()
+    rt = ReplyTextEdit(source, controller)
+    mock_old_placeholder = mocker.MagicMock()
+    rt.placeholder = mock_old_placeholder
+    rt.set_placeholder("Hello, World!")
+    # The old placeholder is hidden and replaced with a new QLabel with the
+    # expected text.
+    mock_old_placeholder.hide.assert_called_once_with()
+    assert rt.placeholder is not mock_old_placeholder
+    assert rt.placeholder.text() == "Hello, World!"
+
+
 def test_update_conversation_maintains_old_items(mocker, session):
     """
     Calling update_conversation deletes and adds old items back to layout


### PR DESCRIPTION
# Description

Fixes ##684.

This was an adventure. After exploring a Qt rabbit hole I proved my hunch was correct (the size of the QLabel wasn't being redrawn when the `setText` method was called, hence the truncated text). Investigating a workaround ended up with the first commit which was created because I was unaware of the `adjustSize` method on the QWidget base class. However, once I found it, I scratched by work-around approach and now it works. :-)

# Test Plan

None (needed).

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes