### PR TITLE
Speed up update_local_storage in sync

### DIFF
--- a/securedrop_client/utils.py
+++ b/securedrop_client/utils.py
@@ -1,5 +1,10 @@
-import os
+import logging
 import math
+import os
+import time
+
+from contextlib import contextmanager
+from typing import Generator
 
 
 def safe_mkdir(sdc_home: str, relative_path: str = None) -> None:
@@ -67,3 +72,12 @@ def humanize_filesize(filesize: int) -> str:
         return '{}KB'.format(math.floor(filesize / 1024))
     else:
         return '{}MB'.format(math.floor(filesize / 1024 ** 2))
+
+
+@contextmanager
+def chronometer(logger: logging.Logger, description: str) -> Generator:
+    start = time.perf_counter()
+    yield
+    elapsed = time.perf_counter() - start
+
+    logger.debug(f"{description} duration: {elapsed:.4f}s")

--- a/tests/api_jobs/test_sync.py
+++ b/tests/api_jobs/test_sync.py
@@ -1,7 +1,7 @@
 import os
 
 from securedrop_client.api_jobs.sync import MetadataSyncJob
-from securedrop_client.crypto import GpgHelper, CryptoError
+from securedrop_client.crypto import GpgHelper
 
 from tests import factory
 
@@ -22,7 +22,6 @@ def test_MetadataSyncJob_success(mocker, homedir, session, session_maker):
         }
     )
 
-    mock_key_import = mocker.patch.object(job.gpg, 'import_key')
     mock_get_remote_data = mocker.patch(
         'securedrop_client.api_jobs.sync.get_remote_data',
         return_value=([mock_source], [], []))
@@ -33,41 +32,6 @@ def test_MetadataSyncJob_success(mocker, homedir, session, session_maker):
 
     job.call_api(api_client, session)
 
-    assert mock_key_import.call_args[0][0] == mock_source.uuid
-    assert mock_key_import.call_args[0][1] == mock_source.key['public']
-    assert mock_key_import.call_args[0][2] == mock_source.key['fingerprint']
-    assert mock_get_remote_data.call_count == 1
-
-
-def test_MetadataSyncJob_success_with_key_import_fail(mocker, homedir, session, session_maker):
-    """
-    Check that we can gracefully handle a key import failure.
-    """
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
-    job = MetadataSyncJob(homedir, gpg)
-
-    mock_source = factory.RemoteSource(
-        key={
-            'type': 'PGP',
-            'public': PUB_KEY,
-            'fingerprint': '123456ABC',
-        }
-    )
-
-    mock_key_import = mocker.patch.object(job.gpg, 'import_key',
-                                          side_effect=CryptoError)
-    mock_get_remote_data = mocker.patch(
-        'securedrop_client.api_jobs.sync.get_remote_data',
-        return_value=([mock_source], [], []))
-
-    api_client = mocker.MagicMock()
-    api_client.default_request_timeout = mocker.MagicMock()
-
-    job.call_api(api_client, session)
-
-    assert mock_key_import.call_args[0][0] == mock_source.uuid
-    assert mock_key_import.call_args[0][1] == mock_source.key['public']
-    assert mock_key_import.call_args[0][2] == mock_source.key['fingerprint']
     assert mock_get_remote_data.call_count == 1
 
 
@@ -98,43 +62,3 @@ def test_MetadataSyncJob_success_with_missing_key(mocker, homedir, session, sess
 
     assert mock_key_import.call_count == 0
     assert mock_get_remote_data.call_count == 1
-
-
-def test_MetadataSyncJob_only_import_new_source_keys(mocker, homedir, session, session_maker):
-    """
-    Verify that we only import source keys we don't already have.
-    """
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
-    job = MetadataSyncJob(homedir, gpg)
-
-    mock_source = factory.RemoteSource(
-        key={
-            'type': 'PGP',
-            'public': PUB_KEY,
-            'fingerprint': '123456ABC',
-        }
-    )
-
-    mock_get_remote_data = mocker.patch(
-        'securedrop_client.api_jobs.sync.get_remote_data',
-        return_value=([mock_source], [], []))
-
-    api_client = mocker.MagicMock()
-    api_client.default_request_timeout = mocker.MagicMock()
-
-    crypto_logger = mocker.patch('securedrop_client.crypto.logger')
-    storage_logger = mocker.patch('securedrop_client.storage.logger')
-
-    job.call_api(api_client, session)
-
-    assert mock_get_remote_data.call_count == 1
-
-    log_msg = crypto_logger.debug.call_args_list[0][0]
-    assert log_msg == ('Importing key with fingerprint %s', mock_source.key['fingerprint'])
-
-    job.call_api(api_client, session)
-
-    assert mock_get_remote_data.call_count == 2
-
-    log_msg = storage_logger.debug.call_args_list[1][0][0]
-    assert log_msg == 'Source key data is unchanged'

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -37,14 +37,18 @@ def User(**attrs):
 
 
 def Source(**attrs):
+
+    with open(os.path.join(os.path.dirname(__file__), 'files', 'test-key.gpg.pub.asc')) as f:
+        pub_key = f.read()
+
     global SOURCE_COUNT
     SOURCE_COUNT += 1
     defaults = dict(
         uuid='source-uuid-{}'.format(SOURCE_COUNT),
         journalist_designation='testy-mctestface',
         is_flagged=False,
-        public_key='mah pub key',
-        fingerprint='mah fingerprint',
+        public_key=pub_key,
+        fingerprint='B2FF7FB28EED8CABEBC5FB6C6179D97BCFA52E5F',
         interaction_count=0,
         is_starred=False,
         last_updated=datetime.now(),

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -21,8 +21,7 @@ from securedrop_client.storage import get_local_sources, get_local_messages, get
     delete_single_submission_or_reply_on_disk, get_local_files, find_new_files, \
     source_exists, set_message_or_reply_content, mark_as_downloaded, mark_as_decrypted, get_file, \
     get_message, get_reply, update_and_get_user, update_missing_files, mark_as_not_downloaded, \
-    mark_all_pending_drafts_as_failed, delete_local_source_by_uuid, update_source_key, \
-    update_file_size
+    mark_all_pending_drafts_as_failed, delete_local_source_by_uuid, update_file_size
 
 from securedrop_client import db
 from tests import factory
@@ -367,50 +366,6 @@ def test_update_sources(homedir, mocker, session_maker, session):
     assert file_delete_fcn.call_count == 1
 
 
-def test_update_source_key_without_fingerprint(mocker, session):
-    """
-    Checks handling of a source from the API that lacks a fingerprint.
-    """
-
-    error_logger = mocker.patch('securedrop_client.storage.logger.error')
-
-    local_source = factory.Source(public_key=None, fingerprint=None)
-    session.add(local_source)
-
-    remote_source = factory.RemoteSource()
-    remote_source.key = {}
-
-    update_source_key(None, local_source, remote_source)
-
-    error_logger.assert_called_once_with("New source data lacks key fingerprint")
-
-    local_source2 = session.query(db.Source).filter_by(uuid=local_source.uuid).one()
-    assert not local_source2.fingerprint
-    assert not local_source2.public_key
-
-
-def test_update_source_key_without_key(mocker, session):
-    """
-    Checks handling of a source from the API that lacks a public key.
-    """
-
-    error_logger = mocker.patch('securedrop_client.storage.logger.error')
-
-    local_source = factory.Source(public_key=None, fingerprint=None)
-    session.add(local_source)
-
-    remote_source = factory.RemoteSource()
-    del remote_source.key["public"]
-
-    update_source_key(None, local_source, remote_source)
-
-    error_logger.assert_called_once_with("New source data lacks public key")
-
-    local_source2 = session.query(db.Source).filter_by(uuid=local_source.uuid).one()
-    assert not local_source2.fingerprint
-    assert not local_source2.public_key
-
-
 def add_test_file_to_temp_dir(home_dir, filename):
     """
     Add test file with the given filename to data dir.
@@ -721,7 +676,7 @@ def test_update_messages(homedir, mocker):
     assert mock_session.commit.call_count == 1
 
 
-def test_update_replies(homedir, mocker):
+def test_update_replies(homedir, mocker, session):
     """
     Check that:
 
@@ -732,67 +687,61 @@ def test_update_replies(homedir, mocker):
     * References to journalist's usernames are correctly handled.
     """
     data_dir = os.path.join(homedir, 'data')
-    mock_session = mocker.MagicMock()
-    # Source object related to the submissions.
-    source = mocker.MagicMock()
-    source.uuid = str(uuid.uuid4())
-    source.journalist_filename = 'test'
+
+    journalist = factory.User(id=1)
+    session.add(journalist)
+
+    source = factory.Source()
+    session.add(source)
+
     # Some remote reply objects from the API, one of which will exist in the
     # local database, the other will NOT exist in the local database
     # (this will be added to the database)
-    remote_reply_update = make_remote_reply(source.uuid)
-    remote_reply_create = make_remote_reply(source.uuid, 'unknownuser')
+    remote_reply_update = make_remote_reply(source.uuid, journalist.uuid)
+    remote_reply_create = make_remote_reply(source.uuid, journalist.uuid)
+    remote_reply_create.file_counter = 3
+    remote_reply_create.filename = "3-reply.gpg"
+
     remote_replies = [remote_reply_update, remote_reply_create]
+
     # Some local reply objects. One already exists in the API results
     # (this will be updated), one does NOT exist in the API results (this will
     # be deleted from the local database).
-    local_reply_update = mocker.MagicMock()
-    local_reply_update.uuid = remote_reply_update.uuid
-    local_filename = "originalsubmissionname.txt"
-    local_reply_update.filename = local_filename
-    local_reply_update.journalist_uuid = str(uuid.uuid4())
-    local_reply_delete = mocker.MagicMock()
-    local_reply_delete.uuid = str(uuid.uuid4())
-    local_reply_delete.filename = "local_reply_delete.filename"
-    local_reply_delete.journalist_uuid = str(uuid.uuid4())
-    local_reply_delete_source_dir = os.path.join(homedir, source.journalist_filename)
-    local_reply_delete.location = mocker.MagicMock(
-        return_value=os.path.join(local_reply_delete_source_dir, local_reply_delete.filename))
-    local_replies = [local_reply_update, local_reply_delete]
-    # There needs to be a corresponding local_source and local_user
-    local_source = mocker.MagicMock()
-    local_source.uuid = source.uuid
-    local_source.id = 666  # };-)
-    local_user = mocker.MagicMock()
-    local_user.username = remote_reply_create.journalist_username
-    local_user.id = 42
-    mock_session.query().filter_by.side_effect = [[local_source, ],
-                                                  NoResultFound()]
-    mock_focu = mocker.MagicMock(return_value=local_user)
-    mocker.patch('securedrop_client.storage.find_or_create_user', mock_focu)
+    local_reply_update = factory.Reply(
+        uuid=remote_reply_update.uuid,
+        source_id=source.id,
+        source=source,
+        journalist_id=journalist.id,
+        filename="1-original-reply.gpg.",
+        size=2,
+    )
+    session.add(local_reply_update)
 
-    update_replies(remote_replies, local_replies, mock_session, data_dir)
+    local_reply_delete = factory.Reply(
+        source_id=source.id,
+        source=source,
+    )
+    session.add(local_reply_delete)
+
+    local_replies = [local_reply_update, local_reply_delete]
+
+    update_replies(remote_replies, local_replies, session, data_dir)
+    session.commit()
 
     # Check the expected local reply object has been updated with values
     # from the API.
-    assert local_reply_update.journalist_id == local_user.id
-    assert local_reply_update.filename == local_filename
+    assert local_reply_update.journalist_id == journalist.id
     assert local_reply_update.size == remote_reply_update.size
+    assert local_reply_update.filename == remote_reply_update.filename
 
-    # Check the expected local source object has been created with values from
-    # the API.
-    assert mock_session.add.call_count == 1
-    new_reply = mock_session.add.call_args_list[0][0][0]
-    assert new_reply.uuid == remote_reply_create.uuid
-    assert new_reply.source_id == local_source.id
-    assert new_reply.journalist_id == local_user.id
+    new_reply = session.query(db.Reply).filter_by(uuid=remote_reply_create.uuid).one()
+    assert new_reply.source_id == source.id
+    assert new_reply.journalist_id == journalist.id
     assert new_reply.size == remote_reply_create.size
     assert new_reply.filename == remote_reply_create.filename
-    # Ensure the record for the local source that is missing from the results
-    # of the API is deleted.
-    mock_session.delete.assert_called_once_with(local_reply_delete)
-    # Session is committed to database.
-    assert mock_session.commit.call_count == 1
+
+    # Ensure the local reply that is not in the API results is deleted.
+    assert session.query(db.Reply).filter_by(uuid=local_reply_delete.uuid).count() == 0
 
 
 def test_update_replies_cleanup_drafts(homedir, mocker, session):


### PR DESCRIPTION
# Description

Stop importing source GPG keys during sync. We have a place on `Source` to store fingerprint and key, which is all we need for the import, and which is what we check when deciding whether to enable the reply box, so let's just update the database here and defer import to the keyring until someone actually wants to reply. It takes milliseconds that won't be noticed then, but do add up during sync.

Avoid dirtying synced objects on update unless they've actually changed.

Use maps instead of sets to hold local objects in the `update_` functions, so it's faster to check if we already have a record of incoming objects.

Reduce the number of database queries during sync: cache sources or journalists instead of looking them up for each incoming object associated with them.

Note that this stops short of switching to SQLAlchemy's bulk operations, so we may be able to speed `update_local_storage` up more when we can take the time to do that.

Fixes #1009.

# Test Plan

- Start the dev server with `NUM_SOURCES=1000` (reduce key size to 1024 in `securedrop/crypto_util.py` line 123 to reduce startup time). 
- Check out this branch.
- Run the client with `LOGLEVEL=debug ./run.sh --sdc-home ~/.securedrop_client`
- The source list should populate within about 30 seconds, and you should be able to reply to sources even though you can't yet read their messages or previous replies, so go ahead and test that.
- Optionally, check the durations of `update_local_storage` operations with `grep duration ~/.securedrop_client/logs/client.log`. None should take longer than about seven seconds with 1000 sources, and most should be quite a bit faster than that.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
