### PR TITLE
Fix wider with to LHS of UI. More space for source preview.

### DIFF
--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -179,7 +179,7 @@ class SecureQLabel(QLabel):
     def setText(self, text: str) -> None:
         self.setTextFormat(Qt.PlainText)
         if self.wordwrap:
-            text = "\n".join(textwrap.wrap(text))
+            text = "\n".join(textwrap.wrap(text, 80))
         elided_text = self.get_elided_text(text)
         self.elided = True if elided_text != text else False
         super().setText(elided_text)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -828,7 +828,7 @@ class SourceList(QListWidget):
         # Set id and styles.
         self.setObjectName('sourcelist')
         self.setStyleSheet(self.CSS)
-        self.setFixedWidth(445)
+        self.setFixedWidth(545)
         self.setUniformItemSizes(True)
 
         # Set layout.
@@ -962,7 +962,7 @@ class SourceWidget(QWidget):
 
     SIDE_MARGIN = 10
     SOURCE_WIDGET_VERTICAL_MARGIN = 10
-    PREVIEW_WIDTH = 312
+    PREVIEW_WIDTH = 412
     PREVIEW_HEIGHT = 60
 
     def __init__(self, source: Source):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -828,7 +828,7 @@ class SourceList(QListWidget):
         # Set id and styles.
         self.setObjectName('sourcelist')
         self.setStyleSheet(self.CSS)
-        self.setFixedWidth(545)
+        self.setFixedWidth(525)
         self.setUniformItemSizes(True)
 
         # Set layout.
@@ -1084,8 +1084,8 @@ class SourceWidget(QWidget):
                 msg_text = content
             else:
                 msg_text = str(msg)
-            if len(msg_text) > 120:
-                msg_text = msg_text[:120] + "..."
+            if len(msg_text) > 150:
+                msg_text = msg_text[:150] + "..."
             self.preview.setText(msg_text)
 
     def delete_source(self, event):

--- a/tests/gui/test_init.py
+++ b/tests/gui/test_init.py
@@ -156,16 +156,19 @@ def test_SecureQLabel_init():
 
 
 def test_SecureQLabel_init_wordwrap(mocker):
-    # 71 character string
-    long_string = '12345678901234567890123456789012345678901234567890123456789012345678901'
+    # 81 character string
+    long_string = ('1234567890123456789012345678901234567890123456789012345678901234567890'
+                   '12345678901')
     sl = SecureQLabel(long_string)
-    wordwrap_string = '1234567890123456789012345678901234567890123456789012345678901234567890\n1'
+    wordwrap_string = ('1234567890123456789012345678901234567890123456789012345678901234567890'
+                       '1234567890\n1')
     assert sl.text() == wordwrap_string
 
 
 def test_SecureQLabel_init_no_wordwrap(mocker):
-    # 71 character string
-    long_string = '12345678901234567890123456789012345678901234567890123456789012345678901'
+    # 81 character string
+    long_string = ('1234567890123456789012345678901234567890123456789012345678901234567890'
+                   '12345678901')
     sl = SecureQLabel(long_string, wordwrap=False)
     assert sl.text() == long_string
 
@@ -195,13 +198,13 @@ def test_SecureQLabel_quotes_not_escaped_for_readability():
     assert sl.text() == "'hello'"
 
 
-def test_SecureQLabel_wraps_on_70():
+def test_SecureQLabel_wraps_on_80():
     msg = (
         "thisisaverylongmessagethatwillnotwrapunlessthistestpassesproperly1234"
         "thisisaverylongmessagethatwillnotwrapunlessthistestpassesproperly1234"
         "thisisaverylongmessagethatwillnotwrapunlessthistestpassesproperly1234"
     )
     sl = SecureQLabel(msg)
-    expected = "\n".join(textwrap.wrap(msg))
+    expected = "\n".join(textwrap.wrap(msg, 80))
     assert sl.text() == expected
     assert sl.wordWrap() is True

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -955,12 +955,12 @@ def test_SourceWidget_set_snippet(mocker):
 
 def test_SourceWidget_update_truncate_latest_msg(mocker):
     """
-    If the latest message in the conversation is longer than 120 characters,
+    If the latest message in the conversation is longer than 150 characters,
     truncate and add "..." to the end.
     """
     source = mocker.MagicMock()
     source.journalist_designation = "Testy McTestface"
-    source.collection = [factory.Message(content="a" * 121), ]
+    source.collection = [factory.Message(content="a" * 151), ]
     sw = SourceWidget(source)
 
     sw.update()


### PR DESCRIPTION
# Description

Fixes #869.

TL;DR width of the LHS pane, width of the preview in the source preview widget, textwrap increased to 80 [was 70] characters a line. Screenie:

![wider_left](https://user-images.githubusercontent.com/37602/76240217-c4e96500-622a-11ea-97ff-580839ea75c0.png)


# Test Plan

@ninavizz looks at it and provides comments. :eyes:

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
