### PR TITLE
Fix flicker on mouse over in download button.

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1998,7 +1998,7 @@ class FileWidget(QWidget):
         # clear, this regularly caused random crashes when running the test
         # suite (on Ubuntu 18.04, Python3.7). The following code expresses the
         # same logic but without causing the random the crash of the test
-        # suite. 
+        # suite.
         if (t == QEvent.HoverEnter or t == QEvent.HoverMove) and not self.downloading:
             self.download_button.setIcon(load_icon('download_file_hover.svg'))
         elif t == QEvent.HoverLeave and not self.downloading:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1991,10 +1991,14 @@ class FileWidget(QWidget):
         if t == QEvent.MouseButtonPress:
             if event.button() == Qt.LeftButton:
                 self._on_left_click()
-        # HERE BE DRAGONS. Usually I'd wrap this in an if not self.download,
-        # but for reasons not entirely clear, this caused a crash. The
-        # following odd way of expressing the same conditional doesn't cause a
-        # crash. Go figure... :-/
+        # HERE BE DRAGONS.
+        # The checks for "not self.downloading" in the following lines of code
+        # probably look strange. The obvious thing to do is to wrap such a
+        # check as a conditional. However, for reasons that are not entirely
+        # clear, this regularly caused random crashes when running the test
+        # suite (on Ubuntu 18.04, Python3.7). The following code expresses the
+        # same logic but without causing the random the crash of the test
+        # suite. 
         if (t == QEvent.HoverEnter or t == QEvent.HoverMove) and not self.downloading:
             self.download_button.setIcon(load_icon('download_file_hover.svg'))
         elif t == QEvent.HoverLeave and not self.downloading:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1995,7 +1995,7 @@ class FileWidget(QWidget):
         # but for reasons not entirely clear, this caused a crash. The
         # following odd way of expressing the same conditional doesn't cause a
         # crash. Go figure... :-/
-        if t == QEvent.HoverEnter or t == QEvent.HoverMove and not self.downloading:
+        if (t == QEvent.HoverEnter or t == QEvent.HoverMove) and not self.downloading:
             self.download_button.setIcon(load_icon('download_file_hover.svg'))
         elif t == QEvent.HoverLeave and not self.downloading:
             self.download_button.setIcon(load_icon('download_file.svg'))

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1991,15 +1991,9 @@ class FileWidget(QWidget):
         if t == QEvent.MouseButtonPress:
             if event.button() == Qt.LeftButton:
                 self._on_left_click()
-        # HERE BE DRAGONS.
-        # The checks for "not self.downloading" in the following lines of code
-        # probably look strange. The obvious thing to do is to wrap such a
-        # check as a conditional. However, for reasons that are not entirely
-        # clear, this regularly caused random crashes when running the test
-        # suite (on Ubuntu 18.04, Python3.7). The following code expresses the
-        # same logic but without causing the random the crash of the test
-        # suite.
-        if (t == QEvent.HoverEnter or t == QEvent.HoverMove) and not self.downloading:
+        # See https://github.com/freedomofpress/securedrop-client/issues/835
+        # for context on code below.
+        if t == QEvent.HoverEnter and not self.downloading:
             self.download_button.setIcon(load_icon('download_file_hover.svg'))
         elif t == QEvent.HoverLeave and not self.downloading:
             self.download_button.setIcon(load_icon('download_file.svg'))

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1500,11 +1500,6 @@ def test_FileWidget_event_handler_hover(mocker, session, source):
     fw.eventFilter(fw, test_event)
     assert fw.download_button.setIcon.call_count == 1
     fw.download_button.setIcon.reset_mock()
-    # Hover move
-    test_event = QEvent(QEvent.HoverMove)
-    fw.eventFilter(fw, test_event)
-    assert fw.download_button.setIcon.call_count == 1
-    fw.download_button.setIcon.reset_mock()
     # Hover leave
     test_event = QEvent(QEvent.HoverLeave)
     fw.eventFilter(fw, test_event)


### PR DESCRIPTION
# Description

Fixes #791 

A trivial change. Took a while to spot why the flicker was happening. Parenthesis to clarify logical order of precedence.

# Test Plan

No unit test change needed. Eyeball Mk.1 used to confirm flickering no longer happens. :eyes:

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
