### PR TITLE
use the id of the widget, not the db object

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -963,7 +963,7 @@ class SourceList(QListWidget):
     def get_current_source(self):
         source_item = self.currentItem()
         source_widget = self.itemWidget(source_item)
-        if source_widget and source_exists(self.controller.session, source_widget.source.uuid):
+        if source_widget and source_exists(self.controller.session, source_widget.source_uuid):
             return source_widget.source
 
     def set_snippet(self, source_uuid, message_uuid, content):


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/947

#947 is happening when a source that was deleted outside of the client is selected just after logging back in. When a source is selected, we check to see if it still exists in:

```py
    def get_current_source(self):
        source_item = self.currentItem()
        source_widget = self.itemWidget(source_item)
        if source_widget and source_exists(self.controller.session, source_widget.source.uuid):
            return source_widget.source
```

But if it doesn't exist, then ` source_widget.source.uuid` will fail with the error you see in #899, which we're not catching. Since we only want to delete source widgets and their corresponding conversations in one place (in `show_sources` after a sync is successful), I modified `source_exists(self.controller.session, source_widget.source.uuid)` to `source_exists(self.controller.session, source_widget.source_uuid)` which will return False if the source does not exist.

This is related to https://github.com/freedomofpress/securedrop-client/issues/906 

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [ ] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
