### PR TITLE
no longer access source db obj in snippet

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -927,12 +927,12 @@ class SourceList(QListWidget):
 
                 try:
                     del self.source_widgets[list_widget.source_uuid]
-                    deleted_uuids.append(list_widget.source_uuid)
                 except KeyError:
                     pass
-                finally:
-                    self.takeItem(i)
-                    list_widget.deleteLater()
+
+                self.takeItem(i)
+                deleted_uuids.append(list_widget.source_uuid)
+                list_widget.deleteLater()
 
         # Create new widgets for new sources
         widget_uuids = [self.itemWidget(self.item(i)).source_uuid for i in range(self.count())]
@@ -966,15 +966,33 @@ class SourceList(QListWidget):
         if source_widget and source_exists(self.controller.session, source_widget.source_uuid):
             return source_widget.source
 
-    def set_snippet(self, source_uuid, message_uuid, content):
-        """
-        Given a UUID of a source, if the referenced message is the latest
-        message, then update the source's preview snippet to the referenced
-        content.
-        """
-        source_widget = self.source_widgets.get(source_uuid)
+    def get_source_widget(self, source_uuid: str) -> QListWidget:
+        '''
+        First try to get the source widget from the cache, then look for it in the SourceList.
+        '''
+        try:
+            source_widget = self.source_widgets[source_uuid]
+            return source_widget
+        except KeyError:
+            pass
+
+        for i in range(self.count()):
+            list_item = self.item(i)
+            source_widget = self.itemWidget(list_item)
+            if source_widget and source_widget.source_uuid == source_uuid:
+                return source_widget
+
+    @pyqtSlot(str, str, str)
+    def set_snippet(self, source_uuid: str, collection_item_uuid: str, content: str) -> None:
+        '''
+        Set the source widget's preview snippet with the supplied content.
+
+        Note: The signal's `collection_item_uuid` is not needed for setting the preview snippet. It
+        is used by other signal handlers.
+        '''
+        source_widget = self.get_source_widget(source_uuid)
         if source_widget:
-            source_widget.set_snippet(source_uuid, message_uuid, content)
+            source_widget.set_snippet(source_uuid, content)
 
 
 class SourceWidget(QWidget):
@@ -1145,7 +1163,13 @@ class SourceWidget(QWidget):
             self.controller.session.refresh(self.source)
             self.timestamp.setText(_(arrow.get(self.source.last_updated).format('DD MMM')))
             self.name.setText(self.source.journalist_designation)
-            self.set_snippet(self.source.uuid)
+
+            if not self.source.collection:
+                self.set_snippet(self.source_uuid, '')
+            else:
+                last_collection_obj = self.source.collection[-1]
+                self.set_snippet(self.source_uuid, str(last_collection_obj))
+
             if self.source.document_count == 0:
                 self.paperclip.hide()
             self.star.update()
@@ -1153,29 +1177,14 @@ class SourceWidget(QWidget):
             logger.error(f"Could not update SourceWidget for source {self.source_uuid}: {e}")
             raise
 
-    def set_snippet(self, source: str, uuid: str = None, content: str = None):
+    def set_snippet(self, source_uuid: str, content: str):
         """
-        Update the preview snippet only if the new message is for the
-        referenced source and there's a source collection. If a uuid and
-        content are passed then use these, otherwise default to whatever the
-        latest item in the conversation might be.
+        Update the preview snippet if the source_uuid matches our own.
         """
-        if source != self.source_uuid:
+        if source_uuid != self.source_uuid:
             return
 
-        self.preview.setText("")
-
-        try:
-            self.controller.session.refresh(self.source)
-            if not self.source.collection:
-                return
-            last_collection_object = self.source.collection[-1]
-            if uuid == last_collection_object.uuid and content:
-                self.preview.setText(content)
-            else:
-                self.preview.setText(str(last_collection_object))
-        except sqlalchemy.exc.InvalidRequestError as e:
-            logger.error(f"Could not update snippet for source {self.source_uuid}: {e}")
+        self.preview.setText(content)
 
     def delete_source(self, event):
         if self.controller.api is None:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -22,7 +22,7 @@ import html
 import sys
 
 from gettext import gettext as _
-from typing import Dict, List, Union  # noqa: F401
+from typing import Dict, List, Union, Optional  # noqa: F401
 from uuid import uuid4
 from PyQt5.QtCore import Qt, pyqtSlot, pyqtSignal, QEvent, QTimer, QSize, pyqtBoundSignal, \
     QObject, QPoint
@@ -966,7 +966,7 @@ class SourceList(QListWidget):
         if source_widget and source_exists(self.controller.session, source_widget.source_uuid):
             return source_widget.source
 
-    def get_source_widget(self, source_uuid: str) -> QListWidget:
+    def get_source_widget(self, source_uuid: str) -> Optional[QListWidget]:
         '''
         First try to get the source widget from the cache, then look for it in the SourceList.
         '''
@@ -981,6 +981,8 @@ class SourceList(QListWidget):
             source_widget = self.itemWidget(list_item)
             if source_widget and source_widget.source_uuid == source_uuid:
                 return source_widget
+
+        return None
 
     @pyqtSlot(str, str, str)
     def set_snippet(self, source_uuid: str, collection_item_uuid: str, content: str) -> None:


### PR DESCRIPTION
# Description

Towards https://github.com/freedomofpress/securedrop-client/issues/906 and minimizing access of database objects in the GUI.

# Test Plan

1. Regression test the preview snippet
2. Review code to see that we no longer need to worry about source db object deletions in `set_snippet` because it no longer accesses `self.source.collection` or `self.source.uuid`

(Next step/PR is to make sure `update` doesn't raise an exception in the SourceWidget constructor.)

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

