### PR TITLE
Revert usage of subprocess.check_output text parameter

### DIFF
--- a/securedrop_client/crypto.py
+++ b/securedrop_client/crypto.py
@@ -153,7 +153,7 @@ class GpgHelper:
         cmd = self._gpg_cmd_base()
         cmd.extend(["--list-public-keys", "--fingerprint", "--with-colons",
                     "--fixed-list-mode", "--list-options", "no-show-photos"])
-        output = subprocess.check_output(cmd, text=True)
+        output = subprocess.check_output(cmd, universal_newlines=True)
 
         fingerprints = {}
         for line in output.splitlines():


### PR DESCRIPTION
# Description

It's the same as universal_newlines, so just use the one that works with our specified target of Python 3.5.

# Test Plan

Same as #749.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
