### PR TITLE
Adds wordwrap and text selectability for messages and replies

### DIFF
--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -21,7 +21,7 @@ import math
 
 from PyQt5.QtWidgets import QLabel, QHBoxLayout, QPlainTextEdit, QPushButton, QWidget
 from PyQt5.QtCore import QSize, Qt
-from PyQt5.QtGui import QFont
+from PyQt5.QtGui import QFocusEvent, QFont, QMouseEvent
 
 from securedrop_client.resources import load_svg, load_icon
 
@@ -244,11 +244,11 @@ class SecureQPlainTextEdit(QPlainTextEdit):
         self.height = self.HEIGHT_BASE + (document_lines * self.LINE_HEIGHT)
         self.setFixedHeight(self.height)
 
-    def mouseReleaseEvent(self, event):
+    def mouseReleaseEvent(self, event: QMouseEvent) -> None:
         self.setFocus()
         super().mouseReleaseEvent(event)
 
-    def focusOutEvent(self, event):
+    def focusOutEvent(self, event: QFocusEvent) -> None:
         clear_text_cursor = self.textCursor()
         clear_text_cursor.clearSelection()
         self.setTextCursor(clear_text_cursor)

--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -212,6 +212,9 @@ class SecureQPlainTextEdit(QPlainTextEdit):
         self.height = self.HEIGHT_BASE
         self.setPlainText(text)
 
+        # Disable copy/paste context menu
+        self.setContextMenuPolicy(Qt.NoContextMenu)
+
     def setPlainText(self, text: str) -> None:
         super().setPlainText(text)
 

--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -201,7 +201,7 @@ class SecureQLabel(QLabel):
 class SecureQPlainTextEdit(QPlainTextEdit):
     MAX_TEXT_WIDTH = 75
     MAX_NATURAL_TEXT_WIDTH = 650
-    HEIGHT_BASE = 40
+    HEIGHT_BASE = 60
     LINE_HEIGHT = 20
 
     def __init__(self, text: str = ""):
@@ -209,20 +209,16 @@ class SecureQPlainTextEdit(QPlainTextEdit):
         self.setReadOnly(True)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.document().setTextWidth(self.MAX_TEXT_WIDTH)
+        self.height = self.HEIGHT_BASE
         self.setPlainText(text)
 
     def setPlainText(self, text):
         super().setPlainText(text)
+
         total_line_count = 0
         for block_num in range(0, self.blockCount()):
             block = self.document().findBlockByNumber(block_num)
-            line_count = 0
-            line_count = line_count + math.ceil(block.length() / self.document().idealWidth())
-            text_layout = block.layout()
-            for line_num in range(0, text_layout.lineCount()):
-                line = text_layout.lineAt(line_num)
-                line_wrap_count = math.floor(line.naturalTextWidth() / self.MAX_NATURAL_TEXT_WIDTH)
-                line_count = line_count + line_wrap_count
+            line_count = math.ceil(block.length() / self.document().idealWidth())
             total_line_count = total_line_count + line_count
 
         self.height = self.HEIGHT_BASE + (total_line_count * self.LINE_HEIGHT)

--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -16,10 +16,9 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-import textwrap
 from typing import Union
 
-from PyQt5.QtWidgets import QPlainTextEdit, QHBoxLayout, QPushButton, QWidget, QLabel
+from PyQt5.QtWidgets import QLabel, QHBoxLayout, QPlainTextEdit, QPushButton, QWidget
 from PyQt5.QtCore import QSize, Qt
 
 from securedrop_client.resources import load_svg, load_icon
@@ -147,7 +146,7 @@ class SvgLabel(QLabel):
         self.layout().addWidget(self.svg)
 
 
-class SecureQLabel(QPlainTextEdit):
+class SecureQLabel(QLabel):
     def __init__(
         self,
         text: str = "",
@@ -157,27 +156,22 @@ class SecureQLabel(QPlainTextEdit):
         max_length: int = 0,
         with_tooltip: bool = False,
     ):
-        super().__init__(parent)
+        super().__init__(parent, flags)
         self.wordwrap = wordwrap
         self.max_length = max_length
+        self.setWordWrap(wordwrap)  # If True, wraps text at default of 70 characters
         self.with_tooltip = with_tooltip
-        self.setReadOnly(True)
         self.setText(text)
-        self.elided = True if self.toPlainText() != text else False
-        self.setStyleSheet("SecureQLabel { border: none; } ")
-        policy = self.sizePolicy()
-        policy.setVerticalStretch(1)
-        self.setSizePolicy(policy)
+        self.elided = True if self.text() != text else False
 
     def setText(self, text: str) -> None:
+        self.setTextFormat(Qt.PlainText)
         elided_text = self.get_elided_text(text)
         self.elided = True if elided_text != text else False
         if self.elided and self.with_tooltip:
             tooltip_label = SecureQLabel(text)
-            tooltip_text = tooltip_label.plainText()
-            self.setToolTip(tooltip_text)
-
-        super().setPlainText(elided_text)
+            self.setToolTip(tooltip_label.text())
+        super().setText(elided_text)
 
     def get_elided_text(self, full_text: str) -> str:
         if not self.max_length:
@@ -202,5 +196,12 @@ class SecureQLabel(QPlainTextEdit):
     def is_elided(self) -> bool:
         return self.elided
 
-    def text(self) -> str:
-        return self.toPlainText()
+
+class SecureQPlainTextEdit(QPlainTextEdit):
+    def __init__(self, text: str = ""):
+        super().__init__()
+        self.setReadOnly(True)
+        self.setPlainText(text)
+        policy = self.sizePolicy()
+        policy.setVerticalStretch(1)
+        self.setSizePolicy(policy)

--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -17,6 +17,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from typing import Union
+import math
 
 from PyQt5.QtWidgets import QLabel, QHBoxLayout, QPlainTextEdit, QPushButton, QWidget
 from PyQt5.QtCore import QSize, Qt
@@ -198,10 +199,31 @@ class SecureQLabel(QLabel):
 
 
 class SecureQPlainTextEdit(QPlainTextEdit):
+    MAX_TEXT_WIDTH = 75
+    MAX_NATURAL_TEXT_WIDTH = 650
+    HEIGHT_BASE = 40
+    LINE_HEIGHT = 20
+
     def __init__(self, text: str = ""):
         super().__init__()
         self.setReadOnly(True)
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.document().setTextWidth(self.MAX_TEXT_WIDTH)
         self.setPlainText(text)
-        policy = self.sizePolicy()
-        policy.setVerticalStretch(1)
-        self.setSizePolicy(policy)
+
+    def setPlainText(self, text):
+        super().setPlainText(text)
+        total_line_count = 0
+        for block_num in range(0, self.blockCount()):
+            block = self.document().findBlockByNumber(block_num)
+            line_count = 0
+            line_count = line_count + math.ceil(block.length() / self.document().idealWidth())
+            text_layout = block.layout()
+            for line_num in range(0, text_layout.lineCount()):
+                line = text_layout.lineAt(line_num)
+                line_wrap_count = math.floor(line.naturalTextWidth() / self.MAX_NATURAL_TEXT_WIDTH)
+                line_count = line_count + line_wrap_count
+            total_line_count = total_line_count + line_count
+
+        self.height = self.HEIGHT_BASE + (total_line_count * self.LINE_HEIGHT)
+        self.setFixedHeight(self.height)

--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -223,3 +223,13 @@ class SecureQPlainTextEdit(QPlainTextEdit):
 
         self.height = self.HEIGHT_BASE + (total_line_count * self.LINE_HEIGHT)
         self.setFixedHeight(self.height)
+
+    def mouseReleaseEvent(self, event):
+        self.setFocus()
+        super().mouseReleaseEvent(event)
+
+    def focusOutEvent(self, event):
+        clear_text_cursor = self.textCursor()
+        clear_text_cursor.clearSelection()
+        self.setTextCursor(clear_text_cursor)
+        super().focusOutEvent(event)

--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -16,6 +16,7 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+import textwrap
 from typing import Union
 
 from PyQt5.QtWidgets import QLabel, QHBoxLayout, QPushButton, QWidget
@@ -170,8 +171,13 @@ class SecureQLabel(QLabel):
         self.elided = True if elided_text != text else False
         if self.elided and self.with_tooltip:
             tooltip_label = SecureQLabel(text)
-            self.setToolTip(tooltip_label.text())
-        super().setText(elided_text)
+            tooltip_text = tooltip_label.text()
+            if tooltip_text.find("\n") != -1:
+                tooltip_text = "".join(tooltip_text.split("\n"))
+            self.setToolTip(tooltip_text)
+
+        wrapped = "\n".join(textwrap.wrap(elided_text))
+        super().setText(wrapped)
 
     def get_elided_text(self, full_text: str) -> str:
         if not self.max_length:

--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -204,7 +204,7 @@ class SecureQPlainTextEdit(QPlainTextEdit):
     HEIGHT_BASE = 60
     LINE_HEIGHT = 20
 
-    def __init__(self, text: str = ""):
+    def __init__(self, text: str = '') -> None:
         super().__init__()
         self.setReadOnly(True)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
@@ -212,7 +212,7 @@ class SecureQPlainTextEdit(QPlainTextEdit):
         self.height = self.HEIGHT_BASE
         self.setPlainText(text)
 
-    def setPlainText(self, text):
+    def setPlainText(self, text: str) -> None:
         super().setPlainText(text)
 
         total_line_count = 0

--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import textwrap
 from typing import Union
 
-from PyQt5.QtWidgets import QLabel, QHBoxLayout, QPushButton, QWidget
+from PyQt5.QtWidgets import QPlainTextEdit, QHBoxLayout, QPushButton, QWidget, QLabel
 from PyQt5.QtCore import QSize, Qt
 
 from securedrop_client.resources import load_svg, load_icon
@@ -147,7 +147,7 @@ class SvgLabel(QLabel):
         self.layout().addWidget(self.svg)
 
 
-class SecureQLabel(QLabel):
+class SecureQLabel(QPlainTextEdit):
     def __init__(
         self,
         text: str = "",
@@ -157,27 +157,27 @@ class SecureQLabel(QLabel):
         max_length: int = 0,
         with_tooltip: bool = False,
     ):
-        super().__init__(parent, flags)
+        super().__init__(parent)
         self.wordwrap = wordwrap
         self.max_length = max_length
-        self.setWordWrap(wordwrap)  # If True, wraps text at default of 70 characters
         self.with_tooltip = with_tooltip
+        self.setReadOnly(True)
         self.setText(text)
-        self.elided = True if self.text() != text else False
+        self.elided = True if self.toPlainText() != text else False
+        self.setStyleSheet("SecureQLabel { border: none; } ")
+        policy = self.sizePolicy()
+        policy.setVerticalStretch(1)
+        self.setSizePolicy(policy)
 
     def setText(self, text: str) -> None:
-        self.setTextFormat(Qt.PlainText)
         elided_text = self.get_elided_text(text)
         self.elided = True if elided_text != text else False
         if self.elided and self.with_tooltip:
             tooltip_label = SecureQLabel(text)
-            tooltip_text = tooltip_label.text()
-            if tooltip_text.find("\n") != -1:
-                tooltip_text = "".join(tooltip_text.split("\n"))
+            tooltip_text = tooltip_label.plainText()
             self.setToolTip(tooltip_text)
 
-        wrapped = "\n".join(textwrap.wrap(elided_text))
-        super().setText(wrapped)
+        super().setPlainText(elided_text)
 
     def get_elided_text(self, full_text: str) -> str:
         if not self.max_length:
@@ -201,3 +201,6 @@ class SecureQLabel(QLabel):
 
     def is_elided(self) -> bool:
         return self.elided
+
+    def text(self) -> str:
+        return self.toPlainText()

--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -232,7 +232,7 @@ class SecureQPlainTextEdit(QPlainTextEdit):
         # Resize widget height to fit text
         document_lines = 0
         fm = self.fontMetrics()
-        max_line_width = self.size().width() + 4
+        max_line_width = self.size().width() + self.document().documentMargin()
         for block_num in range(0, self.blockCount()):
             block = self.document().findBlockByNumber(block_num)
             block_length = fm.horizontalAdvance(block.text())

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -38,7 +38,8 @@ from securedrop_client import __version__ as sd_version
 from securedrop_client.db import DraftReply, Source, Message, File, Reply, User
 from securedrop_client.storage import source_exists
 from securedrop_client.export import ExportStatus, ExportError
-from securedrop_client.gui import SecureQLabel, SvgLabel, SvgPushButton, SvgToggleButton
+from securedrop_client.gui import SecureQLabel, SecureQPlainTextEdit, SvgLabel, SvgPushButton, \
+    SvgToggleButton
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_icon, load_image, load_movie
 from securedrop_client.utils import humanize_filesize
@@ -1899,6 +1900,7 @@ class SpeechBubble(QWidget):
         font-size: 15px;
         background-color: #fff;
         padding: 16px;
+        border: none;
     }
     #color_bar {
         min-height: 5px;
@@ -1929,7 +1931,7 @@ class SpeechBubble(QWidget):
         layout.setSpacing(0)
 
         # Message box
-        self.message = SecureQLabel(text)
+        self.message = SecureQPlainTextEdit(text)
         self.message.setObjectName('message')
 
         # Color bar
@@ -3135,7 +3137,7 @@ class ConversationView(QWidget):
                 # Check if text in item has changed, then update the
                 # widget to reflect this change.
                 if not isinstance(item_widget, FileWidget):
-                    if (item_widget.message.text() != conversation_item.content) and \
+                    if (item_widget.message.toPlainText() != conversation_item.content) and \
                             conversation_item.content:
                         item_widget.message.setText(conversation_item.content)
             else:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1899,7 +1899,7 @@ class SpeechBubble(QWidget):
         font-weight: 400;
         font-size: 15px;
         background-color: #fff;
-        padding: 16px;
+        padding: 24px;
         border: none;
     }
     #color_bar {
@@ -1996,7 +1996,7 @@ class ReplyWidget(SpeechBubble):
         font-size: 15px;
         background-color: #fff;
         color: #3b3b3b;
-        padding: 16px;
+        padding: 24px;
     '''
 
     CSS_COLOR_BAR_REPLY_FAILED = '''
@@ -2019,7 +2019,7 @@ class ReplyWidget(SpeechBubble):
         font-size: 15px;
         background-color: #fff;
         color: #3b3b3b;
-        padding: 16px;
+        padding: 24px;
     '''
 
     CSS_COLOR_BAR_REPLY_SUCCEEDED = '''
@@ -2035,7 +2035,7 @@ class ReplyWidget(SpeechBubble):
         font-size: 15px;
         color: #A9AAAD;
         background-color: #F7F8FC;
-        padding: 16px;
+        padding: 24px;
     '''
 
     CSS_COLOR_BAR_REPLY_PENDING = '''

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1918,7 +1918,7 @@ class SpeechBubble(QWidget):
 
         # Set styles
         self.setStyleSheet(self.CSS)
-        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
 
         # Set layout
         layout = QVBoxLayout()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1899,7 +1899,7 @@ class SpeechBubble(QWidget):
         font-weight: 400;
         font-size: 15px;
         background-color: #fff;
-        padding: 24px;
+        padding: 16px;
         border: none;
     }
     #color_bar {
@@ -1996,7 +1996,7 @@ class ReplyWidget(SpeechBubble):
         font-size: 15px;
         background-color: #fff;
         color: #3b3b3b;
-        padding: 24px;
+        padding: 16px;
     '''
 
     CSS_COLOR_BAR_REPLY_FAILED = '''
@@ -2019,7 +2019,7 @@ class ReplyWidget(SpeechBubble):
         font-size: 15px;
         background-color: #fff;
         color: #3b3b3b;
-        padding: 24px;
+        padding: 16px;
     '''
 
     CSS_COLOR_BAR_REPLY_SUCCEEDED = '''
@@ -2035,7 +2035,7 @@ class ReplyWidget(SpeechBubble):
         font-size: 15px;
         color: #A9AAAD;
         background-color: #F7F8FC;
-        padding: 24px;
+        padding: 16px;
     '''
 
     CSS_COLOR_BAR_REPLY_PENDING = '''

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1939,14 +1939,16 @@ class SpeechBubble(QWidget):
         self.color_bar.setObjectName('color_bar')
 
         # Speech bubble
-        speech_bubble = QWidget()
-        speech_bubble.setObjectName('speech_bubble')
+        self.speech_bubble = QWidget()
+        self.speech_bubble.setObjectName('speech_bubble')
         speech_bubble_layout = QVBoxLayout()
-        speech_bubble.setLayout(speech_bubble_layout)
+        self.speech_bubble.setLayout(speech_bubble_layout)
         speech_bubble_layout.addWidget(self.message)
         speech_bubble_layout.addWidget(self.color_bar)
         speech_bubble_layout.setContentsMargins(0, 0, 0, 0)
         speech_bubble_layout.setSpacing(0)
+        # self.speech_bubble.setFixedHeight(self.message.height)
+        self.speech_bubble.adjustSize()
 
         # Bubble area includes speech bubble plus error message if there is an error
         bubble_area = QWidget()
@@ -1954,7 +1956,7 @@ class SpeechBubble(QWidget):
         self.bubble_area_layout = QHBoxLayout()
         self.bubble_area_layout.setContentsMargins(0, self.TOP_MARGIN, 0, self.BOTTOM_MARGIN)
         bubble_area.setLayout(self.bubble_area_layout)
-        self.bubble_area_layout.addWidget(speech_bubble)
+        self.bubble_area_layout.addWidget(self.speech_bubble)
 
         # Add widget to layout
         layout.addWidget(bubble_area)
@@ -1969,7 +1971,9 @@ class SpeechBubble(QWidget):
         signal matches the uuid of this speech bubble.
         """
         if message_uuid == self.uuid:
-            self.message.setText(text)
+            self.message.setPlainText(text)
+            # self.speech_bubble.setFixedHeight(self.message.height)
+            self.speech_bubble.adjustSize()
 
 
 class MessageWidget(SpeechBubble):

--- a/tests/functional/test_download_file.py
+++ b/tests/functional/test_download_file.py
@@ -44,7 +44,7 @@ def test_download_file(qtbot, mocker):
     # We see the source's message.
     last_msg_id = list(conversation.conversation_view.current_messages.keys())[-2]
     last_msg = conversation.conversation_view.current_messages[last_msg_id]
-    assert last_msg.message.text() == message
+    assert last_msg.message.toPlainText() == message
 
     # Let us download the file
     qtbot.mouseClick(file_msg.download_button, Qt.LeftButton)

--- a/tests/functional/test_export_dialog.py
+++ b/tests/functional/test_export_dialog.py
@@ -44,7 +44,7 @@ def test_export_dialog(qtbot, mocker):
     # We see the source's message.
     last_msg_id = list(conversation.conversation_view.current_messages.keys())[-2]
     last_msg = conversation.conversation_view.current_messages[last_msg_id]
-    assert last_msg.message.text() == message
+    assert last_msg.message.toPlainText() == message
 
     # Let us download the file
     qtbot.mouseClick(file_msg.download_button, Qt.LeftButton)

--- a/tests/functional/test_receive_message.py
+++ b/tests/functional/test_receive_message.py
@@ -44,4 +44,4 @@ def test_receive_message_from_source(qtbot, mocker):
     # We see the source's message.
     last_msg_id = list(conversation.conversation_view.current_messages.keys())[-2]
     last_msg = conversation.conversation_view.current_messages[last_msg_id]
-    assert last_msg.message.text() == message
+    assert last_msg.message.toPlainText() == message

--- a/tests/functional/test_send_reply.py
+++ b/tests/functional/test_send_reply.py
@@ -47,4 +47,4 @@ def test_send_reply_to_source(qtbot, mocker):
     # just typed.
     last_msg_id = list(conversation.conversation_view.current_messages.keys())[-1]
     last_msg = conversation.conversation_view.current_messages[last_msg_id]
-    assert last_msg.message.text() == message
+    assert last_msg.message.toPlainText() == message

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -2031,7 +2031,7 @@ def test_SpeechBubble_init(mocker):
     sb = SpeechBubble('mock id', 'hello', mock_signal, 0)
     ss = sb.styleSheet()
 
-    sb.message.text() == 'hello'
+    sb.message.toPlainText() == 'hello'
     assert mock_connect.called
     assert 'background-color' in ss
 
@@ -2047,11 +2047,11 @@ def test_SpeechBubble_update_text(mocker):
 
     new_msg = 'new message'
     sb._update_text('mock_source_uuid', msg_id, new_msg)
-    assert sb.message.text() == new_msg
+    assert sb.message.toPlainText() == new_msg
 
     newer_msg = 'an even newer message'
     sb._update_text('mock_source_uuid', msg_id + 'xxxxx', newer_msg)
-    assert sb.message.text() == new_msg
+    assert sb.message.toPlainText() == new_msg
 
 
 def test_SpeechBubble_html_init(mocker):
@@ -2062,7 +2062,7 @@ def test_SpeechBubble_html_init(mocker):
     mock_signal = mocker.MagicMock()
 
     bubble = SpeechBubble('mock id', '<b>hello</b>', mock_signal, 0)
-    assert bubble.message.text() == '<b>hello</b>'
+    assert bubble.message.toPlainText() == '<b>hello</b>'
 
 
 def test_SpeechBubble_with_apostrophe_in_text(mocker):
@@ -2071,7 +2071,7 @@ def test_SpeechBubble_with_apostrophe_in_text(mocker):
 
     message = "I'm sure, you are reading my message."
     bubble = SpeechBubble('mock id', message, mock_signal, 0)
-    assert bubble.message.text() == message
+    assert bubble.message.toPlainText() == message
 
 
 def test_MessageWidget_init(mocker):


### PR DESCRIPTION
# Description

Fixes #815 

Wraps the text at the default 70 length

# Test Plan

Follow the STR at https://github.com/freedomofpress/securedrop-client/issues/998

Initial test data:

* Should be one line:
```
WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW
```
* Should be two lines:
```
WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW
```
* Should be one line:
```
.................................................................................................................................
```
* Should be two lines:
```
..................................................................................................................................
```
*
```
thisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashes

thisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashes

thisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashesthisisalongwordwithoutspacesordashes
```

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/master/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance
