### PR TITLE
Remove ConversationView.add_reply_from_reply_box

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3116,39 +3116,16 @@ class ConversationView(QWidget):
         self.scroll.add_widget_to_conversation(index, conversation_item, Qt.AlignRight)
         self.current_messages[reply.uuid] = conversation_item
 
-    def add_reply_from_reply_box(self, uuid: str, content: str) -> None:
-        """
-        Add a reply from the reply box.
-        """
-        if not self.controller.authenticated_user:
-            logger.error("User is no longer authenticated so cannot send reply.")
-            return
-
-        index = len(self.current_messages)
-        conversation_item = ReplyWidget(
-            self.controller,
-            uuid,
-            content,
-            "PENDING",
-            self.controller.reply_ready,
-            self.controller.reply_download_failed,
-            self.controller.reply_succeeded,
-            self.controller.reply_failed,
-            index,
-            self.scroll.widget().width(),
-            self.controller.authenticated_user,
-            True,
-        )
-        self.scroll.add_widget_to_conversation(index, conversation_item, Qt.AlignRight)
-        self.current_messages[uuid] = conversation_item
-
     def on_reply_sent(self, source_uuid: str, reply_uuid: str, reply_text: str) -> None:
         """
         Add the reply text sent from ReplyBoxWidget to the conversation.
         """
         self.reply_flag = True
         if source_uuid == self.source.uuid:
-            self.add_reply_from_reply_box(reply_uuid, reply_text)
+            try:
+                self.update_conversation(self.source.collection)
+            except sqlalchemy.exc.InvalidRequestError as e:
+                logger.debug(e)
             self.update_deletion_markers()
 
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1329,11 +1329,6 @@ class SourceWidget(QWidget):
         if self.deleting or self.deleting_conversation:
             return
 
-        # If the sync started before the deletion finished, then the sync is stale and we do
-        # not want to update the source widget.
-        if self.sync_started_timestamp < self.deletion_scheduled_timestamp:
-            return
-
         # If the source collection is empty yet the interaction_count is greater than zero, then we
         # known that the conversation has been deleted.
         if not self.source.server_collection:
@@ -2944,18 +2939,15 @@ class ConversationView(QWidget):
             logger.debug(f"Could not update ConversationView: {e}")
 
     def update_deletion_markers(self) -> None:
-        try:
-            if self.source.collection:
-                self.scroll.show()
-                if self.source.collection[0].file_counter > 1:
-                    self.deleted_conversation_marker.hide()
-                    self.deleted_conversation_items_marker.show()
-            elif self.source.interaction_count > 0:
-                self.scroll.hide()
-                self.deleted_conversation_items_marker.hide()
-                self.deleted_conversation_marker.show()
-        except sqlalchemy.exc.InvalidRequestError as e:
-            logger.debug(f"Could not Update deletion markers in the ConversationView: {e}")
+        if self.source.collection:
+            self.scroll.show()
+            if self.source.collection[0].file_counter > 1:
+                self.deleted_conversation_marker.hide()
+                self.deleted_conversation_items_marker.show()
+        elif self.source.interaction_count > 0:
+            self.scroll.hide()
+            self.deleted_conversation_items_marker.hide()
+            self.deleted_conversation_marker.show()
 
     def update_conversation(self, collection: list) -> None:
         """
@@ -2976,11 +2968,6 @@ class ConversationView(QWidget):
         passed into this method in case of a mismatch between where the widget
         has been and now is in terms of its index in the conversation.
         """
-        # If the sync started before the deletion finished, then the sync is stale and we do
-        # not want to update the conversation.
-        if self.sync_started_timestamp < self.deletion_scheduled_timestamp:
-            return
-
         self.controller.session.refresh(self.source)
 
         # Keep a temporary copy of the current conversation so we can delete any
@@ -3116,7 +3103,7 @@ class ConversationView(QWidget):
         self.scroll.add_widget_to_conversation(index, conversation_item, Qt.AlignRight)
         self.current_messages[reply.uuid] = conversation_item
 
-    def on_reply_sent(self, source_uuid: str, reply_uuid: str, reply_text: str) -> None:
+    def on_reply_sent(self, source_uuid: str) -> None:
         """
         Add the reply text sent from ReplyBoxWidget to the conversation.
         """
@@ -3126,7 +3113,6 @@ class ConversationView(QWidget):
                 self.update_conversation(self.source.collection)
             except sqlalchemy.exc.InvalidRequestError as e:
                 logger.debug(e)
-            self.update_deletion_markers()
 
 
 class SourceConversationWrapper(QWidget):
@@ -3268,7 +3254,7 @@ class ReplyBoxWidget(QWidget):
     A textbox where a journalist can enter a reply.
     """
 
-    reply_sent = pyqtSignal(str, str, str)
+    reply_sent = pyqtSignal(str)
 
     def __init__(self, source: Source, controller: Controller) -> None:
         super().__init__()
@@ -3365,7 +3351,7 @@ class ReplyBoxWidget(QWidget):
             self.text_edit.setText("")
             reply_uuid = str(uuid4())
             self.controller.send_reply(self.source.uuid, reply_uuid, reply_text)
-            self.reply_sent.emit(self.source.uuid, reply_uuid, reply_text)
+            self.reply_sent.emit(self.source.uuid)
 
     @pyqtSlot(bool)
     def _on_authentication_changed(self, authenticated: bool) -> None:

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1940,41 +1940,6 @@ def test_SourceWidget_set_snippet(mocker, session_maker, session, homedir):
     sw.set_snippet(source_uuid, "mock_file_uuid", "something new")
 
 
-def test_SourceWidget_set_snippet_does_not_update_if_sync_is_stale(mocker):
-    """
-    Ensure that the snippet does not get updated when an update is based on a sync that started
-    before a deletion operation succeeded.
-    """
-    controller = mocker.MagicMock()
-    source = mocker.MagicMock()
-    source.journalist_designation = "Testy McTestface"
-    source.collection = [factory.Message(content="abc123")]
-    source.server_collection = source.collection
-    sw = SourceWidget(controller, source, mocker.MagicMock(), mocker.MagicMock())
-    sw.update()
-    assert sw.preview.text() == "abc123"
-
-    # Make the sync stale
-    sw.sync_started_timestamp = datetime.now()
-    sw.deletion_scheduled_timestamp = datetime.now()
-
-    # Set up source data so that it appears that the conversation was deleted
-    source.collection = []
-    source.interaction_count = 1
-    source.server_collection = source.collection
-
-    # Assert the preview snippet does not get updated because the sync is stale
-    sw.set_snippet(source.uuid, "mock_file_uuid")
-    assert sw.preview.text() == "abc123"
-
-    # The sync is no longer stale so the preview should show that the are no more source
-    # conversation items because they've been deleted
-    sw.deletion_scheduled_timestamp = datetime.now()
-    sw.sync_started_timestamp = datetime.now()
-    sw.set_snippet(source.uuid, "mock_file_uuid")
-    assert sw.preview.text() == "— All files and messages deleted for this source —"
-
-
 def test_SourceWidget_update_truncate_latest_msg(mocker):
     """
     If the latest message in the conversation is longer than 150 characters,
@@ -4325,22 +4290,6 @@ def test_ConversationView__on_conversation_deletion_successful_does_not_hide_dra
     assert not cv.current_messages[draft_reply.uuid].isHidden()
 
 
-def test_ConversationView_update_conversation_skips_if_sync_is_stale(mocker):
-    """
-    If the sync started before the source was scheduled for deletion, do not update the conversation
-    """
-    cv = ConversationView(factory.Source(), mocker.MagicMock())
-    cv.update_deletion_markers = mocker.MagicMock()
-    cv.sync_started_timestamp = datetime.now()
-    cv.deletion_scheduled_timestamp = datetime.now()
-    cv.update_conversation([])
-    cv.update_deletion_markers.assert_not_called()
-    # Also test that a new message will not get added if the sync is stale
-    cv.update_conversation([factory.Message()])
-    assert not cv.current_messages
-    cv.update_deletion_markers.assert_not_called()
-
-
 def test_ConversationView_update_conversation_position_follow(mocker, homedir):
     """
     Check the signal handler sets the correct value for the scrollbar to be
@@ -4451,7 +4400,7 @@ def test_ConversationView_on_reply_sent(mocker):
     cv.update_conversation = mocker.MagicMock()
 
     assert cv.reply_flag is False
-    cv.on_reply_sent(source_uuid=source.uuid, reply_uuid="abc123", reply_text="test message")
+    cv.on_reply_sent(source_uuid=source.uuid)
 
     cv.update_conversation.assert_called_with(source.collection)
     assert cv.reply_flag is True
@@ -4467,7 +4416,7 @@ def test_ConversationView_on_reply_sent_does_not_add_message_intended_for_differ
     cv = ConversationView(source, controller)
     cv.add_reply = mocker.MagicMock()
 
-    cv.on_reply_sent("different_source_id", "mock", "mock")
+    cv.on_reply_sent("different_source_id")
 
     assert not cv.add_reply.called
 
@@ -4484,18 +4433,13 @@ def test_ConversationView_on_reply_sent_with_deleted_source(mocker):
     def collection_error():
         raise sqlalchemy.exc.InvalidRequestError()
 
-    debug_logger = mocker.patch("securedrop_client.gui.widgets.logger.debug")
     mock_collection = mocker.patch(
         "securedrop_client.db.Source.collection", new_callable=PropertyMock
     )
     ire = sqlalchemy.exc.InvalidRequestError()
     mock_collection.side_effect = ire
 
-    cv.on_reply_sent(source.uuid, "mock", "mock")
-
-    debug_logger.assert_any_call(
-        f"Could not Update deletion markers in the ConversationView: {ire}"
-    )
+    cv.on_reply_sent(source.uuid)
 
 
 def test_ConversationView_add_reply(mocker, homedir, session, session_maker):
@@ -4772,7 +4716,7 @@ def test_ReplyBoxWidget_send_reply(mocker):
 
     scw.reply_box.send_reply()
 
-    scw.reply_box.reply_sent.emit.assert_called_once_with("abc123", "456xyz", "Alles für Alle")
+    scw.reply_box.reply_sent.emit.assert_called_once_with("abc123")
     scw.reply_box.text_edit.setText.assert_called_once_with("")
     controller.send_reply.assert_called_once_with("abc123", "456xyz", "Alles für Alle")
 


### PR DESCRIPTION
# Description

Fixes #821.

I had a suspicion that adding widgets to the conversation view outside of `ConversationView.update_conversation` might be a cause for the odd bubbles appearing on top of each other behavior that some are seeing (I've not seen this myself yet), so putting this diff up which I had locally (because I don't think this method is required anymore) in case it's related to that. Will look more tomorrow to try to reproduce the underlying behavior if no one beats me to it. 

# Test Plan

Check you can still send replies and they are confirmed as usual

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
