### PR TITLE
align source name and preview

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1134,7 +1134,6 @@ class SourceWidget(QWidget):
         font-weight: 500;
         font-size: 13px;
         color: #383838;
-        padding-top: 2px;
     }
     QLabel#timestamp {
         font-family: 'Montserrat';


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/987

# Test Plan

See that journalist designation and preview are aligned

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes
