### PR TITLE
Fix HTML entities being escaped in speech bubbles.

### DIFF
--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -17,8 +17,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-import html
-
 from typing import Union
 
 from PyQt5.QtWidgets import QLabel, QHBoxLayout, QPushButton, QWidget
@@ -161,8 +159,8 @@ class SecureQLabel(QLabel):
         flags: Union[Qt.WindowFlags, Qt.WindowType] = Qt.WindowFlags(),
     ):
         super().__init__(parent, flags)
-        self.setTextFormat(Qt.PlainText)
         self.setText(text)
 
     def setText(self, text: str) -> None:
-        super().setText(html.escape(text, quote=False))
+        self.setTextFormat(Qt.PlainText)
+        super().setText(text)

--- a/tests/gui/test_init.py
+++ b/tests/gui/test_init.py
@@ -2,9 +2,7 @@
 Tests for the gui helper functions in __init__.py
 """
 
-import html
-
-from PyQt5.QtCore import QSize
+from PyQt5.QtCore import QSize, Qt
 from PyQt5.QtWidgets import QApplication
 
 from securedrop_client.gui import SecureQLabel, SvgPushButton, SvgLabel, SvgToggleButton
@@ -135,16 +133,19 @@ def test_SvgLabel_init(mocker):
 def test_SecureQLabel_init():
     label_text = '<script>alert("hi!");</script>'
     sl = SecureQLabel(label_text)
-    assert sl.text() == html.escape(label_text, quote=False)
+    assert sl.text() == label_text
 
 
-def test_SecureQLabel_setText():
+def test_SecureQLabel_setText(mocker):
     sl = SecureQLabel("hello")
     assert sl.text() == "hello"
 
     label_text = '<script>alert("hi!");</script>'
+    sl.setTextFormat = mocker.MagicMock()
     sl.setText(label_text)
-    assert sl.text() == html.escape(label_text, quote=False)
+    assert sl.text() == label_text
+    # Ensure *safe* plain text with no HTML entities.
+    sl.setTextFormat.assert_called_once_with(Qt.PlainText)
 
 
 def test_SecureQLabel_quotes_not_escaped_for_readability():

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1,7 +1,6 @@
 """
 Make sure the UI widgets are configured correctly and work as expected.
 """
-import html
 import pytest
 
 from PyQt5.QtCore import Qt, QEvent
@@ -1230,7 +1229,7 @@ def test_SpeechBubble_html_init(mocker):
     mock_signal = mocker.MagicMock()
 
     bubble = SpeechBubble('mock id', '<b>hello</b>', mock_signal)
-    assert bubble.message.text() == html.escape('<b>hello</b>')
+    assert bubble.message.text() == '<b>hello</b>'
 
 
 def test_SpeechBubble_with_apostrophe_in_text(mocker):
@@ -1239,7 +1238,7 @@ def test_SpeechBubble_with_apostrophe_in_text(mocker):
 
     message = "I'm sure, you are reading my message."
     bubble = SpeechBubble('mock id', message, mock_signal)
-    assert bubble.message.text() == html.escape(message, quote=False)
+    assert bubble.message.text() == message
 
 
 def test_MessageWidget_init(mocker):


### PR DESCRIPTION
# Description

Fixes #644. Fixes #645 .

I agree with and have followed @emkll's suggestion for the fix.

# Test Plan

Updated unit tests to reflect changes.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [ ] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
