### PR TITLE
Automatically resizes status bar to width of error message string.

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -382,6 +382,9 @@ class ErrorStatusBar(QWidget):
         continuously show message.
         """
         self.status_bar.showMessage(message, duration)
+        new_width = self.fontMetrics().horizontalAdvance(message)
+        self.status_bar.setMinimumWidth(new_width)
+        self.status_bar.reformat()
 
         if duration != 0:
             self.status_timer.start(duration)


### PR DESCRIPTION
# Description

Fixes #932.

I use the `FontMetric` instance on the `status_bar` object to set the new minimum width, then reformat to dynamically adjust the width.

Screenie:

![error_width](https://user-images.githubusercontent.com/37602/77321823-ac894800-6d0a-11ea-9593-6e05d6cd3d67.png)

# Test Plan

Eyeball Mk1 to ensure the UI changes take effect as expected. :eyes:

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
