### PR TITLE
app: reset source pending status upon unexpected source deletion at server

### DIFF
--- a/securedrop_client/api_jobs/sources.py
+++ b/securedrop_client/api_jobs/sources.py
@@ -1,7 +1,7 @@
 import logging
 import sdclientapi
 
-from sdclientapi import API
+from sdclientapi import API, ServerConnectionError, RequestTimeoutError
 from sqlalchemy.orm.session import Session
 
 from securedrop_client.api_jobs.base import ApiJob
@@ -20,11 +20,25 @@ class DeleteSourceJob(ApiJob):
 
         Delete a source on the server
         '''
-        source_sdk_object = sdclientapi.Source(uuid=self.source_uuid)
+        try:
+            source_sdk_object = sdclientapi.Source(uuid=self.source_uuid)
 
-        # TODO: After https://github.com/freedomofpress/securedrop-client/issues/648 is merged, we
-        # will want to pass the timeout to delete_source instead of setting it on the api object
-        api_client.default_request_timeout = 5
-        api_client.delete_source(source_sdk_object)
+            # TODO: After https://github.com/freedomofpress/securedrop-client/issues/648 is
+            # merged, we will want to pass the timeout to delete_source instead of setting
+            # it on the api object
+            api_client.default_request_timeout = 5
+            api_client.delete_source(source_sdk_object)
 
-        return self.source_uuid
+            return self.source_uuid
+        except (RequestTimeoutError, ServerConnectionError):
+            raise
+        except Exception as e:
+            error_message = "Failed to delete source {uuid} due to {exception}".format(
+                uuid=self.source_uuid, exception=repr(e))
+            raise DeleteSourceJobException(error_message, self.source_uuid)
+
+
+class DeleteSourceJobException(Exception):
+    def __init__(self, message: str, source_uuid: str):
+        super().__init__(message)
+        self.source_uuid = source_uuid

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1085,6 +1085,7 @@ class SourceWidget(QWidget):
 
         self.controller = controller
         self.controller.source_deleted.connect(self._on_source_deleted)
+        self.controller.source_deletion_failed.connect(self._on_source_deletion_failed)
 
         # Store source
         self.source_uuid = source.uuid
@@ -1216,6 +1217,14 @@ class SourceWidget(QWidget):
             self.metadata.hide()
             self.preview.hide()
             self.waiting_delete_confirmation.show()
+
+    @pyqtSlot(str)
+    def _on_source_deletion_failed(self, source_uuid: str):
+        if self.source_uuid == source_uuid:
+            self.waiting_delete_confirmation.hide()
+            self.gutter.show()
+            self.metadata.show()
+            self.preview.show()
 
 
 class StarToggleButton(SvgToggleButton):
@@ -3161,6 +3170,7 @@ class SourceConversationWrapper(QWidget):
 
         self.source_uuid = source.uuid
         controller.source_deleted.connect(self._on_source_deleted)
+        controller.source_deletion_failed.connect(self._on_source_deletion_failed)
 
         # Set layout
         layout = QVBoxLayout()
@@ -3197,6 +3207,14 @@ class SourceConversationWrapper(QWidget):
             self.conversation_view.hide()
             self.reply_box.hide()
             self.waiting_delete_confirmation.show()
+
+    @pyqtSlot(str)
+    def _on_source_deletion_failed(self, source_uuid: str):
+        if self.source_uuid == source_uuid:
+            self.waiting_delete_confirmation.hide()
+            self.conversation_title_bar.show()
+            self.conversation_view.show()
+            self.reply_box.show()
 
 
 class ReplyBoxWidget(QWidget):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1141,6 +1141,32 @@ def test_SourceWidget__on_source_deleted_wrong_uuid(mocker, session, source):
     assert sw.waiting_delete_confirmation.isHidden()
 
 
+def test_SourceWidget__on_source_deletion_failed(mocker, session, source):
+    controller = mocker.MagicMock()
+    sw = SourceWidget(controller, factory.Source(uuid='123'))
+    sw._on_source_deleted('123')
+
+    sw._on_source_deletion_failed('123')
+
+    assert not sw.gutter.isHidden()
+    assert not sw.metadata.isHidden()
+    assert not sw.preview.isHidden()
+    assert sw.waiting_delete_confirmation.isHidden()
+
+
+def test_SourceWidget__on_source_deletion_failed_wrong_uuid(mocker, session, source):
+    controller = mocker.MagicMock()
+    sw = SourceWidget(controller, factory.Source(uuid='123'))
+    sw._on_source_deleted('123')
+
+    sw._on_source_deletion_failed('321')
+
+    assert sw.gutter.isHidden()
+    assert sw.metadata.isHidden()
+    assert sw.preview.isHidden()
+    assert not sw.waiting_delete_confirmation.isHidden()
+
+
 def test_SourceWidget_uses_SecureQLabel(mocker):
     """
     Ensure the source widget preview uses SecureQLabel and is not injectable
@@ -3070,6 +3096,30 @@ def test_SourceConversationWrapper__on_source_deleted_wrong_uuid(mocker):
     assert not scw.conversation_view.isHidden()
     assert not scw.reply_box.isHidden()
     assert scw.waiting_delete_confirmation.isHidden()
+
+
+def test_SourceConversationWrapper__on_source_deletion_failed(mocker):
+    scw = SourceConversationWrapper(factory.Source(uuid='123'), mocker.MagicMock())
+    scw._on_source_deleted('123')
+
+    scw._on_source_deletion_failed('123')
+
+    assert not scw.conversation_title_bar.isHidden()
+    assert not scw.conversation_view.isHidden()
+    assert not scw.reply_box.isHidden()
+    assert scw.waiting_delete_confirmation.isHidden()
+
+
+def test_SourceConversationWrapper__on_source_deletion_failed_wrong_uuid(mocker):
+    scw = SourceConversationWrapper(factory.Source(uuid='123'), mocker.MagicMock())
+    scw._on_source_deleted('123')
+
+    scw._on_source_deletion_failed('321')
+
+    assert scw.conversation_title_bar.isHidden()
+    assert scw.conversation_view.isHidden()
+    assert scw.reply_box.isHidden()
+    assert not scw.waiting_delete_confirmation.isHidden()
 
 
 def test_ConversationView_init(mocker, homedir):

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -13,8 +13,10 @@ from tests import factory
 from securedrop_client import db
 from securedrop_client.logic import APICallRunner, Controller, TIME_BETWEEN_SHOWING_LAST_SYNC_MS
 from securedrop_client.api_jobs.base import ApiInaccessibleError
-from securedrop_client.api_jobs.downloads import DownloadChecksumMismatchException, \
-    DownloadDecryptionException, DownloadException
+from securedrop_client.api_jobs.downloads import (
+    DownloadChecksumMismatchException, DownloadDecryptionException, DownloadException
+)
+from securedrop_client.api_jobs.sources import DeleteSourceJobException
 from securedrop_client.api_jobs.updatestar import UpdateStarJobError, UpdateStarJobTimeoutError
 from securedrop_client.api_jobs.uploads import SendReplyJobError, SendReplyJobTimeoutError
 
@@ -1340,7 +1342,7 @@ def test_Controller_on_delete_source_failure(homedir, config, mocker, session_ma
     '''
     mock_gui = mocker.MagicMock()
     co = Controller('http://localhost', mock_gui, session_maker, homedir)
-    co.on_delete_source_failure(Exception())
+    co.on_delete_source_failure(DeleteSourceJobException('weow', 'uuid'))
     co.gui.update_error_status.assert_called_with('Failed to delete source at server')
 
 


### PR DESCRIPTION
# Description

Fixes #966.

# Test Plan

0. First add to the source deletion server API endpoint (above [this](https://github.com/freedomofpress/securedrop/blob/develop/securedrop/journalist_app/api.py#L149) line): 

```
+            early_fail = random.choice([True, False])
+            if early_fail:
+                abort(404)
```

such that you get failures half the time.
1. Delete a source locally.
2. Upon deletion success, the pending status works as expected: the pending status is shown and the source disappears from the UI.
3. Upon deletion failure (_not_ due to timeouts), an error message is shown, the pending status is removed from both the `SourceWidget` in the source list and the conversation wrapper. 

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
