### PR TITLE
On update, only select a current source if it's already selected.

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -838,6 +838,12 @@ class SourceList(QListWidget):
         """
         Reset and update the list with the passed in list of sources.
         """
+        # A flag to show if a source is currently selected (the current source
+        # doesn't have to be selected in a QListWidget -- it appears to default
+        # to whatever is in row 0, whether it's selected or not).
+        has_source_selected = False
+        if self.currentRow() > -1:
+            has_source_selected = self.item(self.currentRow()).isSelected()
         current_source = self.get_current_source()
         current_source_id = current_source and current_source.id
 
@@ -854,7 +860,7 @@ class SourceList(QListWidget):
             self.addItem(list_item)
             self.setItemWidget(list_item, new_source)
 
-            if source.id == current_source_id:
+            if source.id == current_source_id and has_source_selected:
                 self.setCurrentItem(list_item)
 
     def get_current_source(self):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -691,6 +691,7 @@ def test_SourceList_update(mocker):
     sl.addItem = mocker.MagicMock()
     sl.setItemWidget = mocker.MagicMock()
     sl.controller = mocker.MagicMock()
+    sl.setCurrentItem = mocker.MagicMock()
 
     mock_sw = mocker.MagicMock()
     mock_lwi = mocker.MagicMock()
@@ -706,6 +707,41 @@ def test_SourceList_update(mocker):
     assert sl.addItem.call_count == len(sources)
     assert sl.setItemWidget.call_count == len(sources)
     assert len(sl.source_widgets) == len(sources)
+    assert sl.setCurrentItem.call_count == 0
+
+
+def test_SourceList_update_with_pre_selected_source(mocker):
+    """
+    If there's a source already selected. It remains selected after update.
+    """
+    sl = SourceList()
+
+    sl.clear = mocker.MagicMock()
+    sl.addItem = mocker.MagicMock()
+    sl.setItemWidget = mocker.MagicMock()
+    sl.controller = mocker.MagicMock()
+    sl.setCurrentItem = mocker.MagicMock()
+    sl.currentRow = mocker.MagicMock(return_value=1)
+    sl.item = mocker.MagicMock()
+    sl.item().isSelected.return_value = True
+    mock_source = mocker.MagicMock()
+    sl.get_current_source = mocker.MagicMock(return_value=mock_source)
+
+    mock_sw = mocker.MagicMock()
+    mock_lwi = mocker.MagicMock()
+    mocker.patch('securedrop_client.gui.widgets.SourceWidget', mock_sw)
+    mocker.patch('securedrop_client.gui.widgets.QListWidgetItem', mock_lwi)
+
+    sources = [mocker.MagicMock(), mock_source, mocker.MagicMock(), ]
+    sl.update(sources)
+
+    sl.clear.assert_called_once_with()
+    assert mock_sw.call_count == len(sources)
+    assert mock_lwi.call_count == len(sources)
+    assert sl.addItem.call_count == len(sources)
+    assert sl.setItemWidget.call_count == len(sources)
+    assert len(sl.source_widgets) == len(sources)
+    assert sl.setCurrentItem.call_count == 1
 
 
 def test_SourceList_maintains_selection(mocker):


### PR DESCRIPTION
# Description

Fixes #796.

# Test Plan

Updated unit tests to ensure change of state only occurs if a source has been selected.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
