### PR TITLE
update sync method names and message

### DIFF
--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -149,14 +149,14 @@ class Window(QMainWindow):
         """
         self.main_view.show_sources(sources)
 
-    def show_sync(self, updated_on):
+    def show_last_sync(self, updated_on):
         """
-        Display a message indicating the data-sync state.
+        Display a message indicating the time of last sync with the server.
         """
         if updated_on:
             self.update_activity_status(_('Last Refresh: {}').format(updated_on.humanize()))
         else:
-            self.update_activity_status(_('Waiting to refresh...'), 5000)
+            self.update_activity_status(_('Last Refresh: never'))
 
     def set_logged_in_as(self, db_user: User):
         """

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -223,26 +223,26 @@ def test_clear_error_status(mocker):
     w.top_pane.clear_error_status.assert_called_once_with()
 
 
-def test_show_sync(mocker):
+def test_show_last_sync(mocker):
     """
     If there's a value display the result of its "humanize" method.humanize
     """
     w = Window()
     w.update_activity_status = mocker.MagicMock()
     updated_on = mocker.MagicMock()
-    w.show_sync(updated_on)
+    w.show_last_sync(updated_on)
     w.update_activity_status.assert_called_once_with(
         'Last Refresh: {}'.format(updated_on.humanize()))
 
 
-def test_show_sync_no_sync(mocker):
+def test_show_last_sync_no_sync(mocker):
     """
     If there's no value to display, default to a "waiting" message.
     """
     w = Window()
     w.update_activity_status = mocker.MagicMock()
-    w.show_sync(None)
-    w.update_activity_status.assert_called_once_with('Waiting to refresh...', 5000)
+    w.show_last_sync(None)
+    w.update_activity_status.assert_called_once_with('Last Refresh: never')
 
 
 def test_set_logged_in_as(mocker):


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/806

+ a little name refactor

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes