### PR TITLE
Fixes #776 fixes mkdir permission in apparmor

### DIFF
--- a/files/usr.bin.securedrop-client
+++ b/files/usr.bin.securedrop-client
@@ -58,7 +58,7 @@
   owner /home/user/.securedrop_client/ rw,
   owner /home/user/.securedrop_client/config.json r,
   owner /home/user/.securedrop_client/data/ w,
-  owner /home/user/.securedrop_client/data/* rwl,
+  owner /home/user/.securedrop_client/data/** rwl,
   owner /home/user/.securedrop_client/gpg/ rw,
   owner /home/user/.securedrop_client/gpg/* rwl,
   owner /home/user/.securedrop_client/logs/ rw,


### PR DESCRIPTION


# Description

Fixes #776

Now the client can create directories under
/home/user/.securedrop-client/data/
for different sources.

# Test Plan

- [ ] Open a client and see it is downloading files/messages properly and decrypting
- [ ] No apparmor error in `/var/log/syslog`.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
