### PR TITLE
Ensure UI remains responsive at all times during sync with server.

### DIFF
--- a/securedrop_client/api_jobs/downloads.py
+++ b/securedrop_client/api_jobs/downloads.py
@@ -55,7 +55,7 @@ class MetadataSyncJob(ApiJob):
         # TODO: Once https://github.com/freedomofpress/securedrop-client/issues/648, we will want to
         # pass the default request timeout to api calls instead of setting it on the api object
         # directly.
-        api_client.default_request_timeout = 20
+        api_client.default_request_timeout = 40
         remote_sources, remote_submissions, remote_replies = \
             get_remote_data(api_client)
 

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -332,7 +332,6 @@ class Controller(QObject):
             self.api.journalist_last_name,
             self.session)
         self.gui.show_main_window(user)
-        self.update_sources()
         self.api_job_queue.login(self.api)
         self.sync_api()
         self.is_authenticated = True
@@ -533,7 +532,6 @@ class Controller(QObject):
         self.gui.clear_error_status()  # remove any permanent error status message
         message = storage.get_message(self.session, uuid)
         self.message_ready.emit(message.uuid, message.content)
-        self.update_sources()
 
     def on_message_download_failure(self, exception: Exception) -> None:
         """
@@ -711,7 +709,6 @@ class Controller(QObject):
         """
         self.gui.clear_error_status()  # remove any permanent error status message
         self.file_ready.emit(result)
-        self.update_sources()
 
     def on_file_download_failure(self, exception: Exception) -> None:
         """

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -195,7 +195,6 @@ def test_Controller_on_authenticate_success(homedir, config, mocker, session_mak
     mock_api_job_queue = mocker.patch("securedrop_client.logic.ApiJobQueue")
     co = Controller('http://localhost', mock_gui, session_maker, homedir)
     co.sync_api = mocker.MagicMock()
-    co.update_sources = mocker.MagicMock()
     co.session.add(user)
     co.session.commit()
     co.api = mocker.MagicMock()
@@ -211,7 +210,6 @@ def test_Controller_on_authenticate_success(homedir, config, mocker, session_mak
     co.sync_api.assert_called_once_with()
     assert co.is_authenticated
     assert mock_api_job_queue.called
-    co.update_sources.assert_called_once_with()
     login.assert_called_with(co.api)
     co.resume_queues.assert_called_once_with()
 
@@ -736,7 +734,6 @@ def test_Controller_on_file_downloaded_success(homedir, config, mocker, session_
     mock_gui = mocker.MagicMock()
 
     co = Controller('http://localhost', mock_gui, session_maker, homedir)
-    co.update_sources = mocker.MagicMock()
 
     # signal when file is downloaded
     mock_file_ready = mocker.patch.object(co, 'file_ready')
@@ -745,7 +742,6 @@ def test_Controller_on_file_downloaded_success(homedir, config, mocker, session_
     co.on_file_download_success(mock_uuid)
 
     mock_file_ready.emit.assert_called_once_with(mock_uuid)
-    co.update_sources.assert_called_once_with()
 
 
 def test_Controller_on_file_downloaded_api_failure(homedir, config, mocker, session_maker):
@@ -1178,7 +1174,6 @@ def test_Controller_on_message_downloaded_success(mocker, homedir, session_maker
     Check that a successful download emits proper signal.
     """
     co = Controller('http://localhost', mocker.MagicMock(), session_maker, homedir)
-    co.update_sources = mocker.MagicMock()
     message_ready = mocker.patch.object(co, 'message_ready')
     message = factory.Message(source=factory.Source())
     mocker.patch('securedrop_client.storage.get_message', return_value=message)
@@ -1186,7 +1181,6 @@ def test_Controller_on_message_downloaded_success(mocker, homedir, session_maker
     co.on_message_download_success(message.uuid)
 
     message_ready.emit.assert_called_once_with(message.uuid, message.content)
-    co.update_sources.assert_called_once_with()
 
 
 def test_Controller_on_message_downloaded_failure(mocker, homedir, session_maker):


### PR DESCRIPTION
# Description

Fixes #716 

**DO NOT MERGE** this is a work in progress while further investigation takes place.

The initial removal of `update_sources` on message download ensures the UI remains responsive.

However, given a server with 200 sources, while the UI is now responsive, I no longer see the results I was able to see with far fewer sources (50) in previous tests. The server activity looks like this:

```
172.17.0.1 - - [27/Jan/2020 11:51:51] "POST /api/v1/token HTTP/1.1" 200 -
172.17.0.1 - - [27/Jan/2020 11:52:20] "GET /api/v1/sources HTTP/1.1" 200 -
172.17.0.1 - - [27/Jan/2020 11:52:43] "GET /api/v1/sources HTTP/1.1" 200 -
2020-01-27 11:52:45,411 INFO Clearing shredder
2020-01-27 11:52:45,411 INFO Files to delete: 0
```

Which suggests something is pinging the API every 20 seconds or so. Not sure what though. I also notice from `top` that the client is taking up around 50% of my CPU and spawning lots of `gpg2` related processes. After a while the client (responsively!) reports "The SecureDrop server cannot be reached".

As I understand it, we download **everything** in one go. Is there an API call we can make to get just the sources with their latest message id and just download them instead. Upon clicking the source, if not already downloaded, perhaps *only* the messages for the specific source could be downloaded and processed..?

In any case, the end result is that the client responsively hangs and takes up CPU resources when there are a large number of sources. When there are only 50 the application appears to work fine except the latest-message preview in the source list is never updated (which can be coded around, see screenie below).

![50_sources](https://user-images.githubusercontent.com/37602/73174595-09e48c80-4100-11ea-8f7c-bac063024abe.png)

My gut feeling is while the UI is now responsive, this highlights yet another performance problem -- i.e. the processing of large numbers of sources and their associated conversations.

Thoughts welcome.

# Test Plan

Currently, keep poking with a stick and ask more questions.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [ ] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
