### PR TITLE
Don't import source pubkeys we already have

### DIFF
--- a/tests/api_jobs/test_downloads.py
+++ b/tests/api_jobs/test_downloads.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from typing import Tuple
+from uuid import UUID
 
 from sdclientapi import BaseError
 from sdclientapi import Submission as SdkSubmission
@@ -40,7 +41,6 @@ def test_MetadataSyncJob_success(mocker, homedir, session, session_maker):
 
     api_client = mocker.MagicMock()
     api_client.default_request_timeout = mocker.MagicMock()
-    api_client.default_request_timeout = mocker.MagicMock()
 
     mocker.patch(
         'securedrop_client.api_jobs.downloads.update_local_storage',
@@ -52,6 +52,58 @@ def test_MetadataSyncJob_success(mocker, homedir, session, session_maker):
     assert mock_key_import.call_args[0][1] == mock_source.key['public']
     assert mock_key_import.call_args[0][2] == mock_source.key['fingerprint']
     assert mock_get_remote_data.call_count == 1
+
+
+def test_MetadataSyncJob_only_imports_new_source_keys(mocker, homedir, session, session_maker):
+    """
+    Verify that we only import source keys we don't already have.
+    """
+    class LimitedImportGpgHelper(GpgHelper):
+        def import_key(self, source_uuid: UUID, key_data: str, fingerprint: str) -> None:
+            self._import(key_data)
+
+    gpg = LimitedImportGpgHelper(homedir, session_maker, is_qubes=False)
+    job = MetadataSyncJob(homedir, gpg)
+
+    mock_source = mocker.MagicMock()
+    mock_source.uuid = 'bar'
+    mock_source.key = {
+        'type': 'PGP',
+        'public': PUB_KEY,
+        'fingerprint': 'B2FF7FB28EED8CABEBC5FB6C6179D97BCFA52E5F',
+    }
+
+    mock_get_remote_data = mocker.patch(
+        'securedrop_client.api_jobs.downloads.get_remote_data',
+        return_value=([mock_source], [], []))
+
+    api_client = mocker.MagicMock()
+    api_client.default_request_timeout = mocker.MagicMock()
+
+    mocker.patch(
+        'securedrop_client.api_jobs.downloads.update_local_storage',
+        return_value=([mock_source], [], []))
+
+    mock_logger = mocker.patch('securedrop_client.api_jobs.downloads.logger')
+
+    job.call_api(api_client, session)
+
+    assert mock_get_remote_data.call_count == 1
+    assert len(gpg.fingerprints()) == 2
+
+    log_msg = mock_logger.debug.call_args_list[0][0][0]
+    assert log_msg.startswith(
+        'Importing key with fingerprint {}'.format(mock_source.key['fingerprint'])
+    )
+
+    job.call_api(api_client, session)
+
+    assert mock_get_remote_data.call_count == 2
+
+    log_msg = mock_logger.debug.call_args_list[1][0][0]
+    assert log_msg.startswith(
+        'Skipping import of key with fingerprint {}'.format(mock_source.key['fingerprint'])
+    )
 
 
 def test_MetadataSyncJob_success_with_key_import_fail(mocker, homedir, session, session_maker):


### PR DESCRIPTION
# Description

This improves MetadataSyncJob to only import source keys we don't yet have.

Fixes #735.

# Test Plan

- Start a SecureDrop development server with `make dev`
- Start the client with `LOGLEVEL=debug ./run.sh` and log in.
- Tail `$SDC_HOME/logs/client.log`. You should see lines like:
  `Importing key with fingerprint 35A20B41C773755691BFF27110776C0CDBECCC6F`
- Wait a minute for the next metadata sync. Now in the logs you should see that we're not importing the keys we just imported:
  `Skipping import of key with fingerprint 35A20B41C773755691BFF27110776C0CDBECCC6F`

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
