### PR TITLE
fix remaining app crasher bugs

### DIFF
--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -142,13 +142,6 @@ class Window(QMainWindow):
         self.login_dialog.accept()
         self.login_dialog = None
 
-    def delete_source_wrapper(self, source: Source) -> None:
-        """
-        Remove the SourceConversationWrapper for this source. This deletes
-        all its children, including the ConversationView.
-        """
-        self.main_view.delete_source(source)
-
     def show_sources(self, sources: List[Source]):
         """
         Update the left hand sources list in the UI with the passed in list of

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -142,6 +142,13 @@ class Window(QMainWindow):
         self.login_dialog.accept()
         self.login_dialog = None
 
+    def delete_source_wrapper(self, source: Source) -> None:
+        """
+        Remove the SourceConversationWrapper for this source. This deletes
+        all its children, including the ConversationView.
+        """
+        self.main_view.delete_source(source)
+
     def show_sources(self, sources: List[Source]):
         """
         Update the left hand sources list in the UI with the passed in list of

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -721,7 +721,7 @@ class MainView(QWidget):
         else:
             self.clear_conversation()
 
-    def delete_source(self, source_uuid) -> None:
+    def delete_source(self, source_uuid: str) -> None:
         """
         When we delete a source, we should delete its SourceConversationWrapper,
         and remove the reference to it in self.source_conversations

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -718,6 +718,19 @@ class MainView(QWidget):
         else:
             self.clear_conversation()
 
+    def delete_source(self, source) -> None:
+        """
+        When we delete a source, we should delete its SourceConversationWrapper,
+        and remove the reference to it in self.source_conversations
+        """
+        try:
+            logger.debug('Deleting SourceConversationWrapper for {}'.format(source.uuid))
+            conversation_wrapper = self.source_conversations[source]
+            conversation_wrapper.deleteLater()
+            self.source_conversations.pop(source)
+        except KeyError:
+            logger.debug('No SourceConversationWrapper for {} to delete'.format(source.uuid))
+
     def set_conversation(self, widget):
         """
         Update the view holder to contain the referenced widget.

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2814,7 +2814,9 @@ class ConversationView(QWidget):
 
         # If any items remain in current_conversation, they are no longer in the
         # source collection and should be removed from both the layout and the conversation
-        # dict.
+        # dict. Note that an item may be removed from the source collection if it is deleted
+        # by another user (a journalist using the Web UI is able to delete individual
+        # submissions).
         for item_widget in current_conversation.values():
             self.current_messages.pop(item_widget.uuid)
             self.conversation_layout.removeWidget(item_widget)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -730,7 +730,7 @@ class MainView(QWidget):
             logger.debug('Deleting SourceConversationWrapper for {}'.format(source_uuid))
             conversation_wrapper = self.source_conversations[source_uuid]
             conversation_wrapper.deleteLater()
-            self.source_conversations.pop(source_uuid)
+            del self.source_conversations[source_uuid]
         except KeyError:
             logger.debug('No SourceConversationWrapper for {} to delete'.format(source_uuid))
 
@@ -2063,14 +2063,12 @@ class FileWidget(QWidget):
     def _on_file_downloaded(self, source_uuid: str, file_uuid: str, filename: str) -> None:
         if file_uuid == self.uuid:
             self.downloading = False
-            self.file = self.controller.get_file(self.uuid)
             QTimer.singleShot(300, self.stop_button_animation)
 
     @pyqtSlot(str, str, str)
     def _on_file_missing(self, source_uuid: str, file_uuid: str, filename: str) -> None:
         if file_uuid == self.uuid:
             self.downloading = False
-            self.file = self.controller.get_file(self.uuid)
             QTimer.singleShot(300, self.stop_button_animation)
 
     @pyqtSlot()

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -751,9 +751,12 @@ class Controller(QObject):
         """
         Handler for when a source deletion succeeds.
         """
-        # Delete the local version of the source.
+        # Remove the source widgets for the deleted source.
+        source = self.session.query(db.Source).filter_by(uuid=result).one()
+        self.gui.delete_source_wrapper(source)
+        # Now delete the local version of the source from the database.
         storage.delete_local_source_by_uuid(self.session, result, self.data_dir)
-        # Update the sources UI.
+        # Finally update the sources list.
         self.update_sources()
 
     def on_delete_source_failure(self, e: Exception) -> None:

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -751,12 +751,9 @@ class Controller(QObject):
         """
         Handler for when a source deletion succeeds.
         """
-        # Remove the source widgets for the deleted source.
-        source = self.session.query(db.Source).filter_by(uuid=result).one()
-        self.gui.delete_source_wrapper(source)
-        # Now delete the local version of the source from the database.
+        # Delete the local version of the source from the database.
         storage.delete_local_source_by_uuid(self.session, result, self.data_dir)
-        # Finally update the sources list.
+        # Update the sources UI.
         self.update_sources()
 
     def on_delete_source_failure(self, e: Exception) -> None:

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -614,7 +614,7 @@ def test_MainView_on_source_changed_SourceConversationWrapper_is_preserved(mocke
     # But if we click back (call on_source_changed again) to the source,
     # its SourceConversationWrapper should _not_ be recreated.
     mv.source_list.get_current_source = mocker.MagicMock(return_value=source)
-    conversation_wrapper = mv.source_conversations[source]
+    conversation_wrapper = mv.source_conversations[source.uuid]
     conversation_wrapper.conversation_view = mocker.MagicMock()
     conversation_wrapper.conversation_view.update_conversation = mocker.MagicMock()
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -504,6 +504,58 @@ def test_MainView_show_sources_with_no_sources_at_all(mocker):
     mv.empty_conversation_view.show.assert_called_once_with()
 
 
+def test_MainView_show_sources_when_sources_are_deleted(mocker):
+    """
+    Ensure that show_sources also calls delete_source to delete the
+    SourceConversationWrapper for a deleted source.
+    """
+    mv = MainView(None)
+    mv.source_list = mocker.MagicMock()
+    mv.empty_conversation_view = mocker.MagicMock()
+    mv.source_list.update = mocker.MagicMock(return_value=[])
+    mv.delete_source = mocker.MagicMock()
+
+    mv.show_sources([1, 2, 3, 4])
+
+    mv.source_list.update = mocker.MagicMock(return_value=[4])
+
+    mv.show_sources([1, 2, 3])
+
+    mv.delete_source.assert_called_once_with(4)
+
+
+def test_MainView_delete_source_when_conv_wrapper_exists(mocker):
+    """
+    Ensure that delete_source deletes the SourceConversationWrapper
+    if it exists.
+    """
+    source_uuid = 'foo'
+    mock_source_conv_wrapper_widget = mocker.MagicMock()
+    mock_source_conv_wrapper_widget.deleteLater = mocker.MagicMock()
+    mv = MainView(None)
+    mv.source_conversations = {}
+    mv.source_conversations[source_uuid] = mock_source_conv_wrapper_widget
+
+    mv.delete_source(source_uuid)
+
+    mock_source_conv_wrapper_widget.deleteLater.assert_called_once_with()
+    assert mv.source_conversations == {}
+
+
+def test_MainView_delete_source_when_conv_wrapper_does_not_exist(mocker):
+    """
+    Ensure that delete_source throws no exception if the SourceConversationWrapper
+    does not exist.
+    """
+    source_uuid = 'foo'
+    mv = MainView(None)
+    mv.source_conversations = {}
+
+    mv.delete_source(source_uuid)
+
+    assert mv.source_conversations == {}
+
+
 def test_MainView_on_source_changed(mocker):
     """
     Ensure set_conversation is called when source changes.


### PR DESCRIPTION
# Description

Similar fix to #887 but for the remaining crasher bugs

Fixes #859
Fixes #857

# Test Plan

0. Start dev server
1. Run client with debug-level logs: `LOGLEVEL=DEBUG ./run.sh`
2. Click on a source (this creates its `SourceConversationWrapper`). 
3. Delete the source locally, see that the `SourceConversationWrapper` was deleted: 

```
2020-03-09 17:58:59,541 - securedrop_client.storage:61(delete_local_source_by_uuid) INFO: Deleted source with UUID c84874c7-cf7c-4d66-9fdb-c98334a4de07 from local database.
2020-03-09 17:58:59,598 - securedrop_client.gui.widgets:729(delete_source) DEBUG: Deleting SourceConversationWrapper for c84874c7-cf7c-4d66-9fdb-c98334a4de07
```

4. Use the JI to delete a source that you haven't clicked on yet in the client. Wait for a sync. See that you see the following:

```
2020-03-09 18:00:39,426 - securedrop_client.gui.widgets:729(delete_source) DEBUG: Deleting SourceConversationWrapper for 6985ed05-c77d-4120-90ff-4af8fa737882
2020-03-09 18:00:39,426 - securedrop_client.gui.widgets:734(delete_source) DEBUG: No SourceConversationWrapper for 6985ed05-c77d-4120-90ff-4af8fa737882 to delete
```

4. Now click on a third source in the client. 
5. Use the JI to delete that third source. Wait for a sync. See that you see the following:

```
2020-03-09 18:02:47,263 - securedrop_client.gui.widgets:729(delete_source) DEBUG: Deleting SourceConversationWrapper for 070fbe2a-7fc8-4350-87c7-7450728888a7
```

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
