### PR TITLE
app: do not show drafts in preview

### DIFF
--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -50,8 +50,8 @@ class Source(Base):
 
     @property
     def collection(self) -> List:
-        """Return the list of submissions and replies for this source, sorted
-        in ascending order by the filename/interaction count."""
+        """Return the list of submissions, replies, messages, and drafts for this
+        source, sorted in ascending order by the filename/interaction count."""
         collection = []  # type: List
         collection.extend(self.messages)
         collection.extend(self.files)
@@ -61,6 +61,18 @@ class Source(Base):
         collection.sort(key=lambda x: (x.file_counter,
                                        getattr(x, "timestamp",
                                                datetime.datetime(datetime.MINYEAR, 1, 1))))
+        return collection
+
+    @property
+    def server_collection(self) -> List:
+        """Return the list of submissions, replies, and messages for this source.
+        These are the items that have been either successfully sent to the server,
+        or they have been retrieved from the server."""
+        collection = []  # type: List
+        collection.extend(self.messages)
+        collection.extend(self.files)
+        collection.extend(self.replies)
+        collection.sort(key=lambda x: x.file_counter)
         return collection
 
     @property

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1228,10 +1228,10 @@ class SourceWidget(QWidget):
             self.timestamp.setText(_(arrow.get(self.source.last_updated).format('DD MMM')))
             self.name.setText(self.source.journalist_designation)
 
-            if not self.source.collection:
+            if not self.source.server_collection:
                 self.set_snippet(self.source_uuid, '')
             else:
-                last_collection_obj = self.source.collection[-1]
+                last_collection_obj = self.source.server_collection[-1]
                 self.set_snippet(self.source_uuid, str(last_collection_obj))
 
             if self.source.document_count == 0:

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1178,6 +1178,25 @@ def test_SourceWidget_update_raises_InvalidRequestError(mocker):
         assert mock_logger.error.call_count == 1
 
 
+def test_SourceWidget_set_snippet_draft_only(mocker, session_maker, session, homedir):
+    """
+    Snippets/previews do not include draft messages.
+    """
+    mock_gui = mocker.MagicMock()
+    controller = logic.Controller('http://localhost', mock_gui, session_maker, homedir)
+    source = factory.Source(document_count=1)
+    f = factory.File(source=source)
+    reply = factory.DraftReply(source=source)
+    session.add(f)
+    session.add(source)
+    session.add(reply)
+    session.commit()
+
+    sw = SourceWidget(controller, source)
+    sw.set_snippet(source.uuid, f.filename)
+    assert sw.preview.text() == f.filename
+
+
 def test_SourceWidget_set_snippet(mocker, session_maker, session, homedir):
     """
     Snippets are set as expected.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -142,6 +142,33 @@ def test_source_collection():
     assert source.collection[2] == message
 
 
+def test_source_server_collection():
+    # Create some test submissions and replies
+    source = factory.Source()
+    file_ = File(source=source, uuid="test", size=123, filename="2-test.doc.gpg",
+                 download_url='http://test/test')
+    message = Message(source=source, uuid="test", size=123, filename="3-test.doc.gpg",
+                      download_url='http://test/test')
+    user = User(username='hehe')
+    reply = Reply(source=source, journalist=user, filename="1-reply.gpg",
+                  size=1234, uuid='test')
+    draft_reply = DraftReply(source=source, journalist=user,
+                             uuid='test',
+                             timestamp=datetime.datetime(2002, 6, 6, 6, 0))
+    source.files = [file_]
+    source.messages = [message]
+    source.replies = [reply]
+    source.draftreplies = [draft_reply]
+
+    # Now these items should be in the source collection in the proper order
+    assert source.server_collection[0] == reply
+    assert source.server_collection[1] == file_
+    assert source.server_collection[2] == message
+
+    # Drafts do not appear in the server_collection, they are local only.
+    assert draft_reply not in source.server_collection
+
+
 def test_source_collection_ordering_with_multiple_draft_replies():
     # Create some test submissions, replies, and draft replies.
     source = factory.Source()


### PR DESCRIPTION
# Description

Fixes #997. The previews should show activity from the server only (cc @ninavizz), that is successful replies, and activity from the source. 

# Test Plan

0. Add to below [this line](https://github.com/freedomofpress/securedrop/blob/develop/securedrop/journalist_app/api.py#L231) in the server endpoint:

```diff
+            early_fail = random.choice([True, False])
+            if early_fail:
+                abort(404)
```
1. Submit replies until one fails.
2. Verify that the preview snippet does not contain the text of the failed reply. 

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
