### PR TITLE
Speed update replies

### DIFF
--- a/securedrop_client/api_jobs/uploads.py
+++ b/securedrop_client/api_jobs/uploads.py
@@ -75,7 +75,9 @@ class SendReplyJob(ApiJob):
             draft_file_counter = draft_reply_db_object.file_counter
             draft_timestamp = draft_reply_db_object.timestamp
             update_draft_replies(
-                session, source.id, draft_timestamp, draft_file_counter, new_file_counter)
+                session, source.id, draft_timestamp, draft_file_counter, new_file_counter,
+                commit=False
+            )
 
             # Add reply to replies table and increase the source interaction count by 1 and delete
             # the draft reply.

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -329,9 +329,7 @@ def update_replies(remote_replies: List[SDKReply], local_replies: List[Reply],
     session.commit()
 
 
-def find_or_create_user(uuid: str,
-                        username: str,
-                        session: Session) -> User:
+def find_or_create_user(uuid: str, username: str, session: Session, commit: bool = True) -> User:
     """
     Returns a user object representing the referenced journalist UUID.
     If the user does not already exist in the data, a new instance is created.
@@ -343,12 +341,14 @@ def find_or_create_user(uuid: str,
         new_user = User(username=username)
         new_user.uuid = uuid
         session.add(new_user)
-        session.commit()
+        if commit:
+            session.commit()
         return new_user
 
     if user.username != username:
         user.username = username
-        session.commit()
+        if commit:
+            session.commit()
 
     return user
 

--- a/securedrop_client/utils.py
+++ b/securedrop_client/utils.py
@@ -88,7 +88,7 @@ def chronometer(logger: logging.Logger, description: str) -> Generator:
         yield
     finally:
         elapsed = time.perf_counter() - start
-        logger.debug(f"{description} duration: {elapsed:.4f}s")
+        logger.info(f"{description} duration: {elapsed:.4f}s")
 
 
 class SourceCache(object):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -20,7 +20,8 @@ from securedrop_client.storage import get_local_sources, get_local_messages, get
     delete_single_submission_or_reply_on_disk, get_local_files, find_new_files, \
     source_exists, set_message_or_reply_content, mark_as_downloaded, mark_as_decrypted, get_file, \
     get_message, get_reply, update_and_get_user, update_missing_files, mark_as_not_downloaded, \
-    mark_all_pending_drafts_as_failed, delete_local_source_by_uuid, update_file_size
+    mark_all_pending_drafts_as_failed, delete_local_source_by_uuid, update_file_size, \
+    update_draft_replies
 
 from securedrop_client import db
 from tests import factory
@@ -1206,3 +1207,16 @@ def test_update_file_size(homedir, session):
     update_file_size(f.uuid, data_dir, session)
 
     assert f.size == real_size
+
+
+def test_update_draft_replies_commit(mocker, session):
+    """
+    Tests the commit argument of storage.update_draft_replies.
+    """
+    session.commit = mocker.MagicMock()
+
+    update_draft_replies(session, "notreal", datetime.datetime.now(), 1, 2, commit=False)
+    assert session.commit.call_count == 0
+
+    update_draft_replies(session, "notreal", datetime.datetime.now(), 1, 2)
+    assert session.commit.call_count == 1


### PR DESCRIPTION
# Description

A bit more progress toward #1009.

# Test Plan

- Run the dev server with 1000 sources.
- Check out this branch and run the client. 
- Ensure that syncing completes, that the source list and conversation view populate correctly, and that you can reply to sources. If you `grep duration` in the client log, `update_replies` should take around 2.5 seconds on this branch, compared to just over three on the `minimize_sync_lookups` branch upon which this is based.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/master/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance
