### PR TITLE
Ensure that sources are properly refreshed on sync

### DIFF
--- a/securedrop_client/api_jobs/base.py
+++ b/securedrop_client/api_jobs/base.py
@@ -1,4 +1,5 @@
 import logging
+import traceback
 
 from PyQt5.QtCore import QObject, pyqtSignal
 from sdclientapi import API, AuthError, RequestTimeoutError, ServerConnectionError
@@ -77,6 +78,11 @@ class ApiJob(QueueJob):
                     raise
             except Exception as e:
                 self.failure_signal.emit(e)
+                logger.error(
+                    "%s API call error: %s",
+                    self.__class__.__name__,
+                    traceback.format_exc()
+                )
                 raise
             else:
                 self.success_signal.emit(result)

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -468,7 +468,7 @@ class Controller(QObject):
         a sync fails is ApiInaccessibleError then we need to log the user out for security reasons
         and show them the login window in order to get a new token.
         """
-        logger.debug('The SecureDrop server cannot be reached due to Error: {}'.format(result))
+        logger.error('sync failure: {}'.format(result))
 
         if isinstance(result, ApiInaccessibleError):
             # Don't show login window if the user is already logged out

--- a/securedrop_client/sync.py
+++ b/securedrop_client/sync.py
@@ -2,7 +2,7 @@ import logging
 
 from PyQt5.QtCore import pyqtSignal, QObject, QThread, QTimer, Qt
 from sqlalchemy.orm import scoped_session
-from sdclientapi import API, RequestTimeoutError, ServerConnectionError
+from sdclientapi import API
 
 from securedrop_client.api_jobs.base import ApiInaccessibleError
 from securedrop_client.api_jobs.sync import MetadataSyncJob
@@ -75,8 +75,7 @@ class ApiSync(QObject):
         Only start another sync on failure if the reason is a timeout request.
         '''
         self.sync_failure.emit(result)
-        if isinstance(result, (RequestTimeoutError, ServerConnectionError)):
-            QTimer.singleShot(self.TIME_BETWEEN_SYNCS_MS, self.api_sync_bg_task.sync)
+        QTimer.singleShot(self.TIME_BETWEEN_SYNCS_MS, self.api_sync_bg_task.sync)
 
 
 class ApiSyncBackgroundTask(QObject):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -166,7 +166,7 @@ def test_ApiSync_on_sync_failure(mocker, session_maker, homedir):
     api_sync.on_sync_failure(error)
 
     sync_failure.emit.assert_called_once_with(error)
-    singleShot_fn.assert_not_called()
+    singleShot_fn.assert_called_once_with(15000, api_sync.api_sync_bg_task.sync)
 
 
 @pytest.mark.parametrize("exception", [RequestTimeoutError, ServerConnectionError])


### PR DESCRIPTION
# Description

Fixes #888.

In `widgets.SourceList.update`, make sure that existing `SourceWidget`s are updated. This requires refreshing each source's state in the controller session. On sync, sources were being properly updated in the database via `storage.update_sources`, but without this refresh, a source being unstarred on the server, for example, wouldn't be reflected in the UI until some other operation caused the source to be refreshed in the controller's session.
    
Commit after updating a source's `is_starred` field in `widgets.StarToggleButton.on_update`, preventing a `sqlite3.OperationalError` saying "database is locked".
    
In `sync.ApiSync.on_sync_failure`, keep syncing no matter the error, and have the log message say less about the cause.
    
Log more details about API job failure in `api_jobs.base.ApiJob._do_call_api`.

# Test Plan

Follow #888 STR. You should not get a "database locked" error and when the source is unstarred in the journalist interface, it should also be unstarred in the client after the very next sync.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
