### PR TITLE
Re-order widgets in the SourceList on update.

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -889,6 +889,22 @@ class EmptyConversationView(QWidget):
         self.no_source_selected.show()
 
 
+class SourceListWidgetItem(QListWidgetItem):
+
+    def __lt__(self, other):
+        """
+        Used for ordering widgets by timestamp of last interaction.
+        """
+        lw = self.listWidget()
+        me = lw.itemWidget(self)
+        them = lw.itemWidget(other)
+        if me and them:
+            my_ts = arrow.get(me.source.last_updated)
+            other_ts = arrow.get(them.source.last_updated)
+            return my_ts < other_ts
+        return True
+
+
 class SourceList(QListWidget):
     """
     Displays the list of sources.
@@ -920,6 +936,9 @@ class SourceList(QListWidget):
         # Set layout.
         layout = QVBoxLayout(self)
         self.setLayout(layout)
+
+        # Enable ordering.
+        self.setSortingEnabled(True)
 
         # To hold references to SourceWidget instances indexed by source UUID.
         self.source_widgets = {}
@@ -975,11 +994,13 @@ class SourceList(QListWidget):
                 new_source = SourceWidget(self.controller, source)
                 self.source_widgets[source.uuid] = new_source
 
-                list_item = QListWidgetItem()
+                list_item = SourceListWidgetItem()
                 self.insertItem(0, list_item)
                 list_item.setSizeHint(new_source.sizeHint())
                 self.setItemWidget(list_item, new_source)
 
+        # Sort..!
+        self.sortItems(Qt.DescendingOrder)
         return deleted_uuids
 
     def initial_update(self, sources: List[Source]):
@@ -1003,7 +1024,7 @@ class SourceList(QListWidget):
             for source in sources_slice:
                 new_source = SourceWidget(self.controller, source)
                 self.source_widgets[source.uuid] = new_source
-                list_item = QListWidgetItem(self)
+                list_item = SourceListWidgetItem(self)
                 list_item.setSizeHint(new_source.sizeHint())
 
                 self.insertItem(0, list_item)

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -769,7 +769,7 @@ def test_SourceList_update_adds_new_sources(mocker):
     mock_sw = mocker.MagicMock()
     mock_lwi = mocker.MagicMock()
     mocker.patch('securedrop_client.gui.widgets.SourceWidget', mock_sw)
-    mocker.patch('securedrop_client.gui.widgets.QListWidgetItem', mock_lwi)
+    mocker.patch('securedrop_client.gui.widgets.SourceListWidgetItem', mock_lwi)
 
     sources = [mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), ]
     sl.update(sources)
@@ -1009,7 +1009,7 @@ def test_SourceList_add_source_closure_adds_sources(mocker):
     mock_sw = mocker.MagicMock()
     mock_lwi = mocker.MagicMock()
     mocker.patch('securedrop_client.gui.widgets.SourceWidget', mock_sw)
-    mocker.patch('securedrop_client.gui.widgets.QListWidgetItem', mock_lwi)
+    mocker.patch('securedrop_client.gui.widgets.SourceListWidgetItem', mock_lwi)
     sources = [mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), ]
     mock_timer = mocker.MagicMock()
     with mocker.patch("securedrop_client.gui.widgets.QTimer", mock_timer):
@@ -1044,7 +1044,7 @@ def test_SourceList_add_source_closure_exits_on_no_more_sources(mocker):
     mock_sw = mocker.MagicMock()
     mock_lwi = mocker.MagicMock()
     mocker.patch('securedrop_client.gui.widgets.SourceWidget', mock_sw)
-    mocker.patch('securedrop_client.gui.widgets.QListWidgetItem', mock_lwi)
+    mocker.patch('securedrop_client.gui.widgets.SourceListWidgetItem', mock_lwi)
     sources = []
     mock_timer = mocker.MagicMock()
     with mocker.patch("securedrop_client.gui.widgets.QTimer", mock_timer):


### PR DESCRIPTION
# Description

Fixes #914.

Ensure the widgets are ordered by timestamp on update in the source list. Screenie of the behaviour:

![reorder](https://user-images.githubusercontent.com/37602/77659214-ad6ee380-6f6f-11ea-9739-379e67e5a6fd.gif)

Implementation of this was interesting. I was quite a way through doing something in the `update` method since the `sources` list passed into the method is in the correct order. However, I took a detour and wondered if Qt had some way to order widgets in a QListWidget. Turns out that it does and so I went for this far simpler code. Also, this will be a faster ordering since the ordering is being done in the Qt (C++) level rather than in pure Python.

# Test Plan

Updated the unit tests to patch the new `SourceListWidgetItem` class. Eyeball Mk.1 to ensure the order is correct (see screenie). :eyes:

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [X] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
