### PR TITLE
Fix starring behavior

### DIFF
--- a/securedrop_client/api_jobs/updatestar.py
+++ b/securedrop_client/api_jobs/updatestar.py
@@ -35,7 +35,7 @@ class UpdateStarJob(ApiJob):
 
             return self.source_uuid
         except (RequestTimeoutError, ServerConnectionError) as e:
-            error_message = f'Failed to update star on source {self.source_uuid} due to {e}'
+            error_message = f'Failed to update star on source {self.source_uuid} due to error: {e}'
             raise UpdateStarJobTimeoutError(error_message, self.source_uuid, self.is_starred)
         except Exception as e:
             error_message = f'Failed to update star on source {self.source_uuid} due to {e}'

--- a/securedrop_client/api_jobs/updatestar.py
+++ b/securedrop_client/api_jobs/updatestar.py
@@ -36,25 +36,23 @@ class UpdateStarJob(ApiJob):
             return self.source_uuid
         except (RequestTimeoutError, ServerConnectionError) as e:
             error_message = f'Failed to update star on source {self.source_uuid} due to error: {e}'
-            raise UpdateStarJobTimeoutError(error_message, self.source_uuid, self.is_starred)
+            raise UpdateStarJobTimeoutError(error_message, self.source_uuid)
         except Exception as e:
             error_message = f'Failed to update star on source {self.source_uuid} due to {e}'
-            raise UpdateStarJobError(error_message, self.source_uuid, self.is_starred)
+            raise UpdateStarJobError(error_message, self.source_uuid)
 
 
 class UpdateStarJobError(Exception):
-    def __init__(self, message: str, source_uuid: str, is_starred: bool) -> None:
+    def __init__(self, message: str, source_uuid: str) -> None:
         super().__init__(message)
         self.source_uuid = source_uuid
-        self.is_starred = is_starred
 
 
 class UpdateStarJobTimeoutError(RequestTimeoutError):
-    def __init__(self, message: str, source_uuid: str, is_starred: bool) -> None:
+    def __init__(self, message: str, source_uuid: str) -> None:
         super().__init__()
         self.message = message
         self.source_uuid = source_uuid
-        self.is_starred = is_starred
 
     def __str__(self) -> str:
         return self.message

--- a/securedrop_client/api_jobs/updatestar.py
+++ b/securedrop_client/api_jobs/updatestar.py
@@ -12,10 +12,10 @@ logger = logging.getLogger(__name__)
 
 
 class UpdateStarJob(ApiJob):
-    def __init__(self, source_uuid: str, star_status: bool) -> None:
+    def __init__(self, source_uuid: str, is_starred: bool) -> None:
         super().__init__()
         self.source_uuid = source_uuid
-        self.star_status = star_status
+        self.is_starred = is_starred
 
     def call_api(self, api_client: API, session: Session) -> Tuple[str, bool]:
         '''
@@ -30,21 +30,22 @@ class UpdateStarJob(ApiJob):
             # want to pass the default request timeout to remove_star and add_star instead of
             # setting it on the api object directly.
             api_client.default_request_timeout = 5
-            if self.star_status:
+            if self.is_starred:
                 api_client.remove_star(source_sdk_object)
             else:
                 api_client.add_star(source_sdk_object)
 
             # Identify the source and *new* state of the star so the UI can be
             # updated.
-            return self.source_uuid, not self.star_status
+            return self.source_uuid, not self.is_starred
         except Exception as e:
             error_message = "Failed to update star on source {uuid} due to {exception}".format(
                 uuid=self.source_uuid, exception=repr(e))
-            raise UpdateStarJobException(error_message, self.source_uuid)
+            raise UpdateStarJobException(error_message, self.source_uuid, self.is_starred)
 
 
 class UpdateStarJobException(Exception):
-    def __init__(self, message: str, source_uuid: str):
+    def __init__(self, message: str, source_uuid: str, is_starred: bool) -> None:
         super().__init__(message)
         self.source_uuid = source_uuid
+        self.is_starred = is_starred

--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -58,12 +58,6 @@ class SvgToggleButton(QPushButton):
         # Make this a toggle button
         self.setCheckable(True)
 
-    def enable(self) -> None:
-        self.setEnabled(True)
-
-    def disable(self) -> None:
-        self.setEnabled(False)
-
     def set_icon(self, on: str, off: str) -> None:
         self.icon = load_icon(normal=on, normal_off=off)
         self.setIcon(self.icon)
@@ -115,12 +109,6 @@ class SvgPushButton(QPushButton):
             disabled_off=disabled)
         self.setIcon(self.icon)
         self.setIconSize(svg_size) if svg_size else self.setIconSize(QSize())
-
-    def enable(self) -> None:
-        self.setEnabled(True)
-
-    def disable(self) -> None:
-        self.setEnabled(False)
 
 
 class SvgLabel(QLabel):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1231,10 +1231,7 @@ class StarToggleButton(SvgToggleButton):
     '''
 
     def __init__(self, controller: Controller, source: Source):
-        super().__init__(
-            on='star_on.svg',
-            off='star_off.svg',
-            svg_size=QSize(16, 16))
+        super().__init__(on='star_on.svg', off='star_off.svg', svg_size=QSize(16, 16))
 
         self.controller = controller
         self.source = source
@@ -1328,24 +1325,13 @@ class StarToggleButton(SvgToggleButton):
         Tell the controller to make an API call to update the source's starred field.
         """
         if self.is_api_call_enabled:
-            self.controller.update_star(self.source, self.on_update)
+            self.controller.update_star(self.source)
 
     def on_toggle_offline(self):
         """
         Show error message when not authenticated.
         """
         self.controller.on_action_requiring_login()
-
-    def on_update(self, result):
-        """
-        The result is a uuid for the source and boolean flag for the new state
-        of the star.
-        """
-        enabled = result[1]
-        self.source.is_starred = enabled
-        self.controller.session.commit()
-        self.controller.update_sources()
-        self.setChecked(enabled)
 
     def update(self):
         """

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1352,14 +1352,14 @@ class StarToggleButton(SvgToggleButton):
             self.is_starred = is_starred
             self.setChecked(self.is_starred)
 
-    @pyqtSlot(str)
+    @pyqtSlot(str, bool)
     def on_star_update_failed(self, source_uuid: str, is_starred: bool) -> None:
         """
         If the star update failed to update on the server, toggle back to previous state.
         """
         if self.source_uuid == source_uuid:
             self.is_starred = is_starred
-            self.setChecked(is_starred)
+            self.setChecked(self.is_starred)
             self.pending_count = self.pending_count - 1
 
     @pyqtSlot(str)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1355,6 +1355,7 @@ class DeleteSourceMessageBox:
 
     def __init__(self, source, controller):
         self.source = source
+        self.source_uuid = source.uuid
         self.controller = controller
 
     def launch(self):
@@ -1370,7 +1371,7 @@ class DeleteSourceMessageBox:
             None, "", _(message), QMessageBox.Cancel | QMessageBox.Yes, QMessageBox.Cancel)
 
         if reply == QMessageBox.Yes:
-            logger.debug("Deleting source %s" % (self.source.uuid,))
+            logger.debug(f'Deleting source {self.source_uuid}')
             self.controller.delete_source(self.source)
 
     def _construct_message(self, source: Source) -> str:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1089,7 +1089,6 @@ class SourceWidget(QWidget):
         # Store source
         self.source_uuid = source.uuid
         self.source = source
-        self.source_uuid = source.uuid
 
         # Set styles
         self.setStyleSheet(self.CSS)
@@ -1115,7 +1114,7 @@ class SourceWidget(QWidget):
         gutter_layout = QVBoxLayout(self.gutter)
         gutter_layout.setContentsMargins(0, 0, 0, 0)
         gutter_layout.setSpacing(0)
-        self.star = StarToggleButton(self.controller, self.source)
+        self.star = StarToggleButton(self.controller, self.source_uuid, source.is_starred)
         gutter_layout.addWidget(self.star)
         gutter_layout.addStretch()
 
@@ -1230,12 +1229,12 @@ class StarToggleButton(SvgToggleButton):
     }
     '''
 
-    def __init__(self, controller: Controller, source: Source):
+    def __init__(self, controller: Controller, source_uuid: str, is_starred: bool):
         super().__init__(on='star_on.svg', off='star_off.svg', svg_size=QSize(16, 16))
 
         self.controller = controller
-        self.source_uuid = source.uuid
-        self.is_starred = source.is_starred
+        self.source_uuid = source_uuid
+        self.is_starred = is_starred
         self.pending_count = 0
         self.wait_until_next_sync = False
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1359,8 +1359,8 @@ class StarToggleButton(SvgToggleButton):
         """
         if self.source_uuid == source_uuid:
             self.is_starred = is_starred
-            self.setChecked(self.is_starred)
             self.pending_count = self.pending_count - 1
+            QTimer.singleShot(250, lambda: self.setChecked(self.is_starred))
 
     @pyqtSlot(str)
     def on_star_update_successful(self, source_uuid: str) -> None:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1238,6 +1238,7 @@ class StarToggleButton(SvgToggleButton):
         self.is_starred = source.is_starred
 
         self.controller.authentication_state.connect(self.on_authentication_changed)
+        self.controller.star_update_failed.connect(self.on_star_update_failed)
         self.installEventFilter(self)
 
         self.setObjectName('star_button')
@@ -1335,6 +1336,15 @@ class StarToggleButton(SvgToggleButton):
         if self.is_starred != is_starred:
             self.is_starred = is_starred
             self.setChecked(self.is_starred)
+
+    @pyqtSlot(str)
+    def on_star_update_failed(self, source_uuid: str, is_starred: bool) -> None:
+        """
+        If the star update failed to update on the server, toggle back to previous state.
+        """
+        if self.source_uuid == source_uuid:
+            self.is_starred = is_starred
+            self.setChecked(is_starred)
 
 
 class DeleteSourceMessageBox:
@@ -1456,7 +1466,7 @@ class SignInButton(QPushButton):
         effect.setBlurRadius(8)
         effect.setColor(QColor('#aa000000'))
         self.setGraphicsEffect(effect)
-        self.selectedIndexes
+        self.update()
 
 
 class LoginErrorBar(QWidget):

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -505,11 +505,11 @@ class Controller(QObject):
         self.gui.update_error_status(_('Failed to update star.'))
 
     @login_required
-    def update_star(self, source_db_object):
+    def update_star(self, source_uuid: str, is_starred: bool):
         """
         Star or unstar.
         """
-        job = UpdateStarJob(source_db_object.uuid, source_db_object.is_starred)
+        job = UpdateStarJob(source_uuid, is_starred)
         job.success_signal.connect(self.on_update_star_success, type=Qt.QueuedConnection)
         job.failure_signal.connect(self.on_update_star_failure, type=Qt.QueuedConnection)
 

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -505,14 +505,12 @@ class Controller(QObject):
         self.gui.update_error_status(_('Failed to update star.'))
 
     @login_required
-    def update_star(self, source_db_object, callback):
+    def update_star(self, source_db_object):
         """
-        Star or unstar. The callback here is the API sync as we first make sure
-        that we apply the change to the server, and then update locally.
+        Star or unstar.
         """
         job = UpdateStarJob(source_db_object.uuid, source_db_object.is_starred)
         job.success_signal.connect(self.on_update_star_success, type=Qt.QueuedConnection)
-        job.success_signal.connect(callback, type=Qt.QueuedConnection)
         job.failure_signal.connect(self.on_update_star_failure, type=Qt.QueuedConnection)
 
         self.api_job_queue.enqueue(job)

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -34,14 +34,13 @@ from sqlalchemy.orm.session import sessionmaker
 from securedrop_client import storage
 from securedrop_client import db
 from securedrop_client.api_jobs.base import ApiInaccessibleError
-from securedrop_client.api_jobs.downloads import (
-    DownloadChecksumMismatchException, DownloadDecryptionException, FileDownloadJob,
-    MessageDownloadJob, ReplyDownloadJob,
-)
+from securedrop_client.api_jobs.downloads import DownloadChecksumMismatchException, \
+    DownloadDecryptionException, FileDownloadJob, MessageDownloadJob, ReplyDownloadJob
 from securedrop_client.api_jobs.sources import DeleteSourceJob
 from securedrop_client.api_jobs.uploads import SendReplyJob, SendReplyJobError, \
     SendReplyJobTimeoutError
-from securedrop_client.api_jobs.updatestar import UpdateStarJob, UpdateStarJobException
+from securedrop_client.api_jobs.updatestar import UpdateStarJob, UpdateStarJobError, \
+    UpdateStarJobTimeoutError
 from securedrop_client.crypto import GpgHelper
 from securedrop_client.export import Export
 from securedrop_client.queue import ApiJobQueue
@@ -189,6 +188,14 @@ class Controller(QObject):
         str: the source UUID
     """
     source_deleted = pyqtSignal(str)
+
+    """
+    This signal indicates that a star update request succeeded.
+
+    Emits:
+        str: the source UUID
+    """
+    star_update_successful = pyqtSignal(str)
 
     """
     This signal indicates that a star update request failed.
@@ -506,12 +513,16 @@ class Controller(QObject):
             sources.sort(key=lambda x: x.last_updated)
         self.gui.show_sources(sources)
 
-    def on_update_star_success(self, result) -> None:
-        pass
+    def on_update_star_success(self, source_uuid: str) -> None:
+        self.star_update_successful.emit(source_uuid)
 
-    def on_update_star_failure(self, error: UpdateStarJobException) -> None:
-        self.gui.update_error_status(_('Failed to update star.'))
-        self.gui.star_update_failed.emit(error.source_uuid, error.is_starred)
+    def on_update_star_failure(
+        self,
+        error: Union[UpdateStarJobError, UpdateStarJobTimeoutError]
+    ) -> None:
+        if isinstance(error, UpdateStarJobError):
+            self.gui.update_error_status(_('Failed to update star.'))
+            self.star_update_failed.emit(error.source_uuid, error.is_starred)
 
     @login_required
     def update_star(self, source_uuid: str, is_starred: bool):
@@ -814,12 +825,7 @@ class Controller(QObject):
         self.session.add(draft_reply)
         self.session.commit()
 
-        job = SendReplyJob(
-            source_uuid,
-            reply_uuid,
-            message,
-            self.gpg,
-        )
+        job = SendReplyJob(source_uuid, reply_uuid, message, self.gpg)
         job.success_signal.connect(self.on_reply_success, type=Qt.QueuedConnection)
         job.failure_signal.connect(self.on_reply_failure, type=Qt.QueuedConnection)
 

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -202,8 +202,9 @@ class Controller(QObject):
 
     Emits:
         str: the source UUID
+        bool: is_starred
     """
-    star_update_failed = pyqtSignal(str)
+    star_update_failed = pyqtSignal(str, bool)
 
     def __init__(self, hostname: str, gui, session_maker: sessionmaker,
                  home: str, proxy: bool = True, qubes: bool = True) -> None:
@@ -522,7 +523,8 @@ class Controller(QObject):
     ) -> None:
         if isinstance(error, UpdateStarJobError):
             self.gui.update_error_status(_('Failed to update star.'))
-            self.star_update_failed.emit(error.source_uuid, error.is_starred)
+            source = self.session.query(db.Source).filter_by(uuid=error.source_uuid).one()
+            self.star_update_failed.emit(error.source_uuid, source.is_starred)
 
     @login_required
     def update_star(self, source_uuid: str, is_starred: bool):

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -190,6 +190,14 @@ class Controller(QObject):
     """
     source_deleted = pyqtSignal(str)
 
+    """
+    This signal indicates that a star update request failed.
+
+    Emits:
+        str: the source UUID
+    """
+    star_update_failed = pyqtSignal(str)
+
     def __init__(self, hostname: str, gui, session_maker: sessionmaker,
                  home: str, proxy: bool = True, qubes: bool = True) -> None:
         """
@@ -501,8 +509,9 @@ class Controller(QObject):
     def on_update_star_success(self, result) -> None:
         pass
 
-    def on_update_star_failure(self, result: UpdateStarJobException) -> None:
+    def on_update_star_failure(self, error: UpdateStarJobException) -> None:
         self.gui.update_error_status(_('Failed to update star.'))
+        self.gui.star_update_failed.emit(error.source_uuid, error.is_starred)
 
     @login_required
     def update_star(self, source_uuid: str, is_starred: bool):

--- a/tests/functional/test_star_source.py
+++ b/tests/functional/test_star_source.py
@@ -34,4 +34,4 @@ def test_star_source(qtbot, mocker):
     qtbot.mouseClick(first_source_widget.star, Qt.LeftButton)
     qtbot.wait(1000)
     # Check the source is now checked.
-    assert first_source_widget.star.source.is_starred is True
+    assert first_source_widget.star.is_starred is True

--- a/tests/functional/test_unstar_source.py
+++ b/tests/functional/test_unstar_source.py
@@ -34,4 +34,4 @@ def test_unstar_source(qtbot, mocker):
     qtbot.mouseClick(first_source_widget.star, Qt.LeftButton)
     qtbot.wait(1000)
     # Check the source isn't checked once more.
-    assert first_source_widget.star.source.is_starred is False
+    assert first_source_widget.star.is_starred is False

--- a/tests/gui/test_init.py
+++ b/tests/gui/test_init.py
@@ -28,24 +28,6 @@ def test_SvgToggleButton_init(mocker):
     setIconSize_fn.assert_called_once_with(svg_size)
 
 
-def test_SvgToggleButton_enable(mocker):
-    """
-    Ensure enable.
-    """
-    stb = SvgToggleButton(on='mock_on', off='mock_off')
-    stb.enable()
-    assert stb.isEnabled() is True
-
-
-def test_SvgToggleButton_disable(mocker):
-    """
-    Ensure disable.
-    """
-    stb = SvgToggleButton(on='mock_on', off='mock_off')
-    stb.disable()
-    assert stb.isEnabled() is False
-
-
 def test_SvgToggleButton_toggle(mocker):
     """
     Make sure we're not calling this a toggle button for no reason.
@@ -93,24 +75,6 @@ def test_SvgPushButton_init(mocker):
         normal='mock1', disabled='mock2', active='mock3', selected='mock4', disabled_off='mock2')
     setIcon_fn.assert_called_once_with(icon)
     setIconSize_fn.assert_called_once_with(svg_size)
-
-
-def test_SvgPushButton_enable(mocker):
-    """
-    Ensure enable.
-    """
-    spb = SvgPushButton(normal='mock1', disabled='mock2', active='mock3', selected='mock4')
-    spb.enable()
-    assert spb.isEnabled() is True
-
-
-def test_SvgPushButton_disable(mocker):
-    """
-    Ensure disable.
-    """
-    spb = SvgPushButton(normal='mock1', disabled='mock2', active='mock3', selected='mock4')
-    spb.disable()
-    assert spb.isEnabled() is False
 
 
 def test_SvgLabel_init(mocker):

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -584,11 +584,13 @@ def test_Controller_on_update_star_failed(homedir, config, mocker):
     gui = mocker.MagicMock()
     co = Controller('http://localhost', gui, mocker.MagicMock(), homedir)
     co.star_update_failed = mocker.MagicMock()
+    source = factory.Source()
+    co.session.query().filter_by().one.return_value = source
 
-    error = UpdateStarJobError('mock_message', 'mock_uuid', True)
+    error = UpdateStarJobError('mock_message', source.uuid)
     co.on_update_star_failure(error)
 
-    co.star_update_failed.emit.assert_called_once_with(error.source_uuid, error.is_starred)
+    co.star_update_failed.emit.assert_called_once_with(source.uuid, source.is_starred)
     gui.update_error_status.assert_called_once_with('Failed to update star.')
 
 
@@ -601,7 +603,7 @@ def test_Controller_on_update_star_failed_due_to_timeout(homedir, config, mocker
     co = Controller('http://localhost', gui, mocker.MagicMock(), homedir)
     co.star_update_failed = mocker.MagicMock()
 
-    error = UpdateStarJobTimeoutError('mock_message', 'mock_uuid', True)
+    error = UpdateStarJobTimeoutError('mock_message', 'mock_uuid')
     co.on_update_star_failure(error)
 
     co.star_update_failed.emit.assert_not_called()


### PR DESCRIPTION
# Description

WIP until I update unit tests and write a test plan.

Fixes https://github.com/freedomofpress/securedrop-client/issues/946
Resolves https://github.com/freedomofpress/securedrop-client/issues/760
Closes https://github.com/freedomofpress/securedrop-client/issues/811
Fixes https://github.com/freedomofpress/securedrop-client/issues/954

This fixes the crash reported in #946, resolves #760 and part of #954 by no longer updating sources whenever a source is starred, closes #811 by retrying star jobs that fail due to timeout, and fixes the rest of #954 so that stars are updated immediately and only toggle back at the same time an error is displayed that says "Failed to update star" or when a star is updated on the server. This also removed the extra callback that toggled stars unpredictably given that there were two callbacks.

# Test Plan

1. Make sure this fixes the crash reported in #946
2. To test #811, cause a timeout when starring a source and see the standard "Trying to reconnect" message
3. Test a non-timeout error and see the star toggle back to its original state before the failure along with the error message "Failed to update star"
4. To test the rest of the starring behavior, see #954 and how each of the 4 issues has been fixed. Remember to test in Qubes, also while comparing this PR branch with `master`

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes