### PR TITLE
Ensure correct StarToggleButton signal handler state

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1231,14 +1231,14 @@ class StarToggleButton(SvgToggleButton):
         try:
             while True:
                 self.toggled.disconnect(self.on_toggle)
-        except Exception as e:
-            logger.warning("Could not disconnect on_toggle from self.toggled: %s", e)
+        except Exception:
+            pass
 
         try:
             while True:
                 self.pressed.disconnect(self.on_toggle_offline)
-        except Exception as e:
-            logger.warning("Could not disconnect on_toggle_offline from self.pressed: %s", e)
+        except Exception:
+            pass
 
         self.toggled.connect(self.on_toggle)
 

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -260,8 +260,8 @@ class Controller(QObject):
     @is_authenticated.setter
     def is_authenticated(self, is_authenticated: bool) -> None:
         if self.__is_authenticated != is_authenticated:
-            self.authentication_state.emit(is_authenticated)
             self.__is_authenticated = is_authenticated
+            self.authentication_state.emit(is_authenticated)
 
     @is_authenticated.deleter
     def is_authenticated(self) -> None:

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1112,10 +1112,13 @@ def test_StarToggleButton_on_authentication_changed_while_authenticated_and_not_
     should result in the button being unchecked.
     """
     source = mocker.MagicMock()
+    source.is_starred = False
     stb = StarToggleButton(source=source)
-    stb.setChecked(False)
     stb.on_toggle = mocker.MagicMock()
+    assert stb.isChecked() is False
+
     stb.on_authentication_changed(authenticated=True)
+    assert stb.isChecked() is False
 
     stb.toggle()
 
@@ -1150,7 +1153,6 @@ def test_StarToggleButton_on_toggle(mocker):
     stb.on_toggle()
 
     stb.controller.update_star.assert_called_once_with(source, stb.on_update)
-    assert stb.isCheckable() is True
 
 
 def test_StarToggleButton_on_toggle_offline(mocker):
@@ -1162,9 +1164,7 @@ def test_StarToggleButton_on_toggle_offline(mocker):
     stb.controller = mocker.MagicMock()
 
     stb.on_toggle_offline()
-
     stb.controller.on_action_requiring_login.assert_called_once_with()
-    assert stb.isCheckable() is False
 
 
 def test_StarToggleButton_on_toggle_offline_when_checked(mocker):
@@ -1176,11 +1176,14 @@ def test_StarToggleButton_on_toggle_offline_when_checked(mocker):
     stb = StarToggleButton(source)
     stb.controller = mocker.MagicMock()
     set_icon_fn = mocker.patch('securedrop_client.gui.SvgToggleButton.set_icon')
-    stb.on_toggle_offline()
 
-    stb.controller.on_action_requiring_login.assert_called_once_with()
+    # go offline
+    stb.on_authentication_changed(False)
     assert stb.isCheckable() is False
     set_icon_fn.assert_called_with(on='star_on.svg', off='star_on.svg')
+
+    stb.on_toggle_offline()
+    stb.controller.on_action_requiring_login.assert_called_once_with()
 
 
 def test_StarToggleButton_on_update(mocker):


### PR DESCRIPTION
# Description

`StarToggleButton.on_authentication_changed` would just keep connecting signal handlers without ever disconnecting those previously installed.

When not authenticated, we'd set a signal handler to show the "You must sign in" message when pressed. That handler was never disconnected once authentication was successful, so if the timing were right at startup, it would get installed permanently.

Similarly, we could end up with multiple `on_toggle` handlers, sending multiple `UpdateStarJob`s for a single click on the `StarToggleButton`.

This change disconnects all handlers for the previous authentication state when authentication state changes.

Also, the `Controller.is_authenticated` setter emitted the `authentication_state` signal before updating `self.__is_authenticated`. To prevent that ever being a problem for signal handlers that check the property and not the signal value, the order of those calls has been swapped.

Fixes #919.

# Test Plan

- Run the client with `LOGLEVEL=debug`, preferably in an environment where you were able to reproduce #919 (I could only trigger the problem in `sd-app` talking to my staging environment; it never happened for me in the dev environment).
- Log in to the client.
- Try to star a source. It should work, without an error message saying you need to log in.
- Log out.
- Try to star a source. It should not work, and you _should_ see an error message saying you need to log in.
- Log back in and star a source.
- Check the client log. Only one `UpdateStarJob` should have been sent for your last action.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
