### PR TITLE
Make sure snippet is updated on submission deletion

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1167,15 +1167,15 @@ class SourceWidget(QWidget):
 
         try:
             self.controller.session.refresh(self.source)
-            if self.source.collection:
-                last_collection_object = self.source.collection[-1]
-                if uuid == last_collection_object.uuid and content:
-                    self.preview.setText(content)
-                else:
-                    self.preview.setText(str(last_collection_object))
+            if not self.source.collection:
+                return
+            last_collection_object = self.source.collection[-1]
+            if uuid == last_collection_object.uuid and content:
+                self.preview.setText(content)
+            else:
+                self.preview.setText(str(last_collection_object))
         except sqlalchemy.exc.InvalidRequestError as e:
             logger.error(f"Could not update snippet for source {self.source_uuid}: {e}")
-            raise
 
     def delete_source(self, event):
         if self.controller.api is None:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1153,7 +1153,7 @@ class SourceWidget(QWidget):
             logger.error(f"Could not update SourceWidget for source {self.source_uuid}: {e}")
             raise
 
-    def set_snippet(self, source, uuid=None, content=None) -> None:
+    def set_snippet(self, source: str, uuid: str = None, content: str = None):
         """
         Update the preview snippet only if the new message is for the
         referenced source and there's a source collection. If a uuid and

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1157,19 +1157,24 @@ class SourceWidget(QWidget):
             )
             raise
 
-    def set_snippet(self, source, uuid=None, content=None):
+    def set_snippet(self, source, uuid=None, content=None) -> None:
         """
         Update the preview snippet only if the new message is for the
         referenced source and there's a source collection. If a uuid and
         content are passed then use these, otherwise default to whatever the
         latest item in the conversation might be.
         """
-        if source == self.source.uuid and self.source.collection:
+        if source != self.source.uuid:
+            return
+
+        if self.source.collection:
             last_collection_object = self.source.collection[-1]
             if uuid and uuid == last_collection_object.uuid and content:
                 self.preview.setText(content)
             else:
                 self.preview.setText(str(last_collection_object))
+        else:
+            self.preview.setText("")
 
     def delete_source(self, event):
         if self.controller.api is None:

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1013,6 +1013,9 @@ def test_SourceWidget_set_snippet(mocker):
     sw.set_snippet(source.uuid, msg.uuid, msg.content)
     assert sw.preview.text() == "abcdefg"
 
+    sw.set_snippet('not-the-source-uuid', msg.uuid, 'something new')
+    assert sw.preview.text() == "abcdefg"
+
 
 def test_SourceWidget_update_truncate_latest_msg(mocker):
     """


### PR DESCRIPTION
# Description

Fixes #922.

# Test Plan

Follow #922 STR. ~Note that the FileWidget may not be deleted automatically on sync. I believe that will be fixed by #937.~ Indeed it was. Everything should behave as you'd expect now.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
