### PR TITLE
app: fix conversation refresh/syncing

### DIFF
--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -108,7 +108,8 @@ class Message(Base):
     source_id = Column(Integer, ForeignKey('sources.id'), nullable=False)
     source = relationship("Source",
                           backref=backref("messages", order_by=id,
-                                          cascade="delete"))
+                                          cascade="delete"),
+                          lazy="joined")
 
     def __init__(self, **kwargs: Any) -> None:
         if 'file_counter' in kwargs:
@@ -174,7 +175,8 @@ class File(Base):
     source_id = Column(Integer, ForeignKey('sources.id'), nullable=False)
     source = relationship("Source",
                           backref=backref("files", order_by=id,
-                                          cascade="delete"))
+                                          cascade="delete"),
+                          lazy="joined")
 
     def __init__(self, **kwargs: Any) -> None:
         if 'file_counter' in kwargs:
@@ -221,7 +223,8 @@ class Reply(Base):
     source_id = Column(Integer, ForeignKey('sources.id'), nullable=False)
     source = relationship("Source",
                           backref=backref("replies", order_by=id,
-                                          cascade="delete"))
+                                          cascade="delete"),
+                          lazy="joined")
 
     journalist_id = Column(Integer, ForeignKey('users.id'))
     journalist = relationship(
@@ -291,7 +294,8 @@ class DraftReply(Base):
     source_id = Column(Integer, ForeignKey('sources.id'), nullable=False)
     source = relationship("Source",
                           backref=backref("draftreplies", order_by=id,
-                                          cascade="delete"))
+                                          cascade="delete"),
+                          lazy="joined")
     journalist_id = Column(Integer, ForeignKey('users.id'))
     journalist = relationship(
         "User", backref=backref('draftreplies', order_by=id))

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -142,6 +142,12 @@ class Window(QMainWindow):
         self.login_dialog.accept()
         self.login_dialog = None
 
+    def refresh_current_source_conversation(self):
+        """
+        Update the current conversation if the source collection has changed.
+        """
+        self.main_view.on_source_changed()
+
     def show_sources(self, sources: List[Source]):
         """
         Update the left hand sources list in the UI with the passed in list of

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -707,10 +707,11 @@ class MainView(QWidget):
         if not source:
             return
 
-        self.controller.session.refresh(source)
+        self.controller.session.expire_all()
         # Try to get the SourceConversationWrapper from the persistent dict,
         # else we create it.
         try:
+            logger.debug('Drawing source conversation for {}'.format(source.uuid))
             conversation_wrapper = self.source_conversations[source.uuid]
 
             # Redraw the conversation view such that new messages, replies, files appear.
@@ -3002,6 +3003,7 @@ class ConversationView(QWidget):
         # by another user (a journalist using the Web UI is able to delete individual
         # submissions).
         for item_widget in current_conversation.values():
+            logger.debug('Deleting item: {}'.format(item_widget.uuid))
             self.current_messages.pop(item_widget.uuid)
             self.conversation_layout.removeWidget(item_widget)
 
@@ -3009,6 +3011,7 @@ class ConversationView(QWidget):
         """
         Add a file from the source.
         """
+        logger.debug('Adding file for {}'.format(file.uuid))
         conversation_item = FileWidget(
             file.uuid,
             self.controller,

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -707,7 +707,7 @@ class MainView(QWidget):
         if not source:
             return
 
-        self.controller.session.expire_all()
+        self.controller.session.refresh(source)
         # Try to get the SourceConversationWrapper from the persistent dict,
         # else we create it.
         try:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2196,6 +2196,7 @@ class FileWidget(QWidget):
 
     def _set_file_state(self):
         if self.file.is_decrypted:
+            logger.debug('Changing file {} state to decrypted/downloaded'.format(self.uuid))
             self._set_file_name()
             self.download_button.hide()
             self.no_file_name.hide()
@@ -2204,6 +2205,7 @@ class FileWidget(QWidget):
             self.print_button.show()
             self.file_name.show()
         else:
+            logger.debug('Changing file {} state to not downloaded'.format(self.uuid))
             self.download_button.setText(_('DOWNLOAD'))
             # Ensure correct icon depending on mouse hover state.
             if self.download_button.underMouse():
@@ -3005,6 +3007,7 @@ class ConversationView(QWidget):
         for item_widget in current_conversation.values():
             logger.debug('Deleting item: {}'.format(item_widget.uuid))
             self.current_messages.pop(item_widget.uuid)
+            item_widget.deleteLater()
             self.conversation_layout.removeWidget(item_widget)
 
     def add_file(self, file: File, index):

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -457,6 +457,7 @@ class Controller(QObject):
             self.file_missing.emit(missed_file.source.uuid, missed_file.uuid,
                                    str(missed_file))
         self.update_sources()
+        self.gui.refresh_current_source_conversation()
         self.download_new_messages()
         self.download_new_replies()
         self.sync_events.emit('synced')

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -157,6 +157,20 @@ def test_hide_login(mocker):
     assert w.login_dialog is None
 
 
+def test_refresh_current_source_conversation(mocker):
+    """
+    Ensure on_source_changed is called on the MainView (which
+    updates the current conversation) when
+    refresh_current_source_conversation() is called.
+    """
+    w = Window()
+    w.main_view = mocker.MagicMock()
+
+    w.refresh_current_source_conversation()
+
+    w.main_view.on_source_changed.assert_called_once_with()
+
+
 def test_show_sources(mocker):
     """
     Ensure the sources list is passed to the main view to be updated.


### PR DESCRIPTION
# Description

Fixes #891.
Fixes #939.

# Test Plan

## Submission deleted via JI

1. Login to client, click on a source
2. Delete a single submission via the JI for that source
3. You should see the submission be deleted from the conversation view after sync
4. For good measure, try sending a reply from the JI and ensure it appears in the conversation view

## File deleted via JI

**Precondition:** Submit a file as a source

1. Login to client, click on a source
2. Delete a single file via the JI for that source
3. You should see the file be deleted from the conversation view after sync
4. Now submit another file as a source
5. You should see the new file appear in the conversation view after sync
6. For good measure, try sending a reply from the JI and ensure it appears in the conversation view
7. For good measure, try sending a message from the source and ensure it appears in the conversation view

You should not see any of the behavior reported in https://github.com/freedomofpress/securedrop-workstation/issues/494#issuecomment-597961125: the application should not crash with a SQLAlchemy exception, nor should there be any overlaid file widgets in the conversation view.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
