### PR TITLE
logging audit

### DIFF
--- a/securedrop_client/api_jobs/downloads.py
+++ b/securedrop_client/api_jobs/downloads.py
@@ -176,8 +176,8 @@ class DownloadJob(ApiJob):
             mark_as_decrypted(
                 type(db_object), db_object.uuid, session, original_filename=original_filename
             )
-            logger.info("File decrypted: {} (decrypted file: {})".format(
-                os.path.basename(filepath), original_filename)
+            logger.info("File decrypted: {} (decrypted file in: {})".format(
+                os.path.basename(filepath), os.path.dirname(original_filename))
             )
         except CryptoError as e:
             mark_as_decrypted(type(db_object), db_object.uuid, session, is_decrypted=False)
@@ -374,5 +374,6 @@ class FileDownloadJob(DownloadJob):
         original_filename = self.gpg.decrypt_submission_or_reply(
             filepath, plaintext_filepath, is_doc=True
         )
-        logger.info("""Decrypted file "%s" to "%s" """, filepath, original_filename)
+        logger.info("Decrypted file '{}' to folder '{}'".format(
+            filepath, os.path.dirname(original_filename)))
         return original_filename

--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -94,7 +94,6 @@ def configure_logging(sdc_home: str) -> None:
                                        backupCount=5, delay=False,
                                        encoding=ENCODING)
     handler.setFormatter(formatter)
-    handler.setLevel(logging.DEBUG)
 
     # For rsyslog handler
     if platform.system() != "Linux":  # pragma: no cover
@@ -104,7 +103,6 @@ def configure_logging(sdc_home: str) -> None:
 
     sysloghandler = SysLogHandler(address=syslog_file)
     sysloghandler.setFormatter(formatter)
-    handler.setLevel(logging.DEBUG)
 
     # set up primary log
     log = logging.getLogger()

--- a/securedrop_client/config.py
+++ b/securedrop_client/config.py
@@ -24,7 +24,7 @@ class Config:
             with open(full_path) as f:
                 json_config = json.loads(f.read())
         except Exception as e:
-            logger.warning('Error opening config file at {}: {}'.format(full_path, e))
+            logger.error('Error opening config file at {}: {}'.format(full_path, e))
             json_config = {}
 
         return cls(

--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -46,7 +46,7 @@ class Source(Base):
     last_updated = Column(DateTime)
 
     def __repr__(self) -> str:
-        return '<Source {}>'.format(self.journalist_designation)
+        return '<Source {}: {}>'.format(self.uuid, self.journalist_designation)
 
     @property
     def collection(self) -> List:
@@ -128,7 +128,7 @@ class Message(Base):
             return '<Message not yet available>'
 
     def __repr__(self) -> str:
-        return '<Message {}>'.format(self.filename)
+        return '<Message {}: {}>'.format(self.uuid, self.filename)
 
     def location(self, data_dir: str) -> str:
         '''
@@ -195,7 +195,7 @@ class File(Base):
             return '<Encrypted file on server>'
 
     def __repr__(self) -> str:
-        return '<File {}>'.format(self.filename)
+        return '<File {}>'.format(self.uuid)
 
     def location(self, data_dir: str) -> str:
         '''
@@ -269,7 +269,7 @@ class Reply(Base):
             return '<Reply not yet available>'
 
     def __repr__(self) -> str:
-        return '<Reply {}>'.format(self.filename)
+        return '<Reply {}: {}>'.format(self.uuid, self.filename)
 
     def location(self, data_dir: str) -> str:
         '''

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3311,7 +3311,7 @@ class ReplyBoxWidget(QWidget):
         try:
             self.update_authentication_state(authenticated)
         except sqlalchemy.orm.exc.ObjectDeletedError:
-            logger.error(
+            logger.debug(
                 "On authentication change, ReplyBoxWidget found its source had been deleted."
             )
             self.destroy()
@@ -3333,7 +3333,7 @@ class ReplyBoxWidget(QWidget):
             else:
                 self.refocus_after_sync = False
         except sqlalchemy.orm.exc.ObjectDeletedError:
-            logger.error("During sync, ReplyBoxWidget found its source had been deleted.")
+            logger.debug("During sync, ReplyBoxWidget found its source had been deleted.")
             self.destroy()
 
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -3462,7 +3462,7 @@ def test_ReplyBoxWidget_on_sync_source_deleted(mocker, source):
     controller = mocker.MagicMock()
     rb = ReplyBoxWidget(s, controller)
 
-    error_logger = mocker.patch('securedrop_client.gui.widgets.logger.error')
+    error_logger = mocker.patch('securedrop_client.gui.widgets.logger.debug')
 
     def pretend_source_was_deleted(self):
         raise sqlalchemy.orm.exc.ObjectDeletedError(
@@ -3529,7 +3529,7 @@ def test_ReplyBoxWidget_on_authentication_changed_source_deleted(mocker, source)
     controller = mocker.MagicMock()
     rb = ReplyBoxWidget(s, controller)
 
-    error_logger = mocker.patch('securedrop_client.gui.widgets.logger.error')
+    error_logger = mocker.patch('securedrop_client.gui.widgets.logger.debug')
 
     def pretend_source_was_deleted(self):
         raise sqlalchemy.orm.exc.ObjectDeletedError(

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -907,7 +907,7 @@ def test_Controller_on_file_downloaded_checksum_failure(homedir, config, mocker,
     mock_set_status = mocker.patch.object(co, 'set_status')
     mock_file_ready = mocker.patch.object(co, 'file_ready')
 
-    debug_logger = mocker.patch('securedrop_client.logic.logger.debug')
+    warning_logger = mocker.patch('securedrop_client.logic.logger.warning')
     co._submit_download_job = mocker.MagicMock()
 
     co.on_file_download_failure(DownloadChecksumMismatchException('bang!',
@@ -917,7 +917,7 @@ def test_Controller_on_file_downloaded_checksum_failure(homedir, config, mocker,
 
     # Job should get resubmitted and we should log this is happening
     assert co._submit_download_job.call_count == 1
-    debug_logger.call_args_list[0][0][0] == \
+    warning_logger.call_args_list[0][0][0] == \
         'Failure due to checksum mismatch, retrying {}'.format(file_.uuid)
 
     # No status will be set if it's a file corruption issue, the file just gets
@@ -1061,13 +1061,13 @@ def test_Controller_on_file_open_file_missing(mocker, homedir, session_maker, se
     session.add(file)
     session.commit()
     mocker.patch('securedrop_client.logic.Controller.get_file', return_value=file)
-    debug_logger = mocker.patch('securedrop_client.logic.logger.debug')
+    warning_logger = mocker.patch('securedrop_client.logic.logger.warning')
 
     co.on_file_open(file)
 
-    log_msg = 'Cannot find {} in the data directory. File does not exist.'.format(
-        file.filename)
-    debug_logger.assert_called_once_with(log_msg)
+    log_msg = 'Cannot find file in {}. File does not exist.'.format(
+        os.path.dirname(file.filename))
+    warning_logger.assert_called_once_with(log_msg)
 
 
 def test_Controller_on_file_open_file_missing_not_qubes(
@@ -1082,13 +1082,13 @@ def test_Controller_on_file_open_file_missing_not_qubes(
     session.add(file)
     session.commit()
     mocker.patch('securedrop_client.logic.Controller.get_file', return_value=file)
-    debug_logger = mocker.patch('securedrop_client.logic.logger.debug')
+    warning_logger = mocker.patch('securedrop_client.logic.logger.warning')
 
     co.on_file_open(file)
 
-    log_msg = 'Cannot find {} in the data directory. File does not exist.'.format(
-        file.filename)
-    debug_logger.assert_called_once_with(log_msg)
+    log_msg = 'Cannot find file in {}. File does not exist.'.format(
+        os.path.dirname(file.filename))
+    warning_logger.assert_called_once_with(log_msg)
 
 
 def test_Controller_download_new_replies_with_new_reply(mocker, session, session_maker, homedir):
@@ -1159,12 +1159,12 @@ def test_Controller_on_reply_downloaded_failure(mocker, homedir, session_maker):
     reply_ready = mocker.patch.object(co, 'reply_ready')
     reply = factory.Reply(source=factory.Source())
     mocker.patch('securedrop_client.storage.get_reply', return_value=reply)
-    debug_logger = mocker.patch('securedrop_client.logic.logger.debug')
+    info_logger = mocker.patch('securedrop_client.logic.logger.info')
     co._submit_download_job = mocker.MagicMock()
 
     co.on_reply_download_failure('mock_exception')
 
-    debug_logger.assert_called_once_with('Failed to download reply: mock_exception')
+    info_logger.assert_called_once_with('Failed to download reply: mock_exception')
     reply_ready.emit.assert_not_called()
 
     # Job should not get automatically resubmitted if the failure was generic
@@ -1179,18 +1179,19 @@ def test_Controller_on_reply_downloaded_checksum_failure(mocker, homedir, sessio
     reply_ready = mocker.patch.object(co, 'reply_ready')
     reply = factory.Reply(source=factory.Source())
     mocker.patch('securedrop_client.storage.get_reply', return_value=reply)
-    debug_logger = mocker.patch('securedrop_client.logic.logger.debug')
+    warning_logger = mocker.patch('securedrop_client.logic.logger.warning')
+    info_logger = mocker.patch('securedrop_client.logic.logger.info')
     co._submit_download_job = mocker.MagicMock()
 
     co.on_reply_download_failure(DownloadChecksumMismatchException('bang!',
                                  type(reply), reply.uuid))
 
-    debug_logger.call_args_list[0][0][0] == 'Failed to download reply: bang!'
+    info_logger.call_args_list[0][0][0] == 'Failed to download reply: bang!'
     reply_ready.emit.assert_not_called()
 
     # Job should get resubmitted and we should log this is happening
     co._submit_download_job.call_count == 1
-    debug_logger.call_args_list[1][0][0] == \
+    warning_logger.call_args_list[0][0][0] == \
         'Failure due to checksum mismatch, retrying {}'.format(reply.uuid)
 
 
@@ -1265,11 +1266,11 @@ def test_Controller_on_message_downloaded_failure(mocker, homedir, session_maker
     message = factory.Message(source=factory.Source())
     mocker.patch('securedrop_client.storage.get_message', return_value=message)
     co._submit_download_job = mocker.MagicMock()
-    debug_logger = mocker.patch('securedrop_client.logic.logger.debug')
+    info_logger = mocker.patch('securedrop_client.logic.logger.info')
 
     co.on_message_download_failure('mock_exception')
 
-    debug_logger.assert_called_once_with('Failed to download message: mock_exception')
+    info_logger.assert_called_once_with('Failed to download message: mock_exception')
     message_ready.emit.assert_not_called()
 
     # Job should not get automatically resubmitted if the failure was generic
@@ -1285,17 +1286,18 @@ def test_Controller_on_message_downloaded_checksum_failure(mocker, homedir, sess
     message = factory.Message(source=factory.Source())
     mocker.patch('securedrop_client.storage.get_message', return_value=message)
     co._submit_download_job = mocker.MagicMock()
-    debug_logger = mocker.patch('securedrop_client.logic.logger.debug')
+    warning_logger = mocker.patch('securedrop_client.logic.logger.warning')
+    info_logger = mocker.patch('securedrop_client.logic.logger.info')
 
     co.on_message_download_failure(DownloadChecksumMismatchException('bang!',
                                    type(message), message.uuid))
 
-    debug_logger.call_args_list[0][0][0] == 'Failed to download message: bang!'
+    info_logger.call_args_list[0][0][0] == 'Failed to download message: bang!'
     message_ready.emit.assert_not_called()
 
     # Job should get resubmitted and we should log this is happening
     co._submit_download_job.call_count == 1
-    debug_logger.call_args_list[1][0][0] == \
+    warning_logger.call_args_list[0][0][0] == \
         'Failure due to checksum mismatch, retrying {}'.format(message.uuid)
 
 
@@ -1417,7 +1419,7 @@ def test_Controller_on_reply_success(homedir, mocker, session_maker, session):
     reply_succeeded = mocker.patch.object(co, 'reply_succeeded')
     reply_failed = mocker.patch.object(co, 'reply_failed')
     reply = factory.Reply(source=factory.Source())
-    debug_logger = mocker.patch('securedrop_client.logic.logger.debug')
+    info_logger = mocker.patch('securedrop_client.logic.logger.info')
 
     mock_storage = mocker.MagicMock()
     mock_reply = mocker.MagicMock()
@@ -1428,7 +1430,7 @@ def test_Controller_on_reply_success(homedir, mocker, session_maker, session):
     with mocker.patch("securedrop_client.logic.storage", mock_storage):
         co.on_reply_success(reply.uuid)
 
-    assert debug_logger.call_args_list[0][0][0] == '{} sent successfully'.format(reply.uuid)
+    assert info_logger.call_args_list[0][0][0] == '{} sent successfully'.format(reply.uuid)
     reply_succeeded.emit.assert_called_once_with("source_uuid", reply.uuid, "reply_message_mock")
     reply_failed.emit.assert_not_called()
 
@@ -1665,12 +1667,12 @@ def test_Controller_print_file_file_missing(homedir, mocker, session, session_ma
     session.add(file)
     session.commit()
     mocker.patch('securedrop_client.logic.Controller.get_file', return_value=file)
-    debug_logger = mocker.patch('securedrop_client.logic.logger.debug')
+    warning_logger = mocker.patch('securedrop_client.logic.logger.warning')
 
     co.print_file(file.uuid)
 
-    log_msg = 'Cannot find {} in the data directory. File does not exist.'.format(file.filename)
-    debug_logger.assert_called_once_with(log_msg)
+    log_msg = 'Cannot find file in {}. File does not exist.'.format(os.path.dirname(file.filename))
+    warning_logger.assert_called_once_with(log_msg)
 
 
 def test_Controller_print_file_file_missing_not_qubes(
@@ -1686,13 +1688,13 @@ def test_Controller_print_file_file_missing_not_qubes(
     session.add(file)
     session.commit()
     mocker.patch('securedrop_client.logic.Controller.get_file', return_value=file)
-    debug_logger = mocker.patch('securedrop_client.logic.logger.debug')
+    warning_logger = mocker.patch('securedrop_client.logic.logger.warning')
 
     co.print_file(file.uuid)
 
-    log_msg = 'Cannot find {} in the data directory. File does not exist.'.format(
-        file.filename)
-    debug_logger.assert_called_once_with(log_msg)
+    log_msg = 'Cannot find file in {}. File does not exist.'.format(
+        os.path.dirname(file.filename))
+    warning_logger.assert_called_once_with(log_msg)
 
 
 def test_Controller_print_file_when_orig_file_already_exists(
@@ -1833,13 +1835,13 @@ def test_Controller_export_file_to_usb_drive_file_missing(homedir, mocker, sessi
     session.add(file)
     session.commit()
     mocker.patch('securedrop_client.logic.Controller.get_file', return_value=file)
-    debug_logger = mocker.patch('securedrop_client.logic.logger.debug')
+    warning_logger = mocker.patch('securedrop_client.logic.logger.warning')
 
     co.export_file_to_usb_drive(file.uuid, 'mock passphrase')
 
-    log_msg = 'Cannot find {} in the data directory. File does not exist.'.format(
-        file.filename)
-    debug_logger.assert_called_once_with(log_msg)
+    log_msg = 'Cannot find file in {}. File does not exist.'.format(
+        os.path.dirname(file.filename))
+    warning_logger.assert_called_once_with(log_msg)
 
 
 def test_Controller_export_file_to_usb_drive_file_missing_not_qubes(
@@ -1855,13 +1857,13 @@ def test_Controller_export_file_to_usb_drive_file_missing_not_qubes(
     session.add(file)
     session.commit()
     mocker.patch('securedrop_client.logic.Controller.get_file', return_value=file)
-    debug_logger = mocker.patch('securedrop_client.logic.logger.debug')
+    warning_logger = mocker.patch('securedrop_client.logic.logger.warning')
 
     co.export_file_to_usb_drive(file.uuid, 'mock passphrase')
 
-    log_msg = 'Cannot find {} in the data directory. File does not exist.'.format(
-        file.filename)
-    debug_logger.assert_called_once_with(log_msg)
+    log_msg = 'Cannot find file in {}. File does not exist.'.format(
+        os.path.dirname(file.filename))
+    warning_logger.assert_called_once_with(log_msg)
 
 
 def test_Controller_export_file_to_usb_drive_when_orig_file_already_exists(


### PR DESCRIPTION
# Description

Towards https://github.com/freedomofpress/securedrop-workstation/issues/397

There's also some logging in `securedrop-export` that we'll want to remove (original filenames), I will do that separately 

# Test Plan

- [ ] Ensure that for sources no _original_ filenames or content of source messages will be logged at any log level (in case these logs may be shared for debugging purposes)
- [ ] Ensure that log levels are set appropriately: info or higher will be logged in prod, debug will be used mostly for devs. Regardless, debug lines should not log filenames 

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
