### PR TITLE
no longer mark replies as failed if they time out

### DIFF
--- a/securedrop_client/api_jobs/uploads.py
+++ b/securedrop_client/api_jobs/uploads.py
@@ -71,7 +71,6 @@ class SendReplyJob(ApiJob):
         except (RequestTimeoutError, ServerConnectionError) as e:
             message = "Failed to send reply for source {id} due to Exception: {error}".format(
                 id=self.source_uuid, error=e)
-            self._set_status_to_failed(session)
             raise SendReplyJobTimeoutError(message, self.reply_uuid)
         except Exception as e:
             message = "Failed to send reply for source {id} due to Exception: {error}".format(

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -813,7 +813,10 @@ class Controller(QObject):
         exception: Union[SendReplyJobError, SendReplyJobTimeoutError]
     ) -> None:
         logger.debug('{} failed to send'.format(exception.reply_uuid))
-        self.reply_failed.emit(exception.reply_uuid)
+
+        # only emit failure signal for non-timeout errors
+        if isinstance(exception, SendReplyJobError):
+            self.reply_failed.emit(exception.reply_uuid)
 
     def get_file(self, file_uuid: str) -> db.File:
         file = storage.get_file(self.session, file_uuid)


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/604
Towards https://github.com/freedomofpress/securedrop-client/issues/653

We have another draft PR (https://github.com/freedomofpress/securedrop-client/pull/818) that I'll be looking at today that is working to fix #653. This PR fixes the out-of-order issue for replies that time out (since we no longer mark them as failed). https://github.com/freedomofpress/securedrop-client/pull/818 will fix the out-of-order issue for replies that fail for some other reason.

This will go from draft->ready for review once I update tests.

# Test Plan

Run through STR#1 for #653 and make sure replies are no longer out of order and that replies that time out are still shown as pending.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes
