### PR TITLE
Removes container's upstream virtualenv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,10 @@
 ---
 common-steps:
+  - &removevirtualenv
+    run:
+      name: Removes the upstream virtualenv from the original container image
+      command: sudo pip uninstall virtualenv -y
+
   - &run_tests
     run:
       name: Install requirements and run tests
@@ -71,6 +76,7 @@ jobs:
       - image: circleci/python:3.7-buster
     steps:
       - checkout
+      - *removevirtualenv
       - *install_packaging_dependencies
       - *verify_requirements
       - *make_source_tarball


### PR DESCRIPTION


# Description

https://github.com/freedomofpress/securedrop-debian-packaging/pull/142
^^ related to above PR.

# Test Plan

CI should be green.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
