### PR TITLE
Make the login modal, thus ensuring only one instance is possible at once.

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1605,6 +1605,9 @@ class LoginDialog(QDialog):
         self.parent = parent
         super().__init__(self.parent)
 
+        # Set modal
+        self.setModal(True)
+
         # Set css id
         self.setObjectName('login_dialog')
 


### PR DESCRIPTION
# Description

Fixes #971.

Making the login widget modal is the *ideal* solution since this is precisely the use case for such modal dialogs. Let Qt do the work for you. ;-)

# Test Plan

Please check with Eyeball Mk1. :eyes: Feedback from @ninavizz and @eloquence on possible UI change of behaviour.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
