### PR TITLE
remove default highlight for source in source list

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -841,16 +841,14 @@ class SourceList(QListWidget):
     Displays the list of sources.
     """
 
-    # Thick 500px border in QListView::item:selected is a workaround.
-    # See https://github.com/freedomofpress/securedrop-client/issues/331
     CSS = '''
     QListView {
         border: none;
-        show-decoration-selected: 1;
+        show-decoration-selected: 0;
         border-right: 3px solid #f3f5f9;
     }
     QListView::item:selected {
-        border: 500px solid #f3f5f9;
+        background-color: #f3f5f9;
     }
     '''
 


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/331 which was reintroduced at some point.

See how the first item in the SourceList is highlighted when nothing is displaying for that source. Also the highlight coloring is using the QListView default instead of our own:

![highlight-incorrect](https://user-images.githubusercontent.com/4522213/72195580-ddbed100-33c7-11ea-9134-7890cc5d4d65.png)

# Test Plan

1. Log into the client in offline mode and now see that the first item is not highlighted. Also when you select an item in the source list it will appear with the correct highlight color, see:

![Screenshot from 2020-01-10 16-39-43](https://user-images.githubusercontent.com/4522213/72195637-2c6c6b00-33c8-11ea-9ded-8956e5b7497c.png)

![Screenshot from 2020-01-10 16-39-55](https://user-images.githubusercontent.com/4522213/72195647-355d3c80-33c8-11ea-95c4-16360631a502.png)
