### PR TITLE
Improve efficiency of source key management

### DIFF
--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -124,9 +124,7 @@ def update_local_storage(session: Session,
     update_replies(remote_replies, get_local_replies(session), session, data_dir)
 
 
-def update_source_key(
-        gpg: GpgHelper, session: Session, local_source: Source, remote_source: SDKSource
-) -> None:
+def update_source_key(gpg: GpgHelper, local_source: Source, remote_source: SDKSource) -> None:
     """
     Updates a source's GPG key.
     """
@@ -146,9 +144,6 @@ def update_source_key(
         return
 
     try:
-        # commit so the new source is visible to import_key, which uses a new session
-        session.commit()
-
         # import_key updates the source's key and fingerprint, and commits
         gpg.import_key(
             remote_source.uuid,
@@ -182,8 +177,9 @@ def update_sources(gpg: GpgHelper, remote_sources: List[SDKSource],
             local_source.document_count = source.number_of_documents
             local_source.is_starred = source.is_starred
             local_source.last_updated = parse(source.last_updated)
+            session.commit()
 
-            update_source_key(gpg, session, local_source, source)
+            update_source_key(gpg, local_source, source)
 
             # Removing the UUID from local_sources_by_uuid ensures
             # this record won't be deleted at the end of this
@@ -200,8 +196,9 @@ def update_sources(gpg: GpgHelper, remote_sources: List[SDKSource],
                         last_updated=parse(source.last_updated),
                         document_count=source.number_of_documents)
             session.add(ns)
+            session.commit()
 
-            update_source_key(gpg, session, ns, source)
+            update_source_key(gpg, ns, source)
 
             logger.debug('Added new source {}'.format(source.uuid))
 

--- a/tests/api_jobs/test_sync.py
+++ b/tests/api_jobs/test_sync.py
@@ -1,8 +1,10 @@
 import os
-from uuid import UUID
 
 from securedrop_client.api_jobs.sync import MetadataSyncJob
 from securedrop_client.crypto import GpgHelper, CryptoError
+
+from tests import factory
+
 
 with open(os.path.join(os.path.dirname(__file__), '..', 'files', 'test-key.gpg.pub.asc')) as f:
     PUB_KEY = f.read()
@@ -12,26 +14,22 @@ def test_MetadataSyncJob_success(mocker, homedir, session, session_maker):
     gpg = GpgHelper(homedir, session_maker, is_qubes=False)
     job = MetadataSyncJob(homedir, gpg)
 
-    mock_source = mocker.MagicMock()
-    mock_source.uuid = 'bar'
-    mock_source.key = {
-        'type': 'PGP',
-        'public': PUB_KEY,
-        'fingerprint': '123456ABC',
-    }
+    mock_source = factory.RemoteSource(
+        key={
+            'type': 'PGP',
+            'public': PUB_KEY,
+            'fingerprint': '123456ABC',
+        }
+    )
 
     mock_key_import = mocker.patch.object(job.gpg, 'import_key')
     mock_get_remote_data = mocker.patch(
         'securedrop_client.api_jobs.sync.get_remote_data',
-        return_value=([mock_source], 'submissions', 'replies'))
+        return_value=([mock_source], [], []))
 
     api_client = mocker.MagicMock()
     api_client.default_request_timeout = mocker.MagicMock()
     api_client.default_request_timeout = mocker.MagicMock()
-
-    mocker.patch(
-        'securedrop_client.api_jobs.sync.update_local_storage',
-        return_value=([mock_source], 'submissions', 'replies'))
 
     job.call_api(api_client, session)
 
@@ -48,26 +46,22 @@ def test_MetadataSyncJob_success_with_key_import_fail(mocker, homedir, session, 
     gpg = GpgHelper(homedir, session_maker, is_qubes=False)
     job = MetadataSyncJob(homedir, gpg)
 
-    mock_source = mocker.MagicMock()
-    mock_source.uuid = 'bar'
-    mock_source.key = {
-        'type': 'PGP',
-        'public': PUB_KEY,
-        'fingerprint': '123456ABC',
-    }
+    mock_source = factory.RemoteSource(
+        key={
+            'type': 'PGP',
+            'public': PUB_KEY,
+            'fingerprint': '123456ABC',
+        }
+    )
 
     mock_key_import = mocker.patch.object(job.gpg, 'import_key',
                                           side_effect=CryptoError)
     mock_get_remote_data = mocker.patch(
         'securedrop_client.api_jobs.sync.get_remote_data',
-        return_value=([mock_source], 'submissions', 'replies'))
+        return_value=([mock_source], [], []))
 
     api_client = mocker.MagicMock()
     api_client.default_request_timeout = mocker.MagicMock()
-
-    mocker.patch(
-        'securedrop_client.api_jobs.sync.update_local_storage',
-        return_value=([mock_source], 'submissions', 'replies'))
 
     job.call_api(api_client, session)
 
@@ -84,25 +78,21 @@ def test_MetadataSyncJob_success_with_missing_key(mocker, homedir, session, sess
     gpg = GpgHelper(homedir, session_maker, is_qubes=False)
     job = MetadataSyncJob(homedir, gpg)
 
-    mock_source = mocker.MagicMock()
-    mock_source.uuid = 'bar'
-    mock_source.key = {
-        'type': 'PGP',
-        'pub_key': '',
-        'fingerprint': ''
-    }
+    mock_source = factory.RemoteSource(
+        key={
+            'type': 'PGP',
+            'public': '',
+            'fingerprint': '',
+        }
+    )
 
     mock_key_import = mocker.patch.object(job.gpg, 'import_key')
     mock_get_remote_data = mocker.patch(
         'securedrop_client.api_jobs.sync.get_remote_data',
-        return_value=([mock_source], 'submissions', 'replies'))
+        return_value=([mock_source], [], []))
 
     api_client = mocker.MagicMock()
     api_client.default_request_timeout = mocker.MagicMock()
-
-    mocker.patch(
-        'securedrop_client.api_jobs.sync.update_local_storage',
-        return_value=([mock_source], 'submissions', 'replies'))
 
     job.call_api(api_client, session)
 
@@ -114,20 +104,16 @@ def test_MetadataSyncJob_only_import_new_source_keys(mocker, homedir, session, s
     """
     Verify that we only import source keys we don't already have.
     """
-    class LimitedImportGpgHelper(GpgHelper):
-        def import_key(self, source_uuid: UUID, key_data: str, fingerprint: str) -> None:
-            self._import(key_data)
-
-    gpg = LimitedImportGpgHelper(homedir, session_maker, is_qubes=False)
+    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
     job = MetadataSyncJob(homedir, gpg)
 
-    mock_source = mocker.MagicMock()
-    mock_source.uuid = 'bar'
-    mock_source.key = {
-        'type': 'PGP',
-        'public': PUB_KEY,
-        'fingerprint': 'B2FF7FB28EED8CABEBC5FB6C6179D97BCFA52E5F',
-    }
+    mock_source = factory.RemoteSource(
+        key={
+            'type': 'PGP',
+            'public': PUB_KEY,
+            'fingerprint': '123456ABC',
+        }
+    )
 
     mock_get_remote_data = mocker.patch(
         'securedrop_client.api_jobs.sync.get_remote_data',
@@ -136,27 +122,19 @@ def test_MetadataSyncJob_only_import_new_source_keys(mocker, homedir, session, s
     api_client = mocker.MagicMock()
     api_client.default_request_timeout = mocker.MagicMock()
 
-    mocker.patch(
-        'securedrop_client.api_jobs.sync.update_local_storage',
-        return_value=([mock_source], [], []))
-
-    mock_logger = mocker.patch('securedrop_client.api_jobs.sync.logger')
+    crypto_logger = mocker.patch('securedrop_client.crypto.logger')
+    storage_logger = mocker.patch('securedrop_client.storage.logger')
 
     job.call_api(api_client, session)
 
     assert mock_get_remote_data.call_count == 1
-    assert len(gpg.fingerprints()) == 2
 
-    log_msg = mock_logger.debug.call_args_list[0][0][0]
-    assert log_msg.startswith(
-        'Importing key with fingerprint {}'.format(mock_source.key['fingerprint'])
-    )
+    log_msg = crypto_logger.debug.call_args_list[0][0]
+    assert log_msg == ('Importing key with fingerprint %s', mock_source.key['fingerprint'])
 
     job.call_api(api_client, session)
 
     assert mock_get_remote_data.call_count == 2
 
-    log_msg = mock_logger.debug.call_args_list[1][0][0]
-    assert log_msg.startswith(
-        'Skipping import of key with fingerprint {}'.format(mock_source.key['fingerprint'])
-    )
+    log_msg = storage_logger.debug.call_args_list[1][0][0]
+    assert log_msg == 'Source key data is unchanged'

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -3,7 +3,11 @@ changes forcing an update of all test code.
 """
 from datetime import datetime
 from itertools import cycle
+import os
 from typing import List
+import uuid
+
+from sdclientapi import Source as SDKSource
 
 from securedrop_client import db
 from securedrop_client.api_jobs.base import ApiJob
@@ -40,6 +44,7 @@ def Source(**attrs):
         journalist_designation='testy-mctestface',
         is_flagged=False,
         public_key='mah pub key',
+        fingerprint='mah fingerprint',
         interaction_count=0,
         is_starred=False,
         last_updated=datetime.now(),
@@ -156,3 +161,33 @@ def dummy_job_factory(mocker, return_value, **kwargs):
                 return return_value
 
     return DummyApiJob
+
+
+def RemoteSource(**attrs):
+
+    with open(os.path.join(os.path.dirname(__file__), 'files', 'test-key.gpg.pub.asc')) as f:
+        pub_key = f.read()
+
+    defaults = dict(
+        add_star_url='foo',
+        interaction_count=0,
+        is_flagged=False,
+        is_starred=True,
+        journalist_designation='testy-mctestface',
+        key={
+            'public': pub_key,
+            'fingerprint': 'B2FF7FB28EED8CABEBC5FB6C6179D97BCFA52E5F'
+        },
+        last_updated=datetime.now().isoformat(),
+        number_of_documents=0,
+        number_of_messages=0,
+        remove_star_url='baz',
+        replies_url='qux',
+        submissions_url='wibble',
+        url='url',
+        uuid=str(uuid.uuid4())
+    )
+
+    defaults.update(attrs)
+
+    return SDKSource(**defaults)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -258,7 +258,7 @@ def test_update_source_key_without_fingerprint(mocker, session):
     remote_source = factory.RemoteSource()
     remote_source.key = {}
 
-    update_source_key(None, session, local_source, remote_source)
+    update_source_key(None, local_source, remote_source)
 
     error_logger.assert_called_once_with("New source data lacks key fingerprint")
 
@@ -280,7 +280,7 @@ def test_update_source_key_without_key(mocker, session):
     remote_source = factory.RemoteSource()
     del remote_source.key["public"]
 
-    update_source_key(None, session, local_source, remote_source)
+    update_source_key(None, local_source, remote_source)
 
     error_logger.assert_called_once_with("New source data lacks public key")
 


### PR DESCRIPTION
# Description

Only set `db.Source.public_key` and `db.Source.fingerprint` when a source's key is successfully imported to the local key ring. This allows us to use those columns to check the presence of the key and save a call to GPG during sync.

Fixes #757.

# Test Plan

Run the client against a local dev server with `LOGLEVEL=debug`. Observe in the logs that the initial sync imports source public keys, and subsequent ones skip the imports. Observe that there is no keyring access popup for syncs where no new keys are imported.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
