### PR TITLE
Use SecureQLabel for message previews

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -994,7 +994,7 @@ class SourceWidget(QWidget):
         summary_layout.setSpacing(0)
         self.name = QLabel()
         self.name.setObjectName('source_name')
-        self.preview = QLabel()
+        self.preview = SecureQLabel()
         self.preview.setObjectName('preview')
         self.preview.setFixedSize(QSize(self.PREVIEW_WIDTH, self.PREVIEW_HEIGHT))
         self.preview.setWordWrap(True)

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -16,7 +16,7 @@ from securedrop_client.gui.widgets import MainView, SourceList, SourceWidget, Lo
     DeleteSourceMessageBox, DeleteSourceAction, SourceMenu, TopPane, LeftPane, RefreshButton, \
     ErrorStatusBar, ActivityStatusBar, UserProfile, UserButton, UserMenu, LoginButton, \
     ReplyBoxWidget, ReplyTextEdit, SourceConversationWrapper, StarToggleButton, LoginOfflineLink, \
-    LoginErrorBar, EmptyConversationView, ExportDialog, PrintDialog, PasswordEdit
+    LoginErrorBar, EmptyConversationView, ExportDialog, PrintDialog, PasswordEdit, SecureQLabel
 from tests import factory
 
 
@@ -798,6 +798,24 @@ def test_SourceWidget_delete_source_when_user_chooses_cancel(mocker, session, so
     )
     sw.delete_source(None)
     sw.controller.delete_source.assert_not_called()
+
+
+def test_SourceWidget_uses_SecureQLabel(mocker):
+    """
+    Ensure the source widget preview uses SecureQLabel and is not injectable
+    """
+    source = mocker.MagicMock()
+    source.journalist_designation = "Testy McTestface"
+    source.collection = [factory.Message(content="a" * 121), ]
+    sw = SourceWidget(source)
+
+    sw.update()
+    assert isinstance(sw.preview, SecureQLabel)
+
+    sw.preview.setTextFormat = mocker.MagicMock()
+    sw.preview.setText("<b>bad text</b>")
+    sw.update()
+    sw.preview.setTextFormat.assert_called_with(Qt.PlainText)
 
 
 def test_StarToggleButton_init_source_starred(mocker):


### PR DESCRIPTION
# Description

Fixes #706 , ensures the message previews are properly escaped. Reply previews are also escaped.

#### before:
![before](https://user-images.githubusercontent.com/15223328/72850409-1045b500-3c77-11ea-8dc7-6600b0f6e314.png)
### after:
![after](https://user-images.githubusercontent.com/15223328/72850408-1045b500-3c77-11ea-9a06-494989b07280.png)


# Test Plan
- Build a deb on this branch
- install into `sd-app` or `sd-app-buster-template`
- submit a message with rich text tags on source interface
- observe tags are escaped properly
- the tests provided in this pr provide sufficient coverage


# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
