### PR TITLE
Change how ReplyWidget style is updated on changes

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1657,8 +1657,7 @@ class ReplyWidget(SpeechBubble):
     Represents a reply to a source.
     """
 
-    CSS_REPLY_FAILED = '''
-    #message {
+    CSS_MESSAGE_REPLY_FAILED = '''
         min-width: 540px;
         max-width: 540px;
         font-family: 'Source Sans Pro';
@@ -1667,23 +1666,23 @@ class ReplyWidget(SpeechBubble):
         background-color: #fff;
         color: #3b3b3b;
         padding: 16px;
-    }
-    #color_bar {
+    '''
+
+    CSS_COLOR_BAR_REPLY_FAILED = '''
         min-height: 5px;
         max-height: 5px;
         background-color: #ff3366;
         border: 0px;
-    }
-    #error_message {
+    '''
+
+    CSS_ERROR_MESSAGE_REPLY_FAILED = '''
         font-family: 'Source Sans Pro';
         font-weight: 500;
         font-size: 13px;
         color: #ff3366;
-    }
     '''
 
-    CSS_REPLY_SUCCEEDED = '''
-    #message {
+    CSS_MESSAGE_REPLY_SUCCEEDED = '''
         min-width: 540px;
         max-width: 540px;
         font-family: 'Source Sans Pro';
@@ -1692,19 +1691,16 @@ class ReplyWidget(SpeechBubble):
         background-color: #fff;
         color: #3b3b3b;
         padding: 16px;
-    }
-    #color_bar {
+    '''
+
+    CSS_COLOR_BAR_REPLY_SUCCEEDED = '''
         min-height: 5px;
         max-height: 5px;
         background-color: #0065db;
         border: 0px;
-    }
     '''
 
-    # Custom pending CSS styling simulates the effect of opacity which is only
-    # supported by tooltips for QSS.
-    CSS_REPLY_PENDING = '''
-    #message {
+    CSS_MESSAGE_REPLY_PENDING = '''
         min-width: 540px;
         max-width: 540px;
         font-family: 'Source Sans Pro';
@@ -1713,13 +1709,13 @@ class ReplyWidget(SpeechBubble):
         color: #A9AAAD;
         background-color: #F7F8FC;
         padding: 16px;
-    }
-    #color_bar {
+    '''
+
+    CSS_COLOR_BAR_REPLY_PENDING = '''
         min-height: 5px;
         max-height: 5px;
         background-color: #0065db;
         border: 0px;
-    }
     '''
 
     def __init__(
@@ -1740,6 +1736,7 @@ class ReplyWidget(SpeechBubble):
         error_icon.setFixedWidth(12)
         error_message = SecureQLabel('Failed to send')
         error_message.setObjectName('error_message')
+        error_message.setStyleSheet(self.CSS_ERROR_MESSAGE_REPLY_FAILED)
 
         self.error = QWidget()
         error_layout = QHBoxLayout()
@@ -1760,13 +1757,16 @@ class ReplyWidget(SpeechBubble):
 
     def _set_reply_state(self, status: str) -> None:
         if status == 'SUCCEEDED':
-            self.setStyleSheet(self.CSS_REPLY_SUCCEEDED)
+            self.message.setStyleSheet(self.CSS_MESSAGE_REPLY_SUCCEEDED)
+            self.color_bar.setStyleSheet(self.CSS_COLOR_BAR_REPLY_SUCCEEDED)
             self.error.hide()
         elif status == 'FAILED':
-            self.setStyleSheet(self.CSS_REPLY_FAILED)
+            self.message.setStyleSheet(self.CSS_MESSAGE_REPLY_FAILED)
+            self.color_bar.setStyleSheet(self.CSS_COLOR_BAR_REPLY_FAILED)
             self.error.show()
         elif status == 'PENDING':
-            self.setStyleSheet(self.CSS_REPLY_PENDING)
+            self.message.setStyleSheet(self.CSS_MESSAGE_REPLY_PENDING)
+            self.color_bar.setStyleSheet(self.CSS_COLOR_BAR_REPLY_PENDING)
 
     @pyqtSlot(str, str, str)
     def _on_reply_success(self, source_id: str, message_id: str, content: str) -> None:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1786,6 +1786,25 @@ class ReplyWidget(SpeechBubble):
         if message_id == self.message_id:
             self._set_reply_state('FAILED')
 
+    @pyqtSlot(str, str, str)
+    def _update_text(self, source_id: str, message_id: str, text: str) -> None:
+        """
+        Update the ReplyWidget text and state.
+
+        Conditionally update this ReplyWidget's text if and only if
+        the message_id of the emitted signal matches the message_id of
+        this speech bubble.
+
+        Also, if the text is worth updating, assume that the reply is
+        in a successful state, so its widget should be too. This
+        allows us to correct a situation in which a reply actually did
+        make it to the server, the client did not believe that to be
+        the case because of timeout or error, and a later sync has
+        downloaded the reply.
+        """
+        super()._update_text(source_id, message_id, text)
+        self._set_reply_state('SUCCEEDED')
+
 
 class FileWidget(QWidget):
     """

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1465,14 +1465,14 @@ def test_ReplyWidget_update_text(mocker):
     )
 
     assert rw.message.text() == original_text
-    assert rw.styleSheet() == rw.CSS_REPLY_FAILED
+    assert rw.message.styleSheet() == rw.CSS_MESSAGE_REPLY_FAILED
     assert not rw.error.isHidden()
 
     new_text = 'updated text'
     thing.reply_ready.emit(source_id, reply_id, new_text)
 
     assert rw.message.text() == new_text
-    assert rw.styleSheet() == rw.CSS_REPLY_SUCCEEDED
+    assert rw.message.styleSheet() == rw.CSS_MESSAGE_REPLY_SUCCEEDED
     assert rw.error.isHidden()
 
 


### PR DESCRIPTION
# Description

Sets ReplyWidget state to succeeded when its text is updated. Apply CSS to its children according to its state.

This solves the problem of replies being stuck in pending state if their uploads only seemed to the client to fail, but did in fact succeed.

It also works around a new failure in Qt stylesheet handling which _might_ be due to changes in the Debian package `qtbase-opensource-src` at `5.11.3+dfsg1-1+deb10u2`, which incorporated upstream changes that changed how stylesheets are applied to children. 

That theory is a bit shaky, though, because with the same system packages installed, installing the same version of PyQt5 in a virtualenv results in the old approach working fine. That's unfortunately not an option for us at this time, as it would be a huge addition to the production requirements, and potentially painful to keep in sync with the system Qt packages.

Fixes #825.

# Test Plan

## To test the stylesheet failures:

- Build this package and install it in `sd-app`.
- Start the client and reply to a source. The reply appearance should transition from pending to successful normally.

## To test the reply timeout scenario:

1. In your SecureDrop dev server environment, insert this:
```
            import time
            time.sleep(7)
```
at  [line 232 of `securedrop/journalist_app/api.py`](https://github.com/freedomofpress/securedrop/blob/72c4b11615bbaaf324aeeb9a8b536b1bc5378bef/securedrop/journalist_app/api.py#L232) (right after `elif request.method == 'POST':`). This will ensure that the client's reply jobs will time out.

2. Run `make dev`
3. In your `securedrop-client` repo, on the master branch, start the client with `run.sh`.
4. Reply to a source. It should be pending for ~25 seconds, then transition to `Failed to send`.
5. Stop the client.
6. Check out this branch and start the client again.
7. Send a new reply. This time, after it times out, there will be an unfortunate flash of the error state and then it will immediately correct.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
