### PR TITLE
Fix star hover state

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1351,7 +1351,7 @@ class StarToggleButton(SvgToggleButton):
         t = event.type()
         if t == QEvent.HoverEnter:
             self.setIcon(load_icon('star_hover.svg'))
-        elif t == QEvent.HoverLeave:
+        elif t == QEvent.HoverLeave or t == QEvent.MouseButtonPress:
             self.set_icon(on='star_on.svg', off='star_off.svg')
 
         return QObject.event(obj, event)


### PR DESCRIPTION
# Description

Fixes #985
Towards #986

This PR fixes the above two issues to the extent that Erik has described the expected initial solution (todo: hover background).

Screenie here:

![starmageddon](https://user-images.githubusercontent.com/37602/77553841-396c0700-6ead-11ea-882f-41442ed83f8a.gif)

# Test Plan

Eyeball Mk.1 :eyes:

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
