### PR TITLE
Adds SysLogHandler to log everything on rsyslog

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -39,12 +39,14 @@ def test_configure_logging(homedir, mocker):
     expected (rotating logs) manner.
     """
     mock_log_conf = mocker.patch('securedrop_client.app.TimedRotatingFileHandler')
+    mock_log_conf_sys = mocker.patch('securedrop_client.app.SysLogHandler')
     mock_logging = mocker.patch('securedrop_client.app.logging')
     mock_log_file = os.path.join(homedir, 'logs', 'client.log')
     configure_logging(homedir)
     mock_log_conf.assert_called_once_with(mock_log_file, when='midnight',
                                           backupCount=5, delay=0,
                                           encoding=ENCODING)
+    mock_log_conf_sys.assert_called_once_with(address="/dev/log")
     mock_logging.getLogger.assert_called_once_with()
     assert sys.excepthook == excepthook
 


### PR DESCRIPTION
Now all log lines will go to `/var/log/syslog` file.
Also `black` reformatted the file.


# Test Plan

- [ ] Run the application
- [ ] Try to Login as a journalist account (name or password is incorrect)
- [ ] login with a proper account

You should be able to see the log entries in `/var/log/syslog` file. 


# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes