### PR TITLE
reset remaining attempts for each sync

### DIFF
--- a/securedrop_client/sync.py
+++ b/securedrop_client/sync.py
@@ -115,6 +115,7 @@ class ApiSyncBackgroundTask(QObject):
         try:
             self.sync_started.emit()
             session = self.session_maker()
+            self.job.remaining_attempts = 2
             self.job._do_call_api(self.api_client, session)
         except ApiInaccessibleError as e:
             self.job.failure_signal.emit(e)  # the job's failure signal is not emitted in base

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -79,6 +79,20 @@ def test_ApiSyncBackgroundTask_sync(mocker, session_maker, homedir):
     assert _do_call_api_fn.called
 
 
+def test_ApiSyncBackgroundTask_sync_resets_retries(mocker, session_maker, homedir):
+    '''
+    Ensure sync enqueues a MetadataSyncJob and calls it's parent's processing function
+    '''
+    api_client = mocker.MagicMock()
+    api_sync = ApiSync(api_client, session_maker, mocker.MagicMock(), homedir)
+
+    api_sync.api_sync_bg_task.sync()
+    assert api_sync.api_sync_bg_task.job.remaining_attempts == 1
+
+    api_sync.api_sync_bg_task.sync()
+    assert api_sync.api_sync_bg_task.job.remaining_attempts == 1
+
+
 def test_ApiSyncBackgroundTask_sync_catches_ApiInaccessibleError(mocker, session_maker, homedir):
     '''
     Ensure sync calls the parent processing function of MetadataSyncJob, catches


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/781

This bug was introduced when I made a change to stop recreating MetadataSyncJob every time we run the sync method: https://github.com/freedomofpress/securedrop-client/pull/739/commits/417473be8954ef499aae3de3d38013eac3d03aa3. This made it so that whenever sync was called, the remaining attempts would equal `NUMBER_OF_TIMES_TO_RETRY_AN_API_CALL` - 1 and eventually equal zero, so we would no longer process the job.

I added a regression test to make sure we reset the remaining attempts each time sync is called.

# Test Plan

1. Verify that on `master` the number of syncs you see is equal to 1+ `NUMBER_OF_TIMES_TO_RETRY_AN_API_CALL`. Go into the code and modify `NUMBER_OF_TIMES_TO_RETRY_AN_API_CALL` so that you can see this is True. Also, to save time, decrease `TIME_BETWEEN_SYNCS_MS` to be somewhere around 5 seconds.

2. Now checkout this branch and see that the syncs continue passed the number of retry attempts.

3. Also make sure the syncs are indeed grabbing new messages from sources.

# Checklist

 - [x] These changes should not need testing in Qubes
