### PR TITLE
align file name and PRINT button

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2157,7 +2157,7 @@ class FileWidget(QWidget):
         max-width: 48px;
         font-family: 'Source Sans Pro';
         font-weight: 400;
-        font-size: 14px;
+        font-size: 13px;
         color: #2a319d;
     }
     QWidget#horizontal_line {
@@ -2186,6 +2186,7 @@ class FileWidget(QWidget):
     FILE_FONT_SPACING = 2
     FILE_OPTIONS_FONT_SPACING = 1.6
     FILENAME_WIDTH_PX = 360
+    FILE_OPTIONS_LAYOUT_SPACING = 8
 
     def __init__(
         self,
@@ -2229,7 +2230,7 @@ class FileWidget(QWidget):
         file_options_layout = QHBoxLayout()
         self.file_options.setLayout(file_options_layout)
         file_options_layout.setContentsMargins(0, 0, 0, 0)
-        file_options_layout.setSpacing(8)
+        file_options_layout.setSpacing(self.FILE_OPTIONS_LAYOUT_SPACING)
         file_options_layout.setAlignment(Qt.AlignLeft)
         self.download_button = QPushButton(_(' DOWNLOAD'))
         self.download_button.setObjectName('download_button')


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/1033

Must be seen on Qubes because it looked fine on Debian.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes
