### PR TITLE
Immediate update of snippets

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1018,9 +1018,10 @@ class SourceWidget(QWidget):
         """
         self.controller = controller
         self.star.setup(self.controller)
-        self.controller.message_ready.connect(self.update_snippet)
-        self.controller.reply_ready.connect(self.update_snippet)
-        self.controller.file_ready.connect(self.update_snippet)
+        self.controller.message_ready.connect(self.set_snippet)
+        self.controller.reply_ready.connect(self.set_snippet)
+        self.controller.reply_succeeded.connect(self.set_snippet)
+        self.controller.file_ready.connect(self.set_snippet)
 
     def update(self):
         """
@@ -1032,12 +1033,16 @@ class SourceWidget(QWidget):
         if self.source.document_count == 0:
             self.paperclip.hide()
 
-    def set_snippet(self):
+    def set_snippet(self, uuid=None, content=None):
         if self.source.collection:
-            msg = str(self.source.collection[-1])
-            if len(msg) > 120:
-                msg = msg[:120] + "..."
-            self.preview.setText(msg)
+            msg = self.source.collection[-1]
+            if uuid and uuid == msg.uuid and content:
+                msg_text = content
+            else:
+                msg_text = str(msg)
+            if len(msg_text) > 120:
+                msg_text = msg_text[:120] + "..."
+            self.preview.setText(msg_text)
 
     def delete_source(self, event):
         if self.controller.api is None:
@@ -1046,9 +1051,6 @@ class SourceWidget(QWidget):
         else:
             messagebox = DeleteSourceMessageBox(self.source, self.controller)
             messagebox.launch()
-
-    def update_snippet(self, *args):
-        self.set_snippet()
 
 
 class StarToggleButton(SvgToggleButton):
@@ -1622,7 +1624,6 @@ class SpeechBubble(QWidget):
         Conditionally update this SpeechBubble's text if and only if the message_id of the emitted
         signal matches the message_id of this speech bubble.
         """
-        print(message_id, text)
         if message_id == self.message_id:
             self.message.setText(text)
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1018,6 +1018,9 @@ class SourceWidget(QWidget):
         """
         self.controller = controller
         self.star.setup(self.controller)
+        self.controller.message_ready.connect(self.update_snippet)
+        self.controller.reply_ready.connect(self.update_snippet)
+        self.controller.file_ready.connect(self.update_snippet)
 
     def update(self):
         """
@@ -1025,13 +1028,16 @@ class SourceWidget(QWidget):
         """
         self.timestamp.setText(_(arrow.get(self.source.last_updated).format('DD MMM')))
         self.name.setText(self.source.journalist_designation)
+        self.set_snippet()
+        if self.source.document_count == 0:
+            self.paperclip.hide()
+
+    def set_snippet(self):
         if self.source.collection:
             msg = str(self.source.collection[-1])
             if len(msg) > 120:
                 msg = msg[:120] + "..."
             self.preview.setText(msg)
-        if self.source.document_count == 0:
-            self.paperclip.hide()
 
     def delete_source(self, event):
         if self.controller.api is None:
@@ -1040,6 +1046,9 @@ class SourceWidget(QWidget):
         else:
             messagebox = DeleteSourceMessageBox(self.source, self.controller)
             messagebox.launch()
+
+    def update_snippet(self, *args):
+        self.set_snippet()
 
 
 class StarToggleButton(SvgToggleButton):
@@ -1613,6 +1622,7 @@ class SpeechBubble(QWidget):
         Conditionally update this SpeechBubble's text if and only if the message_id of the emitted
         signal matches the message_id of this speech bubble.
         """
+        print(message_id, text)
         if message_id == self.message_id:
             self.message.setText(text)
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2508,7 +2508,8 @@ class ConversationView(QWidget):
                 # Check if text in item has changed, then update the
                 # widget to reflect this change.
                 if not isinstance(item_widget, FileWidget):
-                    if item_widget.message.text() != conversation_item.content:
+                    if (item_widget.message.text() != conversation_item.content) and \
+                            conversation_item.content:
                         item_widget.message.setText(conversation_item.content)
                 # Check if this is a draft reply then ensure it's removed.
                 if isinstance(conversation_item, DraftReply):

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -103,7 +103,7 @@ class Controller(QObject):
     Signal that notifies that a reply was accepted by the server. Emits the reply's
     UUID and content as a string.
     """
-    reply_succeeded = pyqtSignal([str, str])
+    reply_succeeded = pyqtSignal([str, str, str])
 
     """
     Signal that notifies that a reply failed to be accepted by the server. Emits the reply's UUID
@@ -122,19 +122,19 @@ class Controller(QObject):
     This signal indicates that a file has been successfully downloaded by emitting the file's
     UUID and original filename as a string.
     """
-    file_ready = pyqtSignal([str, str])
+    file_ready = pyqtSignal([str, str, str])
 
     """
     This signal indicates that a message has been successfully downloaded by emitting the message's
     UUID and content as a string.
     """
-    message_ready = pyqtSignal([str, str])
+    message_ready = pyqtSignal([str, str, str])
 
     """
     This signal indicates that a reply has been successfully downloaded by emitting the reply's
     UUID and content as a string.
     """
-    reply_ready = pyqtSignal([str, str])
+    reply_ready = pyqtSignal([str, str, str])
 
     def __init__(self, hostname: str, gui, session_maker: sessionmaker,
                  home: str, proxy: bool = True, qubes: bool = True) -> None:
@@ -533,7 +533,7 @@ class Controller(QObject):
         self.gui.clear_error_status()  # remove any permanent error status message
         self.session.commit()  # Needed to flush stale data.
         message = storage.get_message(self.session, uuid)
-        self.message_ready.emit(message.uuid, message.content)
+        self.message_ready.emit(message.source.uuid, message.uuid, message.content)
 
     def on_message_download_failure(self, exception: Exception) -> None:
         """
@@ -558,7 +558,7 @@ class Controller(QObject):
         self.gui.clear_error_status()  # remove any permanent error status message
         self.session.commit()  # Needed to flush stale data.
         reply = storage.get_reply(self.session, uuid)
-        self.reply_ready.emit(reply.uuid, reply.content)
+        self.reply_ready.emit(reply.source.uuid, reply.uuid, reply.content)
 
     def on_reply_download_failure(self, exception: Exception) -> None:
         """
@@ -713,7 +713,7 @@ class Controller(QObject):
         self.gui.clear_error_status()  # remove any permanent error status message
         self.session.commit()
         file_obj = storage.get_file(self.session, uuid)
-        self.file_ready.emit(uuid, file_obj.original_filename)
+        self.file_ready.emit(file_obj.source.uuid, uuid, file_obj.original_filename)
 
     def on_file_download_failure(self, exception: Exception) -> None:
         """
@@ -799,7 +799,7 @@ class Controller(QObject):
         self.gui.clear_error_status()  # remove any permanent error status message
         self.session.commit()
         reply = storage.get_reply(self.session, reply_uuid)
-        self.reply_succeeded.emit(reply_uuid, reply.content)
+        self.reply_succeeded.emit(reply.source.uuid, reply_uuid, reply.content)
 
     def on_reply_failure(
         self,

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -703,6 +703,7 @@ def test_SourceList_update(mocker):
     assert mock_lwi.call_count == len(sources)
     assert sl.addItem.call_count == len(sources)
     assert sl.setItemWidget.call_count == len(sources)
+    assert len(sl.source_widgets) == len(sources)
 
 
 def test_SourceList_maintains_selection(mocker):
@@ -719,6 +720,19 @@ def test_SourceList_maintains_selection(mocker):
 
     assert sl.currentItem()
     assert sl.itemWidget(sl.currentItem()).source.id == sources[0].id
+
+
+def test_SourceList_set_snippet(mocker):
+    """
+    Handle the emitted event in the expected manner.
+    """
+    sl = SourceList()
+    mock_widget = mocker.MagicMock()
+    sl.source_widgets = {
+        "a_uuid": mock_widget,
+    }
+    sl.set_snippet("a_uuid", "msg_uuid", "msg_content")
+    mock_widget.set_snippet.assert_called_once_with("a_uuid", "msg_uuid", "msg_content")
 
 
 def test_SourceWidget_init(mocker):
@@ -785,11 +799,12 @@ def test_SourceWidget_set_snippet(mocker):
     Snippets are set as expected.
     """
     source = mocker.MagicMock()
+    source.uuid = "a_uuid"
     source.journalist_designation = "Testy McTestface"
     msg = factory.Message(content="abcdefg")
     source.collection = [msg, ]
     sw = SourceWidget(source)
-    sw.set_snippet(msg.uuid, msg.content)
+    sw.set_snippet(source.uuid, msg.uuid, msg.content)
     assert sw.preview.text() == "abcdefg"
 
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -780,6 +780,19 @@ def test_SourceWidget_update_attachment_icon():
     assert sw.paperclip.isHidden()
 
 
+def test_SourceWidget_set_snippet(mocker):
+    """
+    Snippets are set as expected.
+    """
+    source = mocker.MagicMock()
+    source.journalist_designation = "Testy McTestface"
+    msg = factory.Message(content="abcdefg")
+    source.collection = [msg, ]
+    sw = SourceWidget(source)
+    sw.set_snippet(msg.uuid, msg.content)
+    assert sw.preview.text() == "abcdefg"
+
+
 def test_SourceWidget_update_truncate_latest_msg(mocker):
     """
     If the latest message in the conversation is longer than 120 characters,

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -745,12 +745,13 @@ def test_Controller_on_file_downloaded_success(homedir, config, mocker, session_
     mock_storage = mocker.MagicMock()
     mock_file = mocker.MagicMock()
     mock_file.original_filename = "foo.txt"
+    mock_file.source.uuid = "a_uuid"
     mock_storage.get_file.return_value = mock_file
 
     with mocker.patch("securedrop_client.logic.storage", mock_storage):
         co.on_file_download_success(mock_uuid)
 
-    mock_file_ready.emit.assert_called_once_with(mock_uuid, "foo.txt")
+    mock_file_ready.emit.assert_called_once_with("a_uuid", mock_uuid, "foo.txt")
 
 
 def test_Controller_on_file_downloaded_api_failure(homedir, config, mocker, session_maker):
@@ -1085,7 +1086,7 @@ def test_Controller_on_reply_downloaded_success(mocker, homedir, session_maker):
 
     co.on_reply_download_success(reply.uuid)
 
-    reply_ready.emit.assert_called_once_with(reply.uuid, reply.content)
+    reply_ready.emit.assert_called_once_with(reply.source.uuid, reply.uuid, reply.content)
 
 
 def test_Controller_on_reply_downloaded_failure(mocker, homedir, session_maker):
@@ -1189,7 +1190,7 @@ def test_Controller_on_message_downloaded_success(mocker, homedir, session_maker
 
     co.on_message_download_success(message.uuid)
 
-    message_ready.emit.assert_called_once_with(message.uuid, message.content)
+    message_ready.emit.assert_called_once_with(message.source.uuid, message.uuid, message.content)
 
 
 def test_Controller_on_message_downloaded_failure(mocker, homedir, session_maker):
@@ -1363,13 +1364,14 @@ def test_Controller_on_reply_success(homedir, mocker, session_maker, session):
     mock_storage = mocker.MagicMock()
     mock_reply = mocker.MagicMock()
     mock_reply.content = "a message"
+    mock_reply.source.uuid = "a_uuid"
     mock_storage.get_reply.return_value = mock_reply
 
     with mocker.patch("securedrop_client.logic.storage", mock_storage):
         co.on_reply_success(reply.uuid)
 
     assert debug_logger.call_args_list[0][0][0] == '{} sent successfully'.format(reply.uuid)
-    reply_succeeded.emit.assert_called_once_with(reply.uuid, "a message")
+    reply_succeeded.emit.assert_called_once_with("a_uuid", reply.uuid, "a message")
     reply_failed.emit.assert_not_called()
     co.sync_api.assert_not_called()
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -736,14 +736,21 @@ def test_Controller_on_file_downloaded_success(homedir, config, mocker, session_
     mock_gui = mocker.MagicMock()
 
     co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co.session = mocker.MagicMock()
 
     # signal when file is downloaded
     mock_file_ready = mocker.patch.object(co, 'file_ready')
     mock_uuid = 'mock'
 
-    co.on_file_download_success(mock_uuid)
+    mock_storage = mocker.MagicMock()
+    mock_file = mocker.MagicMock()
+    mock_file.original_filename = "foo.txt"
+    mock_storage.get_file.return_value = mock_file
 
-    mock_file_ready.emit.assert_called_once_with(mock_uuid)
+    with mocker.patch("securedrop_client.logic.storage", mock_storage):
+        co.on_file_download_success(mock_uuid)
+
+    mock_file_ready.emit.assert_called_once_with(mock_uuid, "foo.txt")
 
 
 def test_Controller_on_file_downloaded_api_failure(homedir, config, mocker, session_maker):
@@ -1346,16 +1353,23 @@ def test_Controller_on_reply_success(homedir, mocker, session_maker, session):
     Check that when the method is called, the client emits the correct signal.
     '''
     co = Controller('http://localhost', mocker.MagicMock(), session_maker, homedir)
+    co.session = mocker.MagicMock()
     mocker.patch.object(co, 'sync_api')
     reply_succeeded = mocker.patch.object(co, 'reply_succeeded')
     reply_failed = mocker.patch.object(co, 'reply_failed')
     reply = factory.Reply(source=factory.Source())
     debug_logger = mocker.patch('securedrop_client.logic.logger.debug')
 
-    co.on_reply_success(reply.uuid)
+    mock_storage = mocker.MagicMock()
+    mock_reply = mocker.MagicMock()
+    mock_reply.content = "a message"
+    mock_storage.get_reply.return_value = mock_reply
+
+    with mocker.patch("securedrop_client.logic.storage", mock_storage):
+        co.on_reply_success(reply.uuid)
 
     assert debug_logger.call_args_list[0][0][0] == '{} sent successfully'.format(reply.uuid)
-    reply_succeeded.emit.assert_called_once_with(reply.uuid)
+    reply_succeeded.emit.assert_called_once_with(reply.uuid, "a message")
     reply_failed.emit.assert_not_called()
     co.sync_api.assert_not_called()
 


### PR DESCRIPTION
# Description

Ready for review.

Fixes #707.

This is a preview. **There are performance issues with the code as it stands** (tested with 200 sources), but I wanted to give you a sense of the progress made so far.

It took a while to work around SqlAlchemy, but got there in the end.

* On start, the snippets are updated as soon as the messages / replies etc are downloaded from the server.
* If a new message comes in while the client is active, the snippet is appropriately updated.
* When a new reply is sent and succeeds, the snippet is appropriately updated.
* When a file is downloaded from the server, the snippet is appropriately updated.

Screenie of some of this here:

![snippet_updates](https://user-images.githubusercontent.com/37602/73461415-035d4b80-4372-11ea-8047-a8670527c00a.gif)

Performance refactoring currently underway.

# Test Plan

I've updated the unit tests. Please check with Eyeball mk.1 :eyes: for functionality described above.

Performance sanity check with 200 sources currently results in an unresponsive app while the messages / replies are downloading.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
