### PR TITLE
Ensure width of colour bar at bottom of replies/messages is full width.

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1517,6 +1517,8 @@ class SpeechBubble(QWidget):
         max-height: 5px;
         background-color: #102781;
         border: 0px;
+        min-width: 590px;
+        max-width: 590px;
     }
     '''
 


### PR DESCRIPTION
# Description

Fixes #695.

Simple CSS update did the trick.

![bottom_bar](https://user-images.githubusercontent.com/37602/72537728-88c20580-3874-11ea-802b-a9cb85a14fd2.png)


# Test Plan

N/A or eyeball mk.1 :eyes: 

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [ ] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
