### PR TITLE
Update login UI messages per UI messages audit

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1346,7 +1346,7 @@ class LoginErrorBar(QWidget):
         self.error_icon.setFixedWidth(42)
 
         # Error status bar
-        self.error_status_bar = QLabel()
+        self.error_status_bar = SecureQLabel(wordwrap=False)
         self.error_status_bar.setObjectName('error_status_bar')
         self.setFixedHeight(42)
 
@@ -1557,7 +1557,7 @@ class LoginDialog(QDialog):
         """
         self.setDisabled(False)
         self.submit.setText(_("SIGN IN"))
-        self.error_bar.set_message(html.escape(message))
+        self.error_bar.set_message(message)
 
     def validate(self):
         """
@@ -1575,13 +1575,15 @@ class LoginDialog(QDialog):
             # Validate username
             if len(username) < self.MIN_JOURNALIST_USERNAME:
                 self.setDisabled(False)
-                self.error(_('Your username should be at least 3 characters. '))
+                self.error(_('That username won\'t work.\n'
+                             'It should be at least 3 characters long.'))
                 return
 
             # Validate password
             if len(password) < self.MIN_PASSWORD_LEN or len(password) > self.MAX_PASSWORD_LEN:
                 self.setDisabled(False)
-                self.error(_('Your password should be between 14 and 128 characters. '))
+                self.error(_('That passphrase won\'t work.\n'
+                             'It should be between 14 and 128 characters long.'))
                 return
 
             # Validate 2FA token
@@ -1589,13 +1591,14 @@ class LoginDialog(QDialog):
                 int(tfa_token)
             except ValueError:
                 self.setDisabled(False)
-                self.error(_('Please use only numerals for the two-factor code.'))
+                self.error(_('That two-factor code won\'t work.\n'
+                             'It should only contain numerals.'))
                 return
             self.submit.setText(_("SIGNING IN"))
             self.controller.login(username, password, tfa_token)
         else:
             self.setDisabled(False)
-            self.error(_('Please enter a username, password and '
+            self.error(_('Please enter a username, passphrase and '
                          'two-factor code.'))
 
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1504,7 +1504,7 @@ class LoginDialog(QDialog):
         application_version = QWidget()
         application_version_layout = QHBoxLayout()
         application_version.setLayout(application_version_layout)
-        application_version_label = QLabel(_("Workstation app v") + sd_version)
+        application_version_label = QLabel(_("SecureDrop Client v") + sd_version)
         application_version_label.setAlignment(Qt.AlignHCenter)
         application_version_label.setStyleSheet("QLabel {color: #9fddff;}")
         application_version_layout.addWidget(application_version_label)

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -396,7 +396,8 @@ class Controller(QObject):
     def on_authenticate_failure(self, result: Exception) -> None:
         # Failed to authenticate. Reset state with failure message.
         self.invalidate_token()
-        error = _('There was a problem signing in. Please verify your credentials and try again.')
+        error = _('That didn\'t work. Please check everything and try again.\n'
+                  'Make sure to use a new two-factor code.')
         self.gui.show_login_error(error=error)
         self.api_sync.stop()
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -189,8 +189,9 @@ def test_Controller_on_authenticate_failure(homedir, config, mocker, session_mak
 
     co.api_sync.stop.assert_called_once_with()
     mock_gui.show_login_error.\
-        assert_called_once_with(error='There was a problem signing in. Please '
-                                'verify your credentials and try again.')
+        assert_called_once_with(error='That didn\'t work. '
+                                      'Please check everything and try again.\n'
+                                      'Make sure to use a new two-factor code.')
 
 
 def test_Controller_on_authenticate_success(homedir, config, mocker, session_maker,


### PR DESCRIPTION
# Status

Ready for review

# Description

Part of #53. Makes error messages a bit more consistent and (hopefully) friendly:

- Always use "passphrase", not sometimes "password".
- Use "that won't work" for form submissions that instantly fail validation, followed by the reason
- Use "that didn't work" for form submissions that fail after being sent, followed by actionable advice (use a fresh two-factor code).

Switches the error bar to SecureQLabel as apostrophes were otherwise displayed incorrectly.

Updates the version string as previously discussed [here](https://github.com/freedomofpress/securedrop-client/pull/789#issuecomment-584782944).

# Test plan

- Verify that all errors are handled as expected per the screenshots below, including in Qubes.

# Checklist

- [ ] Tested in Qubes
- [x] No packaging implications

# Screenshots

<details>
<summary>Click to expand</summary>

![Screenshot from 2020-03-09 23-05-48](https://user-images.githubusercontent.com/213636/76284727-5375da80-625b-11ea-8065-dd76cd6f599c.png)
![Screenshot from 2020-03-09 23-05-41](https://user-images.githubusercontent.com/213636/76284729-540e7100-625b-11ea-9f63-c20a9c61614e.png)
![Screenshot from 2020-03-09 23-05-35](https://user-images.githubusercontent.com/213636/76284730-54a70780-625b-11ea-87bf-d1da6b4c2053.png)
![Screenshot from 2020-03-09 23-05-32](https://user-images.githubusercontent.com/213636/76284732-54a70780-625b-11ea-9bf0-72c41453f97f.png)
![Screenshot from 2020-03-09 23-05-10](https://user-images.githubusercontent.com/213636/76284735-54a70780-625b-11ea-9ea8-16cdeb5fc803.png)

</details>