### PR TITLE
Deletion of source in client problem. A 'blind' fix. Please check.

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -717,20 +717,22 @@ class MainView(QWidget):
 
         if source:
             self.controller.session.refresh(source)
-            # Try to get the SourceConversationWrapper from the persistent dict,
-            # else we create it.
-            try:
-                conversation_wrapper = self.source_conversations[source]
+            if source_exists(self.controller.session, source.uuid):
+                # Try to get the SourceConversationWrapper from the persistent dict,
+                # else we create it.
+                try:
+                    conversation_wrapper = self.source_conversations[source]
 
-                # Redraw the conversation view such that new messages, replies, files appear.
-                conversation_wrapper.conversation_view.update_conversation(source.collection)
-            except KeyError:
-                conversation_wrapper = SourceConversationWrapper(source, self.controller)
-                self.source_conversations[source] = conversation_wrapper
+                    # Redraw the conversation view such that new messages, replies, files appear.
+                    conversation_wrapper.conversation_view.update_conversation(source.collection)
+                except KeyError:
+                    conversation_wrapper = SourceConversationWrapper(source, self.controller)
+                    self.source_conversations[source] = conversation_wrapper
 
-            self.set_conversation(conversation_wrapper)
-        else:
-            self.clear_conversation()
+                self.set_conversation(conversation_wrapper)
+                return
+        # Fall through to clear conversation.
+        self.clear_conversation()
 
     def set_conversation(self, widget):
         """


### PR DESCRIPTION
# Description

Fixes #717

I've not been able to recreate this problem on my dev laptop. However, I've used the information in the referenced issue to add a check to ensure that the referenced source is known to exist on the client (the problem being that in-flight messages were trying to be added to a widget for a source that doesn't exist locally).

# Test Plan

Can someone who can recreate this problem please test this branch and confirm it works..?

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
