### PR TITLE
update gui instead of sync when file missing

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1962,7 +1962,6 @@ class FileWidget(QWidget):
 
     @pyqtSlot(str)
     def _on_file_missing(self, file_uuid: str) -> None:
-        pass
         if file_uuid == self.file.uuid:
             self.file = self.controller.get_file(self.file.uuid)
             if not self.file.is_downloaded:

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -585,7 +585,6 @@ class Controller(QObject):
             logger.debug('Cannot find {} in the data directory. File does not exist.'.format(
                 file.original_filename))
             storage.update_missing_files(self.data_dir, self.session)
-            self.session.refresh(file)
             self.file_missing.emit(file.uuid)
             return False
         return True

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -125,6 +125,11 @@ class Controller(QObject):
     file_ready = pyqtSignal(str)
 
     """
+    This signal indicates that a file needs to be redownloaded by emitting the file's UUID.
+    """
+    file_missing = pyqtSignal(str)
+
+    """
     This signal indicates that a message has been successfully downloaded by emitting the message's
     UUID as a string.
     """
@@ -570,17 +575,18 @@ class Controller(QObject):
 
     def downloaded_file_exists(self, file_uuid: str) -> bool:
         '''
-        Check if the file specified by file_uuid exists. If it doesn't sync the api so that any
-        missing files, including this one, are updated to be re-downloaded.
+        Check if the file specified by file_uuid exists. If it doesn't update the local db and
+        GUI to show the file as not downloaded.
         '''
         file = self.get_file(file_uuid)
         fn_no_ext, dummy = os.path.splitext(os.path.splitext(file.filename)[0])
         filepath = os.path.join(self.data_dir, fn_no_ext)
         if not os.path.exists(filepath):
-            self.gui.update_error_status(_(
-                'File does not exist in the data directory. Please try re-downloading.'))
             logger.debug('Cannot find {} in the data directory. File does not exist.'.format(
                 file.original_filename))
+            storage.update_missing_files(self.data_dir, self.session)
+            self.session.refresh(file)
+            self.file_missing.emit(file.uuid)
             return False
         return True
 
@@ -623,7 +629,6 @@ class Controller(QObject):
         logger.info('Opening file "{}".'.format(file.original_filename))
 
         if not self.downloaded_file_exists(file.uuid):
-            self.sync_api()
             return
 
         if not self.qubes:
@@ -658,7 +663,6 @@ class Controller(QObject):
         logger.info('Exporting file {}'.format(file.original_filename))
 
         if not self.downloaded_file_exists(file.uuid):
-            self.sync_api()
             return
 
         if not self.qubes:
@@ -678,7 +682,6 @@ class Controller(QObject):
         logger.info('Printing file {}'.format(file.original_filename))
 
         if not self.downloaded_file_exists(file.uuid):
-            self.sync_api()
             return
 
         if not self.qubes:

--- a/securedrop_client/resources/__init__.py
+++ b/securedrop_client/resources/__init__.py
@@ -135,7 +135,7 @@ def load_css(name: str) -> str:
     return resource_string(__name__, "css/" + name).decode('utf-8')
 
 
-def load_movie(name: str) -> str:
+def load_movie(name: str) -> QMovie:
     """
     Return a GIF animation to use in the UI.
     """

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1380,7 +1380,7 @@ def test_FileWidget_init_file_not_downloaded(mocker, source, session):
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
 
-    fw = FileWidget('mock', controller, mocker.MagicMock(), 0)
+    fw = FileWidget('mock', controller, mocker.MagicMock(), mocker.MagicMock(), 0)
 
     assert fw.controller == controller
     assert fw.file.is_downloaded is False
@@ -1403,7 +1403,7 @@ def test_FileWidget_init_file_downloaded(mocker, source, session):
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
 
-    fw = FileWidget('mock', controller, mocker.MagicMock(), 0)
+    fw = FileWidget('mock', controller, mocker.MagicMock(), mocker.MagicMock(), 0)
 
     assert fw.controller == controller
     assert fw.file.is_downloaded is True
@@ -1419,8 +1419,6 @@ def test_FileWidget_event_handler(mocker, session, source):
     """
     Left click on filename should trigger an open.
     """
-    mock_signal = mocker.MagicMock()  # not important for this test
-
     file_ = factory.File(source=source['source'],
                          is_downloaded=False,
                          is_decrypted=None)
@@ -1432,7 +1430,7 @@ def test_FileWidget_event_handler(mocker, session, source):
     test_event = QEvent(QEvent.MouseButtonPress)
     test_event.button = mocker.MagicMock(return_value=Qt.LeftButton)
 
-    fw = FileWidget(file_.uuid, mock_controller, mock_signal, 0)
+    fw = FileWidget(file_.uuid, mock_controller, mocker.MagicMock(), mocker.MagicMock(), 0)
     fw._on_left_click = mocker.MagicMock()
 
     fw.eventFilter(fw, test_event)
@@ -1444,8 +1442,6 @@ def test_FileWidget_on_left_click_download(mocker, session, source):
     Left click on download when file is not downloaded should trigger
     a download.
     """
-    mock_signal = mocker.MagicMock()  # not important for this test
-
     file_ = factory.File(source=source['source'],
                          is_downloaded=False,
                          is_decrypted=None)
@@ -1455,7 +1451,7 @@ def test_FileWidget_on_left_click_download(mocker, session, source):
     mock_get_file = mocker.MagicMock(return_value=file_)
     mock_controller = mocker.MagicMock(get_file=mock_get_file)
 
-    fw = FileWidget(file_.uuid, mock_controller, mock_signal, 0)
+    fw = FileWidget(file_.uuid, mock_controller, mocker.MagicMock(), mocker.MagicMock(), 0)
     fw.download_button = mocker.MagicMock()
     mock_get_file.assert_called_once_with(file_.uuid)
     mock_get_file.reset_mock()
@@ -1474,8 +1470,6 @@ def test_FileWidget_start_button_animation(mocker, session, source):
     """
     Ensure widget state is updated when this method is called.
     """
-    mock_signal = mocker.MagicMock()  # not important for this test
-
     file_ = factory.File(source=source['source'],
                          is_downloaded=False,
                          is_decrypted=None)
@@ -1483,7 +1477,7 @@ def test_FileWidget_start_button_animation(mocker, session, source):
     session.commit()
     mock_get_file = mocker.MagicMock(return_value=file_)
     mock_controller = mocker.MagicMock(get_file=mock_get_file)
-    fw = FileWidget(file_.uuid, mock_controller, mock_signal, 0)
+    fw = FileWidget(file_.uuid, mock_controller, mocker.MagicMock(), mocker.MagicMock(), 0)
     fw.download_button = mocker.MagicMock()
     fw.start_button_animation()
     # Check indicators of activity have been updated.
@@ -1496,8 +1490,6 @@ def test_FileWidget_on_left_click_open(mocker, session, source):
     """
     Left click on open when file is downloaded should trigger an open.
     """
-    mock_signal = mocker.MagicMock()  # not important for this test
-
     file_ = factory.File(source=source['source'], is_downloaded=True)
     session.add(file_)
     session.commit()
@@ -1505,7 +1497,7 @@ def test_FileWidget_on_left_click_open(mocker, session, source):
     mock_get_file = mocker.MagicMock(return_value=file_)
     mock_controller = mocker.MagicMock(get_file=mock_get_file)
 
-    fw = FileWidget(file_.uuid, mock_controller, mock_signal, 0)
+    fw = FileWidget(file_.uuid, mock_controller, mocker.MagicMock(), mocker.MagicMock(), 0)
     fw._on_left_click()
     fw.controller.on_file_open.assert_called_once_with(file_.uuid)
 
@@ -1515,8 +1507,6 @@ def test_FileWidget_set_button_animation_frame(mocker, session, source):
     Left click on download when file is not downloaded should trigger
     a download.
     """
-    mock_signal = mocker.MagicMock()  # not important for this test
-
     file_ = factory.File(source=source['source'],
                          is_downloaded=False,
                          is_decrypted=None)
@@ -1526,7 +1516,7 @@ def test_FileWidget_set_button_animation_frame(mocker, session, source):
     mock_get_file = mocker.MagicMock(return_value=file_)
     mock_controller = mocker.MagicMock(get_file=mock_get_file)
 
-    fw = FileWidget(file_.uuid, mock_controller, mock_signal, 0)
+    fw = FileWidget(file_.uuid, mock_controller, mocker.MagicMock(), mocker.MagicMock(), 0)
     fw.download_button = mocker.MagicMock()
     fw.set_button_animation_frame(1)
     assert fw.download_button.setIcon.call_count == 1
@@ -1541,7 +1531,7 @@ def test_FileWidget_update(mocker, session, source):
     session.commit()
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
-    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), 0)
+    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0)
 
     fw.update()
 
@@ -1561,7 +1551,7 @@ def test_FileWidget_on_file_download_updates_items_when_uuid_matches(mocker, sou
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
 
-    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), 0)
+    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0)
     fw.update = mocker.MagicMock()
 
     fw._on_file_downloaded(file.uuid)
@@ -1587,7 +1577,7 @@ def test_FileWidget_on_file_download_updates_items_when_uuid_does_not_match(
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
 
-    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), 0)
+    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0)
     fw.clear = mocker.MagicMock()
     fw.update = mocker.MagicMock()
 
@@ -1602,6 +1592,52 @@ def test_FileWidget_on_file_download_updates_items_when_uuid_does_not_match(
     assert not fw.file_name.isHidden()
 
 
+def test_FileWidget_on_file_missing_show_download_button_when_uuid_matches(mocker, source, session):
+    """
+    The _on_file_missing method should update the FileWidget when uuid matches.
+    """
+    file = factory.File(source=source['source'], is_decrypted=None, is_downloaded=False)
+    session.add(file)
+    session.commit()
+
+    get_file = mocker.MagicMock(return_value=file)
+    controller = mocker.MagicMock(get_file=get_file)
+
+    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0)
+    fw.update = mocker.MagicMock()
+
+    fw._on_file_missing(file.uuid)
+
+    assert not fw.download_button.isHidden()
+    assert fw.export_button.isHidden()
+    assert fw.middot.isHidden()
+    assert fw.print_button.isHidden()
+    assert not fw.no_file_name.isHidden()
+    assert fw.file_name.isHidden()
+    assert fw.download_animation.state() == QMovie.NotRunning
+
+
+def test_FileWidget_on_file_missing_does_not_show_download_button_when_uuid_does_not_match(
+    mocker, homedir, session, source,
+):
+    """
+    The _on_file_missing method should not update the FileWidget when uuid doesn't match.
+    """
+    file = factory.File(source=source['source'])
+    session.add(file)
+    session.commit()
+
+    get_file = mocker.MagicMock(return_value=file)
+    controller = mocker.MagicMock(get_file=get_file)
+
+    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0)
+    fw.download_button.show = mocker.MagicMock()
+
+    fw._on_file_missing('not a matching uuid')
+
+    fw.download_button.show.assert_not_called()
+
+
 def test_FileWidget__on_export_clicked(mocker, session, source):
     """
     Ensure preflight checks start when the EXPORT button is clicked and that password is requested
@@ -1613,7 +1649,7 @@ def test_FileWidget__on_export_clicked(mocker, session, source):
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
 
-    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), 0)
+    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0)
     fw.update = mocker.MagicMock()
     mocker.patch('securedrop_client.gui.widgets.QDialog.exec')
     controller.run_export_preflight_checks = mocker.MagicMock()
@@ -1640,7 +1676,7 @@ def test_FileWidget__on_export_clicked_missing_file(mocker, session, source):
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
 
-    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), 0)
+    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0)
     fw.update = mocker.MagicMock()
     mocker.patch('securedrop_client.gui.widgets.QDialog.exec')
     controller.run_export_preflight_checks = mocker.MagicMock()
@@ -1664,7 +1700,7 @@ def test_FileWidget__on_print_clicked(mocker, session, source):
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
 
-    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), 0)
+    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0)
     fw.update = mocker.MagicMock()
     mocker.patch('securedrop_client.gui.widgets.QDialog.exec')
     controller.print_file = mocker.MagicMock()
@@ -1691,7 +1727,7 @@ def test_FileWidget__on_print_clicked_missing_file(mocker, session, source):
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
 
-    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), 0)
+    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0)
     fw.update = mocker.MagicMock()
     mocker.patch('securedrop_client.gui.widgets.QDialog.exec')
     controller.print_file = mocker.MagicMock()

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -985,12 +985,10 @@ def test_Controller_on_file_open_file_missing(mocker, homedir, session_maker, se
 
     co.on_file_open(file.uuid)
 
-    user_error = 'File does not exist in the data directory. Please try re-downloading.'
     log_msg = 'Cannot find {} in the data directory. File does not exist.'.format(
         file.original_filename)
-    co.gui.update_error_status.assert_called_once_with(user_error)
     debug_logger.assert_called_once_with(log_msg)
-    co.sync_api.assert_called_once_with()
+    co.sync_api.assert_not_called()
 
 
 def test_Controller_on_file_open_file_missing_not_qubes(
@@ -1012,12 +1010,10 @@ def test_Controller_on_file_open_file_missing_not_qubes(
 
     co.on_file_open(file.uuid)
 
-    user_error = 'File does not exist in the data directory. Please try re-downloading.'
     log_msg = 'Cannot find {} in the data directory. File does not exist.'.format(
         file.original_filename)
-    co.gui.update_error_status.assert_called_once_with(user_error)
     debug_logger.assert_called_once_with(log_msg)
-    co.sync_api.assert_called_once_with()
+    co.sync_api.assert_not_called()
 
 
 def test_Controller_download_new_replies_with_new_reply(mocker, session, session_maker, homedir):
@@ -1564,12 +1560,10 @@ def test_Controller_print_file_file_missing(homedir, mocker, session, session_ma
 
     co.print_file(file.uuid)
 
-    user_error = 'File does not exist in the data directory. Please try re-downloading.'
     log_msg = 'Cannot find {} in the data directory. File does not exist.'.format(
         file.original_filename)
-    co.gui.update_error_status.assert_called_once_with(user_error)
     debug_logger.assert_called_once_with(log_msg)
-    co.sync_api.assert_called_once_with()
+    co.sync_api.assert_not_called()
 
 
 def test_Controller_print_file_file_missing_not_qubes(
@@ -1591,12 +1585,10 @@ def test_Controller_print_file_file_missing_not_qubes(
 
     co.print_file(file.uuid)
 
-    user_error = 'File does not exist in the data directory. Please try re-downloading.'
     log_msg = 'Cannot find {} in the data directory. File does not exist.'.format(
         file.original_filename)
-    co.gui.update_error_status.assert_called_once_with(user_error)
     debug_logger.assert_called_once_with(log_msg)
-    co.sync_api.assert_called_once_with()
+    co.sync_api.assert_not_called()
 
 
 def test_Controller_print_file_when_orig_file_already_exists(
@@ -1758,12 +1750,10 @@ def test_Controller_export_file_to_usb_drive_file_missing(homedir, mocker, sessi
 
     co.export_file_to_usb_drive(file.uuid, 'mock passphrase')
 
-    user_error = 'File does not exist in the data directory. Please try re-downloading.'
     log_msg = 'Cannot find {} in the data directory. File does not exist.'.format(
         file.original_filename)
-    co.gui.update_error_status.assert_called_once_with(user_error)
     debug_logger.assert_called_once_with(log_msg)
-    co.sync_api.assert_called_once_with()
+    co.sync_api.assert_not_called()
 
 
 def test_Controller_export_file_to_usb_drive_file_missing_not_qubes(
@@ -1785,12 +1775,10 @@ def test_Controller_export_file_to_usb_drive_file_missing_not_qubes(
 
     co.export_file_to_usb_drive(file.uuid, 'mock passphrase')
 
-    user_error = 'File does not exist in the data directory. Please try re-downloading.'
     log_msg = 'Cannot find {} in the data directory. File does not exist.'.format(
         file.original_filename)
-    co.gui.update_error_status.assert_called_once_with(user_error)
     debug_logger.assert_called_once_with(log_msg)
-    co.sync_api.assert_called_once_with()
+    co.sync_api.assert_not_called()
 
 
 def test_Controller_export_file_to_usb_drive_when_orig_file_already_exists(


### PR DESCRIPTION
# Description

Closes https://github.com/freedomofpress/securedrop-client/issues/670

# Test Plan

1. Download a file
2. Delete it from the filesystem
3. Try to open it and see that the gui is updated to show that the file needs to be downloaded

Repeat steps 1-3 for export and print

## Known issue

Currently refreshing the file object in the session clears the error status message so I removed the error message for now, see: https://github.com/freedomofpress/securedrop-client/issues/723
