### PR TITLE
Adjust the clickable area for logging out to include the user's icon.

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -448,17 +448,20 @@ class UserProfile(QLabel):
         # Login button
         self.login_button = LoginButton()
 
+        # User button
+        self.user_button = UserButton()
+
         # User icon
-        self.user_icon = QLabel()
+        self.user_icon = UserIconLabel()
         self.user_icon.setObjectName('user_icon')  # Set css id
         self.user_icon.setFixedSize(QSize(30, 30))
         self.user_icon.setAlignment(Qt.AlignCenter)
         self.user_icon_font = QFont()
         self.user_icon_font.setLetterSpacing(QFont.AbsoluteSpacing, 0.58)
         self.user_icon.setFont(self.user_icon_font)
-
-        # User button
-        self.user_button = UserButton()
+        self.user_icon.clicked.connect(self.user_button.click)
+        # Set cursor.
+        self.user_icon.setCursor(QCursor(Qt.PointingHandCursor))
 
         # Add widgets to user auth layout
         layout.addWidget(self.login_button, 1)
@@ -486,6 +489,17 @@ class UserProfile(QLabel):
         self.user_icon.hide()
         self.user_button.hide()
         self.login_button.show()
+
+
+class UserIconLabel(QLabel):
+    """
+    Makes a label clickable. (For the label containing the user icon.)
+    """
+
+    clicked = pyqtSignal()
+
+    def mousePressEvent(self, e):
+        self.clicked.emit()
 
 
 class UserButton(SvgPushButton):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -22,7 +22,7 @@ from securedrop_client.gui.widgets import MainView, SourceList, SourceWidget, Se
     ErrorStatusBar, ActivityStatusBar, UserProfile, UserButton, UserMenu, LoginButton, \
     ReplyBoxWidget, ReplyTextEdit, SourceConversationWrapper, StarToggleButton, LoginOfflineLink, \
     LoginErrorBar, EmptyConversationView, FramelessDialog, ExportDialog, PrintDialog, \
-    PasswordEdit, SourceProfileShortWidget
+    PasswordEdit, SourceProfileShortWidget, UserIconLabel
 from tests import factory
 
 
@@ -381,6 +381,13 @@ def test_UserProfile_hide(mocker):
     up.user_icon.hide.assert_called_once_with()
     up.user_button.hide.assert_called_once_with()
     up.login_button.show.assert_called_once_with()
+
+
+def test_UserIconLabel_clicks(mocker):
+    uil = UserIconLabel()
+    uil.clicked = mocker.MagicMock()
+    uil.mousePressEvent(None)
+    uil.clicked.emit.assert_called_once_with()
 
 
 def test_UserButton_setup(mocker):


### PR DESCRIPTION
# Description

Towards #285.

Screenie of modified behaviour:

![sign-out](https://user-images.githubusercontent.com/37602/77318211-99737980-6d04-11ea-916a-ef2e14227d93.gif)

Took a while to work out the simplest / easiest approach. But in the end I just created a child class from QLabel which emitted click events and connected the emitted click to the button with the menu.

# Test Plan

Added unit test.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
