### PR TITLE
ensure we delete individual submissions on disk

### DIFF
--- a/securedrop_client/api_jobs/downloads.py
+++ b/securedrop_client/api_jobs/downloads.py
@@ -141,7 +141,7 @@ class DownloadJob(ApiJob):
         Download the encrypted file. Check file integrity and move it to the data directory before
         marking it as downloaded.
 
-        Note: On Qubes OS, files are downloaded to ~/QubesIncoming.
+        Note: On Qubes OS, files are downloaded to /home/user/QubesIncoming/sd-proxy
         '''
         try:
             etag, download_path = self.call_download_api(api, db_object)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -924,10 +924,15 @@ class SourceList(QListWidget):
             if list_widget and list_widget.source_uuid not in source_uuids:
                 if list_item.isSelected():
                     self.setCurrentItem(None)
-                del self.source_widgets[list_widget.source_uuid]
-                deleted_uuids.append(list_widget.source_uuid)
-                self.takeItem(i)
-                list_widget.deleteLater()
+
+                try:
+                    del self.source_widgets[list_widget.source_uuid]
+                    deleted_uuids.append(list_widget.source_uuid)
+                except KeyError:
+                    pass
+                finally:
+                    self.takeItem(i)
+                    list_widget.deleteLater()
 
         # Create new widgets for new sources
         widget_uuids = [self.itemWidget(self.item(i)).source_uuid for i in range(self.count())]

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -207,10 +207,7 @@ def update_sources(gpg: GpgHelper, remote_sources: List[SDKSource],
     # The uuids remaining in local_uuids do not exist on the remote server, so
     # delete the related records.
     for deleted_source in local_sources_by_uuid.values():
-        for document in deleted_source.collection:
-            if isinstance(document, (Message, File, Reply)):
-                delete_single_submission_or_reply_on_disk(document, data_dir)
-
+        delete_source_collection(deleted_source.journalist_filename, data_dir)
         session.delete(deleted_source)
         logger.debug('Deleted source {}'.format(deleted_source.uuid))
 

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -21,7 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from datetime import datetime
 import logging
-import glob
 import os
 import shutil
 from dateutil.parser import parse
@@ -541,21 +540,20 @@ def delete_source_collection(journalist_filename: str, data_dir: str) -> None:
 def delete_single_submission_or_reply_on_disk(obj_db: Union[File, Message, Reply],
                                               data_dir: str) -> None:
     """
-    Delete on disk a single submission or reply.
+    Delete on disk any files associated with a single submission or reply.
     """
-    files_to_delete = []
-    filename_without_extensions = obj_db.filename.split('.')[0]
-    file_glob_pattern = os.path.join(
-        data_dir,
-        '{}*'.format(filename_without_extensions)
-    )
-    files_to_delete.extend(glob.glob(file_glob_pattern))
 
-    for file_to_delete in files_to_delete:
+    try:
+        os.remove(obj_db.location(data_dir))
+    except FileNotFoundError:
+        logging.info('Object %s already deleted, skipping', obj_db.location(data_dir))
+
+    if isinstance(obj_db, File):
+        # Also delete the file's enclosing folder.
         try:
-            os.remove(file_to_delete)
+            shutil.rmtree(os.path.dirname(obj_db.location(data_dir)))
         except FileNotFoundError:
-            logging.info('File %s already deleted, skipping', file_to_delete)
+            pass
 
 
 def source_exists(session: Session, source_uuid: str) -> bool:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -33,6 +33,7 @@ def test_excepthook(mocker):
     mock_exit.assert_called_once_with(1)
 
 
+@pytest.mark.skipif(platform.system() != 'Linux', reason="this test fails on mac")
 def test_configure_logging(homedir, mocker):
     """
     Ensure logging directory is created and logging is configured in the


### PR DESCRIPTION
# Description

Fixes #892.

# Test Plan

Given the importance of the deletion functionality, I recommend testing the following cases:

**_Precondition for each case:_** Via the source interface, create a source with at least one file. Log into the client and download the file.

1. Source is deleted by the local user. The entire source directory `~/.securedrop_client/data/intrusive_smattering` should be deleted. 
2. Source is deleted by another user (you can simulate this by deleting an entire source in the JI). The entire source directory `~/.securedrop_client/data/intrusive_smattering` should be deleted. 
3. An individual submission is deleted by another user (you can do this by deleting an individual submission in the JI). The file _and_ its enclosing folder should be deleted: `~/.securedrop_client/data/intrusive_smattering/1-intrusive_smattering-doc`. 

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes - I ran through the test plan above using the existing AppArmor profile
 - [ ] I don't know and would appreciate guidance
