### PR TITLE
update conversation view on login

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -313,6 +313,7 @@ class Controller(QObject):
         faster.
         """
         storage.mark_all_pending_drafts_as_failed(self.session)
+        self.update_sources()
         self.api = sdclientapi.API(
             self.hostname, username, password, totp, self.proxy, default_request_timeout=60)
         self.call_api(self.api.authenticate,

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -136,9 +136,11 @@ def test_Controller_login(homedir, config, mocker, session_maker):
 
     co = Controller('http://localhost', mock_gui, session_maker, homedir)
     co.call_api = mocker.MagicMock()
+    co.update_sources = mocker.MagicMock()
 
     co.login('username', 'password', '123456')
 
+    co.update_sources.assert_called_once_with()
     co.call_api.assert_called_once_with(mock_api().authenticate,
                                         co.on_authenticate_success,
                                         co.on_authenticate_failure)


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/745

# Test Plan

1. start a dev server with NUM_SOURCES equals 100 or so
2. log into the client and see `Nothing to see just yet!` mesage instead of a blank conversation view