### PR TITLE
Remove source db object from SourceWidget

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -927,12 +927,12 @@ class SourceList(QListWidget):
 
                 try:
                     del self.source_widgets[list_widget.source_uuid]
-                    deleted_uuids.append(list_widget.source_uuid)
                 except KeyError:
                     pass
-                finally:
-                    self.takeItem(i)
-                    list_widget.deleteLater()
+
+                self.takeItem(i)
+                deleted_uuids.append(list_widget.source_uuid)
+                list_widget.deleteLater()
 
         # Create new widgets for new sources
         widget_uuids = [self.itemWidget(self.item(i)).source_uuid for i in range(self.count())]
@@ -966,15 +966,33 @@ class SourceList(QListWidget):
         if source_widget and source_exists(self.controller.session, source_widget.source_uuid):
             return source_widget.source
 
-    def set_snippet(self, source_uuid, message_uuid, content):
-        """
-        Given a UUID of a source, if the referenced message is the latest
-        message, then update the source's preview snippet to the referenced
-        content.
-        """
-        source_widget = self.source_widgets.get(source_uuid)
+    def get_source_widget(self, source_uuid: str) -> QListWidget:
+        '''
+        First try to get the source widget from the cache, then look for it in the SourceList.
+        '''
+        try:
+            source_widget = self.source_widgets[source_uuid]
+            return source_widget
+        except KeyError:
+            pass
+
+        for i in range(self.count()):
+            list_item = self.item(i)
+            source_widget = self.itemWidget(list_item)
+            if source_widget and source_widget.source_uuid == source_uuid:
+                return source_widget
+
+    @pyqtSlot(str, str, str)
+    def set_snippet(self, source_uuid: str, collection_item_uuid: str, content: str) -> None:
+        '''
+        Set the source widget's preview snippet with the supplied content.
+
+        Note: The signal's `collection_item_uuid` is not needed for setting the preview snippet. It
+        is used by other signal handlers.
+        '''
+        source_widget = self.get_source_widget(source_uuid)
         if source_widget:
-            source_widget.set_snippet(source_uuid, message_uuid, content)
+            source_widget.set_snippet(source_uuid, content)
 
 
 class SourceWidget(QWidget):
@@ -1145,7 +1163,13 @@ class SourceWidget(QWidget):
             self.controller.session.refresh(self.source)
             self.timestamp.setText(_(arrow.get(self.source.last_updated).format('DD MMM')))
             self.name.setText(self.source.journalist_designation)
-            self.set_snippet(self.source.uuid)
+
+            if not self.source.collection:
+                self.set_snippet(self.source_uuid, '')
+            else:
+                last_collection_obj = self.source.collection[-1]
+                self.set_snippet(self.source_uuid, str(last_collection_obj))
+
             if self.source.document_count == 0:
                 self.paperclip.hide()
             self.star.update()
@@ -1153,29 +1177,14 @@ class SourceWidget(QWidget):
             logger.error(f"Could not update SourceWidget for source {self.source_uuid}: {e}")
             raise
 
-    def set_snippet(self, source: str, uuid: str = None, content: str = None):
+    def set_snippet(self, source_uuid: str, content: str):
         """
-        Update the preview snippet only if the new message is for the
-        referenced source and there's a source collection. If a uuid and
-        content are passed then use these, otherwise default to whatever the
-        latest item in the conversation might be.
+        Update the preview snippet if the source_uuid matches our own.
         """
-        if source != self.source_uuid:
+        if source_uuid != self.source_uuid:
             return
 
-        self.preview.setText("")
-
-        try:
-            self.controller.session.refresh(self.source)
-            if not self.source.collection:
-                return
-            last_collection_object = self.source.collection[-1]
-            if uuid == last_collection_object.uuid and content:
-                self.preview.setText(content)
-            else:
-                self.preview.setText(str(last_collection_object))
-        except sqlalchemy.exc.InvalidRequestError as e:
-            logger.error(f"Could not update snippet for source {self.source_uuid}: {e}")
+        self.preview.setText(content)
 
     def delete_source(self, event):
         if self.controller.api is None:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -36,7 +36,6 @@ import sqlalchemy.orm.exc
 
 from securedrop_client import __version__ as sd_version
 from securedrop_client.db import DraftReply, Source, Message, File, Reply, User
-from securedrop_client.storage import source_exists
 from securedrop_client.export import ExportStatus, ExportError
 from securedrop_client.gui import SecureQLabel, SvgLabel, SvgPushButton, SvgToggleButton
 from securedrop_client.logic import Controller
@@ -1103,10 +1102,10 @@ class SourceWidget(QWidget):
         try:
             source = self.controller.get_source(self.source_uuid)
             self.star = StarToggleButton(self.controller, source)
+            gutter_layout.addWidget(self.star)
         except sqlalchemy.exc.InvalidRequestError as e:
             logger.error(f'Cannot update star icon for source: {self.source_uuid}: {e}')
 
-        gutter_layout.addWidget(self.star)
         gutter_layout.addStretch()
 
         # Set up summary

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -833,6 +833,11 @@ class Controller(QObject):
         if isinstance(exception, SendReplyJobError):
             self.reply_failed.emit(exception.reply_uuid)
 
+    def get_source(self, source_uuid: str) -> db.Source:
+        source = storage.get_source(self.session, source_uuid)
+        self.session.refresh(source)
+        return source
+
     def get_file(self, file_uuid: str) -> db.File:
         file = storage.get_file(self.session, file_uuid)
         self.session.refresh(file)

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -564,6 +564,10 @@ def source_exists(session: Session, source_uuid: str) -> bool:
         return False
 
 
+def get_source(session: Session, uuid: str) -> Source:
+    return session.query(Source).filter_by(uuid=uuid).one()
+
+
 def get_file(session: Session, uuid: str) -> File:
     return session.query(File).filter_by(uuid=uuid).one()
 


### PR DESCRIPTION
# Description

After https://github.com/freedomofpress/securedrop-client/pull/964 is merged, this will need a rebase and will be ready for review.

Towards #906 and minimizing access of database objects in the GUI in order to avoid crashes. This removes the source database object from the SourceWidget and fixes #1 in https://github.com/freedomofpress/securedrop-client/issues/906.

[The PR that removes the source object from the star](https://github.com/freedomofpress/securedrop-client/pull/952) will either need to be merged after this PR or if before, I'll need to do a rebase.

# Test Plan

1. Regression test around the source widget
2. See how we no longer can raise an exception in the constructor of SourceWidget

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [ ] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
