### PR TITLE
When finding new files/messages/replies, work back in time

### DIFF
--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -429,7 +429,9 @@ def update_draft_replies(
 
 
 def find_new_files(session: Session) -> List[File]:
-    return session.query(File).filter_by(is_downloaded=False).all()
+    q = session.query(File).join(Source).filter_by(is_downloaded=False)
+    q = q.order_by(desc(Source.last_updated))
+    return q.all()
 
 
 def find_new_messages(session: Session) -> List[Message]:
@@ -441,10 +443,15 @@ def find_new_messages(session: Session) -> List[Message]:
     * The message has not yet had decryption attempted.
     * Decryption previously failed on a message.
     """
-    return session.query(Message).filter(
-        or_(Message.is_downloaded == False,
+    q = session.query(Message).join(Source).filter(
+        or_(
+            Message.is_downloaded == False,
             Message.is_decrypted == False,
-            Message.is_decrypted == None)).all()  # noqa: E711
+            Message.is_decrypted == None
+        )
+    )  # noqa: E712
+    q = q.order_by(desc(Source.last_updated))
+    return q.all()
 
 
 def find_new_replies(session: Session) -> List[Reply]:
@@ -456,10 +463,15 @@ def find_new_replies(session: Session) -> List[Reply]:
     * The reply has not yet had decryption attempted.
     * Decryption previously failed on a reply.
     """
-    return session.query(Reply).filter(
-        or_(Reply.is_downloaded == False,
+    q = session.query(Reply).join(Source).filter(
+        or_(
+            Reply.is_downloaded == False,
             Reply.is_decrypted == False,
-            Reply.is_decrypted == None)).all()  # noqa: E711
+            Reply.is_decrypted == None
+        )
+    )  # noqa: E712
+    q = q.order_by(desc(Source.last_updated))
+    return q.all()
 
 
 def mark_as_not_downloaded(uuid: str, session: Session) -> None:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -903,7 +903,7 @@ def test_find_new_files(mocker, session):
     mock_submission = mocker.MagicMock()
     mock_submission.is_downloaded = False
     mock_submissions = [mock_submission]
-    mock_session.query().filter_by().all.return_value = mock_submissions
+    mock_session.query().join().filter_by().order_by().all.return_value = mock_submissions
     submissions = find_new_files(mock_session)
     assert submissions[0].is_downloaded is False
 


### PR DESCRIPTION
# Description

Retrieving submissions and replies for the most recently active sources first will make the initial sync feel faster, as the visible part of the source list is updated first, and will make it possible to for journalists to work with what are likely the most interesting sources sooner.

Fixes #1042.
Fixes #883.

# Test Plan

- Check out this branch.
- Run the dev server with NUM_SOURCES=20.
- Start the client. The sources at the top of the list should have their messages and replies populated first. You should be able to see the progress of the sync as it works down through the source list (unfortunately, retrieving the individual submissions and replies is still that slow).

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, packaging logic (e.g., the AppArmor profile) may need to be updated. Please check as applicable:

 - [ ] I have submitted a separate PR to the [packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging)
 - [x] No update to the packaging logic (e.g., AppArmor profile) is required for these changes
 - [ ] I don't know and would appreciate guidance
