### PR TITLE
Ensure StarToggleButton hover states honor offline status

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1263,11 +1263,15 @@ class StarToggleButton(SvgToggleButton):
         self.toggled.connect(self.on_toggle)
 
     def eventFilter(self, obj, event):
+        checkable = self.isCheckable()
         t = event.type()
-        if t == QEvent.HoverEnter:
+        if t == QEvent.HoverEnter and checkable:
             self.setIcon(load_icon('star_hover.svg'))
         elif t == QEvent.HoverLeave:
-            self.set_icon(on='star_on.svg', off='star_off.svg')
+            if checkable:
+                self.set_icon(on='star_on.svg', off='star_off.svg')
+            else:
+                self.set_icon(on='star_on.svg', off='star_on.svg')
         return QObject.event(obj, event)
 
     def on_authentication_changed(self, authenticated: bool):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1107,6 +1107,12 @@ def test_StarToggleButton_eventFilter(mocker):
     stb.eventFilter(stb, test_event)
     stb.set_icon.assert_called_once_with(on='star_on.svg', off='star_off.svg')
 
+    # Hover leave when disabled
+    stb.disable()
+    test_event = QEvent(QEvent.HoverLeave)
+    stb.eventFilter(stb, test_event)
+    stb.set_icon.assert_called_with(on='star_on.svg', off='star_on.svg')
+
 
 def test_StarToggleButton_on_authentication_changed_while_authenticated_and_checked(mocker):
     """


### PR DESCRIPTION
# Description

Fixes #935 .

# Test Plan

- Start the client and log in.
- Confirm that you can star and unstar sources and the star icons behave.
- Log out.
- Confirm that you can not star or unstar sources, and that the star icons do not change, and there's no hover state suggesting they can.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
