### PR TITLE
app/queue: prioritize user-triggered state changes

### DIFF
--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -42,14 +42,13 @@ class RunnableQueue(QObject):
     JOB_PRIORITIES = {
         # TokenInvalidationJob: 10,  # Not yet implemented
         PauseQueueJob: 11,
-        MetadataSyncJob: 12,
         FileDownloadJob: 13,  # File downloads processed in separate queue
-        MessageDownloadJob: 13,
-        ReplyDownloadJob: 13,
         DeleteSourceJob: 14,
         SendReplyJob: 15,
         UpdateStarJob: 16,
-        # FlagJob: 16,  # Not yet implemented
+        MetadataSyncJob: 17,
+        MessageDownloadJob: 18,
+        ReplyDownloadJob: 18,
     }
 
     '''


### PR DESCRIPTION
# Description

Fixes #657

# Test Plan

In terms of testing, you _can_ test interactively in Qubes but I think determining if you agree with the following logic is sufficient for merge:
1. User-triggered actions should be as fast as possible
2. File downloads happen in another queue so it doesn't really matter what priority they are
3. Metadata syncs will be moved in #652

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
