### PR TITLE
update slots and signals to match

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -845,6 +845,7 @@ class SourceList(QListWidget):
         self.controller.message_ready.connect(self.set_snippet)
         self.controller.reply_ready.connect(self.set_snippet)
         self.controller.file_ready.connect(self.set_snippet)
+        self.controller.file_missing.connect(self.set_snippet)
 
     def update(self, sources: List[Source]):
         """

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -161,7 +161,7 @@ class Controller(QObject):
     Emits:
         str: the file UUID
     """
-    file_missing = pyqtSignal(str)
+    file_missing = pyqtSignal(str, str, str)
 
 
     def __init__(self, hostname: str, gui, session_maker: sessionmaker,
@@ -629,7 +629,7 @@ class Controller(QObject):
             logger.debug('Cannot find {} in the data directory. File does not exist.'.format(
                 file.filename))
             storage.update_missing_files(self.data_dir, self.session)
-            self.file_missing.emit(file.uuid)
+            self.file_missing.emit(file.source.uuid, file.uuid, str(file))
             return False
         return True
 

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -101,18 +101,6 @@ class Controller(QObject):
     sync_events = pyqtSignal(str)
 
     """
-    Signal that notifies that a reply was accepted by the server. Emits the reply's
-    UUID and content as a string.
-    """
-    reply_succeeded = pyqtSignal([str, str, str])
-
-    """
-    Signal that notifies that a reply failed to be accepted by the server. Emits the reply's UUID
-    as a string.
-    """
-    reply_failed = pyqtSignal(str)
-
-    """
     A signal that emits a signal when the authentication state changes.
     - `True` when the client becomes authenticated
     - `False` when the client becomes unauthenticated
@@ -120,27 +108,61 @@ class Controller(QObject):
     authentication_state = pyqtSignal(bool)
 
     """
-    This signal indicates that a file has been successfully downloaded by emitting the file's
-    UUID and original filename as a string.
+    This signal indicates that a reply was successfully sent and received by the server.
+
+    Emits:
+        str: the reply's source UUID
+        str: the reply UUID
+        str: the content of the reply
     """
-    file_ready = pyqtSignal([str, str, str])
+    reply_succeeded = pyqtSignal(str, str, str)
 
     """
-    This signal indicates that a file needs to be redownloaded by emitting the file's UUID.
+    This signal indicates that a reply was not successfully sent or received by the server.
+
+    Emits:
+        str: the reply UUID
+    """
+    reply_failed = pyqtSignal(str)
+
+    """
+    This signal indicates that a reply has been successfully downloaded.
+
+    Emits:
+        str: the reply's source UUID
+        str: the reply UUID
+        str: the content of the reply
+    """
+    reply_ready = pyqtSignal(str, str, str)
+
+    """
+    This signal indicates that a message has been successfully downloaded.
+
+    Emits:
+        str: the message's source UUID
+        str: the message UUID
+        str: the content of the message
+    """
+    message_ready = pyqtSignal(str, str, str)
+
+    """
+    This signal indicates that a file has been successfully downloaded.
+
+    Emits:
+        str: the file's source UUID
+        str: the file UUID
+        str: the name of the file
+    """
+    file_ready = pyqtSignal(str, str, str)
+
+    """
+    This signal indicates that a file is missing.
+
+    Emits:
+        str: the file UUID
     """
     file_missing = pyqtSignal(str)
 
-    """
-    This signal indicates that a message has been successfully downloaded by emitting the message's
-    UUID and content as a string.
-    """
-    message_ready = pyqtSignal([str, str, str])
-
-    """
-    This signal indicates that a reply has been successfully downloaded by emitting the reply's
-    UUID and content as a string.
-    """
-    reply_ready = pyqtSignal([str, str, str])
 
     def __init__(self, hostname: str, gui, session_maker: sessionmaker,
                  home: str, proxy: bool = True, qubes: bool = True) -> None:
@@ -782,7 +804,7 @@ class Controller(QObject):
         self.gui.clear_error_status()  # remove any permanent error status message
         self.session.commit()
         reply = storage.get_reply(self.session, reply_uuid)
-        self.reply_succeeded.emit(reply.source.uuid, reply_uuid, reply.content)
+        self.reply_succeeded.emit(reply.source.uuid, reply.uuid, reply.content)
 
     def on_reply_failure(
         self,

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -163,7 +163,6 @@ class Controller(QObject):
     """
     file_missing = pyqtSignal(str, str, str)
 
-
     def __init__(self, hostname: str, gui, session_maker: sessionmaker,
                  home: str, proxy: bool = True, qubes: bool = True) -> None:
         """
@@ -804,7 +803,7 @@ class Controller(QObject):
         self.gui.clear_error_status()  # remove any permanent error status message
         self.session.commit()
         reply = storage.get_reply(self.session, reply_uuid)
-        self.reply_succeeded.emit(reply.source.uuid, reply.uuid, reply.content)
+        self.reply_succeeded.emit(reply.source.uuid, reply_uuid, reply.content)
 
     def on_reply_failure(
         self,

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1325,11 +1325,11 @@ def test_SpeechBubble_update_text(mocker):
     sb = SpeechBubble(msg_id, 'hello', mock_signal, 0)
 
     new_msg = 'new message'
-    sb._update_text(msg_id, new_msg)
+    sb._update_text('mock_source_uuid', msg_id, new_msg)
     assert sb.message.text() == new_msg
 
     newer_msg = 'an even newer message'
-    sb._update_text(msg_id + 'xxxxx', newer_msg)
+    sb._update_text('mock_source_uuid', msg_id + 'xxxxx', newer_msg)
     assert sb.message.text() == new_msg
 
 
@@ -1582,7 +1582,7 @@ def test_FileWidget_on_file_download_updates_items_when_uuid_matches(mocker, sou
     fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0)
     fw.update = mocker.MagicMock()
 
-    fw._on_file_downloaded(file.uuid)
+    fw._on_file_downloaded(file.source.uuid, file.uuid, str(file))
 
     assert fw.download_button.isHidden()
     assert not fw.export_button.isHidden()
@@ -1609,7 +1609,7 @@ def test_FileWidget_on_file_download_updates_items_when_uuid_does_not_match(
     fw.clear = mocker.MagicMock()
     fw.update = mocker.MagicMock()
 
-    fw._on_file_downloaded('not a matching uuid')
+    fw._on_file_downloaded('not a matching source uuid', 'not a matching file uuid', 'mock')
 
     fw.clear.assert_not_called()
     assert fw.download_button.isHidden()
@@ -1634,7 +1634,7 @@ def test_FileWidget_on_file_missing_show_download_button_when_uuid_matches(mocke
     fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0)
     fw.update = mocker.MagicMock()
 
-    fw._on_file_missing(file.uuid)
+    fw._on_file_missing(file.source.uuid, file.uuid, str(file))
 
     assert not fw.download_button.isHidden()
     assert fw.export_button.isHidden()
@@ -1661,7 +1661,7 @@ def test_FileWidget_on_file_missing_does_not_show_download_button_when_uuid_does
     fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0)
     fw.download_button.show = mocker.MagicMock()
 
-    fw._on_file_missing('not a matching uuid')
+    fw._on_file_missing('not a matching source uuid', 'not a matching file uuid', 'mock filename')
 
     fw.download_button.show.assert_not_called()
 
@@ -2738,24 +2738,17 @@ def test_ReplyWidget_success_failure_slots(mocker):
     assert mock_update_signal.connect.called  # to ensure no stale mocks
 
     # check the success slog
-    mock_logger = mocker.patch('securedrop_client.gui.widgets.logger')
-    widget._on_reply_success(msg_id + "x")
+    widget._on_reply_success('mock_source_id', msg_id + "x", 'lol')
     assert widget.error.isHidden()
-    assert not mock_logger.debug.called
-    widget._on_reply_success(msg_id)
+    widget._on_reply_success('mock_source_id', msg_id, 'lol')
     assert widget.error.isHidden()
-    assert mock_logger.debug.called
-    mock_logger.reset_mock()
 
     # check the failure slot where message id does not match
-    mock_logger = mocker.patch('securedrop_client.gui.widgets.logger')
     widget._on_reply_failure(msg_id + "x")
     assert widget.error.isHidden()
-    assert not mock_logger.debug.called
     # check the failure slot where message id matches
     widget._on_reply_failure(msg_id)
     assert not widget.error.isHidden()
-    assert mock_logger.debug.called
 
 
 def test_ReplyBoxWidget__on_authentication_changed(mocker, homedir):

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -822,18 +822,17 @@ def test_Controller_on_file_downloaded_success(homedir, config, mocker, session_
 
     # signal when file is downloaded
     mock_file_ready = mocker.patch.object(co, 'file_ready')
-    mock_uuid = 'mock'
 
     mock_storage = mocker.MagicMock()
     mock_file = mocker.MagicMock()
     mock_file.filename = "foo.txt"
-    mock_file.source.uuid = "a_uuid"
+    mock_file.source.uuid = "source_uuid"
     mock_storage.get_file.return_value = mock_file
 
     with mocker.patch("securedrop_client.logic.storage", mock_storage):
-        co.on_file_download_success(mock_uuid)
+        co.on_file_download_success('file_uuid')
 
-    mock_file_ready.emit.assert_called_once_with("a_uuid", mock_uuid, "foo.txt")
+    mock_file_ready.emit.assert_called_once_with("source_uuid", 'file_uuid', "foo.txt")
 
 
 def test_Controller_on_file_downloaded_api_failure(homedir, config, mocker, session_maker):
@@ -1358,15 +1357,15 @@ def test_Controller_on_reply_success(homedir, mocker, session_maker, session):
 
     mock_storage = mocker.MagicMock()
     mock_reply = mocker.MagicMock()
-    mock_reply.content = "a message"
-    mock_reply.source.uuid = "a_uuid"
+    mock_reply.content = "reply_message_mock"
+    mock_reply.source.uuid = "source_uuid"
     mock_storage.get_reply.return_value = mock_reply
 
     with mocker.patch("securedrop_client.logic.storage", mock_storage):
         co.on_reply_success(reply.uuid)
 
     assert debug_logger.call_args_list[0][0][0] == '{} sent successfully'.format(reply.uuid)
-    reply_succeeded.emit.assert_called_once_with("a_uuid", reply.uuid, "a message")
+    reply_succeeded.emit.assert_called_once_with("source_uuid", reply.uuid, "reply_message_mock")
     reply_failed.emit.assert_not_called()
     co.sync_api.assert_not_called()
 


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/771
Fixes https://github.com/freedomofpress/securedrop-client/issues/774
Fixes https://github.com/freedomofpress/securedrop-client/issues/769
Fixes https://github.com/freedomofpress/securedrop-client/issues/766

I recommend testing on Qubes to be able to see slower state changes. Follow each bug's STR to verify that it no longer happens and for issue #771 just make sure slots expect the right arguments from their respective signals.

Still need to add tests