### PR TITLE
Fix blocked ui on start

### DIFF
--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -472,6 +472,7 @@ def test_MainView_setup(mocker):
 
     assert mv.controller == controller
     mv.source_list.setup.assert_called_once_with(controller)
+    mv.source_list.delete_source_by_uuid.connect.assert_called_once_with(mv.delete_source)
 
 
 def test_MainView_show_sources_with_none_selected(mocker):
@@ -504,26 +505,7 @@ def test_MainView_show_sources_with_no_sources_at_all(mocker):
     mv.empty_conversation_view.show.assert_called_once_with()
 
 
-def test_MainView_show_sources_when_sources_are_deleted(mocker):
-    """
-    Ensure that show_sources also deletes the SourceConversationWrapper for a deleted source.
-    """
-    mv = MainView(None)
-    mv.source_list = mocker.MagicMock()
-    mv.empty_conversation_view = mocker.MagicMock()
-    mv.source_list.update = mocker.MagicMock(return_value=[])
-    mv.delete_conversation = mocker.MagicMock()
-
-    mv.show_sources([1, 2, 3, 4])
-
-    mv.source_list.update = mocker.MagicMock(return_value=[4])
-
-    mv.show_sources([1, 2, 3])
-
-    mv.delete_conversation.assert_called_once_with(4)
-
-
-def test_MainView_delete_conversation_when_conv_wrapper_exists(mocker):
+def test_MainView_delete_source_when_conv_wrapper_exists(mocker):
     """
     Ensure SourceConversationWrapper is deleted if it exists.
     """
@@ -735,10 +717,39 @@ def test_SourceList_update_adds_new_sources(mocker):
     sl = SourceList()
 
     sl.clear = mocker.MagicMock()
-    sl.insertItem = mocker.MagicMock()
-    sl.takeItem = mocker.MagicMock()
+    sl.add_source = mocker.MagicMock()
     sl.setItemWidget = mocker.MagicMock()
+    sl.currentRow = mocker.MagicMock(return_value=0)
+    sl.item = mocker.MagicMock()
+    sl.item().isSelected.return_value = True
+    sources = [mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), ]
+    sl.update(sources)
+    sl.clear.assert_called_once_with()
+    sl.add_source.assert_called_once_with({}, sources, None, True)
+
+
+def test_SourceList_add_source_starts_timer(mocker, session_maker, homedir):
+    """
+    When the add_source method is called it schedules the addition of a source
+    to the source list via a single-shot QTimer.
+    """
+    sl = SourceList()
+    sources = [mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), ]
+    mock_timer = mocker.MagicMock()
+    with mocker.patch("securedrop_client.gui.widgets.QTimer", mock_timer):
+        sl.add_source({}, sources, None, False)
+    assert mock_timer.singleShot.call_count == 1
+
+
+def test_SourceList_add_source_closure_adds_sources(mocker):
+    """
+    The closure (function created within the add_source function) behaves in
+    the expected way given the context of the call to add_source.
+    """
+    sl = SourceList()
     sl.controller = mocker.MagicMock()
+    sl.addItem = mocker.MagicMock()
+    sl.setItemWidget = mocker.MagicMock()
     sl.setCurrentItem = mocker.MagicMock()
 
     mock_sw = mocker.MagicMock()
@@ -747,157 +758,95 @@ def test_SourceList_update_adds_new_sources(mocker):
     mocker.patch('securedrop_client.gui.widgets.QListWidgetItem', mock_lwi)
 
     sources = [mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), ]
-    sl.update(sources)
+    mock_timer = mocker.MagicMock()
+    with mocker.patch("securedrop_client.gui.widgets.QTimer", mock_timer):
+        sl.add_source({}, sources, 1, False)
+        # Now grab the function created within add_source:
+        inner_fn = mock_timer.singleShot.call_args_list[0][0][1]
+        # Ensure add_source is mocked to avoid recursion in the test and so we
+        # can spy on how it's called.
+        sl.add_source = mocker.MagicMock()
+        # Call the inner function (as if the timer had completed).
+        inner_fn()
+        assert mock_sw.call_count == 1
+        assert mock_lwi.call_count == 1
+        assert sl.addItem.call_count == 1
+        assert sl.setItemWidget.call_count == 1
+        assert len(sl.source_widgets) == 1
+        assert sl.setCurrentItem.call_count == 0
+        sl.add_source.assert_called_once_with({}, sources[1:], 1, False, 2)
 
-    assert mock_sw.call_count == len(sources)
-    assert mock_lwi.call_count == len(sources)
-    assert sl.insertItem.call_count == len(sources)
-    assert sl.setItemWidget.call_count == len(sources)
-    assert len(sl.source_widgets) == len(sources)
-    assert sl.setCurrentItem.call_count == 0
-    sl.clear.assert_not_called()
-    sl.takeItem.assert_not_called()
-    mock_sw.deleteLater.assert_not_called()
 
-
-def test_SourceList_update_when_source_deleted(mocker, session, session_maker, homedir):
+def test_SourceList_add_source_closure_sets_current_item(mocker):
     """
-    Test that SourceWidget.update raises an exception when its source has been deleted.
-
-    When SourceList.update calls SourceWidget.update and that
-    SourceWidget's source has been deleted, SourceList.update should
-    catch the resulting excpetion, delete the SourceWidget and add its
-    source UUID to the list of deleted source UUIDs.
-    """
-    mock_gui = mocker.MagicMock()
-    controller = logic.Controller('http://localhost', mock_gui, session_maker, homedir)
-
-    # create the source in another session
-    source = factory.Source()
-    session.add(source)
-    session.commit()
-
-    # construct the SourceWidget with the source fetched in its
-    # controller's session
-    oss = controller.session.query(db.Source).filter_by(id=source.id).one()
-
-    # add it to the SourceList
-    sl = SourceList()
-    sl.setup(controller)
-    deleted_uuids = sl.update([oss])
-    assert not deleted_uuids
-    assert len(sl.source_widgets) == 1
-
-    # now delete it
-    session.delete(source)
-    session.commit()
-
-    # and finally verify that updating raises an exception, causing
-    # the SourceWidget to be deleted
-    deleted_uuids = sl.update([source])
-    assert len(deleted_uuids) == 1
-    assert source.uuid in deleted_uuids
-    assert len(sl.source_widgets) == 0
-
-
-def test_SourceList_update_maintains_selection(mocker):
-    """
-    Maintains the selected item if present in new list
+    The closure (function created within the add_source function) ensures that
+    if an item being added to the UI is the currently selected item and is
+    already selected in the UI, it is marked as such.
     """
     sl = SourceList()
     sl.controller = mocker.MagicMock()
-    sources = [factory.Source(), factory.Source()]
-    sl.update(sources)
+    sl.addItem = mocker.MagicMock()
+    sl.setItemWidget = mocker.MagicMock()
+    sl.setCurrentItem = mocker.MagicMock()
 
-    sl.setCurrentItem(sl.itemAt(0, 0))  # select the first source
-    sl.update(sources)
+    mock_sw = mocker.MagicMock()
+    mock_lwi = mocker.MagicMock()
+    mocker.patch('securedrop_client.gui.widgets.SourceWidget', mock_sw)
+    mocker.patch('securedrop_client.gui.widgets.QListWidgetItem', mock_lwi)
 
-    assert sl.currentItem()
-    assert sl.itemWidget(sl.currentItem()).source.id == sources[0].id
+    mock_source = mocker.MagicMock()
+    mock_source.id = 1
 
-    sl.setCurrentItem(sl.itemAt(1, 0))  # select the second source
-    sl.update(sources)
+    sources = [mock_source, mocker.MagicMock(), mocker.MagicMock(), ]
+    mock_timer = mocker.MagicMock()
+    with mocker.patch("securedrop_client.gui.widgets.QTimer", mock_timer):
+        sl.add_source({}, sources, 1, True)
+        # Now grab the function created within add_source:
+        inner_fn = mock_timer.singleShot.call_args_list[0][0][1]
+        # Ensure add_source is mocked to avoid recursion in the test and so we
+        # can spy on how it's called.
+        sl.add_source = mocker.MagicMock()
+        # Call the inner function (as if the timer had completed).
+        inner_fn()
+        assert sl.setCurrentItem.call_count == 1
 
-    assert sl.currentItem()
-    assert sl.itemWidget(sl.currentItem()).source.id == sources[1].id
 
-
-def test_SourceList_update_with_pre_selected_source_maintains_selection(mocker):
+def test_SourceList_add_source_closure_deletes_sources_when_finished(mocker):
     """
-    Check that an existing source widget that is selected remains selected.
-    """
-    sl = SourceList()
-    sl.controller = mocker.MagicMock()
-    sl.update([factory.Source(), factory.Source()])
-    second_item = sl.itemAt(1, 0)
-    sl.setCurrentItem(second_item)  # select the second source
-    mocker.patch.object(second_item, 'isSelected', return_value=True)
-
-    sl.update([factory.Source(), factory.Source()])
-
-    assert second_item.isSelected() is True
-
-
-def test_SourceList_update_removes_selected_item_results_in_no_current_selection(mocker):
-    """
-    Check that no items are currently selected if the currently selected item is deleted.
+    The closure (function created within the add_source function) ensures that
+    if an item being added to the UI is the currently selected item and is
+    already selected in the UI, it is marked as such.
     """
     sl = SourceList()
     sl.controller = mocker.MagicMock()
-    sl.update([factory.Source(uuid='new'), factory.Source(uuid='newer')])
+    sl.addItem = mocker.MagicMock()
+    sl.setItemWidget = mocker.MagicMock()
+    sl.setCurrentItem = mocker.MagicMock()
 
     sl.setCurrentItem(sl.itemAt(0, 0))  # select source with uuid='newer'
     sl.update([factory.Source(uuid='new')])  # delete source with uuid='newer'
 
-    assert not sl.currentItem()
+    existing_sources = {
+        "uuid1": mocker.MagicMock()
+    }
 
+    sl.source_widgets = {
+        "uuid2": mocker.MagicMock()
+    }
 
-def test_SourceList_update_removes_item_from_end_of_list(mocker):
-    """
-    Check that the item is removed from the source list and dict if the source no longer exists.
-    """
-    sl = SourceList()
-    sl.controller = mocker.MagicMock()
-    sl.update([
-        factory.Source(uuid='new'), factory.Source(uuid='newer'), factory.Source(uuid='newest')])
-    assert sl.count() == 3
-    sl.update([factory.Source(uuid='newer'), factory.Source(uuid='newest')])
-    assert sl.count() == 2
-    assert sl.itemWidget(sl.item(0)).source.uuid == 'newest'
-    assert sl.itemWidget(sl.item(1)).source.uuid == 'newer'
-    assert len(sl.source_widgets) == 2
+    sl.delete_source_by_uuid = mocker.MagicMock()
 
-
-def test_SourceList_update_removes_item_from_middle_of_list(mocker):
-    """
-    Check that the item is removed from the source list and dict if the source no longer exists.
-    """
-    sl = SourceList()
-    sl.controller = mocker.MagicMock()
-    sl.update([
-        factory.Source(uuid='new'), factory.Source(uuid='newer'), factory.Source(uuid='newest')])
-    assert sl.count() == 3
-    sl.update([factory.Source(uuid='new'), factory.Source(uuid='newest')])
-    assert sl.count() == 2
-    assert sl.itemWidget(sl.item(0)).source.uuid == 'newest'
-    assert sl.itemWidget(sl.item(1)).source.uuid == 'new'
-    assert len(sl.source_widgets) == 2
-
-
-def test_SourceList_update_removes_item_from_beginning_of_list(mocker):
-    """
-    Check that the item is removed from the source list and dict if the source no longer exists.
-    """
-    sl = SourceList()
-    sl.controller = mocker.MagicMock()
-    sl.update([
-        factory.Source(uuid='new'), factory.Source(uuid='newer'), factory.Source(uuid='newest')])
-    assert sl.count() == 3
-    sl.update([factory.Source(uuid='new'), factory.Source(uuid='newer')])
-    assert sl.count() == 2
-    assert sl.itemWidget(sl.item(0)).source.uuid == 'newer'
-    assert sl.itemWidget(sl.item(1)).source.uuid == 'new'
-    assert len(sl.source_widgets) == 2
+    mock_timer = mocker.MagicMock()
+    with mocker.patch("securedrop_client.gui.widgets.QTimer", mock_timer):
+        sl.add_source(existing_sources, [], 1, True)
+        # Now grab the function created within add_source:
+        inner_fn = mock_timer.singleShot.call_args_list[0][0][1]
+        # Ensure add_source is mocked to avoid recursion in the test and so we
+        # can spy on how it's called.
+        sl.add_source = mocker.MagicMock()
+        # Call the inner function (as if the timer had completed).
+        inner_fn()
+        sl.delete_source_by_uuid.emit.assert_called_once_with("uuid1")
 
 
 def test_SourceList_set_snippet(mocker):


### PR DESCRIPTION
# Description

Fixes #846.

This was a fun (type 2) nut to crack. ;-)

The problem in #846 is that the GUI blocks on start-up of the client as 1000s of sources are added from local storage. You can see this demonstrated in the screenie below:

![blocked_startup](https://user-images.githubusercontent.com/37602/75795529-5e67d100-5d6a-11ea-8f48-a904833df6e6.gif)

The problem is that the aspect of the code which is causing the blockage is the creation and adding of the source widgets to the source list. This *must* happen on the GUI thread, hence the behaviour we observe.

I looked into several solutions (via several spikes), but the approach taken here feels the simplest and least "invasive".

Essentially, instead of adding all the sources at once, my solution adds them in chunks. When the first chunk is added, a QTimer is created to immediately process the second chunk. In this way the GUI event loop is able to keep iterating and the application remains responsive at all times. I've also made sure that the chunks start with a size of zero and double in size until they get to a chunk size of 32. Through a process of experimentation I've found that any higher number of sources added in a single chunk create a noticeable stuttering **on my development laptop** (please check on a typical/recommended Qubes setup -- my old x220 is slow as sludge). This also means that the first sources are immediately added to the UI. I found that even with a constant chunk size of 32 I was observing a very short, but definitely noticeable black flash (like the screenie above but shorter) as the initial chunk was being loaded into the widget. By starting at one and ramping up in powers of two we don't see this problem.

The end result looks like this:

![responsive_sources](https://user-images.githubusercontent.com/37602/75988626-c8f34b00-5ee9-11ea-9e0a-c4e31137d13e.gif)

In terms of implementation, I've created a new `add_sources` function which creates an inner function (as a closure) which is scheduled by a `QTimer` (`QTimer` doesn't allow you to pass in values to the function it is scheduled to run -- hence the closure trick to ensure the correct state is used). It is the inner function that actually adds the sources to the UI. The sources are sliced by current chunk size and, if there are any left, the inner-function calls the `add_sources` function again to re-schedule the processing of the remaining sources. This took a while to get right. ;-)

**I'd like feedback on my approach please**, hence the draft nature of this PR. As always I **love** feedback and I'm more than happy to change anything and welcome suggestions, critique and ideas. Thank you..! :-)

# Test Plan

Updated unit tests in light of the refactoring. Requires eyeballs and feedback to ensure it's not introduced any regressions. To run the server with 1000s of sources type, `$ NUM_SOURCES=1000 make dev` then go make a coffee (this takes quite a while to start). Start the client and let it download the sources. Stop the client. Restart the client (with the same home directory) and notice how it's not blocked as it was and remains responsive while the sources list is being populated.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [X] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
