### PR TITLE
no longer sync after sending a reply

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -815,7 +815,6 @@ class Controller(QObject):
         logger.debug('{} sent successfully'.format(reply_uuid))
         self.gui.clear_error_status()  # remove any permanent error status message
         self.reply_succeeded.emit(reply_uuid)
-        self.sync_api()
 
     def on_reply_failure(
         self,

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1392,7 +1392,7 @@ def test_Controller_on_reply_success(homedir, mocker, session_maker, session):
     assert debug_logger.call_args_list[0][0][0] == '{} sent successfully'.format(reply.uuid)
     reply_succeeded.emit.assert_called_once_with(reply.uuid)
     reply_failed.emit.assert_not_called()
-    co.sync_api.assert_called_once_with()
+    co.sync_api.assert_not_called()
 
 
 def test_Controller_on_reply_failure(homedir, mocker, session_maker):


### PR DESCRIPTION
# Description

Resolves https://github.com/freedomofpress/securedrop-client/issues/660

# Test Plan

1. Send a reply
2. See it updated in the gui