### PR TITLE
app: prevent duplicate file downloads at the UI level

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2330,7 +2330,7 @@ class FileWidget(QWidget):
         if self.file.is_decrypted:
             # Open the already downloaded and decrypted file.
             self.controller.on_file_open(self.file)
-        else:
+        elif not self.downloading:
             if self.controller.api:
                 self.start_button_animation()
             # Download the file.

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -2092,6 +2092,31 @@ def test_FileWidget_on_left_click_download(mocker, session, source):
         db.File, file_.uuid)
 
 
+def test_FileWidget_on_left_click_downloading_in_progress(mocker, session, source):
+    """
+    Left click on download when file is not downloaded but is in progress
+    downloading should not trigger a download.
+    """
+    file_ = factory.File(source=source['source'],
+                         is_downloaded=False,
+                         is_decrypted=None)
+    session.add(file_)
+    session.commit()
+
+    mock_get_file = mocker.MagicMock(return_value=file_)
+    mock_controller = mocker.MagicMock(get_file=mock_get_file)
+
+    fw = FileWidget(file_.uuid, mock_controller, mocker.MagicMock(), mocker.MagicMock(), 0)
+    fw.downloading = True
+    fw.download_button = mocker.MagicMock()
+    mock_get_file.assert_called_once_with(file_.uuid)
+    mock_get_file.reset_mock()
+
+    fw._on_left_click()
+    mock_get_file.call_count == 0
+    mock_controller.on_submission_download.call_count == 0
+
+
 def test_FileWidget_start_button_animation(mocker, session, source):
     """
     Ensure widget state is updated when this method is called.


### PR DESCRIPTION
# Description

Fixes #116.

This is a UI layer solution for the purpose of the beta to resolve the above issue where multiple clicks result in attempting to download a file multiple times (see `prevent-duplicate-jobs` for a generic approach for ensuring duplicate jobs in general cannot be added to the queue).

# Test Plan

0. Submit a file as a source.
1. Sign into the client with debug level logging (`LOGLEVEL=DEBUG ./run.sh`), attempt to download the file.
2. While it is downloading (note: for test purposes you should submit a large file that takes some time to download OR add a `time.sleep(2)` in the submission download endpoint server-side), keep clicking.
3. Ensure that no additional jobs are added. 

You should see the following line only once. indicating that duplicated clicks did not result in duplicate `FileDownloadJob`s being enqueued:

```
2020-03-20 20:17:25,768 - securedrop_client.queue:233(enqueue) DEBUG: Added FileDownloadJob to download queue
```

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
