### PR TITLE
Improve download file handling

### DIFF
--- a/alembic/versions/fb657f2ee8a7_drop_file_original_filename.py
+++ b/alembic/versions/fb657f2ee8a7_drop_file_original_filename.py
@@ -1,0 +1,71 @@
+"""drop File.original_filename
+
+Revision ID: fb657f2ee8a7
+Revises: 86b01b6290da
+Create Date: 2020-01-23 18:55:09.857324
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "fb657f2ee8a7"
+down_revision = "86b01b6290da"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    op.rename_table("files", "original_files")
+
+    conn.execute(
+        """
+        CREATE TABLE files (
+                id INTEGER NOT NULL,
+                uuid VARCHAR(36) NOT NULL,
+                filename VARCHAR(255) NOT NULL,
+                file_counter INTEGER NOT NULL,
+                size INTEGER NOT NULL,
+                download_url VARCHAR(255) NOT NULL,
+                is_downloaded BOOLEAN DEFAULT 0 NOT NULL,
+                is_read BOOLEAN DEFAULT 0 NOT NULL,
+                is_decrypted BOOLEAN,
+                source_id INTEGER NOT NULL,
+                CONSTRAINT pk_files PRIMARY KEY (id),
+                CONSTRAINT fk_files_source_id_sources FOREIGN KEY(source_id) REFERENCES sources (id),
+                CONSTRAINT uq_messages_source_id_file_counter UNIQUE (source_id, file_counter),
+                CONSTRAINT uq_files_uuid UNIQUE (uuid),
+                CONSTRAINT files_compare_is_downloaded_vs_is_decrypted CHECK (CASE WHEN is_downloaded = 0 THEN is_decrypted IS NULL ELSE 1 END),
+                CONSTRAINT ck_files_is_downloaded CHECK (is_downloaded IN (0, 1)),
+                CONSTRAINT ck_files_is_read CHECK (is_read IN (0, 1)),
+                CONSTRAINT ck_files_is_decrypted CHECK (is_decrypted IN (0, 1))
+        )
+        """
+    )
+
+    conn.execute(
+        """
+        INSERT INTO files
+        (id, uuid, filename, file_counter, size, download_url, is_downloaded,
+        is_decrypted, is_read, source_id)
+        SELECT id, uuid, filename, file_counter, size, download_url, is_downloaded,
+        is_decrypted, is_read, source_id
+        FROM original_files
+    """
+    )
+
+    op.drop_table("original_files")
+
+
+def downgrade():
+    op.add_column(
+        "files",
+        sa.Column(
+            "original_filename",
+            sa.VARCHAR(length=255),
+            server_default=sa.text("''"),
+            nullable=False,
+        ),
+    )

--- a/securedrop_client/crypto.py
+++ b/securedrop_client/crypto.py
@@ -125,8 +125,12 @@ class GpgHelper:
 
             # Store the plaintext in the file located at the specified plaintext_filepath
             if is_doc:
-                original_filename = read_gzip_header_filename(out.name)
-                with gzip.open(out.name, 'rb') as infile, open(plaintext_filepath, 'wb') as outfile:
+                original_filename = read_gzip_header_filename(out.name) or plaintext_filepath
+                decrypt_path = os.path.join(
+                    os.path.dirname(filepath),
+                    os.path.basename(original_filename)
+                )
+                with gzip.open(out.name, 'rb') as infile, open(decrypt_path, 'wb') as outfile:
                     shutil.copyfileobj(infile, outfile)
             else:
                 shutil.copy(out.name, plaintext_filepath)

--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -123,6 +123,19 @@ class Message(Base):
     def __repr__(self) -> str:
         return '<Message {}>'.format(self.filename)
 
+    def location(self, data_dir: str) -> str:
+        '''
+        Return the full path to the Message's file.
+        '''
+        return os.path.abspath(
+            os.path.join(
+                data_dir,
+                self.__class__.__name__,
+                self.uuid,
+                self.filename,
+            )
+        )
+
 
 class File(Base):
 
@@ -134,15 +147,6 @@ class File(Base):
     id = Column(Integer, primary_key=True)
     uuid = Column(String(36), unique=True, nullable=False)
     filename = Column(String(255), nullable=False)
-
-    # Files from the SecureDrop journalist API are gzipped, then
-    # encrypted with GPG. The gzip header contains the original
-    # filename, which makes it easier for the client to open the file
-    # with the right application. We'll record that filename here
-    # after we've downloaded, decrypted and extracted the file.
-    # If the header does not contain the filename for some reason,
-    # this should be the same as filename.
-    original_filename = Column(String(255), nullable=False, server_default="")
 
     file_counter = Column(Integer, nullable=False)
     size = Column(Integer, nullable=False)
@@ -179,12 +183,25 @@ class File(Base):
         Return something that's a useful string representation of the file.
         """
         if self.is_downloaded:
-            return "File: {}".format(self.original_filename)
+            return "File: {}".format(self.filename)
         else:
             return '<Encrypted file on server>'
 
     def __repr__(self) -> str:
         return '<File {}>'.format(self.filename)
+
+    def location(self, data_dir: str) -> str:
+        '''
+        Return the full path to the File's file.
+        '''
+        return os.path.abspath(
+            os.path.join(
+                data_dir,
+                self.__class__.__name__,
+                self.uuid,
+                self.filename,
+            )
+        )
 
 
 class Reply(Base):
@@ -245,6 +262,19 @@ class Reply(Base):
 
     def __repr__(self) -> str:
         return '<Reply {}>'.format(self.filename)
+
+    def location(self, data_dir: str) -> str:
+        '''
+        Return the full path to the Reply's file.
+        '''
+        return os.path.abspath(
+            os.path.join(
+                data_dir,
+                self.__class__.__name__,
+                self.uuid,
+                self.filename,
+            )
+        )
 
 
 class DraftReply(Base):

--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -63,6 +63,12 @@ class Source(Base):
                                                datetime.datetime(datetime.MINYEAR, 1, 1))))
         return collection
 
+    @property
+    def journalist_filename(self) -> str:
+        valid_chars = 'abcdefghijklmnopqrstuvwxyz1234567890-_'
+        return ''.join([c for c in self.journalist_designation.lower().replace(
+            ' ', '_') if c in valid_chars])
+
 
 class Message(Base):
 
@@ -130,9 +136,8 @@ class Message(Base):
         return os.path.abspath(
             os.path.join(
                 data_dir,
-                self.__class__.__name__,
-                self.uuid,
-                self.filename,
+                self.source.journalist_filename,
+                os.path.splitext(self.filename)[0] + '.txt'
             )
         )
 
@@ -197,9 +202,9 @@ class File(Base):
         return os.path.abspath(
             os.path.join(
                 data_dir,
-                self.__class__.__name__,
-                self.uuid,
-                self.filename,
+                self.source.journalist_filename,
+                '{}-{}-doc'.format(self.file_counter, self.source.journalist_filename),
+                self.filename
             )
         )
 
@@ -270,9 +275,8 @@ class Reply(Base):
         return os.path.abspath(
             os.path.join(
                 data_dir,
-                self.__class__.__name__,
-                self.uuid,
-                self.filename,
+                self.source.journalist_filename,
+                os.path.splitext(self.filename)[0] + '.txt'
             )
         )
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1897,7 +1897,7 @@ class FileWidget(QWidget):
         self.print_button.clicked.connect(self._on_print_clicked)
 
         # File name or default string
-        self.file_name = SecureQLabel(self.file.original_filename)
+        self.file_name = SecureQLabel(self.file.filename)
         self.file_name.setObjectName('file_name')
         self.file_name.installEventFilter(self)
         self.no_file_name = SecureQLabel('ENCRYPTED FILE ON SERVER')
@@ -1952,7 +1952,7 @@ class FileWidget(QWidget):
         if file_uuid == self.file.uuid:
             self.file = self.controller.get_file(self.file.uuid)
             if self.file.is_downloaded:
-                self.file_name.setText(self.file.original_filename)
+                self.file_name.setText(self.file.filename)
                 self.download_button.hide()
                 self.no_file_name.hide()
                 self.export_button.show()
@@ -1983,10 +1983,11 @@ class FileWidget(QWidget):
         """
         Called when the export button is clicked.
         """
-        if not self.controller.downloaded_file_exists(self.file.uuid):
+        if not self.controller.downloaded_file_exists(self.file):
             return
 
-        dialog = ExportDialog(self.controller, self.file.uuid, self.file.original_filename)
+        dialog = ExportDialog(self.controller, self.file.uuid,
+                              self.file.filename)
         dialog.show()
         dialog.export()
         dialog.exec()
@@ -1996,7 +1997,7 @@ class FileWidget(QWidget):
         """
         Called when the print button is clicked.
         """
-        if not self.controller.downloaded_file_exists(self.file.uuid):
+        if not self.controller.downloaded_file_exists(self.file):
             return
 
         dialog = PrintDialog(self.controller, self.file.uuid)
@@ -2014,7 +2015,7 @@ class FileWidget(QWidget):
 
         if self.file.is_downloaded:
             # Open the already downloaded file.
-            self.controller.on_file_open(self.file.uuid)
+            self.controller.on_file_open(self.file)
         else:
             if self.controller.api:
                 # Indicate in downloading state... but only after 0.3 seconds (i.e.

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -122,7 +122,6 @@ def File(**attrs):
     defaults = dict(
         uuid='file-uuid-{}'.format(FILE_COUNT),
         filename='{}-doc.gz.gpg'.format(FILE_COUNT),
-        original_filename='{}-doc.txt'.format(FILE_COUNT),
         size=123,
         download_url='http://wat.onion/abc',
         is_decrypted=True,

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1499,7 +1499,7 @@ def test_FileWidget_on_left_click_open(mocker, session, source):
 
     fw = FileWidget(file_.uuid, mock_controller, mocker.MagicMock(), mocker.MagicMock(), 0)
     fw._on_left_click()
-    fw.controller.on_file_open.assert_called_once_with(file_.uuid)
+    fw.controller.on_file_open.assert_called_once_with(file_)
 
 
 def test_FileWidget_set_button_animation_frame(mocker, session, source):
@@ -1662,7 +1662,7 @@ def test_FileWidget__on_export_clicked(mocker, session, source):
     # Also assert that the dialog is initialized
     dialog = mocker.patch('securedrop_client.gui.widgets.ExportDialog')
     fw._on_export_clicked()
-    dialog.assert_called_once_with(controller, file.uuid, file.original_filename)
+    dialog.assert_called_once_with(controller, file.uuid, file.filename)
 
 
 def test_FileWidget__on_export_clicked_missing_file(mocker, session, source):


### PR DESCRIPTION
# Description

Eliminate `File.original_file` column and hard links to downloaded files. Now as files are downloaded and decrypted, `File.filename` will be updated.

Instead of downloading directly into the root of the data directory, create a directory therein for each downloadable object, named with its UUID, and process downloaded files in that directory. This should
eliminate collisions if multiple sources upload documents with the same names.

Fixes #714.

# Test Plan

- Start a SecureDrop development server with `make dev`
- Visit the source interface and upload a file.
- Run the client with `run.sh`. Find your source in the list and:
  - download the file
  - verify that it can be opened in a disp VM by clicking on it
  - verify that it can be exported
  - verify that a metadata sync does not change the filename
- In the shell, confirm that exactly one file is present under the `$SDC_HOME/data_dir/File/{file-uuid}/` directory, with no files hard linked to it.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
