### PR TITLE
no longer delete all source widgets each update

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -858,19 +858,21 @@ class SourceList(QListWidget):
         """
         # Delete widgets that no longer exist in source list
         source_uuids = [source.uuid for source in sources]
+        deleted_uuids = []
         for i in range(self.count()):
             list_item = self.item(i)
             list_widget = self.itemWidget(list_item)
 
-            if list_widget and list_widget.source.uuid not in source_uuids:
+            if list_widget and list_widget.source_uuid not in source_uuids:
                 if list_item.isSelected():
                     self.setCurrentItem(None)
-                del self.source_widgets[list_widget.source.uuid]
+                del self.source_widgets[list_widget.source_uuid]
+                deleted_uuids.append(list_widget.source_uuid)
                 self.takeItem(i)
                 list_widget.deleteLater()
 
         # Create new widgets for new sources
-        widget_uuids = [self.itemWidget(self.item(i)).source.uuid for i in range(self.count())]
+        widget_uuids = [self.itemWidget(self.item(i)).source_uuid for i in range(self.count())]
         for source in sources:
             if source.uuid not in widget_uuids:
                 new_source = SourceWidget(source)
@@ -882,7 +884,6 @@ class SourceList(QListWidget):
                 list_item.setSizeHint(new_source.sizeHint())
                 self.setItemWidget(list_item, new_source)
 
-        deleted_uuids = list(set(existing_source_widgets.keys()) - set(self.source_widgets.keys()))
         return deleted_uuids
 
     def get_current_source(self):
@@ -969,6 +970,7 @@ class SourceWidget(QWidget):
 
         # Store source
         self.source = source
+        self.source_uuid = source.uuid
 
         # Set styles
         self.setStyleSheet(self.CSS)

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -485,7 +485,7 @@ class Controller(QObject):
         """
         sources = list(storage.get_local_sources(self.session))
         if sources:
-            sources.sort(key=lambda x: x.last_updated, reverse=True)
+            sources.sort(key=lambda x: x.last_updated)
         self.gui.show_sources(sources)
 
     def on_update_star_success(self, result) -> None:

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -537,7 +537,7 @@ def test_Controller_update_sources(homedir, config, mocker):
     co = Controller('http://localhost', mock_gui, mock_session_maker, homedir)
 
     mock_storage = mocker.patch('securedrop_client.logic.storage')
-    source_list = [factory.Source(last_updated=2), factory.Source(last_updated=1)]
+    source_list = [factory.Source(last_updated=1), factory.Source(last_updated=2)]
     mock_storage.get_local_sources.return_value = source_list
 
     co.update_sources()


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/905
Fixes https://github.com/freedomofpress/securedrop-client/issues/352

We currently delete all source widgets and recreated them every time a user logs in, a user deletes a source, and whenever the client syncs with the server.

This PR makes it so only add source widgets when there are new sources and delete source widgets when the source has been deleted.

Performance testing on a large source list will need to be done over the next day or so. Also we should check if this helps with the flicker issue.

# Test Plan

Make sure there are no regressions. This is a refactor so the source list should behave the same.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes