### PR TITLE
increase sync timeout

### DIFF
--- a/securedrop_client/api_jobs/sync.py
+++ b/securedrop_client/api_jobs/sync.py
@@ -34,7 +34,10 @@ class MetadataSyncJob(ApiJob):
         # TODO: Once https://github.com/freedomofpress/securedrop-client/issues/648, we will want to
         # pass the default request timeout to api calls instead of setting it on the api object
         # directly.
-        api_client.default_request_timeout = 40
+        #
+        # This timeout is used for 3 different requests: `get_sources`, `get_all_submissions`, and
+        # `get_all_replies`
+        api_client.default_request_timeout = 60
         remote_sources, remote_submissions, remote_replies = get_remote_data(api_client)
 
         update_local_storage(session,


### PR DESCRIPTION
# Description

We are increasing the qrexec subprocess timeout for `get_sources`, `get_all_submissions`, and `get_all_replies` from 40 to 60 while we continue to investigate workstation performance.

I also think it would make sense to decrease the number of retries to 1 so that we can inform the user of a connection issue after 2 minutes instead of 3. I can add that to here if others agree.

# Test Plan

Make sure there are no regressions.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/master/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance
