### PR TITLE
only force relogin if not already logged out

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -462,6 +462,10 @@ class Controller(QObject):
         logger.debug('The SecureDrop server cannot be reached due to Error: {}'.format(result))
 
         if isinstance(result, ApiInaccessibleError):
+            # Don't show login window if the user is already logged out
+            if not self.is_authenticated or not self.api:
+                return
+
             self.invalidate_token()
             self.logout()
             self.gui.show_login(error=_('Your session expired. Please log in again.'))


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/882

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes