### PR TITLE
If a source is deleted during sync, don't add its messages

### DIFF
--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -255,11 +255,12 @@ def __update_submissions(model: Union[Type[File], Type[Message]],
         else:
             # A new submission to be added to the database.
             _, source_uuid = submission.source_url.rsplit('/', 1)
-            source = session.query(Source).filter_by(uuid=source_uuid)[0]
-            ns = model(source_id=source.id, uuid=submission.uuid, size=submission.size,
-                       filename=submission.filename, download_url=submission.download_url)
-            session.add(ns)
-            logger.debug('Added new submission {}'.format(submission.uuid))
+            source = session.query(Source).filter_by(uuid=source_uuid).first()
+            if source:
+                ns = model(source_id=source.id, uuid=submission.uuid, size=submission.size,
+                           filename=submission.filename, download_url=submission.download_url)
+                session.add(ns)
+                logger.debug('Added new submission {}'.format(submission.uuid))
 
     # The uuids remaining in local_uuids do not exist on the remote server, so
     # delete the related records.


### PR DESCRIPTION
# Description

Fixes #717 .

# Test Plan

This is hard to test manually. I've added an automated test in `test_storage.py::test_sync_delete_race`; please scrutinize that to make sure it's faithful to the hypothetical scenario.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
