### PR TITLE
Fix potential crash situation WRT queue.

### DIFF
--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -344,19 +344,23 @@ def test_ApiJobQueue_enqueue_no_auth(mocker):
     job_queue = ApiJobQueue(mock_client, mock_session_maker)
     mock_download_file_queue = mocker.patch.object(job_queue, 'download_file_queue')
     mock_main_queue = mocker.patch.object(job_queue, 'main_queue')
+    mock_metadata_queue = mocker.patch.object(job_queue, 'metadata_queue')
     mock_download_file_add_job = mocker.patch.object(mock_download_file_queue, 'add_job')
     mock_main_queue_add_job = mocker.patch.object(mock_main_queue, 'add_job')
+    mock_metadata_queue_add_job = mocker.patch.object(mock_metadata_queue, "add_job")
     job_queue.main_queue.api_client = None
     job_queue.download_file_queue.api_client = None
+    job_queue.metadata_queue.api_client = None
     mock_start_queues = mocker.patch.object(job_queue, 'start_queues')
 
     dummy_job = factory.dummy_job_factory(mocker, 'mock')()
     job_queue.JOB_PRIORITIES = {type(dummy_job): 1}
     job_queue.enqueue(dummy_job)
 
-    assert not mock_download_file_add_job.called
-    assert not mock_main_queue_add_job.called
-    assert not mock_start_queues.called
+    assert mock_download_file_add_job.call_count == 0
+    assert mock_main_queue_add_job.call_count == 0
+    assert mock_metadata_queue_add_job.call_count == 0
+    assert mock_start_queues.call_count == 0
 
 
 def test_ApiJobQueue_login_if_queues_not_running(mocker):


### PR DESCRIPTION
# Description

Found while fixing #716. Perhaps addresses #662?

If the queue has an upper limit (like the metadata queue does), then the `re_add_job` method may try to do something that results in a `queue.Full` exception being thrown. This can be safely ignored. Because this case wasn't handled, I encountered an application crash while investigating #716 which led to this fix.

In addition I noticed there being a possibility of jobs being put onto the metadata queue if the user wasn't logged in (something which shouldn't happen). This has also been fixed.

# Test Plan

Unit tests updated to reflect both changes.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
