### PR TITLE
Reply focus state fix.

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2606,10 +2606,11 @@ class ReplyBoxWidget(QWidget):
         """
         reply_text = self.text_edit.toPlainText().strip()
         if reply_text:
+            # Clear text before sending signals. See #691.
+            self.text_edit.setText('')
             reply_uuid = str(uuid4())
             self.controller.send_reply(self.source.uuid, reply_uuid, reply_text)
             self.reply_sent.emit(self.source.uuid, reply_uuid, reply_text)
-            self.text_edit.setText('')
 
     def _on_authentication_changed(self, authenticated: bool) -> None:
         if authenticated:


### PR DESCRIPTION
# Description

Fixes #691 (sort of -- see below).

I've spent some time looking into this and it was turning into a time sink of pig wrestling with Qubes and/or Debian.

Here's my approach and I'd appreciate some testing / feedback please on those systems where it's not be observed to work (despite my best efforts, I can't recreate the problem).

The placeholder text that's not clearing is handled by the `ReplyTextEdit`'s `focusInEvent` and `focusOutEvent`. In both these event handlers there's a check to ensure there's no  text currently in the widget. If there isn't, the placeholder logic happens and the UI is updated as expected.

I notice that when a reply is sent via the `ReplyBoxWidet`'s `send_reply` method, the textual content was being set to blank *after* the lines of code which act on the sending of code. My thinking (in the blind as it were, because I can't recreate this problem), is that something in these previous lines of code was blocking so that any focus change was happening before the text was set to empty meaning the afore mentioned logic in the `focusInEvent` and `focusOutEvent` events wasn't firing. By setting it to empty *immediately* before the logic for sending the reply, I hope this problem is avoided.

My only further idea is that it's a "Debian's version of Qt5" problem. I.e. my version of Qt5.11 is from the official Python wheels. Is your version packaged via Debian? If so, you should know they regularly patch and change such libs so while we're using the same version, we're potentially not using the same version thanks to Debian packaging. 

Not sure what more to suggest. :-/ As always feedback and comments most welcome.

# Test Plan

None needed, this is just a re-arrangement of existing lines of code.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
