### PR TITLE
retry on source deletion timeout

### DIFF
--- a/securedrop_client/api_jobs/sources.py
+++ b/securedrop_client/api_jobs/sources.py
@@ -20,25 +20,11 @@ class DeleteSourceJob(ApiJob):
 
         Delete a source on the server
         '''
-        try:
-            source_sdk_object = sdclientapi.Source(uuid=self.source_uuid)
+        source_sdk_object = sdclientapi.Source(uuid=self.source_uuid)
 
-            # TODO: After
-            # https://github.com/freedomofpress/securedrop-client/issues/648
-            # is merged, we will want to pass the default request
-            # timeout instead of setting it on the api object
-            # directly.
-            api_client.default_request_timeout = 5
-            api_client.delete_source(source_sdk_object)
+        # TODO: After https://github.com/freedomofpress/securedrop-client/issues/648 is merged, we
+        # will want to pass the timeout to delete_source instead of setting it on the api object
+        api_client.default_request_timeout = 5
+        api_client.delete_source(source_sdk_object)
 
-            return self.source_uuid
-        except Exception as e:
-            error_message = "Failed to delete source {uuid} due to {exception}".format(
-                uuid=self.source_uuid, exception=repr(e))
-            raise DeleteSourceJobException(error_message, self.source_uuid)
-
-
-class DeleteSourceJobException(Exception):
-    def __init__(self, message: str, source_uuid: str):
-        super().__init__(message)
-        self.source_uuid = source_uuid
+        return self.source_uuid

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -756,11 +756,10 @@ class Controller(QObject):
         # Update the sources UI.
         self.update_sources()
 
-    def on_delete_source_failure(self, result: Exception) -> None:
-        logging.info("failed to delete source at server")
-
-        error = _('Failed to delete source at server')
-        self.gui.update_error_status(error)
+    def on_delete_source_failure(self, e: Exception) -> None:
+        if not isinstance(e, (RequestTimeoutError, ServerConnectionError)):
+            error = _('Failed to delete source at server')
+            self.gui.update_error_status(error)
 
     @login_required
     def delete_source(self, source: db.Source):

--- a/tests/api_jobs/test_sources.py
+++ b/tests/api_jobs/test_sources.py
@@ -1,6 +1,6 @@
 import pytest
 
-from securedrop_client.api_jobs.sources import DeleteSourceJob, DeleteSourceJobException
+from securedrop_client.api_jobs.sources import DeleteSourceJob
 from tests import factory
 
 
@@ -22,15 +22,16 @@ def test_delete_source_job(homedir, mocker, session, session_maker):
     )
 
     job = DeleteSourceJob(source.uuid)
-    job.call_api(api_client, session)
+    uuid = job.call_api(api_client, session)
 
+    assert uuid == source.uuid
     mock_source_init.assert_called_once_with(uuid=source.uuid)
     api_client.delete_source.assert_called_once_with(mock_sdk_source)
 
 
 def test_failure_to_delete(homedir, mocker, session, session_maker):
     '''
-    Check failure of a DeleteSourceJob.
+    Check failure of a DeleteSourceJob, which relies on ApiBase for error handling.
     '''
     source = factory.Source()
     session.add(source)
@@ -41,5 +42,5 @@ def test_failure_to_delete(homedir, mocker, session, session_maker):
     api_client.delete_source.side_effect = Exception
 
     job = DeleteSourceJob(source.uuid)
-    with pytest.raises(DeleteSourceJobException):
+    with pytest.raises(Exception):
         job.call_api(api_client, session)


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/878

# Test Plan

Watch out for https://github.com/freedomofpress/securedrop-client/issues/859 which this does not resolve.

See that #878 is fixed. You will want to test with `RequestTimeoutError`, `ServerConnectionError`, and `Exception` (any error other than `RequestTimeoutError` and `ServerConnectionError` should show the "Failed to delete source at server" message. Also still open to suggestions on a rewrite of that error message.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes
