### PR TITLE
When token invalid user must log back in

### DIFF
--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -110,7 +110,7 @@ class Window(QMainWindow):
         screen = QDesktopWidget().screenGeometry()
         self.resize(screen.width(), screen.height())
 
-    def show_login(self):
+    def show_login(self, error: str = ''):
         """
         Show the login form.
         """
@@ -122,9 +122,10 @@ class Window(QMainWindow):
         x_center = (screen_size.width() - login_dialog_size.width()) / 2
         y_center = (screen_size.height() - login_dialog_size.height()) / 2
         self.login_dialog.move(x_center, y_center)
-
         self.login_dialog.setup(self.controller)
         self.login_dialog.reset()
+        if error:
+            self.login_dialog.error(error)
         self.login_dialog.exec()
 
     def show_login_error(self, error):

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -289,6 +289,7 @@ class Controller(QObject):
             not self.api_job_queue.download_file_queue.api_client or
             not self.api_job_queue.metadata_queue.api_client
         ):
+            self.api = None
             self.logout()
             self.gui.show_login(error=_('Your session expired. Please log in again.'))
             return
@@ -443,6 +444,7 @@ class Controller(QObject):
         logger.debug('The SecureDrop server cannot be reached due to Error: {}'.format(result))
 
         if isinstance(result, ApiInaccessibleError):
+            self.api = None
             self.logout()
             self.gui.show_login(error=_('Your session expired. Please log in again.'))
 
@@ -497,10 +499,10 @@ class Controller(QObject):
         Call logout function in the API, reset the API object, and force the UI
         to update into a logged out state.
         """
-        self.call_api(self.api.logout,
-                      self.on_logout_success,
-                      self.on_logout_failure)
-        self.api = None
+        if self.api is not None:
+            self.call_api(self.api.logout, self.on_logout_success, self.on_logout_failure)
+            self.api = None
+
         self.api_job_queue.logout()
         storage.mark_all_pending_drafts_as_failed(self.session)
         self.gui.logout()

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -528,7 +528,7 @@ class Controller(QObject):
         if object_type == db.Reply:
             job = ReplyDownloadJob(
                 uuid, self.data_dir, self.gpg
-                )  # type: Union[ReplyDownloadJob, MessageDownloadJob, FileDownloadJob]
+            )  # type: Union[ReplyDownloadJob, MessageDownloadJob, FileDownloadJob]
             job.success_signal.connect(self.on_reply_download_success, type=Qt.QueuedConnection)
             job.failure_signal.connect(self.on_reply_download_failure, type=Qt.QueuedConnection)
         elif object_type == db.Message:

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -183,10 +183,6 @@ class ApiJobQueue(QObject):
         self.metadata_queue.pinged.connect(self.resume_queues)
 
     def logout(self) -> None:
-        self.main_queue.api_client = None
-        self.download_file_queue.api_client = None
-        self.metadata_queue.api_client = None
-
         if self.main_thread.isRunning():
             logger.debug('Stopping main queue thread')
             self.main_thread.quit()

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -136,7 +136,11 @@ class RunnableQueue(QObject):
                 session = self.session_maker()
                 job._do_call_api(self.api_client, session)
                 self.pinged.emit()
-            except (RequestTimeoutError, ApiInaccessibleError) as e:
+            except ApiInaccessibleError as e:
+                logger.debug('Job {} raised an exception: {}: {}'.format(self, type(e).__name__, e))
+                self.api_client = None
+                self.add_job(PauseQueueJob())
+            except RequestTimeoutError as e:
                 logger.debug('Job {} raised an exception: {}: {}'.format(self, type(e).__name__, e))
                 self.add_job(PauseQueueJob())
                 self.re_add_job(job)
@@ -182,6 +186,18 @@ class ApiJobQueue(QObject):
         self.main_queue.api_client = None
         self.download_file_queue.api_client = None
         self.metadata_queue.api_client = None
+
+        if self.main_thread.isRunning():
+            logger.debug('Stopping main queue thread')
+            self.main_thread.quit()
+
+        if self.download_file_thread.isRunning():
+            logger.debug('Stopping download queue thread')
+            self.download_file_thread.quit()
+
+        if self.metadata_thread.isRunning():
+            logger.debug('Stopping metadata queue thread')
+            self.metadata_thread.quit()
 
     def login(self, api_client: API) -> None:
         logger.debug('Passing API token to queues')

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -529,20 +529,19 @@ def get_reply(session: Session, uuid: str) -> Reply:
     return session.query(Reply).filter_by(uuid=uuid).one()
 
 
-def mark_all_pending_drafts_as_failed(session: Session) -> None:
+def mark_all_pending_drafts_as_failed(session: Session) -> List[DraftReply]:
     """
-    When we login (offline or online) or logout, we need to set all
-    the pending replies as failed.
+    When we login (offline or online) or logout, we need to set all the pending replies as failed.
     """
     pending_status = session.query(ReplySendStatus).filter_by(
         name=ReplySendStatusCodes.PENDING.value).one()
     failed_status = session.query(ReplySendStatus).filter_by(
         name=ReplySendStatusCodes.FAILED.value).one()
 
-    pending_drafts = session.query(DraftReply).filter_by(
-        send_status=pending_status
-    ).all()
+    pending_drafts = session.query(DraftReply).filter_by(send_status=pending_status).all()
     for pending_draft in pending_drafts:
         pending_draft.send_status = failed_status
 
     session.commit()
+
+    return pending_drafts

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -112,6 +112,22 @@ def test_show_login(mocker):
     w.login_dialog.exec.assert_called_once_with()
 
 
+def test_show_login_with_error_message(mocker):
+    """
+    The login dialog is displayed with a clean state.
+    """
+    w = Window()
+    w.controller = mocker.MagicMock()
+    mock_ld = mocker.patch('securedrop_client.gui.main.LoginDialog')
+
+    w.show_login('this-is-an-error-message-to-show-on-login-window')
+
+    mock_ld.assert_called_once_with(w)
+    w.login_dialog.reset.assert_called_once_with()
+    w.login_dialog.exec.assert_called_once_with()
+    w.login_dialog.error.assert_called_once_with('this-is-an-error-message-to-show-on-login-window')
+
+
 def test_show_login_error(mocker):
     """
     Ensures that an error message is displayed in the login dialog.

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -553,6 +553,28 @@ def test_Controller_on_update_star_failed(homedir, config, mocker, session_maker
     mock_gui.update_error_status.assert_called_once_with('Failed to update star.')
 
 
+def test_Controller_logout_with_no_api(homedir, config, mocker, session_maker):
+    '''
+    Ensure we don't attempt to make an api call to logout when the api has been set to None
+    because token is invalid.
+    '''
+    mock_gui = mocker.MagicMock()
+    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co.api = None
+    co.api_job_queue = mocker.MagicMock()
+    co.api_job_queue.logout = mocker.MagicMock()
+    co.call_api = mocker.MagicMock()
+    fail_draft_replies = mocker.patch(
+        'securedrop_client.storage.mark_all_pending_drafts_as_failed')
+
+    co.logout()
+
+    co.call_api.assert_not_called()
+    co.api_job_queue.logout.assert_called_once_with()
+    co.gui.logout.assert_called_once_with()
+    fail_draft_replies.called_once_with(co.session)
+
+
 def test_Controller_logout_success(homedir, config, mocker, session_maker):
     """
     Ensure the API is called on logout and if the API call succeeds,

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -386,22 +386,6 @@ def test_ApiJobQueue_login_if_queues_running(mocker):
     assert not mock_metadata_thread.start.called
 
 
-def test_ApiJobQueue_logout_removes_api_client(mocker):
-    mock_client = mocker.MagicMock()
-    mock_session_maker = mocker.MagicMock()
-
-    job_queue = ApiJobQueue(mock_client, mock_session_maker)
-    job_queue.main_queue.api_client = 'my token!!!'
-    job_queue.download_file_queue.api_client = 'my token!!!'
-    job_queue.metadata_queue.api_client = 'my token!!!'
-
-    job_queue.logout()
-
-    assert job_queue.main_queue.api_client is None
-    assert job_queue.download_file_queue.api_client is None
-    assert job_queue.metadata_queue.api_client is None
-
-
 def test_ApiJobQueue_logout_stops_queue_threads(mocker):
     job_queue = ApiJobQueue(mocker.MagicMock(), mocker.MagicMock())
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -176,38 +176,6 @@ def test_RunnableQueue_resubmitted_jobs(mocker):
     queue.re_add_job(job1)
 
 
-def test_RunnableQueue_job_ApiInaccessibleError(mocker):
-    '''
-    Add two jobs to the queue. The first runs into an auth error, and then gets resubmitted for the
-    next pass through the loop.
-    '''
-    queue = RunnableQueue(mocker.MagicMock(), mocker.MagicMock())
-    queue.pause = mocker.MagicMock()
-    job_cls = factory.dummy_job_factory(mocker, ApiInaccessibleError())
-    queue.JOB_PRIORITIES = {PauseQueueJob: 0, job_cls: 1}
-
-    # ApiInaccessibleError will cause the queue to pause, use our fake pause method instead
-    def fake_pause() -> None:
-        queue.add_job(PauseQueueJob())
-    queue.pause.emit = fake_pause
-
-    # Add two jobs that timeout during processing to the queues
-    job1 = job_cls()
-    job2 = job_cls()
-    queue.add_job(job1)
-    queue.add_job(job2)
-
-    # attempt to process job1 knowing that it times out
-    queue.process()
-    assert queue.queue.qsize() == 2  # queue contains: job1, job2
-
-    # now process after making it so job1 no longer times out
-    job1.return_value = 'mock'
-    queue.process()
-    assert queue.queue.qsize() == 1  # queue contains: job2
-    assert queue.queue.get(block=True) == (1, job2)
-
-
 def test_RunnableQueue_job_generic_exception(mocker):
     '''
     Add two jobs to the queue, the first of which will cause a generic exception, which is handled
@@ -233,25 +201,24 @@ def test_RunnableQueue_job_generic_exception(mocker):
 
 def test_RunnableQueue_does_not_run_jobs_when_not_authed(mocker):
     '''
-    Add a job to the queue, ensure we don't run it when not authenticated.
+    Check that the queue is paused when a job returns with aApiInaccessibleError. Check that the
+    job does not get resubmitted since it is not authorized and that its api_client is None.
     '''
     queue = RunnableQueue(mocker.MagicMock(), mocker.MagicMock())
-    queue.pause = mocker.MagicMock()
+    queue.paused = mocker.MagicMock()
+    queue.paused.emit = mocker.MagicMock()
     job_cls = factory.dummy_job_factory(mocker, ApiInaccessibleError())
     queue.JOB_PRIORITIES = {PauseQueueJob: 0, job_cls: 1}
-
-    # ApiInaccessibleError will cause the queue to pause, use our fake pause method instead
-    def fake_pause() -> None:
-        queue.add_job(PauseQueueJob())
-    queue.pause.emit = fake_pause
 
     # Add a job that results in an ApiInaccessibleError to the queue
     job = job_cls()
     queue.add_job(job)
 
-    # attempt to process job1 knowing that it times out
+    # attempt to process job knowing that it errors
     queue.process()
-    assert queue.queue.qsize() == 1  # queue contains: job1
+    assert queue.queue.qsize() == 0  # queue should not contain job since it was not resubmitted
+    assert queue.api_client is None
+    queue.paused.emit.assert_called_once_with()
 
 
 def test_ApiJobQueue_enqueue(mocker):
@@ -433,3 +400,26 @@ def test_ApiJobQueue_logout_removes_api_client(mocker):
     assert job_queue.main_queue.api_client is None
     assert job_queue.download_file_queue.api_client is None
     assert job_queue.metadata_queue.api_client is None
+
+
+def test_ApiJobQueue_logout_stops_queue_threads(mocker):
+    job_queue = ApiJobQueue(mocker.MagicMock(), mocker.MagicMock())
+
+    job_queue.logout()
+
+    assert not job_queue.main_thread.isRunning()
+    assert not job_queue.download_file_thread.isRunning()
+    assert not job_queue.metadata_thread.isRunning()
+
+
+def test_ApiJobQueue_logout_results_in_queue_threads_not_running(mocker):
+    job_queue = ApiJobQueue(mocker.MagicMock(), mocker.MagicMock())
+    job_queue.main_thread = mocker.MagicMock()
+    job_queue.download_file_thread = mocker.MagicMock()
+    job_queue.metadata_thread = mocker.MagicMock()
+
+    job_queue.logout()
+
+    job_queue.main_thread.quit.assert_called_once_with()
+    job_queue.download_file_thread.quit.assert_called_once_with()
+    job_queue.metadata_thread.quit.assert_called_once_with()


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/662
Fixes https://github.com/freedomofpress/securedrop-client/issues/736

Related: https://github.com/freedomofpress/securedrop-client/issues/420 remains open

# Test Plan for #662 

1. With a valid token, log out of the client when there are pending jobs and no longer see error message reported in #662: https://user-images.githubusercontent.com/213636/70762572-d5f70880-1d05-11ea-97c0-f7e2c9b086a5.png

# Test Plan for #736 

1. Update `/securedrop/journalist_app/api.py` in the securedrop repo to return `AuthError` when making a `get_sources` or `get_all_replies` or `get_submissions` request and see the client log you out and open a login window, you can use this diff if you'd like, [see how this results in an `AuthError`](https://github.com/freedomofpress/securedrop-sdk/blob/5af0b200f00bc931cfa78c0923e7354aeda09d0e/sdclientapi/__init__.py#L246-L247):
```diff
     def get_all_sources():
+        return jsonify({'error':'test', 'message':'test'})
```

# Checklist

 - [x] These changes should not need testing in Qubes but as always please test in qubes if you'd like and want bonus points