### PR TITLE
Fix word wrap in source

### DIFF
--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -167,19 +167,21 @@ class SecureQLabel(QLabel):
         parent: QWidget = None,
         flags: Union[Qt.WindowFlags, Qt.WindowType] = Qt.WindowFlags(),
         wordwrap: bool = True,
-        max_length: int = 0
+        max_length: int = 0,
+        wrap_limit: int = 80,
     ):
         super().__init__(parent, flags)
+        self.wrap_limit = wrap_limit
         self.wordwrap = wordwrap
         self.max_length = max_length
         self.setWordWrap(wordwrap)  # If True, wraps text at default of 70 characters
         self.setText(text)
         self.elided = True if self.text() != text else False
 
-    def setText(self, text: str, wrap_limit: int = 80) -> None:
+    def setText(self, text: str) -> None:
         self.setTextFormat(Qt.PlainText)
         if self.wordwrap:
-            text = "\n".join(textwrap.wrap(text, wrap_limit))
+            text = "\n".join(textwrap.wrap(text, self.wrap_limit))
         elided_text = self.get_elided_text(text)
         self.elided = True if elided_text != text else False
         super().setText(elided_text)

--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -176,10 +176,10 @@ class SecureQLabel(QLabel):
         self.setText(text)
         self.elided = True if self.text() != text else False
 
-    def setText(self, text: str) -> None:
+    def setText(self, text: str, wrap_limit: int = 80) -> None:
         self.setTextFormat(Qt.PlainText)
         if self.wordwrap:
-            text = "\n".join(textwrap.wrap(text, 80))
+            text = "\n".join(textwrap.wrap(text, wrap_limit))
         elided_text = self.get_elided_text(text)
         self.elided = True if elided_text != text else False
         super().setText(elided_text)

--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -196,10 +196,9 @@ class SecureQLabel(QLabel):
             elided_text = ''
             for c in full_text:
                 if fm.horizontalAdvance(elided_text) > self.max_length:
-                    elided_text = elided_text + '...'
+                    elided_text = elided_text[:-3] + '...'
                     return elided_text
                 elided_text = elided_text + c
-
         return full_text
 
     def is_elided(self) -> bool:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1147,18 +1147,9 @@ class SourceWidget(QWidget):
                 msg_text = content
             else:
                 msg_text = str(msg)
-            if len(msg_text) > 150:
-                msg_text = msg_text[:150] + "..."
-            # Discover word wrap limit.
-            wrap_limit = 0
-            fm = self.preview.fontMetrics()
-            sentence = ""
-            for c in msg_text:
-                sentence += c
-                if fm.horizontalAdvance(sentence) > self.PREVIEW_WIDTH:
-                    break
-                wrap_limit += 1
-            self.preview.setText(msg_text, wrap_limit)
+            if len(msg_text) > 80:
+                self.preview.max_length = self.PREVIEW_WIDTH
+            self.preview.setText(msg_text)
 
     def delete_source(self, event):
         if self.controller.api is None:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1149,7 +1149,16 @@ class SourceWidget(QWidget):
                 msg_text = str(msg)
             if len(msg_text) > 150:
                 msg_text = msg_text[:150] + "..."
-            self.preview.setText(msg_text)
+            # Discover word wrap limit.
+            wrap_limit = 0
+            fm = self.preview.fontMetrics()
+            sentence = ""
+            for c in msg_text:
+                sentence += c
+                if fm.horizontalAdvance(sentence) > self.PREVIEW_WIDTH:
+                    break
+                wrap_limit += 1
+            self.preview.setText(msg_text, wrap_limit)
 
     def delete_source(self, event):
         if self.controller.api is None:


### PR DESCRIPTION
# Description

Fixes #877. This branch is stacked on top of #897.

This branch ensures that the `textwrap` related work in the `SecureQWidget` class has the optimal value for the max-width for wrapping. I'd like feedback on this approach and a heads-up on what, if anything, this approach may take (as far as I can tell, it's not broken anything).

The end result looks like this:

![word_wrap](https://user-images.githubusercontent.com/37602/76537773-2e10e880-6476-11ea-8617-986099a54e41.png)

# Test Plan

Visual check with Eyeballs Mk.1 to ensure various previously problematic cases are rendered correctly by Qt.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
