### PR TITLE
app/perf: reduce round trips during sync by N_{sources} - 1

### DIFF
--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -76,10 +76,8 @@ def get_remote_data(api: API) -> Tuple[List[SDKSource], List[SDKSubmission], Lis
 
     (remote_sources, remote_submissions, remote_replies)
     """
-    remote_submissions = []  # type: List[SDKSubmission]
     remote_sources = api.get_sources()
-    for source in remote_sources:
-        remote_submissions.extend(api.get_submissions(source))
+    remote_submissions = api.get_all_submissions()
     remote_replies = api.get_all_replies()
 
     logger.info('Fetched {} remote sources.'.format(len(remote_sources)))

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -121,7 +121,7 @@ def test_get_remote_data(mocker):
     source = make_remote_source()
     mock_api.get_sources.return_value = [source, ]
     submission = mocker.MagicMock()
-    mock_api.get_submissions.return_value = [submission, ]
+    mock_api.get_all_submissions.return_value = [submission, ]
     reply = mocker.MagicMock()
     mock_api.get_all_replies.return_value = [reply, ]
     sources, submissions, replies = get_remote_data(mock_api)


### PR DESCRIPTION
# Description

Closes #689

Related to @rmol's investigation in #648, we need to reduce the total number of round trips per sync. On master the number of calls during sync is scaling as N_{sources}, this reduces it to a constant (3 calls, one to each of the reply, source (still too slow due to the gpg keys but we will need to handle some server side changes first), and submission endpoints). 

# Test Plan

Start server (`NUM_SOURCES=20 make dev` - this `NUM_SOURCES` env var adds sources with 2 submissions and 2 replies per source), run this branch.

Instead of a bunch of individual API calls for submission metadata, one per source:

```
[18/Jan/2020 05:46:29] "GET /api/v1/sources/cf74425f-d8a0-4ba3-8949-31cd208db210/submissions HTTP/1.1" 200 -
```

you'll see just one for submission metadata:

```
[18/Jan/2020 05:43:34] "GET /api/v1/submissions HTTP/1.1" 200 -
```

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
