### PR TITLE
Remove "Downloading file" message in sync area

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -721,7 +721,6 @@ class Controller(QObject):
         Download the file associated with the Submission (which may be a File or Message).
         """
         self._submit_download_job(submission_type, submission_uuid)
-        self.set_status(_('Downloading file'))
 
     def on_file_download_success(self, uuid: Any) -> None:
         """


### PR DESCRIPTION
# Status

Ready for review
# Description

Fixes #875
# Test Plan
1. Download a file in the client
2. Verify that "Downloading file" message no longer appears in top left

# Checklist
 - [X] These changes should not need testing in Qubes
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes

