### PR TITLE
show a short notification when new messages about to download

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -562,6 +562,9 @@ class Controller(QObject):
     def download_new_messages(self) -> None:
         messages = storage.find_new_messages(self.session)
 
+        if len(messages) > 0:
+            self.set_status(_('Retrieving new messages'), 2500)
+
         for message in messages:
             self._submit_download_job(type(message), message.uuid)
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1153,6 +1153,7 @@ def test_Controller_download_new_messages_with_new_message(mocker, session, sess
     job = mocker.MagicMock(success_signal=success_signal, failure_signal=failure_signal)
     mocker.patch("securedrop_client.logic.MessageDownloadJob", return_value=job)
     api_job_queue = mocker.patch.object(co, 'api_job_queue')
+    set_status = mocker.patch.object(co, 'set_status')
 
     co.download_new_messages()
 
@@ -1161,6 +1162,7 @@ def test_Controller_download_new_messages_with_new_message(mocker, session, sess
         co.on_message_download_success, type=Qt.QueuedConnection)
     failure_signal.connect.assert_called_once_with(
         co.on_message_download_failure, type=Qt.QueuedConnection)
+    set_status.assert_called_once_with('Retrieving new messages', 2500)
 
 
 def test_Controller_download_new_messages_without_messages(mocker, session, session_maker, homedir):


### PR DESCRIPTION
# Description

Towards https://github.com/freedomofpress/securedrop-client/issues/775 

This implements the part where we add the "Retrieving new messages" notification, but instead of it remaining until the last download job is finished, the notification will last 2.5s.

# Test Plan

1. Send a message or more as a source
2. Right after a sync see the "Retrieving new messages" notifcation for 2.5s

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes