### PR TITLE
waiting delete confirmation support

### DIFF
--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1023,6 +1023,24 @@ def test_SourceWidget_delete_source_when_user_chooses_cancel(mocker, session, so
     sw.controller.delete_source.assert_not_called()
 
 
+def test_SourceWidget__on_source_deleted(mocker, session, source):
+    sw = SourceWidget(factory.Source(uuid='123'))
+    sw._on_source_deleted('123')
+    assert sw.gutter.isHidden()
+    assert sw.metadata.isHidden()
+    assert sw.preview.isHidden()
+    assert not sw.waiting_delete_confirmation.isHidden()
+
+
+def test_SourceWidget__on_source_deleted_wrong_uuid(mocker, session, source):
+    sw = SourceWidget(factory.Source(uuid='123'))
+    sw._on_source_deleted('321')
+    assert not sw.gutter.isHidden()
+    assert not sw.metadata.isHidden()
+    assert not sw.preview.isHidden()
+    assert sw.waiting_delete_confirmation.isHidden()
+
+
 def test_SourceWidget_uses_SecureQLabel(mocker):
     """
     Ensure the source widget preview uses SecureQLabel and is not injectable
@@ -2688,6 +2706,24 @@ def test_PrintDialog__on_preflight_failure_when_status_is_unknown(mocker):
     dialog._on_preflight_failure(ExportError('Some Unknown Error Status'))
     dialog._show_generic_error_message.assert_called_once_with()
     assert dialog.error_status == 'Some Unknown Error Status'
+
+
+def test_SourceConversationWrapper__on_source_deleted(mocker):
+    scw = SourceConversationWrapper(factory.Source(uuid='123'), mocker.MagicMock())
+    scw._on_source_deleted('123')
+    assert scw.conversation_title_bar.isHidden()
+    assert scw.conversation_view.isHidden()
+    assert scw.reply_box.isHidden()
+    assert not scw.waiting_delete_confirmation.isHidden()
+
+
+def test_SourceConversationWrapper__on_source_deleted_wrong_uuid(mocker):
+    scw = SourceConversationWrapper(factory.Source(uuid='123'), mocker.MagicMock())
+    scw._on_source_deleted('321')
+    assert not scw.conversation_title_bar.isHidden()
+    assert not scw.conversation_view.isHidden()
+    assert not scw.reply_box.isHidden()
+    assert scw.waiting_delete_confirmation.isHidden()
 
 
 def test_ConversationView_init(mocker, homedir):

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1298,17 +1298,18 @@ def test_Controller_on_message_downloaded_checksum_failure(mocker, homedir, sess
         'Failure due to checksum mismatch, retrying {}'.format(message.uuid)
 
 
-def test_Controller_on_delete_source_success(homedir, config, mocker, session_maker):
+def test_Controller_on_delete_source_success(mocker, homedir):
     '''
-    Using the `config` fixture to ensure the config is written to disk.
+    Test that on a successful deletion request to the server that we emit a signal back to the gui.
     '''
-    mock_gui = mocker.MagicMock()
+    co = Controller('http://localhost', mocker.MagicMock(), mocker.MagicMock(), homedir)
+    co.source_deleted = mocker.MagicMock()
     storage = mocker.patch('securedrop_client.logic.storage')
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
-    co.update_sources = mocker.MagicMock()
-    co.on_delete_source_success("uuid")
-    storage.delete_local_source_by_uuid.assert_called_once_with(co.session, "uuid", co.data_dir)
-    assert co.update_sources.call_count == 1
+
+    co.on_delete_source_success('uuid')
+
+    storage.delete_local_source_by_uuid.assert_not_called()
+    co.source_deleted.emit.assert_called_once_with('uuid')
 
 
 def test_Controller_on_delete_source_failure(homedir, config, mocker, session_maker):


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/858

# Test Plan

1. Delete a source and see the new pending state
2. confirm https://github.com/freedomofpress/securedrop-client/issues/858 no longer happens

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes