### PR TITLE
Update login screen to latest design.

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1463,7 +1463,7 @@ class LoginDialog(QDialog):
         application_version.setLayout(application_version_layout)
         application_version_label = QLabel(_("Workstation app v") + sd_version)
         application_version_label.setAlignment(Qt.AlignHCenter)
-        application_version_label.setStyleSheet("QLabel {color: #2A319D;}")
+        application_version_label.setStyleSheet("QLabel {color: #9fddff;}")
         application_version_layout.addWidget(application_version_label)
 
         # Add widgets

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -33,6 +33,7 @@ from PyQt5.QtWidgets import QApplication, QListWidget, QLabel, QWidget, QListWid
     QToolButton, QSizePolicy, QPlainTextEdit, QStatusBar, QGraphicsDropShadowEffect, QPushButton, \
     QDialogButtonBox
 
+from securedrop_client import __version__ as sd_version
 from securedrop_client.db import DraftReply, Source, Message, File, Reply, User
 from securedrop_client.storage import source_exists
 from securedrop_client.export import ExportStatus, ExportError
@@ -1378,6 +1379,7 @@ class LoginDialog(QDialog):
         border-radius: 0px;
         height: 30px;
         margin: 0px 0px 0px 0px;
+        padding-left: 5px;
     }
     '''
 
@@ -1459,6 +1461,10 @@ class LoginDialog(QDialog):
         application_version = QWidget()
         application_version_layout = QHBoxLayout()
         application_version.setLayout(application_version_layout)
+        application_version_label = QLabel(_("Workstation app v") + sd_version)
+        application_version_label.setAlignment(Qt.AlignHCenter)
+        application_version_label.setStyleSheet("QLabel {color: #2A319D;}")
+        application_version_layout.addWidget(application_version_label)
 
         # Add widgets
         layout.addWidget(self.error_bar)
@@ -1507,6 +1513,7 @@ class LoginDialog(QDialog):
         Ensures the passed in message is displayed as an error message.
         """
         self.setDisabled(False)
+        self.submit.setText(_("SIGN IN"))
         self.error_bar.set_message(html.escape(message))
 
     def validate(self):
@@ -1541,7 +1548,7 @@ class LoginDialog(QDialog):
                 self.setDisabled(False)
                 self.error(_('Please use only numerals for the two-factor code.'))
                 return
-
+            self.submit.setText(_("SIGNING IN"))
             self.controller.login(username, password, tfa_token)
         else:
             self.setDisabled(False)

--- a/securedrop_client/resources/images/login_bg.svg
+++ b/securedrop_client/resources/images/login_bg.svg
@@ -1,197 +1,53 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="596"
-   height="671"
-   viewBox="0 0 596 671"
-   version="1.1"
-   id="svg48"
-   sodipodi:docname="login_bg2.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <metadata
-     id="metadata52">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title> LoginBasse</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="972"
-     inkscape:window-height="871"
-     id="namedview50"
-     showgrid="false"
-     inkscape:zoom="0.35171386"
-     inkscape:cx="303.68644"
-     inkscape:cy="335.5"
-     inkscape:window-x="944"
-     inkscape:window-y="147"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg48" />
-  <style
-     id="style2">.a{fill:#0C3E75;}</style>
-  <title
-     id="title4"> LoginBasse</title>
-  <desc
-     id="desc6"> Created with Sketch.</desc>
-  <defs
-     id="defs14">
-    <radialGradient
-       cx="50"
-       cy="24.2"
-       fx="50%"
-       fy="24.2104549%"
-       r="80.3"
-       gradientTransform="translate(0.500000,0.242105),scale(1.000000,0.888227),rotate(90.000000),translate(-0.500000,-0.242105)"
-       id="radialGradient-1">
-      <stop
-         stop-color="#00C7FF"
-         offset="0%"
-         id="stop8" />
-      <stop
-         stop-color="#0055DE"
-         offset="100%"
-         id="stop10" />
+<svg id="a5e825db-c5b8-488a-a1bd-bdafd3613a98" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="596.05" height="671.01" viewBox="0 0 596.05 671.01">
+  <defs>
+    <radialGradient id="e5e97f36-6594-4fc7-8a7a-e304d9b5d4ce" cx="-96.55" cy="641.92" r="0.8" gradientTransform="matrix(0, 596, 596, 0, -382286.66, 57706.48)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00c7ff"/>
+      <stop offset="1" stop-color="#0055de"/>
     </radialGradient>
-    <polygon
-       id="path-2"
-       points="0 0.7 216.4 0.7 216.4 252.5 0 252.5" />
+    <mask id="5dfd18e4-fe2e-4c04-bf6c-3f0dc21e67ca" x="297.29" y="-16.29" width="216.37" height="252.16" maskUnits="userSpaceOnUse">
+      <g transform="translate(0.05)">
+        <g id="082ce9dd-062b-4bac-a81b-4bede15a71cc" data-name="mask-3">
+          <polygon id="182d0c8f-60fc-42ca-8b2d-7d2df72ac412" data-name="path-2" points="297.24 -16.29 513.61 -16.29 513.61 235.48 297.24 235.48 297.24 -16.29" fill="#fff"/>
+        </g>
+      </g>
+    </mask>
   </defs>
-  <g
-     id="LoginBasse"
-     fill="none">
-    <g
-       id="•••-HuzzahAlt">
-      <polygon
-         id="MessagePaneBG"
-         points="0 0 596 0 595.8 669.8 0 671"
-         fill="url(#radialGradient-1)" />
-      <g
-         id="ugh222">
-        <g
-           id="Group-69"
-           transform="translate(-351 -17)">
-          <g
-             id="Group-65">
-            <polygon
-               id="Fill-14"
-               points="324.3 252.7 432.4 189.7 432.4 63.7 324.3 0.7 216.2 63.7 216.2 189.7"
-               style="fill:#FFF;opacity:0.1" />
-            <polygon
-               id="Fill-16"
-               points="432.4 441.7 540.5 378.7 540.5 252.7 432.4 189.7 324.3 252.7 324.3 378.7"
-               style="fill:#036FD8;opacity:0.5" />
-            <polygon
-               id="Fill-18"
-               points="324.3 630.8 432.4 567.7 432.4 441.7 324.3 378.7 216.2 441.7 216.2 567.7"
-               style="fill:#013A69;opacity:0.8" />
-            <polygon
-               id="Fill-20"
-               points="432.4 819.6 540.5 756.6 540.5 630.6 432.4 567.6 324.3 630.6 324.3 756.6"
-               class="a" />
-            <polygon
-               id="Fill-25"
-               points="540.5 252.7 648.6 189.7 648.6 63.7 540.5 0.7 432.4 63.7 432.4 189.7"
-               style="fill:#FFF;opacity:0.05" />
-            <polygon
-               id="Fill-27"
-               points="648.6 441.7 756.7 378.7 756.7 252.7 648.6 189.7 540.5 252.7 540.5 378.7"
-               style="fill:#045BAD;opacity:0.2" />
-            <polygon
-               id="Fill-29"
-               points="539.5 630.8 647.6 567.7 647.6 441.7 539.5 378.7 431.4 441.7 431.4 567.7"
-               style="fill:#024482;opacity:0.9" />
-            <polygon
-               id="Fill-31"
-               points="647.6 819.6 755.7 756.6 755.7 630.6 647.6 567.6 539.5 630.6 539.5 756.6"
-               class="a" />
-            <polygon
-               id="Fill-36"
-               points="864.8 441.7 972.9 378.7 972.9 252.7 864.8 189.7 756.7 252.7 756.7 378.7"
-               style="fill:#075394;mix-blend-mode:multiply;opacity:0.2" />
-            <polygon
-               id="Fill-38"
-               points="754.7 630.8 862.8 567.7 862.8 441.7 754.7 378.7 646.6 441.7 646.6 567.7"
-               fill="#095191" />
-            <polygon
-               id="Fill-40"
-               points="862.8 819.6 970.9 756.6 970.9 630.6 862.8 567.6 754.7 630.6 754.7 756.6"
-               class="a" />
-            <polygon
-               id="Fill-45"
-               points="972.9 252.7 1081 189.7 1081 63.7 972.9 0.7 864.8 63.7 864.8 189.7"
-               style="fill:#50E3C2;opacity:0.06" />
-            <polygon
-               id="Fill-49"
-               points="970.9 630.8 1079 567.7 1079 441.7 970.9 378.7 862.8 441.7 862.8 567.7"
-               style="fill:#012C50;opacity:0.6" />
+  <title>LoginBasse-OHYOUWILLWORK</title>
+  <g id="aa13ed56-dd6b-4796-ae30-dd97bccbc27f" data-name="LoginBasse">
+    <g id="840130dd-6d97-4d7e-8eac-a7c9bae7eece" data-name="•••-HuzzahAlt">
+      <polygon id="121efc96-6633-4758-8151-806efb45c9e6" data-name="MessagePaneBG" points="0.05 0 596.05 0 596.05 670.99 0.05 671 0.05 0" fill="url(#e5e97f36-6594-4fc7-8a7a-e304d9b5d4ce)"/>
+      <g id="e8db1a80-eec5-4a04-a2f3-45d0d9fd1a7d" data-name="ugh222">
+        <g id="22b33aa6-37a4-4e88-be25-c71e47e0ca4d" data-name="Group-69">
+          <g id="af6ecf2c-8321-466a-957d-bb931998f078" data-name="Group-65">
+            <polyline id="d743cb5a-753a-41c2-9164-7852917772c3" data-name="Fill-14" points="0.16 220.34 81.55 172.94 81.48 46.69 1.31 0.24 0.13 0.21" fill="#fff" opacity="0.11" style="isolation: isolate"/>
+            <polyline id="c8bb10b2-fa6f-4675-ae75-ea319ef279bc" data-name="Fill-16" points="0.21 377.42 82.38 424.83 189.67 361.56 189.11 235.75 81.55 172.88 0.05 220" fill="#036fd8" opacity="0.63" style="isolation: isolate"/>
+            <polyline id="b21fcb8d-ede7-47ec-bfba-cc8cdc061380" data-name="Fill-18" points="0 598.23 81.47 550.75 82.47 424.74 0.07 377.3" fill="#013a69" opacity="0.76" style="isolation: isolate"/>
+            <polyline id="d78bf86c-56f9-4c5d-a447-91e405ae7d01" data-name="Fill-20" points="0.01 598.22 0.04 671.01 189.57 671 189.57 613.59 81.47 550.58 0.05 598.16" fill="#0c3e75"/>
+            <polyline id="22ecb1e5-f2ef-4912-a457-b21e04d526f7" data-name="Fill-25" points="161.44 0.11 81.47 46.72 81.55 172.91 189.05 235.69 297.68 172.73 297.68 46.72 217.49 0" fill="#fff" opacity="0.05" style="isolation: isolate"/>
+            <polygon id="11e223b7-cd3e-47b8-90e9-86cf8a8b5043" data-name="Fill-27" points="297.15 424.7 405.26 361.69 407.09 235.67 297.15 172.69 189.05 235.69 189.61 361.75 297.15 424.7" fill="#045bad" opacity="0.2" style="isolation: isolate"/>
+            <polygon id="04854747-4910-41ea-b6c6-bef000c5c8e2" data-name="Fill-29" points="188.57 613.75 296.68 550.75 296.68 424.74 189.57 361.73 82.47 424.74 81.47 550.75 188.57 613.75" fill="#024482" opacity="0.89" style="isolation: isolate"/>
+            <polyline points="404.78 670.75 404.78 613.59 296.68 550.58 188.57 613.59 188.64 671 404.76 671" fill="#0c3e75"/>
+            <polyline id="109be0e0-f61d-4b74-b576-c00686adc7a5" data-name="Fill-36" points="596.05 221 513.8 172.75 406.92 235.63 405.74 361.69 512.92 424.84 596.04 375.57" fill="#075394" opacity="0.19" style="isolation: isolate"/>
+            <polygon id="60724360-b824-4918-ab26-cf2c527407f7" data-name="Fill-38" points="403.78 613.75 511.88 550.75 512.88 424.74 405.78 361.74 295.68 424.74 295.68 550.75 403.78 613.75" fill="#095191"/>
+            <polyline id="d7a13685-5c61-4aa4-834f-a1d0990a6646" data-name="Fill-40" points="405.05 671 596.05 671.01 596.05 599.61 511.88 550.58 403.78 613.59 403.78 671" fill="#0c3e75"/>
+            <polyline id="0993a9ba-f467-47b1-bba2-10829f1e60b7" data-name="Fill-45" points="594.35 0 513.88 46.72 513.88 172.73 596.05 221 596.05 1.19" fill="#50e3c2" opacity="0.06" style="isolation: isolate"/>
+            <polyline id="6d827fb6-95db-472d-8e63-f92fa41f822c" data-name="Fill-49" points="596.05 375.57 512.83 424.75 511.86 550.63 596.05 599.61" fill="#012c50" opacity="0.62" style="isolation: isolate"/>
           </g>
-          <g
-             id="Group-68"
-             transform="translate(648.199172 0)"
-             opacity="0.08">
-            <mask
-               id="mask-3"
-               fill="white">
-              <use
-                 xlink:href="#path-2"
-                 id="use31" />
-            </mask>
-            <polygon
-               id="Fill-66"
-               mask="url(#mask-3)"
-               points="108.2 252.5 216.4 189.5 216.4 63.7 108.2 0.7 0 63.7 0 189.5"
-               style="fill:#FFF;mix-blend-mode:multiply" />
+          <g id="7079549b-012a-44a7-884b-2fdeac95f0e3" data-name="Group-68" opacity="0.08">
+            <g mask="url(#5dfd18e4-fe2e-4c04-bf6c-3f0dc21e67ca)">
+              <polyline id="3da36f84-c699-4646-9dc7-36646c5d0bf2" data-name="Fill-66" points="377.52 0.03 297.29 46.66 297.29 172.54 407.05 235.88 513.66 172.54 513.66 46.66 433.39 0" fill="#fff"/>
+            </g>
           </g>
         </g>
       </g>
-      <g
-         id="Nu-Icon"
-         transform="translate(189 47)">
-        <polygon
-           id="Fill-1"
-           points="109 123.3 109 254 218 188.7 218 58"
-           fill="#045FB4" />
-        <polygon
-           id="Fill-2"
-           points="0 58.5 109 124 218 58.5 109 0"
-           fill="#2E8AE8" />
-        <polygon
-           id="Fill-3"
-           points="0 188.7 109 254 109 123.3 0 58"
-           fill="#093D70" />
-        <g
-           id="Group-10"
-           transform="translate(26 38)"
-           fill="#FFF">
-          <path
-             d="M127.7 108.4L152.5 93.7C154.3 92.6 156.4 93.3 157.4 95 157.7 95.6 157.8 96.2 157.9 96.8L157.9 121.2C157.9 124.8 156 128.2 153 129.9L127.8 144.5 127.7 108.4ZM164.7 141.6C169.8 138.5 173 132.8 173 126.7L173 76C173 71.3 169.3 67.5 164.9 67.5 163.5 67.5 162.1 67.9 160.8 68.6L110.8 98.6 110.8 173.8 164.7 141.6Z"
-             id="Fill-4" />
-          <path
-             d="M92.1 47.1L125 27.9 88 17.3C88.7 16.1 89.1 14.6 89.1 13.2 89.1 6.2 79.2 0.3 66.9 0.3 54.6 0.3 44.6 6.2 44.6 13.2 44.6 20.3 54.6 26.2 66.9 26.2 68.5 26.2 70.1 26.1 71.7 25.9L92.1 47.1Z"
-             id="Fill-6" />
-          <polygon
-             id="Fill-8"
-             points="0.1 119.6 38.2 142.4 38.2 133.9 0.1 111.1 0.1 66 55.9 99.3 55.9 117.3 15.2 93.1 15.2 101.6 55.9 125.9 55.9 171.4 0.1 138.1" />
+      <g id="a7fb3245-8820-4d5d-8ee0-0f0ef3fb1d88" data-name="Nu-Icon">
+        <polygon id="3fcb07f3-309c-401c-b70b-ac334d29204d" data-name="Fill-1" points="298.05 170.33 298.05 301 407.05 235.67 407.05 105 298.05 170.33" fill="#045fb4"/>
+        <polygon id="2568a658-2958-4f77-890d-a3b3f686bd32" data-name="Fill-2" points="189.05 105.55 298.01 171 406.96 105 298.01 47 189.05 105.55" fill="#2e8ae8"/>
+        <polygon id="e3090293-2da6-4a03-9128-dcd4e7ef57a2" data-name="Fill-3" points="189.05 235.67 298.05 301 298.13 170.96 189.05 105.55 189.05 235.67" fill="#093d70"/>
+        <g id="3ed6924b-ef8a-4a9a-918e-fb9d3634967d" data-name="Group-10">
+          <path id="dbb93284-73eb-408a-9489-74cc77a6d9e1" data-name="Fill-4" d="M342.73,193.42l24.79-14.76a3.56,3.56,0,0,1,4.89,1.37,4.09,4.09,0,0,1,.5,1.72v24.46a10,10,0,0,1-4.89,8.67l-25.2,14.59Zm37,33.13A17.31,17.31,0,0,0,388,211.7V161a8.36,8.36,0,0,0-8.12-8.5,8.5,8.5,0,0,0-4.06,1.12l-50,30v75.27Z" transform="translate(0.05)" fill="#fff"/>
+          <path id="2d529e3f-a9e3-45ae-9f4e-785599650dcb" data-name="Fill-6" d="M307.12,132.11,340,112.88l-37-10.59a8,8,0,0,0,1.09-4.06c0-7.08-9.94-12.93-22.25-12.93s-22.25,5.85-22.25,12.93,9.94,12.93,22.25,12.93a41.38,41.38,0,0,0,4.83-.28Z" transform="translate(0.05)" fill="#fff"/>
+          <polygon id="c762ee89-0084-48f5-b04f-7faf0e5cb055" data-name="Fill-8" points="215.11 204.58 253.25 227.41 253.25 218.91 215.11 196.08 215.11 151.03 270.9 184.33 270.9 202.35 230.28 178.06 230.28 186.65 270.9 210.93 270.9 256.42 215.11 223.12 215.11 204.58" fill="#fff"/>
         </g>
       </g>
     </g>

--- a/securedrop_client/resources/images/login_bg.svg
+++ b/securedrop_client/resources/images/login_bg.svg
@@ -1,75 +1,199 @@
-<svg width="596px" height="671px" viewBox="0 0 596 671" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 54 (76480) - https://sketchapp.com -->
-    <title>••• HuzzahAlt</title>
-    <desc>Created with Sketch.</desc>
-    <defs>
-        <radialGradient cx="50%" cy="24.2104549%" fx="50%" fy="24.2104549%" r="80.0653923%" gradientTransform="translate(0.500000,0.242105),scale(1.000000,0.890555),rotate(90.000000),translate(-0.500000,-0.242105)" id="radialGradient-1">
-            <stop stop-color="#00C7FF" offset="0%"></stop>
-            <stop stop-color="#0055DE" offset="100%"></stop>
-        </radialGradient>
-        <polygon id="path-2" points="0.0384684709 0.714600314 216.410217 0.714600314 216.410217 252.480008 0.0384684709 252.480008"></polygon>
-        <polygon id="path-4" points="0.132164936 0.386648926 251.132165 0.386648926 251.132165 293.386649 10.2669676 293.235521"></polygon>
-        <polygon id="path-6" points="2.72848411e-12 0.79574752 219.596434 0.79574752 219.596434 133.795748 2.72848411e-12 133.795748"></polygon>
-        <polygon id="path-8" points="0 0 113.462256 0 113.462256 186.619423 0 186.619423"></polygon>
-    </defs>
-    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="LoginBasse" transform="translate(-3.000000, -33.000000)">
-            <g id="•••-HuzzahAlt">
-                <polygon id="MessagePaneBG" fill="url(#radialGradient-1)" fill-rule="nonzero" points="3 33 597.779989 33 598.781302 700.760646 3 702"></polygon>
-                <g id="ugh222" transform="translate(3.000000, 34.000000)">
-                    <g id="Group-69" transform="translate(-350.000000, -13.000000)">
-                        <g id="Group-65">
-                            <polygon id="Fill-14" fill="#FFFFFF" opacity="0.106952195" points="324.314045 252.728999 432.420408 189.727337 432.420408 63.7200989 324.314045 0.714521922 216.207683 63.7200989 216.207683 189.727337"></polygon>
-                            <polygon id="Fill-16" fill="#036FD8" points="432.418856 441.741422 540.525219 378.735845 540.525219 252.728607 432.418856 189.726946 324.312494 252.728607 324.312494 378.735845"></polygon>
-                            <polygon id="Fill-18" fill="#013A69" opacity="0.76297433" points="324.314045 630.75228 432.420408 567.746703 432.420408 441.74338 324.314045 378.737803 216.207683 441.74338 216.207683 567.746703"></polygon>
-                            <polygon id="Fill-20" fill="#0C3E75" points="432.418856 819.594295 540.525219 756.588718 540.525219 630.585395 432.418856 567.579818 324.312494 630.585395 324.312494 756.588718"></polygon>
-                            <polygon id="Fill-25" fill="#FFFFFF" opacity="0.05" points="540.523667 252.728999 648.63003 189.727337 648.63003 63.7200989 540.523667 0.714521922 432.417305 63.7200989 432.417305 189.727337"></polygon>
-                            <polygon id="Fill-27" fill="#045BAD" opacity="0.2" points="648.628478 441.741422 756.734841 378.735845 756.734841 252.728607 648.628478 189.726946 540.522116 252.728607 540.522116 378.735845"></polygon>
-                            <polygon id="Fill-29" fill="#024482" opacity="0.89015532" points="539.523667 630.75228 647.63003 567.746703 647.63003 441.74338 539.523667 378.737803 431.417305 441.74338 431.417305 567.746703"></polygon>
-                            <polygon id="Fill-31" fill="#0C3E75" points="647.628478 819.594295 755.734841 756.588718 755.734841 630.585395 647.628478 567.579818 539.522116 630.585395 539.522116 756.588718"></polygon>
-                            <polygon id="Fill-36" fill="#075394" opacity="0.192824591" style="mix-blend-mode: multiply;" points="864.836549 441.741422 972.942911 378.735845 972.942911 252.728607 864.836549 189.726946 756.734065 252.728607 756.734065 378.735845"></polygon>
-                            <polygon id="Fill-38" fill="#095191" points="754.733677 630.75228 862.836161 567.746703 862.836161 441.74338 754.733677 378.737803 646.627314 441.74338 646.627314 567.746703"></polygon>
-                            <polygon id="Fill-40" fill="#0C3E75" points="862.836549 819.594295 970.942911 756.588718 970.942911 630.585395 862.836549 567.579818 754.734065 630.585395 754.734065 756.588718"></polygon>
-                            <polygon id="Fill-45" fill="#50E3C2" opacity="0.0640438988" points="972.94136 252.728999 1081.04772 189.727337 1081.04772 63.7200989 972.94136 0.714521922 864.834997 63.7200989 864.834997 189.727337"></polygon>
-                            <polygon id="Fill-49" fill="#012C50" opacity="0.618466332" points="970.94136 630.75228 1079.04772 567.746703 1079.04772 441.74338 970.94136 378.737803 862.834997 441.74338 862.834997 567.746703"></polygon>
-                        </g>
-                        <g id="Group-68" opacity="0.0813337054" transform="translate(648.199172, 0.000000)">
-                            <mask id="mask-3" fill="white">
-                                <use xlink:href="#path-2"></use>
-                            </mask>
-                            <g id="Clip-67"></g>
-                            <polygon id="Fill-66" fill="#FFFFFF" style="mix-blend-mode: multiply;" mask="url(#mask-3)" points="108.226283 252.480008 216.410217 189.540417 216.410217 63.6573215 108.226283 0.71381797 0.0384684709 63.6573215 0.0384684709 189.540417"></polygon>
-                        </g>
-                    </g>
-                </g>
-                <g id="Desktop-Icon" transform="translate(306.942724, 224.565721) rotate(1.000000) translate(-306.942724, -224.565721) translate(180.942724, 77.565721)">
-                    <mask id="mask-5" fill="white">
-                        <use xlink:href="#path-4"></use>
-                    </mask>
-                    <g id="Mask" fill-rule="nonzero"></g>
-                    <g id="SD-Logo" mask="url(#mask-5)">
-                        <g transform="translate(10.525993, 0.659056)">
-                            <polygon id="Fill-1" fill="#FFFFFF" points="112.445809 29.6325879 17.615942 84.0523678 18.7231589 191.025805 114.662052 243.58122 209.491919 189.163197 208.382893 82.1880027"></polygon>
-                            <polygon id="Fill-1" fill="#0B5BB4" points="110.819048 125.779113 6.41191945 71.1800939 6.5232598 77.5587781 111.007117 136.553575 213.478063 73.9463686 210.161331 67.9831892"></polygon>
-                            <g id="Top" stroke-width="1" fill="none" transform="translate(0.000000, 0.000000)">
-                                <path d="M155.520841,154.005023 L179.767934,139.164384 C181.448426,138.142336 183.64394,138.718285 184.647311,140.435661 C184.899692,140.925741 185.152074,141.539389 185.164385,142.15932 L185.607592,166.064352 C185.6712,169.532613 183.908633,172.787249 180.908781,174.580022 L156.171288,189.181904 L155.520841,154.005023 Z M192.645548,185.629869 C197.687023,182.559536 200.617111,176.925706 200.506309,170.979816 L199.593222,121.561283 C199.509094,116.976728 195.799291,113.33254 191.430834,113.416315 C189.976049,113.445636 188.648481,113.84147 187.44813,114.608006 L138.477906,144.794025 L139.832149,218.117591 L192.645548,185.629869 Z M113.648078,259.510534 L111.300725,132.42892 L217.883701,66.8146965 L220.229002,193.770648 L113.648078,259.510534 Z" id="D" fill="#0075F7"></path>
-                                <mask id="mask-7" fill="white">
-                                    <use xlink:href="#path-6"></use>
-                                </mask>
-                                <g id="Clip-4"></g>
-                                <path d="M128.418477,92.5469191 L151.285157,78.6348125 L117.449991,66.7579606 C118.098721,65.5196555 118.476802,64.1516631 118.45201,62.7899458 C118.321851,55.8516722 108.272742,50.46128 96.0419194,50.6955539 C83.8110967,50.9298278 73.9727221,56.8347861 74.0987492,63.6391888 C74.2268423,70.4414999 84.2780167,75.965763 96.5088394,75.7335808 C98.1223989,75.7022048 99.7318264,75.5348663 101.34332,75.3675278 L128.418477,92.5469191 Z M110.663124,132.779284 L0.982395289,71.5145582 L108.2996,5.9826999 L217.982395,67.370838 L110.663124,132.779284 Z" id="Fill-3" fill="#0B5BB4" mask="url(#mask-7)"></path>
-                            </g>
-                            <g id="S" stroke-width="1" fill="none" transform="translate(1.184003, 71.630902)">
-                                <mask id="mask-9" fill="white">
-                                    <use xlink:href="#path-8"></use>
-                                </mask>
-                                <g id="Clip-7"></g>
-                                <path d="M26.4216022,94.1218038 L65.3207114,115.483045 L65.1658932,107.26463 L26.2646919,85.9013143 L25.4382977,42.4756402 L82.2230888,73.5653944 L82.5557386,90.9854475 L41.1544332,68.3215394 L41.3113435,76.5378802 L82.7105568,99.2038626 L83.5453196,142.998764 L26.7605285,111.90901 L26.4216022,94.1218038 Z M2.39340509,125.742581 L113.462883,186.619423 L111.067386,60.7544575 L0,0 L2.39340509,125.742581 Z" id="Fill-6" fill="#0C3E75" mask="url(#mask-9)"></path>
-                            </g>
-                        </g>
-                    </g>
-                </g>
-            </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="596"
+   height="671"
+   viewBox="0 0 596 671"
+   version="1.1"
+   id="svg48"
+   sodipodi:docname="login_bg2.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata52">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title> LoginBasse</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="972"
+     inkscape:window-height="871"
+     id="namedview50"
+     showgrid="false"
+     inkscape:zoom="0.35171386"
+     inkscape:cx="303.68644"
+     inkscape:cy="335.5"
+     inkscape:window-x="944"
+     inkscape:window-y="147"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg48" />
+  <style
+     id="style2">.a{fill:#0C3E75;}</style>
+  <title
+     id="title4"> LoginBasse</title>
+  <desc
+     id="desc6"> Created with Sketch.</desc>
+  <defs
+     id="defs14">
+    <radialGradient
+       cx="50"
+       cy="24.2"
+       fx="50%"
+       fy="24.2104549%"
+       r="80.3"
+       gradientTransform="translate(0.500000,0.242105),scale(1.000000,0.888227),rotate(90.000000),translate(-0.500000,-0.242105)"
+       id="radialGradient-1">
+      <stop
+         stop-color="#00C7FF"
+         offset="0%"
+         id="stop8" />
+      <stop
+         stop-color="#0055DE"
+         offset="100%"
+         id="stop10" />
+    </radialGradient>
+    <polygon
+       id="path-2"
+       points="0 0.7 216.4 0.7 216.4 252.5 0 252.5" />
+  </defs>
+  <g
+     id="LoginBasse"
+     fill="none">
+    <g
+       id="•••-HuzzahAlt">
+      <polygon
+         id="MessagePaneBG"
+         points="0 0 596 0 595.8 669.8 0 671"
+         fill="url(#radialGradient-1)" />
+      <g
+         id="ugh222">
+        <g
+           id="Group-69"
+           transform="translate(-351 -17)">
+          <g
+             id="Group-65">
+            <polygon
+               id="Fill-14"
+               points="324.3 252.7 432.4 189.7 432.4 63.7 324.3 0.7 216.2 63.7 216.2 189.7"
+               style="fill:#FFF;opacity:0.1" />
+            <polygon
+               id="Fill-16"
+               points="432.4 441.7 540.5 378.7 540.5 252.7 432.4 189.7 324.3 252.7 324.3 378.7"
+               style="fill:#036FD8;opacity:0.5" />
+            <polygon
+               id="Fill-18"
+               points="324.3 630.8 432.4 567.7 432.4 441.7 324.3 378.7 216.2 441.7 216.2 567.7"
+               style="fill:#013A69;opacity:0.8" />
+            <polygon
+               id="Fill-20"
+               points="432.4 819.6 540.5 756.6 540.5 630.6 432.4 567.6 324.3 630.6 324.3 756.6"
+               class="a" />
+            <polygon
+               id="Fill-25"
+               points="540.5 252.7 648.6 189.7 648.6 63.7 540.5 0.7 432.4 63.7 432.4 189.7"
+               style="fill:#FFF;opacity:0.05" />
+            <polygon
+               id="Fill-27"
+               points="648.6 441.7 756.7 378.7 756.7 252.7 648.6 189.7 540.5 252.7 540.5 378.7"
+               style="fill:#045BAD;opacity:0.2" />
+            <polygon
+               id="Fill-29"
+               points="539.5 630.8 647.6 567.7 647.6 441.7 539.5 378.7 431.4 441.7 431.4 567.7"
+               style="fill:#024482;opacity:0.9" />
+            <polygon
+               id="Fill-31"
+               points="647.6 819.6 755.7 756.6 755.7 630.6 647.6 567.6 539.5 630.6 539.5 756.6"
+               class="a" />
+            <polygon
+               id="Fill-36"
+               points="864.8 441.7 972.9 378.7 972.9 252.7 864.8 189.7 756.7 252.7 756.7 378.7"
+               style="fill:#075394;mix-blend-mode:multiply;opacity:0.2" />
+            <polygon
+               id="Fill-38"
+               points="754.7 630.8 862.8 567.7 862.8 441.7 754.7 378.7 646.6 441.7 646.6 567.7"
+               fill="#095191" />
+            <polygon
+               id="Fill-40"
+               points="862.8 819.6 970.9 756.6 970.9 630.6 862.8 567.6 754.7 630.6 754.7 756.6"
+               class="a" />
+            <polygon
+               id="Fill-45"
+               points="972.9 252.7 1081 189.7 1081 63.7 972.9 0.7 864.8 63.7 864.8 189.7"
+               style="fill:#50E3C2;opacity:0.06" />
+            <polygon
+               id="Fill-49"
+               points="970.9 630.8 1079 567.7 1079 441.7 970.9 378.7 862.8 441.7 862.8 567.7"
+               style="fill:#012C50;opacity:0.6" />
+          </g>
+          <g
+             id="Group-68"
+             transform="translate(648.199172 0)"
+             opacity="0.08">
+            <mask
+               id="mask-3"
+               fill="white">
+              <use
+                 xlink:href="#path-2"
+                 id="use31" />
+            </mask>
+            <polygon
+               id="Fill-66"
+               mask="url(#mask-3)"
+               points="108.2 252.5 216.4 189.5 216.4 63.7 108.2 0.7 0 63.7 0 189.5"
+               style="fill:#FFF;mix-blend-mode:multiply" />
+          </g>
         </g>
+      </g>
+      <g
+         id="Nu-Icon"
+         transform="translate(189 47)">
+        <polygon
+           id="Fill-1"
+           points="109 123.3 109 254 218 188.7 218 58"
+           fill="#045FB4" />
+        <polygon
+           id="Fill-2"
+           points="0 58.5 109 124 218 58.5 109 0"
+           fill="#2E8AE8" />
+        <polygon
+           id="Fill-3"
+           points="0 188.7 109 254 109 123.3 0 58"
+           fill="#093D70" />
+        <g
+           id="Group-10"
+           transform="translate(26 38)"
+           fill="#FFF">
+          <path
+             d="M127.7 108.4L152.5 93.7C154.3 92.6 156.4 93.3 157.4 95 157.7 95.6 157.8 96.2 157.9 96.8L157.9 121.2C157.9 124.8 156 128.2 153 129.9L127.8 144.5 127.7 108.4ZM164.7 141.6C169.8 138.5 173 132.8 173 126.7L173 76C173 71.3 169.3 67.5 164.9 67.5 163.5 67.5 162.1 67.9 160.8 68.6L110.8 98.6 110.8 173.8 164.7 141.6Z"
+             id="Fill-4" />
+          <path
+             d="M92.1 47.1L125 27.9 88 17.3C88.7 16.1 89.1 14.6 89.1 13.2 89.1 6.2 79.2 0.3 66.9 0.3 54.6 0.3 44.6 6.2 44.6 13.2 44.6 20.3 54.6 26.2 66.9 26.2 68.5 26.2 70.1 26.1 71.7 25.9L92.1 47.1Z"
+             id="Fill-6" />
+          <polygon
+             id="Fill-8"
+             points="0.1 119.6 38.2 142.4 38.2 133.9 0.1 111.1 0.1 66 55.9 99.3 55.9 117.3 15.2 93.1 15.2 101.6 55.9 125.9 55.9 171.4 0.1 138.1" />
+        </g>
+      </g>
     </g>
+  </g>
 </svg>


### PR DESCRIPTION
# Description

Fixes #710.

This branch introduces four changes to fix #710 and thus https://github.com/freedomofpress/securedrop-ux/issues/86

1. The background SVG is set to the latest version provided by @ninavizz 
2. Left padding of 5px has been added to text input.
3. Version information has been (re)added -- see further discussion below.
4. When the "SIGN IN" button is clicked its text changes to "SIGNING IN".

Obligatory screenie of this all in action:

![login_update](https://user-images.githubusercontent.com/37602/74157264-e1848400-4c0f-11ea-97f1-daa1b4d0f9e5.gif)

**Further discussion:**

The images in the original ticket (#710) used the colour `#9fddff` which looked like this:

![version_bad](https://user-images.githubusercontent.com/37602/74157379-18f33080-4c10-11ea-9f5a-eb2b69d3ebf2.png)

To my eyes this didn't provide enough contrast, so I've used Grimace Blue instead:

![version_grimace](https://user-images.githubusercontent.com/37602/74157417-2c9e9700-4c10-11ea-8bc5-649185d50bf3.png)

Finally, the SVG referenced in the original ticket (https://github.com/freedomofpress/securedrop-ux/issues/17#issuecomment-478797141) didn't work with Qt and, after some head scratching, I eventually had to import it into Inkscape and then re-save it so it worked. I've not changed anything about the SVG, but please check Inkscape hasn't made changes.

# Test Plan

Could @ninavizz and @eloquence please check it looks good with Eyeball MK.1 :eyes:.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
