### PR TITLE
Predicate FileWidget state on File.is_decrypted, not is_downloaded

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -34,8 +34,10 @@ from sqlalchemy.orm.session import sessionmaker
 from securedrop_client import storage
 from securedrop_client import db
 from securedrop_client.api_jobs.base import ApiInaccessibleError
-from securedrop_client.api_jobs.downloads import FileDownloadJob, MessageDownloadJob, \
-    ReplyDownloadJob, DownloadChecksumMismatchException
+from securedrop_client.api_jobs.downloads import (
+    DownloadChecksumMismatchException, DownloadDecryptionException, FileDownloadJob,
+    MessageDownloadJob, ReplyDownloadJob,
+)
 from securedrop_client.api_jobs.sources import DeleteSourceJob
 from securedrop_client.api_jobs.uploads import SendReplyJob, SendReplyJobError, \
     SendReplyJobTimeoutError
@@ -655,6 +657,7 @@ class Controller(QObject):
         '''
         file = self.get_file(file_uuid)
         file_location = file.location(self.data_dir)
+        logger.info('Exporting file %s', file_location)
 
         if not self.downloaded_file_exists(file):
             return
@@ -713,6 +716,10 @@ class Controller(QObject):
             logger.debug('Failure due to checksum mismatch, retrying {}'.format(exception.uuid))
             self._submit_download_job(exception.object_type, exception.uuid)
         else:
+            if isinstance(exception, DownloadDecryptionException):
+                logger.error("Failed to decrypt %s", exception.uuid)
+                f = self.get_file(exception.uuid)
+                self.file_missing.emit(f.source.uuid, f.uuid, str(f))
             self.gui.update_error_status(_('The file download failed. Please try again.'))
 
     def on_delete_source_success(self, result) -> None:

--- a/tests/api_jobs/test_downloads.py
+++ b/tests/api_jobs/test_downloads.py
@@ -5,8 +5,10 @@ from typing import Tuple
 from sdclientapi import BaseError
 from sdclientapi import Submission as SdkSubmission
 
-from securedrop_client.api_jobs.downloads import DownloadJob, FileDownloadJob, MessageDownloadJob, \
-    ReplyDownloadJob, DownloadChecksumMismatchException
+from securedrop_client.api_jobs.downloads import (
+    DownloadJob, FileDownloadJob, MessageDownloadJob,
+    ReplyDownloadJob, DownloadChecksumMismatchException, DownloadDecryptionException,
+)
 from securedrop_client.crypto import GpgHelper, CryptoError
 from tests import factory
 
@@ -271,7 +273,7 @@ def test_MessageDownloadJob_with_crypto_error(mocker, homedir, session, session_
     path = os.path.join(homedir, 'data')
     api_client.download_submission = mocker.MagicMock(return_value=('', path))
 
-    with pytest.raises(CryptoError):
+    with pytest.raises(DownloadDecryptionException):
         job.call_api(api_client, session)
 
     assert message.content is None
@@ -508,7 +510,7 @@ def test_FileDownloadJob_decryption_error(mocker, homedir, session, session_make
 
     mock_logger = mocker.patch('securedrop_client.api_jobs.downloads.logger')
 
-    with pytest.raises(CryptoError):
+    with pytest.raises(DownloadDecryptionException):
         job.call_api(api_client, session)
 
     log_msg = mock_logger.debug.call_args_list[0][0][0]


### PR DESCRIPTION
# Description

To export or print, a file must have been decrypted, so present `FileWidget` affordances based on that, not just whether it's been downloaded.

Also change how `FileWidget`'s download animation happens: now it starts immediately, and the timer is used when stopping instead, to ensure it always runs for at least 300ms. Credit to @eloquence for that idea.

Finally, start a `DownloadException` hierarchy, adding `DownloadDecryptionException` to the existing
`DownloadChecksumMismatchException`, so we can better diagnose retrieval problems.


Fixes #756.

Also fixes #754 as I had to fix the animation to test.

# Test Plan

- Start a SecureDrop development server instance with `make dev` in a local working copy.
- Run the client with `run.sh`
- In a web browser, upload a file through the dev server's source interface.
- In the client, find the source and the file and click the download button to retrieve it. The downloading animation should start, run briefly, and stop, resulting in the export/print buttons becoming available.
- Stop the client, and add a line like `raise CryptoError("BOOM!")` at the beginning of `FileDownloadJob.call_decrypt`.

- Stop and restart the dev server.
- Upload another file.
- Restart the client.
- Try to download the file. The download animation should start, an error should appear in the status bar, the download animation should stop, and you should be able to retry the download. (This is also the test for #754.)

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
