### PR TITLE
Fix problem where download_button CSS was ignored

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1886,6 +1886,19 @@ class FileWidget(QWidget):
     }
     '''
 
+    download_button_css = """
+    QPushButton#download_button {
+        border: none;
+        font-family: 'Source Sans Pro';
+        font-weight: 600;
+        font-size: 13px;
+        color: #2a319d;
+    }
+    QPushButton#download_button:hover {
+        color: #05a6fe;
+    }
+    """
+
     VERTICAL_MARGIN = 10
     FILE_FONT_SPACING = 2
     FILE_OPTIONS_FONT_SPACING = 1.6
@@ -1940,6 +1953,7 @@ class FileWidget(QWidget):
         self.download_button.setIcon(load_icon('download_file.svg'))
         self.download_button.setFont(self.file_buttons_font)
         self.download_button.setCursor(QCursor(Qt.PointingHandCursor))
+        self.download_button.setStyleSheet(self.download_button_css)
         self.download_animation = load_movie("download_file.gif")
         self.export_button = QPushButton(_('EXPORT'))
         self.export_button.setObjectName('export_print')
@@ -2019,6 +2033,7 @@ class FileWidget(QWidget):
             self.download_button.setIcon(load_icon('download_file.svg'))
             self.download_button.setFont(self.file_buttons_font)
             self.download_button.show()
+            self.download_button.setStyleSheet(self.download_button_css)
             self.no_file_name.hide()
             self.export_button.hide()
             self.middot.hide()
@@ -2029,12 +2044,14 @@ class FileWidget(QWidget):
     @pyqtSlot(str, str, str)
     def _on_file_downloaded(self, source_uuid: str, file_uuid: str, filename: str) -> None:
         if file_uuid == self.file.uuid:
+            self.downloading = False
             self.file = self.controller.get_file(self.file.uuid)
             QTimer.singleShot(300, self.stop_button_animation)
 
     @pyqtSlot(str, str, str)
     def _on_file_missing(self, source_uuid: str, file_uuid: str, filename: str) -> None:
         if file_uuid == self.file.uuid:
+            self.downloading = False
             self.file = self.controller.get_file(self.file.uuid)
             QTimer.singleShot(300, self.stop_button_animation)
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2030,7 +2030,11 @@ class FileWidget(QWidget):
             self.file_name.show()
         else:
             self.download_button.setText(_('DOWNLOAD'))
-            self.download_button.setIcon(load_icon('download_file.svg'))
+            # Ensure correct icon depending on mouse hover state.
+            if self.download_button.underMouse():
+                self.download_button.setIcon(load_icon('download_file_hover.svg'))
+            else:
+                self.download_button.setIcon(load_icon('download_file.svg'))
             self.download_button.setFont(self.file_buttons_font)
             self.download_button.show()
             self.download_button.setStyleSheet(self.download_button_css)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2017,7 +2017,6 @@ class FileWidget(QWidget):
         else:
             self.download_button.setText(_('DOWNLOAD'))
             self.download_button.setIcon(load_icon('download_file.svg'))
-            self.download_button.setStyleSheet('color: #2a319d')
             self.download_button.setFont(self.file_buttons_font)
             self.download_button.show()
             self.no_file_name.hide()

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1522,6 +1522,29 @@ def test_FileWidget_init_file_downloaded(mocker, source, session):
     assert not fw.file_name.isHidden()
 
 
+def test_FileWidget_set_button_state_under_mouse(mocker, source, session):
+    """
+    If the download_button is under the mouse, it should show the "hover"
+    version of the download_file icon.
+    """
+    file_ = factory.File(source=source['source'],
+                         is_downloaded=False,
+                         is_decrypted=None)
+    session.add(file_)
+    session.commit()
+
+    mock_get_file = mocker.MagicMock(return_value=file_)
+    mock_controller = mocker.MagicMock(get_file=mock_get_file)
+
+    fw = FileWidget(file_.uuid, mock_controller, mocker.MagicMock(), mocker.MagicMock(), 0)
+    fw.download_button.underMouse = mocker.MagicMock(return_value=True)
+    fw.download_button.setIcon = mocker.MagicMock()
+    mock_load = mocker.MagicMock()
+    with mocker.patch("securedrop_client.gui.widgets.load_icon", mock_load):
+        fw.set_button_state()
+        mock_load.assert_called_once_with("download_file_hover.svg")
+
+
 def test_FileWidget_event_handler_left_click(mocker, session, source):
     """
     Left click on filename should trigger an open.


### PR DESCRIPTION
# Description

Fixes #804.

Removes the line causing the hover state to be ignored. AFAICT the line that has been deleted shouldn't need to be there since the colour is correctly specified in the CSS for the FileWidget as is. I'm not sure why this was added. Can someone please check I'm not missing some wider context here..?

![hover](https://user-images.githubusercontent.com/37602/74429746-6d3a2280-4e53-11ea-90c9-c694aec0fba8.gif)


# Test Plan

Checked with Eyeball Mk.1 :eyes:

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
