### PR TITLE
Preview oneline and no longer condense text

### DIFF
--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -16,8 +16,6 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-import textwrap
-
 from typing import Union
 
 from PyQt5.QtWidgets import QLabel, QHBoxLayout, QPushButton, QWidget
@@ -168,14 +166,10 @@ class SecureQLabel(QLabel):
         flags: Union[Qt.WindowFlags, Qt.WindowType] = Qt.WindowFlags(),
         wordwrap: bool = True,
         max_length: int = 0,
-        wrap_limit: int = 80,
-        condense_text: bool = False
     ):
         super().__init__(parent, flags)
         self.wordwrap = wordwrap
         self.max_length = max_length
-        self.wrap_limit = wrap_limit
-        self.condense_text = condense_text
         self.setWordWrap(wordwrap)  # If True, wraps text at default of 70 characters
         self.setText(text)
         self.elided = True if self.text() != text else False
@@ -183,8 +177,6 @@ class SecureQLabel(QLabel):
     def setText(self, text: str) -> None:
         self.setTextFormat(Qt.PlainText)
         elided_text = self.get_elided_text(text)
-        if self.condense_text:
-            text = "\n".join(textwrap.wrap(text, self.wrap_limit))
         self.elided = True if elided_text != text else False
         super().setText(elided_text)
 

--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -190,6 +190,10 @@ class SecureQLabel(QLabel):
         if not self.max_length:
             return full_text
 
+        # Only allow one line of elided text
+        if '\n' in full_text:
+            full_text = full_text.split('\n', 1)[0]
+
         fm = self.fontMetrics()
         filename_width = fm.horizontalAdvance(full_text)
         if filename_width > self.max_length:
@@ -201,6 +205,7 @@ class SecureQLabel(QLabel):
                     elided_text = elided_text[:-3] + '...'
                     return elided_text
                 elided_text = elided_text + c
+
         return full_text
 
     def is_elided(self) -> bool:

--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -169,20 +169,22 @@ class SecureQLabel(QLabel):
         wordwrap: bool = True,
         max_length: int = 0,
         wrap_limit: int = 80,
+        condense_text: bool = False
     ):
         super().__init__(parent, flags)
-        self.wrap_limit = wrap_limit
         self.wordwrap = wordwrap
         self.max_length = max_length
+        self.wrap_limit = wrap_limit
+        self.condense_text = condense_text
         self.setWordWrap(wordwrap)  # If True, wraps text at default of 70 characters
         self.setText(text)
         self.elided = True if self.text() != text else False
 
     def setText(self, text: str) -> None:
         self.setTextFormat(Qt.PlainText)
-        if self.wordwrap:
-            text = "\n".join(textwrap.wrap(text, self.wrap_limit))
         elided_text = self.get_elided_text(text)
+        if self.condense_text:
+            text = "\n".join(textwrap.wrap(text, self.wrap_limit))
         self.elided = True if elided_text != text else False
         super().setText(elided_text)
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1073,7 +1073,7 @@ class SourceWidget(QWidget):
         summary_layout.setSpacing(0)
         self.name = QLabel()
         self.name.setObjectName('source_name')
-        self.preview = SecureQLabel(max_length=self.PREVIEW_WIDTH)
+        self.preview = SecureQLabel(max_length=self.PREVIEW_WIDTH, condense_text=True)
         self.preview.setObjectName('preview')
         self.preview.setFixedSize(QSize(self.PREVIEW_WIDTH, self.PREVIEW_HEIGHT))
         self.waiting_delete_confirmation = QLabel('Deletion in progress')

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1073,7 +1073,7 @@ class SourceWidget(QWidget):
         summary_layout.setSpacing(0)
         self.name = QLabel()
         self.name.setObjectName('source_name')
-        self.preview = SecureQLabel()
+        self.preview = SecureQLabel(max_length=self.PREVIEW_WIDTH)
         self.preview.setObjectName('preview')
         self.preview.setFixedSize(QSize(self.PREVIEW_WIDTH, self.PREVIEW_HEIGHT))
         self.waiting_delete_confirmation = QLabel('Deletion in progress')
@@ -1143,14 +1143,11 @@ class SourceWidget(QWidget):
         latest item in the conversation might be.
         """
         if source == self.source.uuid and self.source.collection:
-            msg = self.source.collection[-1]
-            if uuid and uuid == msg.uuid and content:
-                msg_text = content
+            last_collection_object = self.source.collection[-1]
+            if uuid and uuid == last_collection_object.uuid and content:
+                self.preview.setText(content)
             else:
-                msg_text = str(msg)
-            if len(msg_text) > 80:
-                self.preview.max_length = self.PREVIEW_WIDTH
-            self.preview.setText(msg_text)
+                self.preview.setText(str(last_collection_object))
 
     def delete_source(self, event):
         if self.controller.api is None:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1073,7 +1073,7 @@ class SourceWidget(QWidget):
         summary_layout.setSpacing(0)
         self.name = QLabel()
         self.name.setObjectName('source_name')
-        self.preview = SecureQLabel(max_length=self.PREVIEW_WIDTH, condense_text=True)
+        self.preview = SecureQLabel(max_length=self.PREVIEW_WIDTH)
         self.preview.setObjectName('preview')
         self.preview.setFixedSize(QSize(self.PREVIEW_WIDTH, self.PREVIEW_HEIGHT))
         self.waiting_delete_confirmation = QLabel('Deletion in progress')

--- a/tests/gui/test_init.py
+++ b/tests/gui/test_init.py
@@ -1,8 +1,6 @@
 """
 Tests for the gui helper functions in __init__.py
 """
-import textwrap
-
 from PyQt5.QtCore import QSize, Qt
 from PyQt5.QtWidgets import QApplication
 
@@ -156,18 +154,17 @@ def test_SecureQLabel_init():
 
 
 def test_SecureQLabel_init_wordwrap(mocker):
-    # 81 character string
-    long_string = ('1234567890123456789012345678901234567890123456789012345678901234567890'
+    '''
+    Regression test to make sure we don't remove newlines.
+    '''
+    long_string = ('1234567890123456789012345678901234567890123456789012345678901234567890\n'
                    '12345678901')
-    sl = SecureQLabel(long_string)
-    wordwrap_string = ('1234567890123456789012345678901234567890123456789012345678901234567890'
-                       '1234567890\n1')
-    assert sl.text() == wordwrap_string
+    sl = SecureQLabel(long_string, wordwrap=False)
+    assert sl.text() == long_string
 
 
 def test_SecureQLabel_init_no_wordwrap(mocker):
-    # 81 character string
-    long_string = ('1234567890123456789012345678901234567890123456789012345678901234567890'
+    long_string = ('1234567890123456789012345678901234567890123456789012345678901234567890\n'
                    '12345678901')
     sl = SecureQLabel(long_string, wordwrap=False)
     assert sl.text() == long_string
@@ -191,20 +188,36 @@ def test_SecureQLabel_get_elided_text(mocker):
     sl = SecureQLabel(long_string, wordwrap=False, max_length=100)
     elided_text = sl.get_elided_text(long_string)
     assert sl.text() == elided_text
+    assert '...' in elided_text
+
+
+def test_SecureQLabel_get_elided_text_short_string(mocker):
+    # 70 character string
+    long_string = '123456789'
+    sl = SecureQLabel(long_string, wordwrap=False, max_length=100)
+    elided_text = sl.get_elided_text(long_string)
+    assert sl.text() == elided_text
+    assert elided_text == '123456789'
+
+
+def test_SecureQLabel_get_elided_text_only_returns_oneline(mocker):
+    # 70 character string
+    string_with_newline = ('this is a string\n with a newline')
+    sl = SecureQLabel(string_with_newline, wordwrap=False, max_length=100)
+    elided_text = sl.get_elided_text(string_with_newline)
+    assert sl.text() == elided_text
+    assert elided_text == 'this is a string'
+
+
+def test_SecureQLabel_get_elided_text_only_returns_oneline_elided(mocker):
+    # 70 character string
+    string_with_newline = ('this is a string\n with a newline')
+    sl = SecureQLabel(string_with_newline, wordwrap=False, max_length=38)
+    elided_text = sl.get_elided_text(string_with_newline)
+    assert sl.text() == elided_text
+    assert '...' in elided_text
 
 
 def test_SecureQLabel_quotes_not_escaped_for_readability():
     sl = SecureQLabel("'hello'")
     assert sl.text() == "'hello'"
-
-
-def test_SecureQLabel_wraps_on_80():
-    msg = (
-        "thisisaverylongmessagethatwillnotwrapunlessthistestpassesproperly1234"
-        "thisisaverylongmessagethatwillnotwrapunlessthistestpassesproperly1234"
-        "thisisaverylongmessagethatwillnotwrapunlessthistestpassesproperly1234"
-    )
-    sl = SecureQLabel(msg)
-    expected = "\n".join(textwrap.wrap(msg, 80))
-    assert sl.text() == expected
-    assert sl.wordWrap() is True


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/930
Fixes https://github.com/freedomofpress/securedrop-client/issues/885

This fixes the regression where we started condensing message text in order to show 3 lines of preview text. Since we only show one line of preview text now, I removed the code that condenses text, which fixes #885. 

This also makes sure we indeed only show one line of preview text and removes duplicate wrapping code. We now solely rely on QLabel's setWordWrap method.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes
