### PR TITLE
Fix word wrap issue in SecureQLabel.

### DIFF
--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -16,6 +16,7 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+import textwrap
 
 from typing import Union
 
@@ -167,8 +168,11 @@ class SecureQLabel(QLabel):
         flags: Union[Qt.WindowFlags, Qt.WindowType] = Qt.WindowFlags(),
     ):
         super().__init__(parent, flags)
+        self.setWordWrap(True)
         self.setText(text)
 
     def setText(self, text: str) -> None:
         self.setTextFormat(Qt.PlainText)
-        super().setText(text)
+        # Wraps text at default of 70 characters.
+        wrapped = "\n".join(textwrap.wrap(text))
+        super().setText(wrapped)

--- a/tests/gui/test_init.py
+++ b/tests/gui/test_init.py
@@ -1,6 +1,7 @@
 """
 Tests for the gui helper functions in __init__.py
 """
+import textwrap
 
 from PyQt5.QtCore import QSize, Qt
 from PyQt5.QtWidgets import QApplication
@@ -169,3 +170,15 @@ def test_SecureQLabel_setText(mocker):
 def test_SecureQLabel_quotes_not_escaped_for_readability():
     sl = SecureQLabel("'hello'")
     assert sl.text() == "'hello'"
+
+
+def test_SecureQLabel_wraps_on_70():
+    msg = (
+        "thisisaverylongmessagethatwillnotwrapunlessthistestpassesproperly1234"
+        "thisisaverylongmessagethatwillnotwrapunlessthistestpassesproperly1234"
+        "thisisaverylongmessagethatwillnotwrapunlessthistestpassesproperly1234"
+    )
+    sl = SecureQLabel(msg)
+    expected = "\n".join(textwrap.wrap(msg))
+    assert sl.text() == expected
+    assert sl.wordWrap() is True


### PR DESCRIPTION
# Description

Fixes #815.

I use the built-in `textwrap` module with its default behaviour (which seems eminently sensible) to ensure that long words / sentences are wrapped in a way that fits properly in a `SecureQLabel`'s text area.

See the following screenies for example output:

![fixed_reply_wrap](https://user-images.githubusercontent.com/37602/75677357-30f42800-5c83-11ea-8eb7-12feee3933e1.png)

![fixed_message_wrap](https://user-images.githubusercontent.com/37602/75677370-35b8dc00-5c83-11ea-8030-a772c229dcef.png)


# Test Plan

Added unit test to ensure default word wrapping works as expected. Please check with eyeball Mk.1 :eyes:

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
