### PR TITLE
disable the cancel button right before we export the file

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2946,6 +2946,7 @@ class ExportDialog(ModalDialog):
     @pyqtSlot()
     def _export_file(self, checked: bool = False):
         self.start_animate_activestate()
+        self.cancel_button.setEnabled(False)
         self.passphrase_field.setDisabled(True)
         self.controller.export_file_to_usb_drive(self.file_uuid, self.passphrase_field.text())
 
@@ -2978,6 +2979,7 @@ class ExportDialog(ModalDialog):
     @pyqtSlot(object)
     def _on_export_failure(self, error: ExportError):
         self.stop_animate_activestate()
+        self.cancel_button.setEnabled(True)
         self.passphrase_field.setDisabled(False)
         self._update_dialog(error.status)
 


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/992

# Test Plan

If you're not in Qubes:

1. apply this diff:
```diff
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -727,7 +727,8 @@ class Controller(QObject):
             return
 
         if not self.qubes:
-            self.export.export_usb_call_success.emit()
+            import threading
+            threading.Timer(4, lambda: self.export.export_usb_call_success.emit()).start()
             return
 
         self.export.begin_usb_export.emit([file_location], passphrase)
(END)
```
2. Export a file and see the cancel button disabled until it succeeds.
3. Also emit a failure signal and see the cancel button reenable.

Otherwise, just export a file in Qubes and test both cases.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes