### PR TITLE
Fix StarToggleButton hover leave

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1203,7 +1203,6 @@ class StarToggleButton(SvgToggleButton):
         self.source = source
 
         self.installEventFilter(self)
-        self.toggle_event_enabled = True
 
         self.setObjectName('star_button')
         self.setStyleSheet(self.css)
@@ -1222,6 +1221,7 @@ class StarToggleButton(SvgToggleButton):
         to save on state we update the icon's off state image to
         display on (hack).
         """
+        self.disable_api_call()
         self.setCheckable(False)
         if self.source.is_starred:
             self.set_icon(on='star_on.svg', off='star_on.svg')
@@ -1244,6 +1244,7 @@ class StarToggleButton(SvgToggleButton):
         """
         Enable the widget.
         """
+        self.enable_api_call()
         self.setCheckable(True)
         self.set_icon(on='star_on.svg', off='star_off.svg')
         self.setChecked(self.source.is_starred)
@@ -1271,7 +1272,8 @@ class StarToggleButton(SvgToggleButton):
             if checkable:
                 self.set_icon(on='star_on.svg', off='star_off.svg')
             else:
-                self.set_icon(on='star_on.svg', off='star_on.svg')
+                if self.source.is_starred:
+                    self.set_icon(on='star_on.svg', off='star_on.svg')
         return QObject.event(obj, event)
 
     def on_authentication_changed(self, authenticated: bool):
@@ -1288,7 +1290,7 @@ class StarToggleButton(SvgToggleButton):
         """
         Tell the controller to make an API call to update the source's starred field.
         """
-        if self.toggle_event_enabled:
+        if self.is_api_call_enabled:
             self.controller.update_star(self.source, self.on_update)
 
     def on_toggle_offline(self):
@@ -1313,15 +1315,15 @@ class StarToggleButton(SvgToggleButton):
         Update the star to reflect its source's current state.
         """
         self.controller.session.refresh(self.source)
-        self.disable_toggle_event()
+        self.disable_api_call()
         self.setChecked(self.source.is_starred)
-        self.enable_toggle_event()
+        self.enable_api_call()
 
-    def disable_toggle_event(self):
-        self.toggle_event_enabled = False
+    def disable_api_call(self):
+        self.is_api_call_enabled = False
 
-    def enable_toggle_event(self):
-        self.toggle_event_enabled = True
+    def enable_api_call(self):
+        self.is_api_call_enabled = True
 
 
 class DeleteSourceMessageBox:


### PR DESCRIPTION
# Description

The icon was being reset to always-on even if the source weren't starred. This adds a check for that, and also corrects the misleading naming of the attribute determining whether the star API calls should be made when the widget state changes. (If it only takes a weekend for your naming to start tripping you up, it was clearly not thought through.)

Fixes #938.

# Test Plan

Follow #938 STR. Unstarred sources' stars should not be starred on hover, nor suggest they can be in the offline state. The latter is counter to the `Expected behavior` section of #938, but seems less surprising.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
