### PR TITLE
Update ReplyBoxWidget on sync

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3012,10 +3012,7 @@ class ReplyBoxWidget(QWidget):
         main_layout.addWidget(self.replybox)
 
         # Determine whether or not this widget should be rendered in offline mode
-        if self.controller.is_authenticated:
-            self.set_logged_in()
-        else:
-            self.set_logged_out()
+        self.update_authentication_state(self.controller.is_authenticated)
 
         # Text area refocus flag.
         self.refocus_after_sync = False
@@ -3054,12 +3051,17 @@ class ReplyBoxWidget(QWidget):
             self.reply_sent.emit(self.source.uuid, reply_uuid, reply_text)
 
     def _on_authentication_changed(self, authenticated: bool) -> None:
+        self.update_authentication_state(authenticated)
+
+    def update_authentication_state(self, authenticated: bool) -> None:
         if authenticated:
             self.set_logged_in()
         else:
             self.set_logged_out()
 
     def _on_synced(self, data: str) -> None:
+        self.update_authentication_state(self.controller.is_authenticated)
+
         if data == 'syncing' and self.text_edit.hasFocus():
             self.refocus_after_sync = True
         elif data == 'synced' and self.refocus_after_sync:


### PR DESCRIPTION
# Description

This ensures that we will eventually be able to reply to a source who gains a public key after sync.

Fixes #862.

# Test Plan

The problem seems easier to reproduce in a staging or production environment. 

1. You can either build a `securedrop-client` .deb and install it in `sd-app`, or check out this branch, then copy `securedrop_client/gui/widgets.py` to `/opt/venvs/securedrop-client/lib/python3.7/site-packages/securedrop_client/gui/widgets.py`.
2. Run the client with `LOGLEVEL=debug` so you can see the key handling messages.
3. In the source interface, log in as a new source.
4. Back in the client, watch for the new source to appear. It will likely not yet have a public key, so you should see the `Awaiting encryption key...` message in the reply box.
5. After no more than a couple of syncs, the source should be given a public key, and the reply box should update to reflect that.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
