### PR TITLE
Revert the addition of tooltips to most SecureQLabel occurrences

### DIFF
--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -154,7 +154,7 @@ class SecureQLabel(QLabel):
         flags: Union[Qt.WindowFlags, Qt.WindowType] = Qt.WindowFlags(),
         wordwrap: bool = True,
         max_length: int = 0,
-        with_tooltip: bool = True,
+        with_tooltip: bool = False,
     ):
         super().__init__(parent, flags)
         self.wordwrap = wordwrap
@@ -166,11 +166,11 @@ class SecureQLabel(QLabel):
 
     def setText(self, text: str) -> None:
         self.setTextFormat(Qt.PlainText)
-        if self.with_tooltip:
-            tooltip_label = SecureQLabel(text, with_tooltip=False)
-            self.setToolTip(tooltip_label.text())
         elided_text = self.get_elided_text(text)
         self.elided = True if elided_text != text else False
+        if self.elided and self.with_tooltip:
+            tooltip_label = SecureQLabel(text)
+            self.setToolTip(tooltip_label.text())
         super().setText(elided_text)
 
     def get_elided_text(self, full_text: str) -> str:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1175,7 +1175,7 @@ class SourceWidget(QWidget):
         summary_layout.setSpacing(0)
         self.name = QLabel()
         self.name.setObjectName('source_name')
-        self.preview = SecureQLabel(max_length=self.PREVIEW_WIDTH, with_tooltip=False)
+        self.preview = SecureQLabel(max_length=self.PREVIEW_WIDTH)
         self.preview.setObjectName('preview')
         self.preview.setFixedSize(QSize(self.PREVIEW_WIDTH, self.PREVIEW_HEIGHT))
         self.waiting_delete_confirmation = QLabel('Deletion in progress')
@@ -2248,7 +2248,9 @@ class FileWidget(QWidget):
         self.export_button.clicked.connect(self._on_export_clicked)
         self.print_button.clicked.connect(self._on_print_clicked)
 
-        self.file_name = SecureQLabel(wordwrap=False, max_length=self.FILENAME_WIDTH_PX)
+        self.file_name = SecureQLabel(
+            wordwrap=False, max_length=self.FILENAME_WIDTH_PX, with_tooltip=True
+        )
         self.file_name.setObjectName('file_name')
         self.file_name.installEventFilter(self)
         self.file_name.setCursor(QCursor(Qt.PointingHandCursor))

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -2373,6 +2373,29 @@ def test_FileWidget_on_file_download_updates_items_when_uuid_matches(mocker, sou
     assert not fw.file_name.isHidden()
 
 
+def test_FileWidget_filename_truncation(mocker, source, session):
+    """
+    FileWidget should truncate long filenames.
+
+    The full filename should be available in the tooltip.
+    """
+    filename = "1-{}".format("x" * 1000)
+    file = factory.File(source=source['source'], filename=filename)
+    session.add(file)
+    session.commit()
+
+    get_file = mocker.MagicMock(return_value=file)
+    controller = mocker.MagicMock(get_file=get_file)
+
+    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0)
+    fw.update = mocker.MagicMock()
+
+    fw._on_file_downloaded(file.source.uuid, file.uuid, str(file))
+
+    assert fw.file_name.text().endswith("...")
+    assert fw.file_name.toolTip() == filename
+
+
 def test_FileWidget_on_file_download_updates_items_when_uuid_does_not_match(
     mocker, homedir, session, source,
 ):


### PR DESCRIPTION
# Description

Tooltips are only needed in the conversation view for long filenames that get truncated.

Fixes #1015.

# Test Plan

Start the client. Confirm that tooltips are not shown for the preview snippets in the source list, or any content in the conversation view except for long filenames that need to be truncated. You'll need to upload a document with a long filename to test that.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
