### PR TITLE
Preview last message in source list.

### DIFF
--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -179,7 +179,7 @@ class File(Base):
         Return something that's a useful string representation of the file.
         """
         if self.is_downloaded:
-            return "File: {}".format(self.filename)
+            return "File: {}".format(self.original_filename)
         else:
             return '<Encrypted file on server>'
 

--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -111,6 +111,15 @@ class Message(Base):
         kwargs['file_counter'] = int(filename.split('-')[0])
         super().__init__(**kwargs)
 
+    def __str__(self) -> str:
+        """
+        Return something that's a useful string representation of the message.
+        """
+        if self.content is not None:
+            return self.content
+        else:
+            return '<Message not yet available>'
+
     def __repr__(self) -> str:
         return '<Message {}>'.format(self.filename)
 
@@ -165,6 +174,15 @@ class File(Base):
         kwargs['file_counter'] = int(filename.split('-')[0])
         super().__init__(**kwargs)
 
+    def __str__(self) -> str:
+        """
+        Return something that's a useful string representation of the file.
+        """
+        if self.is_downloaded:
+            return "File: {}".format(self.filename)
+        else:
+            return '<Encrypted file on server>'
+
     def __repr__(self) -> str:
         return '<File {}>'.format(self.filename)
 
@@ -216,6 +234,15 @@ class Reply(Base):
         kwargs['file_counter'] = int(filename.split('-')[0])
         super().__init__(**kwargs)
 
+    def __str__(self) -> str:
+        """
+        Return something that's a useful string representation of the reply.
+        """
+        if self.content is not None:
+            return self.content
+        else:
+            return '<Reply not yet available>'
+
     def __repr__(self) -> str:
         return '<Reply {}>'.format(self.filename)
 
@@ -249,6 +276,15 @@ class DraftReply(Base):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
+
+    def __str__(self) -> str:
+        """
+        Return something that's a useful string representation of the reply.
+        """
+        if self.content is not None:
+            return self.content
+        else:
+            return '<Reply not yet available>'
 
     def __repr__(self) -> str:
         return '<DraftReply {}>'.format(self.uuid)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1045,6 +1045,11 @@ class SourceWidget(QWidget):
         """
         self.timestamp.setText(arrow.get(self.source.last_updated).format('DD MMM'))
         self.name.setText(self.source.journalist_designation)
+        if self.source.collection:
+            msg = str(self.source.collection[-1])
+            if len(msg) > 120:
+                msg = msg[:120] + "..."
+            self.preview.setText(msg)
         if self.source.document_count == 0:
             self.paperclip.hide()
 
@@ -2407,23 +2412,13 @@ class ConversationView(QWidget):
         """
         Add a message from the source.
         """
-        if message.content is not None:
-            content = message.content
-        else:
-            content = '<Message not yet available>'
-
-        conversation_item = MessageWidget(message.uuid, content, self.controller.message_ready)
+        conversation_item = MessageWidget(message.uuid, str(message), self.controller.message_ready)
         self.conversation_layout.addWidget(conversation_item, alignment=Qt.AlignLeft)
 
     def add_reply(self, reply: Union[DraftReply, Reply]) -> None:
         """
         Add a reply from a journalist to the source.
         """
-        if reply.content is not None:
-            content = reply.content
-        else:
-            content = '<Reply not yet available>'
-
         try:
             send_status = reply.send_status.name
         except AttributeError:
@@ -2432,7 +2427,7 @@ class ConversationView(QWidget):
         logger.debug('adding reply: with status {}'.format(send_status))
         conversation_item = ReplyWidget(
             reply.uuid,
-            content,
+            str(reply),
             send_status,
             self.controller.reply_ready,
             self.controller.reply_succeeded,

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -555,6 +555,7 @@ class Controller(QObject):
         self.gui.clear_error_status()  # remove any permanent error status message
         message = storage.get_message(self.session, uuid)
         self.message_ready.emit(message.uuid, message.content)
+        self.update_sources()
 
     def on_message_download_failure(self, exception: Exception) -> None:
         """
@@ -732,6 +733,7 @@ class Controller(QObject):
         """
         self.gui.clear_error_status()  # remove any permanent error status message
         self.file_ready.emit(result)
+        self.update_sources()
 
     def on_file_download_failure(self, exception: Exception) -> None:
         """

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -750,7 +750,6 @@ def test_SourceWidget_update_truncate_latest_msg(mocker):
     If the latest message in the conversation is longer than 120 characters,
     truncate and add "..." to the end.
     """
-    #source = factory.Source(document_count=1)
     source = mocker.MagicMock()
     source.journalist_designation = "Testy McTestface"
     source.collection = [factory.Message(content="a" * 121), ]

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -745,6 +745,21 @@ def test_SourceWidget_update_attachment_icon():
     assert sw.paperclip.isHidden()
 
 
+def test_SourceWidget_update_truncate_latest_msg(mocker):
+    """
+    If the latest message in the conversation is longer than 120 characters,
+    truncate and add "..." to the end.
+    """
+    #source = factory.Source(document_count=1)
+    source = mocker.MagicMock()
+    source.journalist_designation = "Testy McTestface"
+    source.collection = [factory.Message(content="a" * 121), ]
+    sw = SourceWidget(source)
+
+    sw.update()
+    assert sw.preview.text().endswith("...")
+
+
 def test_SourceWidget_delete_source(mocker, session, source):
     mock_delete_source_message_box_object = mocker.MagicMock(DeleteSourceMessageBox)
     mock_controller = mocker.MagicMock()

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -769,6 +769,7 @@ def test_Controller_on_file_downloaded_success(homedir, config, mocker, session_
     mock_gui = mocker.MagicMock()
 
     co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co.update_sources = mocker.MagicMock()
 
     # signal when file is downloaded
     mock_file_ready = mocker.patch.object(co, 'file_ready')
@@ -777,6 +778,7 @@ def test_Controller_on_file_downloaded_success(homedir, config, mocker, session_
     co.on_file_download_success(mock_uuid)
 
     mock_file_ready.emit.assert_called_once_with(mock_uuid)
+    co.update_sources.assert_called_once_with()
 
 
 def test_Controller_on_file_downloaded_api_failure(homedir, config, mocker, session_maker):
@@ -1209,6 +1211,7 @@ def test_Controller_on_message_downloaded_success(mocker, homedir, session_maker
     Check that a successful download emits proper signal.
     """
     co = Controller('http://localhost', mocker.MagicMock(), session_maker, homedir)
+    co.update_sources = mocker.MagicMock()
     message_ready = mocker.patch.object(co, 'message_ready')
     message = factory.Message(source=factory.Source())
     mocker.patch('securedrop_client.storage.get_message', return_value=message)
@@ -1216,6 +1219,7 @@ def test_Controller_on_message_downloaded_success(mocker, homedir, session_maker
     co.on_message_download_success(message.uuid)
 
     message_ready.emit.assert_called_once_with(message.uuid, message.content)
+    co.update_sources.assert_called_once_with()
 
 
 def test_Controller_on_message_downloaded_failure(mocker, homedir, session_maker):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -51,21 +51,21 @@ def test_string_representation_of_source():
     source.__repr__()
 
 
-def test_string_representation_of_message():
+def test_repr_representation_of_message():
     source = factory.Source()
     msg = Message(source=source, uuid="test", size=123, filename="1-test.docx",
                   download_url='http://test/test')
     msg.__repr__()
 
 
-def test_string_representation_of_file():
+def test_repr_representation_of_file():
     source = factory.Source()
     file_ = File(source=source, uuid="test", size=123, filename="1-test.docx",
                  download_url='http://test/test')
     file_.__repr__()
 
 
-def test_string_representation_of_reply():
+def test_repr_representation_of_reply():
     user = User(username='hehe')
     source = factory.Source()
     reply = Reply(source=source, journalist=user, filename="1-reply.gpg",
@@ -73,11 +73,42 @@ def test_string_representation_of_reply():
     reply.__repr__()
 
 
-def test_string_representation_of_draft_reply():
+def test_repr_representation_of_draft_reply():
     user = User(username='hehe')
     source = factory.Source()
     draft_reply = DraftReply(source=source, journalist=user, uuid='test')
     draft_reply.__repr__()
+
+
+def test_string_representation_of_message():
+    source = factory.Source()
+    msg = Message(source=source, uuid="test", size=123, filename="1-test.docx",
+                  download_url='http://test/test')
+    msg.__str__()
+
+
+def test_string_representation_of_file():
+    source = factory.Source()
+    file_ = File(source=source, uuid="test", size=123, filename="1-test.docx",
+                 download_url='http://test/test')
+    file_.__str__()
+
+
+def test_string_representation_of_reply():
+    user = User(username='hehe')
+    source = factory.Source()
+    reply = Reply(source=source, journalist=user, filename="1-reply.gpg",
+                  size=1234, uuid='test')
+    reply.__str__()
+
+
+def test_string_representation_of_draft_reply():
+    user = User(username='hehe')
+    source = factory.Source()
+    draft_reply = DraftReply(source=source, journalist=user, uuid='test')
+    draft_reply.__str__()
+    draft_reply.content = "hello"
+    draft_reply.__str__()
 
 
 def test_string_representation_of_send_reply_status():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -92,6 +92,8 @@ def test_string_representation_of_file():
     file_ = File(source=source, uuid="test", size=123, filename="1-test.docx",
                  download_url='http://test/test')
     file_.__str__()
+    file_.is_downloaded = True
+    file_.__str__()
 
 
 def test_string_representation_of_reply():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -85,6 +85,8 @@ def test_string_representation_of_message():
     msg = Message(source=source, uuid="test", size=123, filename="1-test.docx",
                   download_url='http://test/test')
     msg.__str__()
+    msg.content = "hello"
+    msg.__str__()
 
 
 def test_string_representation_of_file():
@@ -101,6 +103,8 @@ def test_string_representation_of_reply():
     source = factory.Source()
     reply = Reply(source=source, journalist=user, filename="1-reply.gpg",
                   size=1234, uuid='test')
+    reply.__str__()
+    reply.content = "hello"
     reply.__str__()
 
 


### PR DESCRIPTION
# Description

Fixes #135.

The UI elements were already there. This was simply a plumbing task. I tried various approaches but this is the simplest one. The result looks like this:

![latest_message_preview](https://user-images.githubusercontent.com/37602/72347460-2e883f80-36d0-11ea-930a-979dcf98a151.gif)

**NOTE** The "not yet available" messages on initial start are cleared when the client refreshes (see screenie above). I did try to connect signals to make this work "automagically" but the code was messy and then I remembered that we're going to make the client update automatically after N-seconds in an upcoming change (i.e. the default behaviour of the client app will ensure the "not yet available" messages will update to the real content of the messages). Trust me, I much prefer this simpler approach. ;-)

One other thing, I've added `__str__` methods to the `db` based classes this touches on, since we re-use the "show me the content of this message" type behaviour in several places now and the object itself should probably be the arbiter of the default means of working out what such a string value should be.

# Test Plan

Added unit tests.

**NOTE** Hmm... the existing tests of `repr` I found **don't actually test anything**. They just run code which means the coverage check passes. I've followed this same approach for testing the new `__str__` methods mentioned above, since this appears to be a convention. However, I don't feel this is a good convention. Surely tests should `assert` something should be the case..? ;-)

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [ ] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
