### PR TITLE
show pending status right after deletion job enqueued

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -761,7 +761,7 @@ class Controller(QObject):
         """
         Rely on sync to delete the source locally so we know for sure it was deleted
         """
-        self.source_deleted.emit(source_uuid)
+        pass
 
     def on_delete_source_failure(self, e: Exception) -> None:
         if not isinstance(e, (RequestTimeoutError, ServerConnectionError)):
@@ -783,6 +783,7 @@ class Controller(QObject):
         job.failure_signal.connect(self.on_delete_source_failure, type=Qt.QueuedConnection)
 
         self.api_job_queue.enqueue(job)
+        self.source_deleted.emit(source.uuid)
 
     @login_required
     def send_reply(self, source_uuid: str, reply_uuid: str, message: str) -> None:


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/951

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes