### PR TITLE
Ensure UI updates if local copy of downloaded file is no longer available.

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -443,7 +443,10 @@ class Controller(QObject):
         with open(self.last_sync_filepath, 'w') as f:
             f.write(arrow.now().format())
 
-        storage.update_missing_files(self.data_dir, self.session)
+        missing_files = storage.update_missing_files(self.data_dir, self.session)
+        for missed_file in missing_files:
+            self.file_missing.emit(missed_file.source.uuid, missed_file.uuid,
+                                   str(missed_file))
         self.update_sources()
         self.download_new_messages()
         self.download_new_replies()
@@ -620,8 +623,9 @@ class Controller(QObject):
                 'File does not exist in the data directory. Please try re-downloading.'))
             logger.debug('Cannot find {} in the data directory. File does not exist.'.format(
                 file.filename))
-            storage.update_missing_files(self.data_dir, self.session)
-            self.file_missing.emit(file.source.uuid, file.uuid, str(file))
+            missing_files = storage.update_missing_files(self.data_dir, self.session)
+            for f in missing_files:
+                self.file_missing.emit(f.source.uuid, f.uuid, str(f))
             return False
         return True
 

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -384,14 +384,17 @@ def update_and_get_user(uuid: str,
     return user
 
 
-def update_missing_files(data_dir: str, session: Session) -> None:
+def update_missing_files(data_dir: str, session: Session) -> List[File]:
     '''
     Update files that are marked as downloaded yet missing from the filesystem.
     '''
     files_that_have_been_downloaded = session.query(File).filter_by(is_downloaded=True).all()
-    for file in files_that_have_been_downloaded:
-        if not os.path.exists(file.location(data_dir)):
-            mark_as_not_downloaded(file.uuid, session)
+    files_that_are_missing = []
+    for f in files_that_have_been_downloaded:
+        if not os.path.exists(f.location(data_dir)):
+            files_that_are_missing.append(f)
+            mark_as_not_downloaded(f.uuid, session)
+    return files_that_are_missing
 
 
 def update_draft_replies(session: Session, source_id: int, timestamp: datetime,

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -459,7 +459,11 @@ def test_Controller_on_sync_success(homedir, config, mocker):
     co.download_new_replies = mocker.MagicMock()
     co.gpg = mocker.MagicMock()
     co.resume_queues = mocker.MagicMock()
+    co.file_missing = mocker.MagicMock()
     mock_storage = mocker.patch('securedrop_client.logic.storage')
+    source = factory.Source()
+    missing = factory.File(is_downloaded=None, is_decrypted=None, source=source)
+    mock_storage.update_missing_files.return_value = [missing, ]
 
     co.on_sync_success()
 
@@ -468,6 +472,8 @@ def test_Controller_on_sync_success(homedir, config, mocker):
     co.download_new_messages.assert_called_once_with()
     co.download_new_replies.assert_called_once_with()
     co.resume_queues.assert_called_once_with()
+    co.file_missing.emit.assert_called_once_with(missing.source.uuid,
+                                                 missing.uuid, str(missing))
 
 
 def test_Controller_show_last_sync(homedir, config, mocker, session_maker):


### PR DESCRIPTION
# Description

Fixes #808 .

I generally work by the "rule of three" when it comes to refactoring repeated code (i.e. the section where there's an iteration over the missing files in `logic.py`). Happy to refactor if you'd like. In any case, UI behaves like this:

![deleted_file](https://user-images.githubusercontent.com/37602/75784812-aaab1500-5d5a-11ea-8031-71764c7ca680.gif)

# Test Plan

Updated unit tests to encompass handling of missing file.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
