### PR TITLE
app: fix reply ordering

### DIFF
--- a/securedrop_client/api_jobs/uploads.py
+++ b/securedrop_client/api_jobs/uploads.py
@@ -63,6 +63,8 @@ class SendReplyJob(ApiJob):
             # Delete draft, add reply to replies table.
             session.add(reply_db_object)
             session.delete(draft_reply_db_object)
+            source.interaction_count += 1
+            session.add(source)
             session.commit()
 
             return reply_db_object.uuid


### PR DESCRIPTION
# Description

Fixes #653.

supersedes #818

# Test Plan

follow STR in 653

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
