### PR TITLE
enter no longer closes dialog

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -27,7 +27,7 @@ from uuid import uuid4
 from PyQt5.QtCore import Qt, pyqtSlot, pyqtSignal, QEvent, QTimer, QSize, pyqtBoundSignal, \
     QObject, QPoint
 from PyQt5.QtGui import QIcon, QPalette, QBrush, QColor, QFont, QLinearGradient, QKeySequence, \
-    QCursor
+    QCursor, QKeyEvent, QCloseEvent
 from PyQt5.QtWidgets import QApplication, QListWidget, QLabel, QWidget, QListWidgetItem, \
     QHBoxLayout, QVBoxLayout, QLineEdit, QScrollArea, QDialog, QAction, QMenu, QMessageBox, \
     QToolButton, QSizePolicy, QPlainTextEdit, QStatusBar, QGraphicsDropShadowEffect, QPushButton, \
@@ -2281,10 +2281,18 @@ class FramelessDialog(QDialog):
         layout.addStretch()
         layout.addWidget(window_buttons)
 
-    def closeEvent(self, e):
+    def closeEvent(self, event: QCloseEvent):
         # ignore any close event that doesn't come from our custom close method
         if not self.internal_close_event_emitted:
-            e.ignore()
+            event.ignore()
+
+    def keyPressEvent(self, event: QKeyEvent):
+        # Since the dialog sets the Qt.Popup window flag (in order to achieve a frameless dialog
+        # window in Qubes), the default behavior is to close the dialog when the Enter or Return
+        # key is clicked, which we override here.
+        if (event.key() == Qt.Key_Enter or event.key() == Qt.Key_Return):
+            return
+        super().keyPressEvent(event)
 
     def close(self):
         self.internal_close_event_emitted = True

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2258,7 +2258,6 @@ class FramelessDialog(QDialog):
         button_layout = QVBoxLayout()
         window_buttons.setLayout(button_layout)
         self.cancel_button = QPushButton(_('CANCEL'))
-        self.cancel_button.setAutoDefault(False)
         self.cancel_button.clicked.connect(self.close)
         self.continue_button = QPushButton(_('CONTINUE'))
         self.continue_button.setObjectName('primary_button')
@@ -2291,7 +2290,12 @@ class FramelessDialog(QDialog):
         # window in Qubes), the default behavior is to close the dialog when the Enter or Return
         # key is clicked, which we override here.
         if (event.key() == Qt.Key_Enter or event.key() == Qt.Key_Return):
+            if self.cancel_button.hasFocus():
+                self.cancel_button.click()
+            else:
+                self.continue_button.click()
             return
+
         super().keyPressEvent(event)
 
     def close(self):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -9,7 +9,7 @@ from PyQt5.QtCore import Qt, QEvent
 from PyQt5.QtGui import QFocusEvent, QKeyEvent, QMovie
 from PyQt5.QtTest import QTest
 from PyQt5.QtWidgets import QWidget, QApplication, QVBoxLayout, QMessageBox, QMainWindow, \
-    QLineEdit, QDialog
+    QLineEdit
 from sqlalchemy.orm import scoped_session, sessionmaker
 
 from securedrop_client import db, logic
@@ -1888,11 +1888,38 @@ def test_FramelessDialog_keyPressEvent_does_not_close_on_enter_or_return(mocker,
          'securedrop_client.gui.widgets.QApplication.activeWindow', return_value=QMainWindow())
     dialog = FramelessDialog()
     dialog.close = mocker.MagicMock()
-    event = QKeyEvent(QEvent.KeyPress, key, Qt.NoModifier)
 
+    event = QKeyEvent(QEvent.KeyPress, key, Qt.NoModifier)
     dialog.keyPressEvent(event)
 
     dialog.close.assert_not_called()
+
+
+@pytest.mark.parametrize("key", [Qt.Key_Enter, Qt.Key_Return])
+def test_FramelessDialog_keyPressEvent_cancel_on_enter_when_focused(mocker, key):
+    mocker.patch(
+         'securedrop_client.gui.widgets.QApplication.activeWindow', return_value=QMainWindow())
+    dialog = FramelessDialog()
+    dialog.cancel_button.click = mocker.MagicMock()
+    dialog.cancel_button.hasFocus = mocker.MagicMock(return_value=True)
+
+    event = QKeyEvent(QEvent.KeyPress, key, Qt.NoModifier)
+    dialog.keyPressEvent(event)
+
+    dialog.cancel_button.click.assert_called_once_with()
+
+
+@pytest.mark.parametrize("key", [Qt.Key_Enter, Qt.Key_Return])
+def test_FramelessDialog_keyPressEvent_continue_on_enter(mocker, key):
+    mocker.patch(
+         'securedrop_client.gui.widgets.QApplication.activeWindow', return_value=QMainWindow())
+    dialog = FramelessDialog()
+    dialog.continue_button.click = mocker.MagicMock()
+
+    event = QKeyEvent(QEvent.KeyPress, key, Qt.NoModifier)
+    dialog.keyPressEvent(event)
+
+    dialog.continue_button.click.assert_called_once_with()
 
 
 @pytest.mark.parametrize("key", [Qt.Key_Alt, Qt.Key_A])
@@ -1901,8 +1928,8 @@ def test_FramelessDialog_keyPressEvent_does_not_close_for_other_keys(mocker, key
          'securedrop_client.gui.widgets.QApplication.activeWindow', return_value=QMainWindow())
     dialog = FramelessDialog()
     dialog.close = mocker.MagicMock()
-    event = QKeyEvent(QEvent.KeyPress, key, Qt.NoModifier)
 
+    event = QKeyEvent(QEvent.KeyPress, key, Qt.NoModifier)
     dialog.keyPressEvent(event)
 
     dialog.close.assert_not_called()


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/828

# Test Plan

In addition to ensuring the "expected" section of the STR in #828 now happens, also ensure that the close button still closes the dialog when it is clicked or when you press Enter while it's focused (by tabbing to it).

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes