### PR TITLE
Defer source key import

### DIFF
--- a/securedrop_client/api_jobs/sync.py
+++ b/securedrop_client/api_jobs/sync.py
@@ -5,7 +5,6 @@ from sdclientapi import API
 from sqlalchemy.orm.session import Session
 
 from securedrop_client.api_jobs.base import ApiJob
-from securedrop_client.crypto import GpgHelper
 from securedrop_client.storage import get_remote_data, update_local_storage
 
 
@@ -19,10 +18,9 @@ class MetadataSyncJob(ApiJob):
 
     NUMBER_OF_TIMES_TO_RETRY_AN_API_CALL = 2
 
-    def __init__(self, data_dir: str, gpg: GpgHelper) -> None:
+    def __init__(self, data_dir: str) -> None:
         super().__init__(remaining_attempts=self.NUMBER_OF_TIMES_TO_RETRY_AN_API_CALL)
         self.data_dir = data_dir
-        self.gpg = gpg
 
     def call_api(self, api_client: API, session: Session) -> Any:
         '''
@@ -40,7 +38,6 @@ class MetadataSyncJob(ApiJob):
         remote_sources, remote_submissions, remote_replies = get_remote_data(api_client)
 
         update_local_storage(session,
-                             self.gpg,
                              remote_sources,
                              remote_submissions,
                              remote_replies,

--- a/securedrop_client/crypto.py
+++ b/securedrop_client/crypto.py
@@ -154,7 +154,7 @@ class GpgHelper:
         self._import(source.public_key)
 
     def _import(self, key_data: str) -> None:
-        '''Wrapper for `gpg --import-keys`'''
+        """Imports a key to the client GnuPG keyring."""
 
         with tempfile.NamedTemporaryFile('w+') as temp_key, \
                 tempfile.NamedTemporaryFile('w+') as stdout, \

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -31,7 +31,6 @@ from sqlalchemy import and_, desc, or_
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.session import Session
 
-from securedrop_client.crypto import GpgHelper
 from securedrop_client.db import (DraftReply, Source, Message, File, Reply, ReplySendStatus,
                                   ReplySendStatusCodes, User)
 from securedrop_client.utils import chronometer
@@ -105,7 +104,6 @@ def get_remote_data(api: API) -> Tuple[List[SDKSource], List[SDKSubmission], Lis
 
 
 def update_local_storage(session: Session,
-                         gpg: GpgHelper,
                          remote_sources: List[SDKSource],
                          remote_submissions: List[SDKSubmission],
                          remote_replies: List[SDKReply],
@@ -123,7 +121,7 @@ def update_local_storage(session: Session,
     # Because of that, each get_local_* function needs to be called just before
     # its respective update_* function.
     with chronometer(logger, "update_sources"):
-        update_sources(gpg, remote_sources, get_local_sources(session), session, data_dir)
+        update_sources(remote_sources, get_local_sources(session), session, data_dir)
 
     with chronometer(logger, "update_files"):
         update_files(remote_files, get_local_files(session), session, data_dir)
@@ -135,8 +133,8 @@ def update_local_storage(session: Session,
         update_replies(remote_replies, get_local_replies(session), session, data_dir)
 
 
-def update_sources(gpg: GpgHelper, remote_sources: List[SDKSource],
-                   local_sources: List[Source], session: Session, data_dir: str) -> None:
+def update_sources(remote_sources: List[SDKSource], local_sources:
+                   List[Source], session: Session, data_dir: str) -> None:
     """
     Given collections of remote sources, the current local sources and a
     session to the local database, ensure the state of the local database

--- a/securedrop_client/sync.py
+++ b/securedrop_client/sync.py
@@ -103,7 +103,7 @@ class ApiSyncBackgroundTask(QObject):
         self.on_sync_success = on_sync_success
         self.on_sync_failure = on_sync_failure
 
-        self.job = MetadataSyncJob(self.data_dir, self.gpg)
+        self.job = MetadataSyncJob(self.data_dir)
         self.job.success_signal.connect(self.on_sync_success, type=Qt.QueuedConnection)
         self.job.failure_signal.connect(self.on_sync_failure, type=Qt.QueuedConnection)
 

--- a/tests/api_jobs/test_sync.py
+++ b/tests/api_jobs/test_sync.py
@@ -1,7 +1,6 @@
 import os
 
 from securedrop_client.api_jobs.sync import MetadataSyncJob
-from securedrop_client.crypto import GpgHelper
 
 from tests import factory
 
@@ -11,8 +10,7 @@ with open(os.path.join(os.path.dirname(__file__), '..', 'files', 'test-key.gpg.p
 
 
 def test_MetadataSyncJob_success(mocker, homedir, session, session_maker):
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
-    job = MetadataSyncJob(homedir, gpg)
+    job = MetadataSyncJob(homedir)
 
     mock_source = factory.RemoteSource(
         key={
@@ -39,8 +37,7 @@ def test_MetadataSyncJob_success_with_missing_key(mocker, homedir, session, sess
     """
     Check that we can gracefully handle missing source keys.
     """
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
-    job = MetadataSyncJob(homedir, gpg)
+    job = MetadataSyncJob(homedir)
 
     mock_source = factory.RemoteSource(
         key={
@@ -50,7 +47,6 @@ def test_MetadataSyncJob_success_with_missing_key(mocker, homedir, session, sess
         }
     )
 
-    mock_key_import = mocker.patch.object(job.gpg, 'import_key')
     mock_get_remote_data = mocker.patch(
         'securedrop_client.api_jobs.sync.get_remote_data',
         return_value=([mock_source], [], []))
@@ -60,5 +56,4 @@ def test_MetadataSyncJob_success_with_missing_key(mocker, homedir, session, sess
 
     job.call_api(api_client, session)
 
-    assert mock_key_import.call_count == 0
     assert mock_get_remote_data.call_count == 1

--- a/tests/api_jobs/test_sync.py
+++ b/tests/api_jobs/test_sync.py
@@ -1,7 +1,7 @@
 import os
 
 from securedrop_client.api_jobs.sync import MetadataSyncJob
-from securedrop_client.crypto import GpgHelper, CryptoError
+from securedrop_client.crypto import GpgHelper
 
 from tests import factory
 
@@ -22,7 +22,6 @@ def test_MetadataSyncJob_success(mocker, homedir, session, session_maker):
         }
     )
 
-    mock_key_import = mocker.patch.object(job.gpg, 'import_key')
     mock_get_remote_data = mocker.patch(
         'securedrop_client.api_jobs.sync.get_remote_data',
         return_value=([mock_source], [], []))
@@ -33,41 +32,6 @@ def test_MetadataSyncJob_success(mocker, homedir, session, session_maker):
 
     job.call_api(api_client, session)
 
-    assert mock_key_import.call_args[0][0] == mock_source.uuid
-    assert mock_key_import.call_args[0][1] == mock_source.key['public']
-    assert mock_key_import.call_args[0][2] == mock_source.key['fingerprint']
-    assert mock_get_remote_data.call_count == 1
-
-
-def test_MetadataSyncJob_success_with_key_import_fail(mocker, homedir, session, session_maker):
-    """
-    Check that we can gracefully handle a key import failure.
-    """
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
-    job = MetadataSyncJob(homedir, gpg)
-
-    mock_source = factory.RemoteSource(
-        key={
-            'type': 'PGP',
-            'public': PUB_KEY,
-            'fingerprint': '123456ABC',
-        }
-    )
-
-    mock_key_import = mocker.patch.object(job.gpg, 'import_key',
-                                          side_effect=CryptoError)
-    mock_get_remote_data = mocker.patch(
-        'securedrop_client.api_jobs.sync.get_remote_data',
-        return_value=([mock_source], [], []))
-
-    api_client = mocker.MagicMock()
-    api_client.default_request_timeout = mocker.MagicMock()
-
-    job.call_api(api_client, session)
-
-    assert mock_key_import.call_args[0][0] == mock_source.uuid
-    assert mock_key_import.call_args[0][1] == mock_source.key['public']
-    assert mock_key_import.call_args[0][2] == mock_source.key['fingerprint']
     assert mock_get_remote_data.call_count == 1
 
 
@@ -98,43 +62,3 @@ def test_MetadataSyncJob_success_with_missing_key(mocker, homedir, session, sess
 
     assert mock_key_import.call_count == 0
     assert mock_get_remote_data.call_count == 1
-
-
-def test_MetadataSyncJob_only_import_new_source_keys(mocker, homedir, session, session_maker):
-    """
-    Verify that we only import source keys we don't already have.
-    """
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
-    job = MetadataSyncJob(homedir, gpg)
-
-    mock_source = factory.RemoteSource(
-        key={
-            'type': 'PGP',
-            'public': PUB_KEY,
-            'fingerprint': '123456ABC',
-        }
-    )
-
-    mock_get_remote_data = mocker.patch(
-        'securedrop_client.api_jobs.sync.get_remote_data',
-        return_value=([mock_source], [], []))
-
-    api_client = mocker.MagicMock()
-    api_client.default_request_timeout = mocker.MagicMock()
-
-    crypto_logger = mocker.patch('securedrop_client.crypto.logger')
-    storage_logger = mocker.patch('securedrop_client.storage.logger')
-
-    job.call_api(api_client, session)
-
-    assert mock_get_remote_data.call_count == 1
-
-    log_msg = crypto_logger.debug.call_args_list[0][0]
-    assert log_msg == ('Importing key with fingerprint %s', mock_source.key['fingerprint'])
-
-    job.call_api(api_client, session)
-
-    assert mock_get_remote_data.call_count == 2
-
-    log_msg = storage_logger.debug.call_args_list[5][0][0]
-    assert log_msg == 'Source key data is unchanged'

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -37,14 +37,18 @@ def User(**attrs):
 
 
 def Source(**attrs):
+
+    with open(os.path.join(os.path.dirname(__file__), 'files', 'test-key.gpg.pub.asc')) as f:
+        pub_key = f.read()
+
     global SOURCE_COUNT
     SOURCE_COUNT += 1
     defaults = dict(
         uuid='source-uuid-{}'.format(SOURCE_COUNT),
         journalist_designation='testy-mctestface',
         is_flagged=False,
-        public_key='mah pub key',
-        fingerprint='mah fingerprint',
+        public_key=pub_key,
+        fingerprint='B2FF7FB28EED8CABEBC5FB6C6179D97BCFA52E5F',
         interaction_count=0,
         is_starred=False,
         last_updated=datetime.now(),

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -21,8 +21,7 @@ from securedrop_client.storage import get_local_sources, get_local_messages, get
     delete_single_submission_or_reply_on_disk, get_local_files, find_new_files, \
     source_exists, set_message_or_reply_content, mark_as_downloaded, mark_as_decrypted, get_file, \
     get_message, get_reply, update_and_get_user, update_missing_files, mark_as_not_downloaded, \
-    mark_all_pending_drafts_as_failed, delete_local_source_by_uuid, update_source_key, \
-    update_file_size
+    mark_all_pending_drafts_as_failed, delete_local_source_by_uuid, update_file_size
 
 from securedrop_client import db
 from tests import factory
@@ -365,50 +364,6 @@ def test_update_sources(homedir, mocker, session_maker, session):
     # Ensure that we called the method to delete the source collection.
     # This will delete any content in that source's data directory.
     assert file_delete_fcn.call_count == 1
-
-
-def test_update_source_key_without_fingerprint(mocker, session):
-    """
-    Checks handling of a source from the API that lacks a fingerprint.
-    """
-
-    error_logger = mocker.patch('securedrop_client.storage.logger.error')
-
-    local_source = factory.Source(public_key=None, fingerprint=None)
-    session.add(local_source)
-
-    remote_source = factory.RemoteSource()
-    remote_source.key = {}
-
-    update_source_key(None, local_source, remote_source)
-
-    error_logger.assert_called_once_with("New source data lacks key fingerprint")
-
-    local_source2 = session.query(db.Source).filter_by(uuid=local_source.uuid).one()
-    assert not local_source2.fingerprint
-    assert not local_source2.public_key
-
-
-def test_update_source_key_without_key(mocker, session):
-    """
-    Checks handling of a source from the API that lacks a public key.
-    """
-
-    error_logger = mocker.patch('securedrop_client.storage.logger.error')
-
-    local_source = factory.Source(public_key=None, fingerprint=None)
-    session.add(local_source)
-
-    remote_source = factory.RemoteSource()
-    del remote_source.key["public"]
-
-    update_source_key(None, local_source, remote_source)
-
-    error_logger.assert_called_once_with("New source data lacks public key")
-
-    local_source2 = session.query(db.Source).filter_by(uuid=local_source.uuid).one()
-    assert not local_source2.fingerprint
-    assert not local_source2.public_key
 
 
 def add_test_file_to_temp_dir(home_dir, filename):


### PR DESCRIPTION
# Description

Stop importing source GPG keys during sync. We have a place on Source to store fingerprint and key, which is all we need for the import, and which is what we check when deciding whether to enable the reply box, so let's just update the database here and defer import to the keyring until someone actually wants to reply. It takes milliseconds that won't be noticed then, but do add up during sync.

This is based on and should be reviewed after #1034.

# Test Plan

Run the SD core dev server. Run the client with `run.sh` and a fresh data directory. Ensure that you can still reply to sources. If you can, then deferring the key import until replying is working.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
