### PR TITLE
fix reply succeeds but still shows up as failed

### DIFF
--- a/securedrop_client/api_jobs/uploads.py
+++ b/securedrop_client/api_jobs/uploads.py
@@ -29,15 +29,36 @@ class SendReplyJob(ApiJob):
         database and return the reply uuid string. Otherwise raise a SendReplyJobException so that
         we can return the reply uuid.
         '''
-        try:
-            draft_reply_db_object = session.query(DraftReply).filter_by(uuid=self.reply_uuid).one()
-            source = session.query(Source).filter_by(uuid=self.source_uuid).one()
-            session.commit()
 
+        try:
+            # If the reply has already made it to the server but we didn't get a 201 response back,
+            # then a reply with self.reply_uuid will exist in the replies table.
+            reply_db_object = session.query(Reply).filter_by(uuid=self.reply_uuid).one_or_none()
+            if reply_db_object:
+                logger.debug('Reply {} has already been sent successfully'.format(self.reply_uuid))
+                return reply_db_object.uuid
+
+            # If the draft does not exist because it was deleted locally then do not send the
+            # message to the source.
+            draft_reply_db_object = session.query(DraftReply).filter_by(
+                uuid=self.reply_uuid).one_or_none()
+            if not draft_reply_db_object:
+                raise Exception('Draft reply {} does not exist'.format(self.reply_uuid))
+
+            # If the source was deleted locally then do not send the message and delete the draft.
+            source = session.query(Source).filter_by(uuid=self.source_uuid).one_or_none()
+            if not source:
+                session.delete(draft_reply_db_object)
+                session.commit()
+                raise Exception('Source {} exists'.format(self.source_uuid))
+
+            # Send the draft reply to the source
             encrypted_reply = self.gpg.encrypt_to_source(self.source_uuid, self.message)
+            sdk_reply = self._make_call(encrypted_reply, api_client)
+
+            # Create a new reply object with an updated filename and file counter
             interaction_count = source.interaction_count + 1
-            filename = '{}-{}-reply.gpg'.format(interaction_count,
-                                                source.journalist_designation)
+            filename = '{}-{}-reply.gpg'.format(interaction_count, source.journalist_designation)
             reply_db_object = Reply(
                 uuid=self.reply_uuid,
                 source_id=source.id,
@@ -45,26 +66,23 @@ class SendReplyJob(ApiJob):
                 journalist_id=api_client.token_journalist_uuid,
                 content=self.message,
                 is_downloaded=True,
-                is_decrypted=True,
-            )
-            sdk_reply = self._make_call(encrypted_reply, api_client)
-
-            # Update filename and file_counter in case they changed on the server
+                is_decrypted=True)
             new_file_counter = int(sdk_reply.filename.split('-')[0])
             reply_db_object.file_counter = new_file_counter
             reply_db_object.filename = sdk_reply.filename
 
+            # Update following draft replies for the same source to reflect the new reply count
             draft_file_counter = draft_reply_db_object.file_counter
             draft_timestamp = draft_reply_db_object.timestamp
+            update_draft_replies(
+                session, source.id, draft_timestamp, draft_file_counter, new_file_counter)
 
-            update_draft_replies(session, source.id, draft_timestamp,
-                                 draft_file_counter, new_file_counter)
-
-            # Delete draft, add reply to replies table.
+            # Add reply to replies table and increase the source interaction count by 1 and delete
+            # the draft reply.
             session.add(reply_db_object)
-            session.delete(draft_reply_db_object)
             source.interaction_count += 1
             session.add(source)
+            session.delete(draft_reply_db_object)
             session.commit()
 
             return reply_db_object.uuid
@@ -73,8 +91,10 @@ class SendReplyJob(ApiJob):
                 id=self.source_uuid, error=e)
             raise SendReplyJobTimeoutError(message, self.reply_uuid)
         except Exception as e:
-            message = "Failed to send reply for source {id} due to Exception: {error}".format(
-                id=self.source_uuid, error=e)
+            # Continue to store the draft reply
+            message = '''
+                Failed to send reply {uuid} for source {id} due to Exception: {error}
+            '''.format(uuid=self.reply_uuid, id=self.source_uuid, error=e)
             self._set_status_to_failed(session)
             raise SendReplyJobError(message, self.reply_uuid)
 
@@ -90,7 +110,7 @@ class SendReplyJob(ApiJob):
             logger.info('SQL error when setting reply {uuid} as failed, skipping: {e}'.format(
                 uuid=self.reply_uuid, e=e))
         except Exception as e:
-            logger.error('unknown error when setting reply {uuid} as failed, skipping: {e}'.format(
+            logger.error('Unknown error when setting reply {uuid} as failed, skipping: {e}'.format(
                 uuid=self.reply_uuid, e=e))
 
     def _make_call(self, encrypted_reply: str, api_client: API) -> sdclientapi.Reply:
@@ -99,7 +119,7 @@ class SendReplyJob(ApiJob):
         # TODO: Once https://github.com/freedomofpress/securedrop-client/issues/648, we will want to
         # pass the default request timeout to reply_source instead of setting it on the api object
         # directly.
-        api_client.default_request_timeout = 5
+        api_client.default_request_timeout = 0.01
         return api_client.reply_source(sdk_source, encrypted_reply, self.reply_uuid)
 
 

--- a/securedrop_client/api_jobs/uploads.py
+++ b/securedrop_client/api_jobs/uploads.py
@@ -50,7 +50,7 @@ class SendReplyJob(ApiJob):
             if not source:
                 session.delete(draft_reply_db_object)
                 session.commit()
-                raise Exception('Source {} exists'.format(self.source_uuid))
+                raise Exception('Source {} does not exists'.format(self.source_uuid))
 
             # Send the draft reply to the source
             encrypted_reply = self.gpg.encrypt_to_source(self.source_uuid, self.message)
@@ -119,7 +119,7 @@ class SendReplyJob(ApiJob):
         # TODO: Once https://github.com/freedomofpress/securedrop-client/issues/648, we will want to
         # pass the default request timeout to reply_source instead of setting it on the api object
         # directly.
-        api_client.default_request_timeout = 0.01
+        api_client.default_request_timeout = 5
         return api_client.reply_source(sdk_source, encrypted_reply, self.reply_uuid)
 
 


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/833

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes