### PR TITLE
Update obsolete original_filename usage in file_ready

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -695,7 +695,7 @@ class Controller(QObject):
         self.gui.clear_error_status()  # remove any permanent error status message
         self.session.commit()
         file_obj = storage.get_file(self.session, uuid)
-        self.file_ready.emit(file_obj.source.uuid, uuid, file_obj.original_filename)
+        self.file_ready.emit(file_obj.source.uuid, uuid, file_obj.filename)
 
     def on_file_download_failure(self, exception: Exception) -> None:
         """

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -826,7 +826,7 @@ def test_Controller_on_file_downloaded_success(homedir, config, mocker, session_
 
     mock_storage = mocker.MagicMock()
     mock_file = mocker.MagicMock()
-    mock_file.original_filename = "foo.txt"
+    mock_file.filename = "foo.txt"
     mock_file.source.uuid = "a_uuid"
     mock_storage.get_file.return_value = mock_file
 


### PR DESCRIPTION
# Description

The File object no longer has an original_filename attribute, which was causing a crash when downloading.

Fixes #770.

# Test Plan

Run the client. Download a file. Confirm it crashes.

Check out this branch and repeat that process. Confirm that it does not crash.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
