### PR TITLE
Remove ReplyWidget._update_text

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1793,25 +1793,6 @@ class ReplyWidget(SpeechBubble):
         if message_id == self.message_id:
             self._set_reply_state('FAILED')
 
-    @pyqtSlot(str, str, str)
-    def _update_text(self, source_id: str, message_id: str, text: str) -> None:
-        """
-        Update the ReplyWidget text and state.
-
-        Conditionally update this ReplyWidget's text if and only if
-        the message_id of the emitted signal matches the message_id of
-        this speech bubble.
-
-        Also, if the text is worth updating, assume that the reply is
-        in a successful state, so its widget should be too. This
-        allows us to correct a situation in which a reply actually did
-        make it to the server, the client did not believe that to be
-        the case because of timeout or error, and a later sync has
-        downloaded the reply.
-        """
-        super()._update_text(source_id, message_id, text)
-        self._set_reply_state('SUCCEEDED')
-
 
 class FileWidget(QWidget):
     """

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -5,7 +5,7 @@ import pytest
 import arrow
 from datetime import datetime
 
-from PyQt5.QtCore import Qt, QEvent, QObject, pyqtSignal
+from PyQt5.QtCore import Qt, QEvent
 from PyQt5.QtGui import QFocusEvent, QMovie
 from PyQt5.QtTest import QTest
 from PyQt5.QtWidgets import QWidget, QApplication, QVBoxLayout, QMessageBox, QMainWindow, \
@@ -1433,47 +1433,6 @@ def test_ReplyWidget_init(mocker):
     assert mock_update_connected.called
     assert mock_success_connected.calledd
     assert mock_failure_connected.called
-
-
-def test_ReplyWidget_update_text(mocker):
-    """
-    Check that the update signal updates both text and status.
-    """
-    class Thing(QObject):
-        reply_ready = pyqtSignal(str, str, str)
-
-    mock_success_signal = mocker.MagicMock()
-    mock_success_connected = mocker.Mock()
-    mock_success_signal.connect = mock_success_connected
-
-    mock_failure_signal = mocker.MagicMock()
-    mock_failure_connected = mocker.Mock()
-    mock_failure_signal.connect = mock_failure_connected
-
-    thing = Thing()
-    source_id = 'source_id'
-    reply_id = 'reply_id'
-    original_text = 'hello'
-    rw = ReplyWidget(
-        reply_id,
-        original_text,
-        'FAILED',
-        thing.reply_ready,
-        mock_success_signal,
-        mock_failure_signal,
-        0,
-    )
-
-    assert rw.message.text() == original_text
-    assert rw.message.styleSheet() == rw.CSS_MESSAGE_REPLY_FAILED
-    assert not rw.error.isHidden()
-
-    new_text = 'updated text'
-    thing.reply_ready.emit(source_id, reply_id, new_text)
-
-    assert rw.message.text() == new_text
-    assert rw.message.styleSheet() == rw.CSS_MESSAGE_REPLY_SUCCEEDED
-    assert rw.error.isHidden()
 
 
 def test_FileWidget_init_file_not_downloaded(mocker, source, session):


### PR DESCRIPTION
# Description

Fixes #843.

# Test Plan

- Ensure that the client will not receive server confirmation of sent replies -- the easiest way is to probably set the job timeout to `0.001` [here](https://github.com/freedomofpress/securedrop-client/blob/8a1fddb4130b6c02abede2b51a63e6f5aaaee3ec/securedrop_client/api_jobs/uploads.py#L122).
- Send a reply. It should not be marked successful because of the timeout.
- Wait for sync. The reply, which actually made it to the server, should be downloaded, and its widget should transition to the success state.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
