### PR TITLE
fix ci after migrating our pip mirror to git-lfs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ common-steps:
       name: Install Debian packaging dependencies and download wheels
       command: |
         mkdir ~/packaging && cd ~/packaging
+        git config --global --unset url.ssh://git@github.com.insteadof
         git clone https://github.com/freedomofpress/securedrop-debian-packaging.git
         cd securedrop-debian-packaging
         make install-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,18 @@ common-steps:
         source .venv/bin/activate
         make bandit
 
+  - &installgitlfs
+    run:
+      name: Install Git LFS.
+      command: |
+        export GIT_LFS_VERSION=2.7.2
+        export GIT_LFS_CHECKSUM=89f5aa2c29800bbb71f5d4550edd69c5f83e3ee9e30f770446436dd7f4ef1d4c
+        wget https://github.com/git-lfs/git-lfs/releases/download/v$GIT_LFS_VERSION/git-lfs-linux-amd64-v$GIT_LFS_VERSION.tar.gz
+        sha256sum git-lfs-linux-amd64-v$GIT_LFS_VERSION.tar.gz | grep $GIT_LFS_CHECKSUM
+        tar xzf git-lfs-linux-amd64-v$GIT_LFS_VERSION.tar.gz
+        sudo mv git-lfs /usr/local/bin/git-lfs
+        git lfs install
+
   - &install_packaging_dependencies
     run:
       name: Install Debian packaging dependencies and download wheels
@@ -70,6 +82,7 @@ jobs:
       - image: circleci/python:3.7-buster
     steps:
       - checkout
+      - *installgitlfs
       - *install_packaging_dependencies
       - *verify_requirements
       - *make_source_tarball

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,16 +65,6 @@ common-steps:
 
 version: 2
 jobs:
-  build-stretch:
-    docker:
-      - image: circleci/python:3.5-stretch
-    steps:
-      - checkout
-      - *install_packaging_dependencies
-      - *verify_requirements
-      - *make_source_tarball
-      - *build_debian_package
-
   build-buster:
     docker:
       - image: circleci/python:3.7-buster
@@ -84,16 +74,6 @@ jobs:
       - *verify_requirements
       - *make_source_tarball
       - *build_debian_package
-
-  test-stretch:
-    docker:
-      - image: circleci/python:3.5-stretch
-    steps:
-      - checkout
-      - run: sudo apt-get install -y sqlite3 libqt5x11extras5
-      - *run_tests
-      - *check_python_dependencies_for_vulns
-      - *run_static_analysis
 
   test-buster:
     docker:
@@ -109,5 +89,5 @@ workflows:
   version: 2
   securedrop_client_ci:
     jobs:
-      - test-stretch
       - test-buster
+      - build-buster

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,18 +27,6 @@ common-steps:
         source .venv/bin/activate
         make bandit
 
-  - &installgitlfs
-    run:
-      name: Install Git LFS.
-      command: |
-        export GIT_LFS_VERSION=2.7.2
-        export GIT_LFS_CHECKSUM=89f5aa2c29800bbb71f5d4550edd69c5f83e3ee9e30f770446436dd7f4ef1d4c
-        wget https://github.com/git-lfs/git-lfs/releases/download/v$GIT_LFS_VERSION/git-lfs-linux-amd64-v$GIT_LFS_VERSION.tar.gz
-        sha256sum git-lfs-linux-amd64-v$GIT_LFS_VERSION.tar.gz | grep $GIT_LFS_CHECKSUM
-        tar xzf git-lfs-linux-amd64-v$GIT_LFS_VERSION.tar.gz
-        sudo mv git-lfs /usr/local/bin/git-lfs
-        git lfs install
-
   - &install_packaging_dependencies
     run:
       name: Install Debian packaging dependencies and download wheels
@@ -82,7 +70,6 @@ jobs:
       - image: circleci/python:3.7-buster
     steps:
       - checkout
-      - *installgitlfs
       - *install_packaging_dependencies
       - *verify_requirements
       - *make_source_tarball

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ common-steps:
         mkdir ~/packaging && cd ~/packaging
         git clone https://github.com/freedomofpress/securedrop-debian-packaging.git
         cd securedrop-debian-packaging
-        make install-deps && make fetch-wheels
+        make install-deps
         PKG_DIR=~/project make requirements
 
   - &verify_requirements


### PR DESCRIPTION
# Description

@ntoll hit a CI failure in #698, that's due to the removal of the fetch-wheels target we made in https://github.com/freedomofpress/securedrop-debian-packaging/pull/124

I'm putting this up for awareness, still working on another outstanding git-lfs issue inline tho..

# Test Plan

- [ ] CI should be fixed
