### PR TITLE
Show warning if source has no public key.

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2812,10 +2812,15 @@ class ReplyTextEdit(QPlainTextEdit):
         super(ReplyTextEdit, self).focusOutEvent(e)
 
     def set_logged_in(self):
-        self.setEnabled(True)
-        source_name = "<strong><font color=\"#24276d\">{}</font></strong>".format(
-            self.source.journalist_designation)
-        placeholder = _("Compose a reply to ") + source_name
+        if self.source.public_key:
+            self.setEnabled(True)
+            source_name = "<strong><font color=\"#24276d\">{}</font></strong>".format(
+                self.source.journalist_designation)
+            placeholder = _("Compose a reply to ") + source_name
+        else:
+            self.setEnabled(False)
+            msg = "<strong><font color=\"#24276d\">Cannot Reply</font></strong>"
+            placeholder = msg + " please wait for something to happen..."
         self.placeholder.setText(placeholder)
         self.placeholder.adjustSize()
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2819,8 +2819,8 @@ class ReplyTextEdit(QPlainTextEdit):
             placeholder = _("Compose a reply to ") + source_name
         else:
             self.setEnabled(False)
-            msg = "<strong><font color=\"#24276d\">Cannot Reply</font></strong>"
-            placeholder = msg + " please wait for something to happen..."
+            msg = "<strong><font color=\"#24276d\">Awaiting action</font></strong>"
+            placeholder = msg + " from the source to enable replies."
         self.placeholder.setText(placeholder)
         self.placeholder.adjustSize()
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -2907,6 +2907,23 @@ def test_ReplyTextEdit_set_logged_in(mocker):
     assert source.journalist_designation in rt.placeholder.text()
 
 
+def test_ReplyTextEdit_set_logged_in_no_public_key(mocker):
+    """
+    If the selected source has no public key, ensure a warning message is
+    shown and the user is unable to send a reply.
+    """
+    source = mocker.MagicMock()
+    source.journalist_designation = 'journalist designation'
+    source.public_key = None
+    controller = mocker.MagicMock()
+    rt = ReplyTextEdit(source, controller)
+
+    rt.set_logged_in()
+
+    assert 'Cannot Reply' in rt.placeholder.text()
+    assert rt.isEnabled() is False
+
+
 def test_update_conversation_maintains_old_items(mocker, session):
     """
     Calling update_conversation maintains old item state / position if there's

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -2920,7 +2920,7 @@ def test_ReplyTextEdit_set_logged_in_no_public_key(mocker):
 
     rt.set_logged_in()
 
-    assert 'Cannot Reply' in rt.placeholder.text()
+    assert 'Awaiting action' in rt.placeholder.text()
     assert rt.isEnabled() is False
 
 


### PR DESCRIPTION
# Description

Fixes #639

If a source has no public key a warning message is displayed in the ReplyBox area and the widget is set to disabled so they can't send anything.

# Test Plan

Added unit test to exercise additional logic.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
