### PR TITLE
app: ensure we do not keep references to a SourceWidget that has been deleted

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -848,7 +848,10 @@ class SourceList(QListWidget):
         current_source = self.get_current_source()
         current_source_id = current_source and current_source.id
 
+        # When we call clear() to delete all SourceWidgets, we should
+        # also clear the source_widgets dict.
         self.clear()
+        self.source_widgets = {}
 
         for source in sources:
             new_source = SourceWidget(source)

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -710,6 +710,34 @@ def test_SourceList_update(mocker):
     assert sl.setCurrentItem.call_count == 0
 
 
+def test_SourceList_update_deleted_source(mocker):
+    """
+    When the SourceList is updated after deleting a source, check that we
+    do not keep references to deleted source widgets on the source_widgets
+    dict.
+    """
+    sl = SourceList()
+
+    sl.clear = mocker.MagicMock()
+    sl.addItem = mocker.MagicMock()
+    sl.setItemWidget = mocker.MagicMock()
+    sl.controller = mocker.MagicMock()
+    sl.setCurrentItem = mocker.MagicMock()
+
+    mock_sw = mocker.MagicMock()
+    mock_lwi = mocker.MagicMock()
+    mocker.patch('securedrop_client.gui.widgets.SourceWidget', mock_sw)
+    mocker.patch('securedrop_client.gui.widgets.QListWidgetItem', mock_lwi)
+
+    sources = [mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), ]
+    sl.update(sources)
+
+    sources.pop()
+    sl.update(sources)
+
+    assert len(sl.source_widgets) == len(sources)
+
+
 def test_SourceList_update_with_pre_selected_source(mocker):
     """
     If there's a source already selected. It remains selected after update.


### PR DESCRIPTION
# Description

Fixes #880

# Test Plan

This is a rare crasher, so you're going to need to verify that the following logic is sound:

- [ ] We only add items and remove items from the `SourceList` via its `update` method
- [ ] We were keeping references to the Python wrappers for source objects that were deleted (well, you can verify this via the test)
- [ ] After verifying that the logic in the test is sound, you can revert the fix and see that the test fails

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
