### PR TITLE
focus passphrase field

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2830,6 +2830,7 @@ class ExportDialog(ModalDialog):
         self.header_line.hide()
         self.error_details.hide()
         self.body.hide()
+        self.passphrase_field.setFocus()
         self.passphrase_form.show()
         self.adjustSize()
 
@@ -2842,6 +2843,7 @@ class ExportDialog(ModalDialog):
         self.header_line.hide()
         self.body.hide()
         self.error_details.show()
+        self.passphrase_field.setFocus()
         self.passphrase_form.show()
         self.adjustSize()
 


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/993

# Test Plan

1. Export and continue until you reach the passphrase field and make sure it's selected by default.
