### PR TITLE
Updates the filesize after download and decryption

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2244,6 +2244,9 @@ class FileWidget(QWidget):
         file_ready_signal.connect(self._on_file_downloaded, type=Qt.QueuedConnection)
         file_missing.connect(self._on_file_missing, type=Qt.QueuedConnection)
 
+    def update_file_size(self):
+        self.file_size.setText(humanize_filesize(self.file.size))
+
     def eventFilter(self, obj, event):
         t = event.type()
         if t == QEvent.MouseButtonPress:
@@ -2267,6 +2270,7 @@ class FileWidget(QWidget):
             self.middot.show()
             self.print_button.show()
             self.file_name.show()
+            self.update_file_size()
         else:
             logger.debug('Changing file {} state to not downloaded'.format(self.uuid))
             self.download_button.setText(_('DOWNLOAD'))

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2245,7 +2245,11 @@ class FileWidget(QWidget):
         file_missing.connect(self._on_file_missing, type=Qt.QueuedConnection)
 
     def update_file_size(self):
-        self.file_size.setText(humanize_filesize(self.file.size))
+        try:
+            self.file_size.setText(humanize_filesize(self.file.size))
+        except Exception as e:
+            logger.error(f"Could not update file size on FileWidget: {e}")
+            self.file_size.setText("")
 
     def eventFilter(self, obj, event):
         t = event.type()

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -768,6 +768,9 @@ class Controller(QObject):
         """
         self.session.commit()
         file_obj = storage.get_file(self.session, uuid)
+        # Let us update the size of the file.
+        storage.update_file_size(uuid, self.data_dir, self.session)
+
         self.file_ready.emit(file_obj.source.uuid, uuid, file_obj.filename)
 
     def on_file_download_failure(self, exception: Exception) -> None:

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -492,6 +492,7 @@ def mark_as_downloaded(
     session.add(db_obj)
     session.commit()
 
+
 def update_file_size(uuid: str, path: str, session: Session) -> None:
     """
     Updates file size to the decrypted size
@@ -501,6 +502,7 @@ def update_file_size(uuid: str, path: str, session: Session) -> None:
     db_obj.size = stat.st_size
     session.add(db_obj)
     session.commit()
+
 
 def mark_as_decrypted(
     model_type: Union[Type[File], Type[Message], Type[Reply]],

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -23,6 +23,7 @@ from datetime import datetime
 import logging
 import os
 import shutil
+from pathlib import Path
 from dateutil.parser import parse
 from typing import List, Tuple, Type, Union
 
@@ -491,6 +492,15 @@ def mark_as_downloaded(
     session.add(db_obj)
     session.commit()
 
+def update_file_size(uuid: str, path: str, session: Session) -> None:
+    """
+    Updates file size to the decrypted size
+    """
+    db_obj = session.query(File).filter_by(uuid=uuid).one()
+    stat = Path(db_obj.location(path)).stat()
+    db_obj.size = stat.st_size
+    session.add(db_obj)
+    session.commit()
 
 def mark_as_decrypted(
     model_type: Union[Type[File], Type[Message], Type[Reply]],

--- a/tests/functional/test_download_file.py
+++ b/tests/functional/test_download_file.py
@@ -49,4 +49,4 @@ def test_download_file(qtbot, mocker):
     qtbot.wait(5000)
     assert file_msg.export_button.isHidden() is False
     assert file_msg.file_name.text() == "hello.txt"
-    assert file_msg.file_size.text() == "625B"
+    assert file_msg.file_size.text() == "9B"

--- a/tests/functional/test_export_dialog.py
+++ b/tests/functional/test_export_dialog.py
@@ -49,7 +49,7 @@ def test_export_dialog(qtbot, mocker):
     qtbot.wait(5000)
     assert file_msg.export_button.isHidden() is False
     assert file_msg.file_name.text() == "hello.txt"
-    assert file_msg.file_size.text() == "625B"
+    assert file_msg.file_size.text() == "9B"
 
     # Let us export
     qtbot.mouseClick(file_msg.export_button, Qt.LeftButton)

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -2397,6 +2397,26 @@ def test_FileWidget__on_print_clicked_missing_file(mocker, session, source):
     dialog.assert_not_called()
 
 
+def test_FileWidget_update_file_size_with_deleted_file(
+    mocker, homedir, config, session_maker, source
+):
+    mock_gui = mocker.MagicMock()
+    controller = logic.Controller('http://localhost', mock_gui, session_maker, homedir)
+
+    file = factory.File(source=source['source'], is_downloaded=True)
+    controller.session.add(file)
+    controller.session.commit()
+
+    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0)
+
+    with mocker.patch(
+        "securedrop_client.gui.widgets.humanize_filesize",
+        side_effect=Exception("boom!")
+    ):
+        fw.update_file_size()
+        assert fw.file_size.text() == ""
+
+
 @pytest.mark.parametrize("key", [Qt.Key_Enter, Qt.Key_Return])
 def test_ModalDialog_keyPressEvent_does_not_close_on_enter_or_return(mocker, key):
     dialog = ModalDialog()


### PR DESCRIPTION
# Description

Fixes #917
This still needs unit test case. I need help with that

# Test Plan

Follow the steps from #917

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [ ] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
