### PR TITLE
HTML-ize the no-source selected text.

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -685,11 +685,11 @@ class MainView(QWidget):
         Update the left hand sources list in the UI with the passed in list of
         sources.
         """
-        if len(sources) == 0:
-            self.empty_conversation_view.show_no_sources_message()
+        if sources:
+            self.empty_conversation_view.show_no_source_selected_message()
             self.empty_conversation_view.show()
         else:
-            self.empty_conversation_view.show_no_source_selected_message()
+            self.empty_conversation_view.show_no_sources_message()
             self.empty_conversation_view.show()
 
         deleted_sources = self.source_list.update(sources)
@@ -751,12 +751,17 @@ class MainView(QWidget):
 class EmptyConversationView(QWidget):
 
     CSS = '''
-    #content {
+    QLabel {
         font-family: Montserrat;
         font-weight: 400;
-        font-size: 35px;
+        font-size: 40px;
         color: #a5b3e9;
         qproperty-alignment: AlignLeft;
+        padding-bottom: 20px;
+    }
+    #content {
+        font-weight: 600;
+        padding-bottom: 40px;
     }
     '''
 
@@ -776,32 +781,43 @@ class EmptyConversationView(QWidget):
         self.layout.setSpacing(0)
 
         # Create widgets
+        self.container = QWidget()
         self.content = QLabel(self)
         self.content.setObjectName('content')
         self.content.setWordWrap(True)
-        content_layout = QVBoxLayout()
-        content_layout.addStretch(1)
-        content_layout.addWidget(self.content, 8)
-        content_layout.addStretch(1)
+        self.bullet1 = QLabel(self)
+        self.bullet1.setText("· Read a conversation")
+        self.bullet2 = QLabel(self)
+        self.bullet2.setText("· View or retrieve files")
+        self.bullet3 = QLabel(self)
+        self.bullet3.setText("· Send a response")
+        self.content_layout = QVBoxLayout()
+        self.content_layout.addWidget(self.content)
+        self.content_layout.addWidget(self.bullet1)
+        self.content_layout.addWidget(self.bullet2)
+        self.content_layout.addWidget(self.bullet3)
+        self.content_layout.addStretch(1)
+        self.container.setLayout(self.content_layout)
 
         # Add widgets
         self.layout.addStretch(1)
-        self.layout.addWidget(self.content, 5)
+        self.layout.addWidget(self.container, 5)
         self.layout.addStretch(1)
 
     def show_no_sources_message(self):
+        self.bullet1.hide()
+        self.bullet2.hide()
+        self.bullet3.hide()
         self.content.setText(
             'Nothing to see just yet!\n\n'
             'Source submissions will be listed to the left, once downloaded and decrypted.\n\n'
             'This is where you will read messages, reply to sources, and work with files.\n\n')
 
     def show_no_source_selected_message(self):
-        self.content.setText(
-            '<b>Select a source from the list, to:</b><br/><br/><br/>'
-            '· Read a conversation<br/><br/>'
-            '· View or retrieve files<br/><br/>'
-            '· Send a response'
-        )
+        self.bullet1.show()
+        self.bullet2.show()
+        self.bullet3.show()
+        self.content.setText('Select a source from the list, to:')
 
 
 class SourceList(QListWidget):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -768,12 +768,12 @@ class EmptyConversationView(QWidget):
         self.setStyleSheet(self.CSS)
 
         # Set layout
-        layout = QHBoxLayout(self)
-        self.setLayout(layout)
+        self.layout = QHBoxLayout(self)
+        self.setLayout(self.layout)
 
         # Set margins and spacing
-        layout.setContentsMargins(0, 100, 0, 0)
-        layout.setSpacing(0)
+        self.layout.setContentsMargins(0, 100, 0, 0)
+        self.layout.setSpacing(0)
 
         # Create widgets
         self.content = QLabel(self)
@@ -785,9 +785,9 @@ class EmptyConversationView(QWidget):
         content_layout.addStretch(1)
 
         # Add widgets
-        layout.addStretch(1)
-        layout.addWidget(self.content, 5)
-        layout.addStretch(1)
+        self.layout.addStretch(1)
+        self.layout.addWidget(self.content, 5)
+        self.layout.addStretch(1)
 
     def show_no_sources_message(self):
         self.content.setText(
@@ -797,14 +797,10 @@ class EmptyConversationView(QWidget):
 
     def show_no_source_selected_message(self):
         self.content.setText(
-            '<hr/>'
-            '<h3>Select a source from the list, to:</h3>'
-            '<ul>'
-            '<li>Read a conversation</li>'
-            '<li>View or retrieve files</li>'
-            '<li>Send a response</li>'
-            '</ul>'
-            '<hr/>'
+            '<b>Select a source from the list, to:</b><br/><br/><br/>'
+            '· Read a conversation<br/><br/>'
+            '· View or retrieve files<br/><br/>'
+            '· Send a response'
         )
 
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -751,19 +751,28 @@ class MainView(QWidget):
 class EmptyConversationView(QWidget):
 
     CSS = '''
+    #bullet {
+        font-size: 30px;
+        font-weight: 600;
+    }
+    #no_sources {
+        min-width: 570px;
+        max-width: 700px;
+    }
     QLabel {
+        margin: 8px 0px 0px 0px;
         font-family: Montserrat;
         font-weight: 400;
         font-size: 40px;
         color: #a5b3e9;
-        qproperty-alignment: AlignLeft;
-        padding-bottom: 20px;
     }
-    #content {
+    #instructions {
         font-weight: 600;
-        padding-bottom: 40px;
     }
     '''
+
+    MARGIN = 30
+    NEWLINE_HEIGHT_PX = 40
 
     def __init__(self):
         super().__init__()
@@ -773,52 +782,85 @@ class EmptyConversationView(QWidget):
         self.setStyleSheet(self.CSS)
 
         # Set layout
-        self.layout = QHBoxLayout(self)
-        self.setLayout(self.layout)
-
-        # Set margins and spacing
-        self.layout.setContentsMargins(0, 100, 0, 0)
-        self.layout.setSpacing(0)
+        layout = QHBoxLayout()
+        layout.setContentsMargins(self.MARGIN, self.MARGIN, self.MARGIN, self.MARGIN)
+        self.setLayout(layout)
 
         # Create widgets
-        self.container = QWidget()
-        self.content = QLabel(self)
-        self.content.setObjectName('content')
-        self.content.setWordWrap(True)
-        self.content.setFixedWidth(520)
-        self.bullet1 = QLabel(self)
-        self.bullet1.setText("· Read a conversation")
-        self.bullet2 = QLabel(self)
-        self.bullet2.setText("· View or retrieve files")
-        self.bullet3 = QLabel(self)
-        self.bullet3.setText("· Send a response")
-        self.content_layout = QVBoxLayout()
-        self.content_layout.addWidget(self.content)
-        self.content_layout.addWidget(self.bullet1)
-        self.content_layout.addWidget(self.bullet2)
-        self.content_layout.addWidget(self.bullet3)
-        self.content_layout.addStretch(1)
-        self.container.setLayout(self.content_layout)
+        self.no_sources = QWidget()
+        self.no_sources.setObjectName('no_sources')
+        no_sources_layout = QVBoxLayout()
+        self.no_sources.setLayout(no_sources_layout)
+        no_sources_instructions = QLabel(_('Nothing to see just yet!'))
+        no_sources_instructions.setObjectName('instructions')
+        no_sources_instructions.setWordWrap(True)
+        no_sources_instruction_details1 = QLabel(
+            _('Source submissions will be listed to the left, once downloaded and decrypted.'))
+        no_sources_instruction_details1.setWordWrap(True)
+        no_sources_instruction_details2 = QLabel(
+            _('This is where you will read messages, reply to sources, and work with files.'))
+        no_sources_instruction_details2.setWordWrap(True)
+        no_sources_layout.addWidget(no_sources_instructions)
+        no_sources_layout.addSpacing(self.NEWLINE_HEIGHT_PX)
+        no_sources_layout.addWidget(no_sources_instruction_details1)
+        no_sources_layout.addSpacing(self.NEWLINE_HEIGHT_PX)
+        no_sources_layout.addWidget(no_sources_instruction_details2)
+
+        self.no_source_selected = QWidget()
+        self.no_source_selected.setFixedWidth(520)
+        no_source_selected_layout = QVBoxLayout()
+        self.no_source_selected.setLayout(no_source_selected_layout)
+        no_source_selected_instructions1 = QLabel(_('Select a source from'))
+        no_source_selected_instructions1.setObjectName('instructions')
+        no_source_selected_instructions1.setWordWrap(True)
+        no_source_selected_instructions2 = QLabel(_('the list, to:'))
+        no_source_selected_instructions2.setObjectName('instructions')
+        no_source_selected_instructions2.setWordWrap(True)
+        bullet1 = QWidget()
+        bullet1_layout = QHBoxLayout()
+        bullet1_layout.setContentsMargins(0, 0, 0, 0)
+        bullet1.setLayout(bullet1_layout)
+        bullet1_bullet = QLabel('•')
+        bullet1_bullet.setObjectName('bullet')
+        bullet1_layout.addWidget(bullet1_bullet)
+        bullet1_layout.addWidget(QLabel(_('Read a conversation')))
+        bullet1_layout.addStretch()
+        bullet2 = QWidget()
+        bullet2_layout = QHBoxLayout()
+        bullet2_layout.setContentsMargins(0, 0, 0, 0)
+        bullet2.setLayout(bullet2_layout)
+        bullet2_bullet = QLabel('•')
+        bullet2_bullet.setObjectName('bullet')
+        bullet2_layout.addWidget(bullet2_bullet)
+        bullet2_layout.addWidget(QLabel(_('View or retrieve files')))
+        bullet2_layout.addStretch()
+        bullet3 = QWidget()
+        bullet3_layout = QHBoxLayout()
+        bullet3_layout.setContentsMargins(0, 0, 0, 0)
+        bullet3.setLayout(bullet3_layout)
+        bullet3_bullet = QLabel('•')
+        bullet3_bullet.setObjectName('bullet')
+        bullet3_layout.addWidget(bullet3_bullet)
+        bullet3_layout.addWidget(QLabel(_('Send a response')))
+        bullet3_layout.addStretch()
+        no_source_selected_layout.addWidget(no_source_selected_instructions1)
+        no_source_selected_layout.addWidget(no_source_selected_instructions2)
+        no_source_selected_layout.addSpacing(self.NEWLINE_HEIGHT_PX)
+        no_source_selected_layout.addWidget(bullet1)
+        no_source_selected_layout.addWidget(bullet2)
+        no_source_selected_layout.addWidget(bullet3)
 
         # Add widgets
-        self.layout.addStretch(1)
-        self.layout.addWidget(self.container, 5)
-        self.layout.addStretch(1)
+        layout.addWidget(self.no_sources, alignment=Qt.AlignCenter)
+        layout.addWidget(self.no_source_selected, alignment=Qt.AlignCenter)
 
     def show_no_sources_message(self):
-        self.bullet1.hide()
-        self.bullet2.hide()
-        self.bullet3.hide()
-        self.content.setText(
-            'Nothing to see just yet!\n\n'
-            'Source submissions will be listed to the left, once downloaded and decrypted.\n\n'
-            'This is where you will read messages, reply to sources, and work with files.\n\n')
+        self.no_sources.show()
+        self.no_source_selected.hide()
 
     def show_no_source_selected_message(self):
-        self.bullet1.show()
-        self.bullet2.show()
-        self.bullet3.show()
-        self.content.setText('Select a source from the list, to:')
+        self.no_sources.hide()
+        self.no_source_selected.show()
 
 
 class SourceList(QListWidget):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -752,15 +752,21 @@ class EmptyConversationView(QWidget):
 
     CSS = '''
     #bullet {
+        margin: 4px 0px 0px 0px;
         font-size: 30px;
         font-weight: 600;
     }
     #no_sources {
         min-width: 570px;
         max-width: 700px;
+        text-align: left;
+    }
+    #no_source_selected {
+        min-width: 520px;
+        max-width: 520px;
+        text-align: left;
     }
     QLabel {
-        margin: 8px 0px 0px 0px;
         font-family: Montserrat;
         font-weight: 400;
         font-size: 40px;
@@ -807,7 +813,7 @@ class EmptyConversationView(QWidget):
         no_sources_layout.addWidget(no_sources_instruction_details2)
 
         self.no_source_selected = QWidget()
-        self.no_source_selected.setFixedWidth(520)
+        self.no_sources.setObjectName('no_source_selected')
         no_source_selected_layout = QVBoxLayout()
         self.no_source_selected.setLayout(no_source_selected_layout)
         no_source_selected_instructions1 = QLabel(_('Select a source from'))
@@ -820,25 +826,23 @@ class EmptyConversationView(QWidget):
         bullet1_layout = QHBoxLayout()
         bullet1_layout.setContentsMargins(0, 0, 0, 0)
         bullet1.setLayout(bullet1_layout)
-        bullet1_bullet = QLabel('•')
+        bullet1_bullet = QLabel('·')
         bullet1_bullet.setObjectName('bullet')
         bullet1_layout.addWidget(bullet1_bullet)
         bullet1_layout.addWidget(QLabel(_('Read a conversation')))
-        bullet1_layout.addStretch()
         bullet2 = QWidget()
         bullet2_layout = QHBoxLayout()
         bullet2_layout.setContentsMargins(0, 0, 0, 0)
         bullet2.setLayout(bullet2_layout)
-        bullet2_bullet = QLabel('•')
+        bullet2_bullet = QLabel('·')
         bullet2_bullet.setObjectName('bullet')
         bullet2_layout.addWidget(bullet2_bullet)
         bullet2_layout.addWidget(QLabel(_('View or retrieve files')))
-        bullet2_layout.addStretch()
         bullet3 = QWidget()
         bullet3_layout = QHBoxLayout()
         bullet3_layout.setContentsMargins(0, 0, 0, 0)
         bullet3.setLayout(bullet3_layout)
-        bullet3_bullet = QLabel('•')
+        bullet3_bullet = QLabel('·')
         bullet3_bullet.setObjectName('bullet')
         bullet3_layout.addWidget(bullet3_bullet)
         bullet3_layout.addWidget(QLabel(_('Send a response')))

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -797,10 +797,15 @@ class EmptyConversationView(QWidget):
 
     def show_no_source_selected_message(self):
         self.content.setText(
-            'Select a source from the list, to:\n\n'
-            '• Read a conversation\n'
-            '• View or retrieve files\n'
-            '• Send a response\n')
+            '<hr/>'
+            '<h3>Select a source from the list, to:</h3>'
+            '<ul>'
+            '<li>Read a conversation</li>'
+            '<li>View or retrieve files</li>'
+            '<li>Send a response</li>'
+            '</ul>'
+            '<hr/>'
+        )
 
 
 class SourceList(QListWidget):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -753,12 +753,12 @@ class EmptyConversationView(QWidget):
     CSS = '''
     #bullet {
         margin: 4px 0px 0px 0px;
-        font-size: 30px;
+        font-size: 35px;
         font-weight: 600;
     }
     #no_sources {
-        min-width: 570px;
-        max-width: 700px;
+        min-width: 520px;
+        max-width: 600px;
         text-align: left;
     }
     #no_source_selected {
@@ -769,16 +769,16 @@ class EmptyConversationView(QWidget):
     QLabel {
         font-family: Montserrat;
         font-weight: 400;
-        font-size: 40px;
+        font-size: 35px;
         color: #a5b3e9;
     }
     #instructions {
-        font-weight: 600;
+        font-weight: 500;
     }
     '''
 
     MARGIN = 30
-    NEWLINE_HEIGHT_PX = 40
+    NEWLINE_HEIGHT_PX = 35
 
     def __init__(self):
         super().__init__()
@@ -813,15 +813,12 @@ class EmptyConversationView(QWidget):
         no_sources_layout.addWidget(no_sources_instruction_details2)
 
         self.no_source_selected = QWidget()
-        self.no_sources.setObjectName('no_source_selected')
+        self.no_sources.setObjectName('no_sources')
         no_source_selected_layout = QVBoxLayout()
         self.no_source_selected.setLayout(no_source_selected_layout)
-        no_source_selected_instructions1 = QLabel(_('Select a source from'))
-        no_source_selected_instructions1.setObjectName('instructions')
-        no_source_selected_instructions1.setWordWrap(True)
-        no_source_selected_instructions2 = QLabel(_('the list, to:'))
-        no_source_selected_instructions2.setObjectName('instructions')
-        no_source_selected_instructions2.setWordWrap(True)
+        no_source_selected_instructions = QLabel(_('Select a source from the list, to:'))
+        no_source_selected_instructions.setObjectName('instructions')
+        no_source_selected_instructions.setWordWrap(True)
         bullet1 = QWidget()
         bullet1_layout = QHBoxLayout()
         bullet1_layout.setContentsMargins(0, 0, 0, 0)
@@ -830,6 +827,7 @@ class EmptyConversationView(QWidget):
         bullet1_bullet.setObjectName('bullet')
         bullet1_layout.addWidget(bullet1_bullet)
         bullet1_layout.addWidget(QLabel(_('Read a conversation')))
+        bullet1_layout.addStretch()
         bullet2 = QWidget()
         bullet2_layout = QHBoxLayout()
         bullet2_layout.setContentsMargins(0, 0, 0, 0)
@@ -838,6 +836,7 @@ class EmptyConversationView(QWidget):
         bullet2_bullet.setObjectName('bullet')
         bullet2_layout.addWidget(bullet2_bullet)
         bullet2_layout.addWidget(QLabel(_('View or retrieve files')))
+        bullet2_layout.addStretch()
         bullet3 = QWidget()
         bullet3_layout = QHBoxLayout()
         bullet3_layout.setContentsMargins(0, 0, 0, 0)
@@ -847,12 +846,12 @@ class EmptyConversationView(QWidget):
         bullet3_layout.addWidget(bullet3_bullet)
         bullet3_layout.addWidget(QLabel(_('Send a response')))
         bullet3_layout.addStretch()
-        no_source_selected_layout.addWidget(no_source_selected_instructions1)
-        no_source_selected_layout.addWidget(no_source_selected_instructions2)
+        no_source_selected_layout.addWidget(no_source_selected_instructions)
         no_source_selected_layout.addSpacing(self.NEWLINE_HEIGHT_PX)
         no_source_selected_layout.addWidget(bullet1)
         no_source_selected_layout.addWidget(bullet2)
         no_source_selected_layout.addWidget(bullet3)
+        no_source_selected_layout.addSpacing(self.NEWLINE_HEIGHT_PX * 4)
 
         # Add widgets
         layout.addWidget(self.no_sources, alignment=Qt.AlignCenter)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -785,6 +785,7 @@ class EmptyConversationView(QWidget):
         self.content = QLabel(self)
         self.content.setObjectName('content')
         self.content.setWordWrap(True)
+        self.content.setFixedWidth(520)
         self.bullet1 = QLabel(self)
         self.bullet1.setText("· Read a conversation")
         self.bullet2 = QLabel(self)

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -697,6 +697,9 @@ def test_MainView_set_conversation(mocker):
 def test_EmptyConversationView_show_no_sources_message(mocker):
     ecv = EmptyConversationView()
     ecv.content = mocker.MagicMock()
+    ecv.bullet1 = mocker.MagicMock()
+    ecv.bullet2 = mocker.MagicMock()
+    ecv.bullet3 = mocker.MagicMock()
 
     ecv.show_no_sources_message()
 
@@ -704,20 +707,24 @@ def test_EmptyConversationView_show_no_sources_message(mocker):
         'Nothing to see just yet!\n\n'
         'Source submissions will be listed to the left, once downloaded and decrypted.\n\n'
         'This is where you will read messages, reply to sources, and work with files.\n\n')
+    ecv.bullet1.hide.assert_called_once_with()
+    ecv.bullet2.hide.assert_called_once_with()
+    ecv.bullet3.hide.assert_called_once_with()
 
 
 def test_EmptyConversationView_show_no_source_selected_message(mocker):
     ecv = EmptyConversationView()
     ecv.content = mocker.MagicMock()
+    ecv.bullet1 = mocker.MagicMock()
+    ecv.bullet2 = mocker.MagicMock()
+    ecv.bullet3 = mocker.MagicMock()
 
     ecv.show_no_source_selected_message()
 
-    ecv.content.setText.assert_called_once_with(
-        '<b>Select a source from the list, to:</b><br/><br/><br/>'
-        '· Read a conversation<br/><br/>'
-        '· View or retrieve files<br/><br/>'
-        '· Send a response'
-    )
+    ecv.content.setText.assert_called_once_with("Select a source from the list, to:")
+    ecv.bullet1.show.assert_called_once_with()
+    ecv.bullet2.show.assert_called_once_with()
+    ecv.bullet3.show.assert_called_once_with()
 
 
 def test_SourceList_get_current_source(mocker):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -696,35 +696,20 @@ def test_MainView_set_conversation(mocker):
 
 def test_EmptyConversationView_show_no_sources_message(mocker):
     ecv = EmptyConversationView()
-    ecv.content = mocker.MagicMock()
-    ecv.bullet1 = mocker.MagicMock()
-    ecv.bullet2 = mocker.MagicMock()
-    ecv.bullet3 = mocker.MagicMock()
 
     ecv.show_no_sources_message()
 
-    ecv.content.setText.assert_called_once_with(
-        'Nothing to see just yet!\n\n'
-        'Source submissions will be listed to the left, once downloaded and decrypted.\n\n'
-        'This is where you will read messages, reply to sources, and work with files.\n\n')
-    ecv.bullet1.hide.assert_called_once_with()
-    ecv.bullet2.hide.assert_called_once_with()
-    ecv.bullet3.hide.assert_called_once_with()
+    assert not ecv.no_sources.isHidden()
+    assert ecv.no_source_selected.isHidden()
 
 
 def test_EmptyConversationView_show_no_source_selected_message(mocker):
     ecv = EmptyConversationView()
-    ecv.content = mocker.MagicMock()
-    ecv.bullet1 = mocker.MagicMock()
-    ecv.bullet2 = mocker.MagicMock()
-    ecv.bullet3 = mocker.MagicMock()
 
     ecv.show_no_source_selected_message()
 
-    ecv.content.setText.assert_called_once_with("Select a source from the list, to:")
-    ecv.bullet1.show.assert_called_once_with()
-    ecv.bullet2.show.assert_called_once_with()
-    ecv.bullet3.show.assert_called_once_with()
+    assert ecv.no_sources.isHidden()
+    assert not ecv.no_source_selected.isHidden()
 
 
 def test_SourceList_get_current_source(mocker):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -713,14 +713,10 @@ def test_EmptyConversationView_show_no_source_selected_message(mocker):
     ecv.show_no_source_selected_message()
 
     ecv.content.setText.assert_called_once_with(
-         '<hr/>'
-         '<h3>Select a source from the list, to:</h3>'
-         '<ul>'
-         '<li>Read a conversation</li>'
-         '<li>View or retrieve files</li>'
-         '<li>Send a response</li>'
-         '</ul>'
-         '<hr/>'
+        '<b>Select a source from the list, to:</b><br/><br/><br/>'
+        '· Read a conversation<br/><br/>'
+        '· View or retrieve files<br/><br/>'
+        '· Send a response'
     )
 
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -713,10 +713,15 @@ def test_EmptyConversationView_show_no_source_selected_message(mocker):
     ecv.show_no_source_selected_message()
 
     ecv.content.setText.assert_called_once_with(
-        'Select a source from the list, to:\n\n'
-        '• Read a conversation\n'
-        '• View or retrieve files\n'
-        '• Send a response\n')
+         '<hr/>'
+         '<h3>Select a source from the list, to:</h3>'
+         '<ul>'
+         '<li>Read a conversation</li>'
+         '<li>View or retrieve files</li>'
+         '<li>Send a response</li>'
+         '</ul>'
+         '<hr/>'
+    )
 
 
 def test_SourceList_get_current_source(mocker):


### PR DESCRIPTION
# Description

Fixes #847. **THIS IS A DRAFT** pending feedback from @ninavizz.

I went for using "rich text" in the QLabel since this avoid hand rolling a bunch of new Qt Widgets. This has had mixed success. Here's a screenie so you see what I mean:

![no-source](https://user-images.githubusercontent.com/37602/76229632-6d42fd80-621a-11ea-9b2f-cd67cc6bdda2.png)

I don't have any control over the size of the bullet points, and the only HTML-ish control I have over the text in Qt is described here: https://doc.qt.io/qt-5/richtext-html-subset.html As a result, while I know the screenie shows something similar or "inspired by" @ninavizz's design, it's honest-to-god the closest damn thing I can get to the design. Also, Qt's HTML doesn't do fixed widths (see their HTML spec) ergo, the behaviour of resizing is shown in the following screenie:

![select_source](https://user-images.githubusercontent.com/37602/76229651-72a04800-621a-11ea-9690-0355e2ae3580.gif)

Yes... I realise the `<hr/>`'s are black -- I don't have control over that. :-( Trying to get this right feels [like this](https://www.youtube.com/watch?v=yAZnV-TxX8g).

Can we perhaps agree on something that looks OK but is **within** the limitations of Qt's rendering of "rich text" (as specified by the limited subset of HTML4 it currently supports)..?

# Test Plan

Ask @ninavizz for :eyes: on the output (see screenies above).

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
