### PR TITLE
Update SecureQLabels to address new wordwrapping behavior

### DIFF
--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -191,7 +191,8 @@ class SecureQLabel(QLabel):
         fm = self.fontMetrics()
         filename_width = fm.horizontalAdvance(full_text)
         if filename_width > self.max_length:
-            self.setToolTip(full_text)
+            wrapped_tool_tip = SecureQLabel(full_text)
+            self.setToolTip(wrapped_tool_tip.text())
             elided_text = ''
             for c in full_text:
                 if fm.horizontalAdvance(elided_text) > self.max_length:

--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -166,18 +166,40 @@ class SecureQLabel(QLabel):
         text: str = "",
         parent: QWidget = None,
         flags: Union[Qt.WindowFlags, Qt.WindowType] = Qt.WindowFlags(),
-        wordwrap: bool = True
+        wordwrap: bool = True,
+        max_length: int = 0
     ):
         super().__init__(parent, flags)
         self.wordwrap = wordwrap
-        self.setWordWrap(wordwrap)
+        self.max_length = max_length
+        self.setWordWrap(wordwrap)  # If True, wraps text at default of 70 characters
         self.setText(text)
+        self.elided = True if self.text() != text else False
 
     def setText(self, text: str) -> None:
-        # self.setTextFormat(Qt.PlainText)
-        # Wraps text at default of 70 characters
+        self.setTextFormat(Qt.PlainText)
         if self.wordwrap:
-            wrapped = "\n".join(textwrap.wrap(text))
-            super().setText(wrapped)
-        else:
-            super().setText(text)
+            text = "\n".join(textwrap.wrap(text))
+        elided_text = self.get_elided_text(text)
+        self.elided = True if elided_text != text else False
+        super().setText(elided_text)
+
+    def get_elided_text(self, full_text: str) -> str:
+        if not self.max_length:
+            return full_text
+
+        fm = self.fontMetrics()
+        filename_width = fm.horizontalAdvance(full_text)
+        if filename_width > self.max_length:
+            self.setToolTip(full_text)
+            elided_text = ''
+            for c in full_text:
+                if fm.horizontalAdvance(elided_text) > self.max_length:
+                    elided_text = elided_text + '...'
+                    return elided_text
+                elided_text = elided_text + c
+
+        return full_text
+
+    def is_elided(self) -> bool:
+        return self.elided

--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -166,13 +166,18 @@ class SecureQLabel(QLabel):
         text: str = "",
         parent: QWidget = None,
         flags: Union[Qt.WindowFlags, Qt.WindowType] = Qt.WindowFlags(),
+        wordwrap: bool = True
     ):
         super().__init__(parent, flags)
-        self.setWordWrap(True)
+        self.wordwrap = wordwrap
+        self.setWordWrap(wordwrap)
         self.setText(text)
 
     def setText(self, text: str) -> None:
-        self.setTextFormat(Qt.PlainText)
-        # Wraps text at default of 70 characters.
-        wrapped = "\n".join(textwrap.wrap(text))
-        super().setText(wrapped)
+        # self.setTextFormat(Qt.PlainText)
+        # Wraps text at default of 70 characters
+        if self.wordwrap:
+            wrapped = "\n".join(textwrap.wrap(text))
+            super().setText(wrapped)
+        else:
+            super().setText(text)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -987,7 +987,6 @@ class SourceWidget(QWidget):
         self.preview = SecureQLabel()
         self.preview.setObjectName('preview')
         self.preview.setFixedSize(QSize(self.PREVIEW_WIDTH, self.PREVIEW_HEIGHT))
-        self.preview.setWordWrap(True)
         summary_layout.addWidget(self.name)
         summary_layout.addWidget(self.preview)
 
@@ -1615,7 +1614,6 @@ class SpeechBubble(QWidget):
         # Message box
         self.message = SecureQLabel(text)
         self.message.setObjectName('message')
-        self.message.setWordWrap(True)
 
         # Color bar
         self.color_bar = QWidget()
@@ -1745,6 +1743,7 @@ class ReplyWidget(SpeechBubble):
         error_icon.setObjectName('error_icon')  # Set css id
         error_icon.setFixedWidth(12)
         error_message = SecureQLabel('Failed to send')
+        error_message.setWordWrap(False)
         error_message.setObjectName('error_message')
         error_message.setStyleSheet(self.CSS_ERROR_MESSAGE_REPLY_FAILED)
 
@@ -1833,7 +1832,7 @@ class FileWidget(QWidget):
         color: #05a6fe;
     }
     QLabel#file_name {
-        min-width: 129px;
+        max-width: 320px;
         padding-right: 8px;
         padding-bottom: 4px;
         padding-top: 1px;
@@ -1963,6 +1962,7 @@ class FileWidget(QWidget):
         self.file_name.installEventFilter(self)
         self.file_name.setCursor(QCursor(Qt.PointingHandCursor))
         self.no_file_name = SecureQLabel('ENCRYPTED FILE ON SERVER')
+        self.no_file_name.setWordWrap(False)
         self.no_file_name.setObjectName('no_file_name')
         self.no_file_name.setFont(file_description_font)
 
@@ -1984,7 +1984,7 @@ class FileWidget(QWidget):
         layout.addWidget(self.file_name)
         layout.addWidget(self.no_file_name)
         layout.addWidget(horizontal_line)
-        layout.addWidget(self.file_size)
+        layout.addWidget(self.file_size, alignment=Qt.AlignCenter)
 
         # Connect signals to slots
         file_ready_signal.connect(self._on_file_downloaded, type=Qt.QueuedConnection)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1742,8 +1742,7 @@ class ReplyWidget(SpeechBubble):
         error_icon = SvgLabel('error_icon.svg', svg_size=QSize(12, 12))
         error_icon.setObjectName('error_icon')  # Set css id
         error_icon.setFixedWidth(12)
-        error_message = SecureQLabel('Failed to send')
-        error_message.setWordWrap(False)
+        error_message = SecureQLabel('Failed to send', wordwrap=False)
         error_message.setObjectName('error_message')
         error_message.setStyleSheet(self.CSS_ERROR_MESSAGE_REPLY_FAILED)
 
@@ -1961,8 +1960,7 @@ class FileWidget(QWidget):
         self.file_name.setObjectName('file_name')
         self.file_name.installEventFilter(self)
         self.file_name.setCursor(QCursor(Qt.PointingHandCursor))
-        self.no_file_name = SecureQLabel('ENCRYPTED FILE ON SERVER')
-        self.no_file_name.setWordWrap(False)
+        self.no_file_name = SecureQLabel('ENCRYPTED FILE ON SERVER', wordwrap=False)
         self.no_file_name.setObjectName('no_file_name')
         self.no_file_name.setFont(file_description_font)
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2454,7 +2454,7 @@ class ExportDialog(FramelessDialog):
 
     PASSPHRASE_LABEL_SPACING = 0.5
     NO_MARGIN = 0
-    FILENAME_WIDTH_PX = 200
+    FILENAME_WIDTH_PX = 320
 
     def __init__(self, controller: Controller, file_uuid: str, file_name: str):
         super().__init__()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1878,7 +1878,7 @@ class FileWidget(QWidget):
     VERTICAL_MARGIN = 10
     FILE_FONT_SPACING = 2
     FILE_OPTIONS_FONT_SPACING = 1.6
-    FILENAME_WIDTH_PX = 400
+    FILENAME_WIDTH_PX = 360
 
     def __init__(
         self,
@@ -2322,7 +2322,7 @@ class FramelessDialog(QDialog):
 
 class PrintDialog(FramelessDialog):
 
-    FILENAME_WIDTH_PX = 320
+    FILENAME_WIDTH_PX = 260
 
     def __init__(self, controller: Controller, file_uuid: str, file_name: str):
         super().__init__()
@@ -2454,7 +2454,7 @@ class ExportDialog(FramelessDialog):
 
     PASSPHRASE_LABEL_SPACING = 0.5
     NO_MARGIN = 0
-    FILENAME_WIDTH_PX = 320
+    FILENAME_WIDTH_PX = 260
 
     def __init__(self, controller: Controller, file_uuid: str, file_name: str):
         super().__init__()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -26,8 +26,8 @@ from typing import Dict, List, Union  # noqa: F401
 from uuid import uuid4
 from PyQt5.QtCore import Qt, pyqtSlot, pyqtSignal, QEvent, QTimer, QSize, pyqtBoundSignal, \
     QObject, QPoint
-from PyQt5.QtGui import QIcon, QPalette, QBrush, QColor, QFont, QLinearGradient, QKeySequence, \
-    QCursor, QKeyEvent, QCloseEvent
+from PyQt5.QtGui import QIcon, QPalette, QBrush, QColor, QFont, QFontMetrics, QLinearGradient, \
+    QKeySequence, QCursor, QKeyEvent, QCloseEvent
 from PyQt5.QtWidgets import QApplication, QListWidget, QLabel, QWidget, QListWidgetItem, \
     QHBoxLayout, QVBoxLayout, QLineEdit, QScrollArea, QDialog, QAction, QMenu, QMessageBox, \
     QToolButton, QSizePolicy, QPlainTextEdit, QStatusBar, QGraphicsDropShadowEffect, QPushButton, \
@@ -1831,10 +1831,7 @@ class FileWidget(QWidget):
         color: #05a6fe;
     }
     QLabel#file_name {
-        max-width: 320px;
-        padding-right: 8px;
-        padding-bottom: 4px;
-        padding-top: 1px;
+        padding-bottom: 2px;
         font-family: 'Source Sans Pro';
         font-weight: 600;
         font-size: 13px;
@@ -1844,8 +1841,6 @@ class FileWidget(QWidget):
         color: #05a6fe;
     }
     QLabel#no_file_name {
-        padding-right: 8px;
-        padding-bottom: 1px;
         font-family: 'Source Sans Pro';
         font-weight: 300;
         font-size: 13px;
@@ -1863,8 +1858,7 @@ class FileWidget(QWidget):
         min-height: 2px;
         max-height: 2px;
         background-color: rgba(211, 216, 234, 0.45);
-        padding-left: 8px;
-        padding-right: 8px;
+        margin: 0px 8px 0px 8px;
     }
     '''
 
@@ -1884,6 +1878,7 @@ class FileWidget(QWidget):
     VERTICAL_MARGIN = 10
     FILE_FONT_SPACING = 2
     FILE_OPTIONS_FONT_SPACING = 1.6
+    ELIDED_TEXT_WIDTH = 400
 
     def __init__(
         self,
@@ -1919,7 +1914,6 @@ class FileWidget(QWidget):
         # Set margins and spacing
         layout.setContentsMargins(0, self.VERTICAL_MARGIN, 0, self.VERTICAL_MARGIN)
         layout.setSpacing(0)
-        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
 
         # File options: download, export, print
         self.file_options = QWidget()
@@ -1955,8 +1949,7 @@ class FileWidget(QWidget):
         self.export_button.clicked.connect(self._on_export_clicked)
         self.print_button.clicked.connect(self._on_print_clicked)
 
-        # File name or default string
-        self.file_name = SecureQLabel(self.file.filename)
+        self.file_name = SecureQLabel(wordwrap=False)
         self.file_name.setObjectName('file_name')
         self.file_name.installEventFilter(self)
         self.file_name.setCursor(QCursor(Qt.PointingHandCursor))
@@ -1965,9 +1958,14 @@ class FileWidget(QWidget):
         self.no_file_name.setFont(file_description_font)
 
         # Line between file name and file size
-        horizontal_line = QWidget()
-        horizontal_line.setObjectName('horizontal_line')
-        horizontal_line.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.horizontal_line = QWidget()
+        self.horizontal_line.setObjectName('horizontal_line')
+        self.horizontal_line.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+
+        # Space between elided file name and file size when horizontal line is hidden
+        self.spacer = QWidget()
+        self.spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.spacer.hide()
 
         # File size
         self.file_size = SecureQLabel(humanize_filesize(self.file.size))
@@ -1975,14 +1973,15 @@ class FileWidget(QWidget):
         self.file_size.setAlignment(Qt.AlignRight)
 
         # Decide what to show or hide based on whether or not the file's been downloaded
-        self.set_button_state()
+        self._set_file_state()
 
         # Add widgets
         layout.addWidget(self.file_options)
         layout.addWidget(self.file_name)
         layout.addWidget(self.no_file_name)
-        layout.addWidget(horizontal_line)
-        layout.addWidget(self.file_size, alignment=Qt.AlignCenter)
+        layout.addWidget(self.horizontal_line)
+        layout.addWidget(self.spacer)
+        layout.addWidget(self.file_size)
 
         # Connect signals to slots
         file_ready_signal.connect(self._on_file_downloaded, type=Qt.QueuedConnection)
@@ -2001,14 +2000,16 @@ class FileWidget(QWidget):
             self.download_button.setIcon(load_icon('download_file.svg'))
         return QObject.event(obj, event)
 
-    def set_button_state(self):
+    def _set_file_state(self):
         if self.file.is_decrypted:
-            self.file_name.setText(self.file.filename)
             self.download_button.hide()
             self.no_file_name.hide()
             self.export_button.show()
             self.middot.show()
             self.print_button.show()
+            self.horizontal_line.show()
+            self.spacer.hide()
+            self._set_file_name()
             self.file_name.show()
         else:
             self.download_button.setText(_('DOWNLOAD'))
@@ -2024,8 +2025,27 @@ class FileWidget(QWidget):
             self.export_button.hide()
             self.middot.hide()
             self.print_button.hide()
+            self.horizontal_line.show()
+            self.spacer.hide()
             self.file_name.hide()
             self.no_file_name.show()
+
+    def _set_file_name(self):
+        self.file_name.setText(self.file.filename)
+        secure_file_name = self.file_name.text()
+        fm = self.file_name.fontMetrics()
+        filename_width = fm.horizontalAdvance(secure_file_name)
+        if filename_width > self.ELIDED_TEXT_WIDTH:
+            self.setToolTip(secure_file_name)
+            elidedText = ''
+            for c in secure_file_name:
+                if fm.horizontalAdvance(elidedText) > self.ELIDED_TEXT_WIDTH:
+                    elidedText = elidedText + '...'
+                    self.horizontal_line.hide()
+                    self.spacer.show()
+                    break
+                elidedText = elidedText + c
+            self.file_name.setText(elidedText)
 
     @pyqtSlot(str, str, str)
     def _on_file_downloaded(self, source_uuid: str, file_uuid: str, filename: str) -> None:
@@ -2102,7 +2122,7 @@ class FileWidget(QWidget):
         Stops the download animation and restores the button to its default state.
         """
         self.download_animation.stop()
-        self.set_button_state()
+        self._set_file_state()
 
 
 class FramelessDialog(QDialog):

--- a/tests/gui/test_init.py
+++ b/tests/gui/test_init.py
@@ -167,6 +167,12 @@ def test_SecureQLabel_setText(mocker):
     sl.setTextFormat.assert_called_once_with(Qt.PlainText)
 
 
+def test_SecureQLabel_get_elided_text(mocker):
+    sl = SecureQLabel('12345678901234567890123456789012345678901234567890')
+    sl.setTextFormat = mocker.MagicMock()
+    assert sl.text() == '12345678901234567890123456789012345678901234567890'
+
+
 def test_SecureQLabel_quotes_not_escaped_for_readability():
     sl = SecureQLabel("'hello'")
     assert sl.text() == "'hello'"

--- a/tests/gui/test_init.py
+++ b/tests/gui/test_init.py
@@ -155,6 +155,23 @@ def test_SecureQLabel_init():
     assert sl.text() == label_text
 
 
+def test_SecureQLabel_init_wordwrap(mocker):
+    # 71 character string
+    long_string = '12345678901234567890123456789012345678901234567890123456789012345678901'
+    sl = SecureQLabel(long_string)
+    wordwrap_string = '1234567890123456789012345678901234567890123456789012345678901234567890\n1'
+    assert sl.text() == wordwrap_string
+
+
+def test_SecureQLabel_init_no_wordwrap(mocker):
+    # 71 character string
+    long_string = '12345678901234567890123456789012345678901234567890123456789012345678901'
+    sl = SecureQLabel(long_string, wordwrap=False)
+    assert sl.text() == long_string
+
+
+
+
 def test_SecureQLabel_setText(mocker):
     sl = SecureQLabel("hello")
     assert sl.text() == "hello"
@@ -168,9 +185,11 @@ def test_SecureQLabel_setText(mocker):
 
 
 def test_SecureQLabel_get_elided_text(mocker):
-    sl = SecureQLabel('12345678901234567890123456789012345678901234567890')
-    sl.setTextFormat = mocker.MagicMock()
-    assert sl.text() == '12345678901234567890123456789012345678901234567890'
+    # 70 character string
+    long_string = '1234567890123456789012345678901234567890123456789012345678901234567890'
+    sl = SecureQLabel(long_string, wordwrap=False, max_length=100)
+    elided_text = sl.get_elided_text(long_string)
+    assert sl.text() == elided_text
 
 
 def test_SecureQLabel_quotes_not_escaped_for_readability():

--- a/tests/gui/test_init.py
+++ b/tests/gui/test_init.py
@@ -170,8 +170,6 @@ def test_SecureQLabel_init_no_wordwrap(mocker):
     assert sl.text() == long_string
 
 
-
-
 def test_SecureQLabel_setText(mocker):
     sl = SecureQLabel("hello")
     assert sl.text() == "hello"

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -2385,7 +2385,7 @@ def test_PrintDialog_init_sanitizes_filename(mocker):
 
     PrintDialog(mocker.MagicMock(), 'mock_uuid', filename)
 
-    secure_qlabel.assert_called_with(filename, max_length=320, wordwrap=False)
+    secure_qlabel.call_args_list[0].assert_called_with(filename)
 
 
 def test_PrintDialog__show_starting_instructions(mocker):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1509,7 +1509,7 @@ def test_FileWidget_init_file_downloaded(mocker, source, session):
     assert not fw.file_name.isHidden()
 
 
-def test_FileWidget_set_button_state_under_mouse(mocker, source, session):
+def test_FileWidget__set_file_state_under_mouse(mocker, source, session):
     """
     If the download_button is under the mouse, it should show the "hover"
     version of the download_file icon.
@@ -1528,7 +1528,7 @@ def test_FileWidget_set_button_state_under_mouse(mocker, source, session):
     fw.download_button.setIcon = mocker.MagicMock()
     mock_load = mocker.MagicMock()
     with mocker.patch("securedrop_client.gui.widgets.load_icon", mock_load):
-        fw.set_button_state()
+        fw._set_file_state()
         mock_load.assert_called_once_with("download_file_hover.svg")
 
 
@@ -2385,7 +2385,7 @@ def test_PrintDialog_init_sanitizes_filename(mocker):
 
     PrintDialog(mocker.MagicMock(), 'mock_uuid', filename)
 
-    secure_qlabel.assert_called_with(filename)
+    secure_qlabel.assert_called_with(filename, max_length=320, wordwrap=False)
 
 
 def test_PrintDialog__show_starting_instructions(mocker):


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/841
Fixes https://github.com/freedomofpress/securedrop-client/issues/854

# Test Plan

Must test in Qubes

1. run the client and see that "ENCRYPTED FILE ON SERVER" no longer word wraps
2. make a reply fail and see that "Failed to send" no longer wraps
3. download a file and see that a long filename no longer word wraps and instead shows the truncated text with `...` at the end and a hoverover tooltip with the full filename length
4. click on export and see that a long filename shows the truncated text with `...` at the end (no tooltip support yet) 
5. click on print and see that a long filename shows the truncated text with `...` at the end (no tooltip support yet) 

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes