### PR TITLE
app: delete source collection when source is deleted locally

### DIFF
--- a/files/usr.bin.securedrop-client
+++ b/files/usr.bin.securedrop-client
@@ -57,7 +57,7 @@
   owner /home/user/.cache/** rwl,
   owner /home/user/.securedrop_client/ rw,
   owner /home/user/.securedrop_client/config.json r,
-  owner /home/user/.securedrop_client/data/ w,
+  owner /home/user/.securedrop_client/data/ rw,
   owner /home/user/.securedrop_client/data/** rwl,
   owner /home/user/.securedrop_client/gpg/ rw,
   owner /home/user/.securedrop_client/gpg/* rwl,

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -749,7 +749,7 @@ class Controller(QObject):
         Handler for when a source deletion succeeds.
         """
         # Delete the local version of the source.
-        storage.delete_local_source_by_uuid(self.session, result)
+        storage.delete_local_source_by_uuid(self.session, result, self.data_dir)
         # Update the sources UI.
         self.update_sources()
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1276,7 +1276,7 @@ def test_Controller_on_delete_source_success(homedir, config, mocker, session_ma
     co = Controller('http://localhost', mock_gui, session_maker, homedir)
     co.update_sources = mocker.MagicMock()
     co.on_delete_source_success("uuid")
-    storage.delete_local_source_by_uuid.assert_called_once_with(co.session, "uuid")
+    storage.delete_local_source_by_uuid.assert_called_once_with(co.session, "uuid", co.data_dir)
     assert co.update_sources.call_count == 1
 
 


### PR DESCRIPTION
# Description

Fixes #856

There are two ways sources can be deleted: via the metadata sync (since sources and submissions can be deleted by other users) and via the source deletion job (if the client user deletes a source). In the latter place, we were previously only deleting the source database row, the documents would remain on disk. 

# Test Plan

1. Apply the AppArmor profile change and this code diff. You can do either by building the deb on this branch and installing it in `sd-app`, OR by copying the AppArmor profile into place (in `/etc/apparmor.d/`), running `sudo service apparmor restart`, and copying the code on top of the existing installed code (e.g. in the root of the git repository `sudo cp -r securedrop_client /opt/venvs/securedrop-client/lib/python3.7/site-packages/`).
2. Start client via `securedrop-client`.
3. Log in.
4. Submit a file as a source. Download it and wait for it to finish.
5. `ls -la ~/.securedrop_client/data`. You should see a folder in here with the designation of the source, and the file inside that folder.
6. Delete the source. 
7. Check syslog and verify no AppArmor denials.
8. `ls -la ~/.securedrop_client/data`. You should see the file and the entire folder is now gone.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic is required for these changes - the AppArmor change is included here
 - [ ] I don't know and would appreciate guidance
