### PR TITLE
Prevent tooltips on source preview labels

### DIFF
--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -154,16 +154,21 @@ class SecureQLabel(QLabel):
         flags: Union[Qt.WindowFlags, Qt.WindowType] = Qt.WindowFlags(),
         wordwrap: bool = True,
         max_length: int = 0,
+        with_tooltip: bool = True,
     ):
         super().__init__(parent, flags)
         self.wordwrap = wordwrap
         self.max_length = max_length
         self.setWordWrap(wordwrap)  # If True, wraps text at default of 70 characters
+        self.with_tooltip = with_tooltip
         self.setText(text)
         self.elided = True if self.text() != text else False
 
     def setText(self, text: str) -> None:
         self.setTextFormat(Qt.PlainText)
+        if self.with_tooltip:
+            tooltip_label = SecureQLabel(text, with_tooltip=False)
+            self.setToolTip(tooltip_label.text())
         elided_text = self.get_elided_text(text)
         self.elided = True if elided_text != text else False
         super().setText(elided_text)
@@ -179,8 +184,6 @@ class SecureQLabel(QLabel):
         fm = self.fontMetrics()
         filename_width = fm.horizontalAdvance(full_text)
         if filename_width > self.max_length:
-            wrapped_tool_tip = SecureQLabel(full_text)
-            self.setToolTip(wrapped_tool_tip.text())
             elided_text = ''
             for c in full_text:
                 if fm.horizontalAdvance(elided_text) > self.max_length:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1175,7 +1175,7 @@ class SourceWidget(QWidget):
         summary_layout.setSpacing(0)
         self.name = QLabel()
         self.name.setObjectName('source_name')
-        self.preview = SecureQLabel(max_length=self.PREVIEW_WIDTH)
+        self.preview = SecureQLabel(max_length=self.PREVIEW_WIDTH, with_tooltip=False)
         self.preview.setObjectName('preview')
         self.preview.setFixedSize(QSize(self.PREVIEW_WIDTH, self.PREVIEW_HEIGHT))
         self.waiting_delete_confirmation = QLabel('Deletion in progress')


### PR DESCRIPTION
# Description

Allow `SecureQLabel` to disable tooltips via the `with_tooltip` constructor argument, which if `False` will prevent tooltips being automatically set for the `SecureQLabel` when its `setText` method is called.

Set `with_tooltip=False` on `SourceWidget`'s preview `SecureQLabel` so that no tooltip appears when hovering over it.

Fixes #999.

# Test Plan

- Check out this branch.
- Run the client. 
- Verify that hovering over the preview labels in the source list does not produce any tooltips.
- Upload a file with a very long name, download it in the client, and ensure that:
  - its name is truncated in the conversation view
  - its full name is shown in a tooltip if you hover over it

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
