### PR TITLE
rely on sdk default for most requests

### DIFF
--- a/securedrop_client/api_jobs/sources.py
+++ b/securedrop_client/api_jobs/sources.py
@@ -22,11 +22,6 @@ class DeleteSourceJob(ApiJob):
         '''
         try:
             source_sdk_object = sdclientapi.Source(uuid=self.source_uuid)
-
-            # TODO: After https://github.com/freedomofpress/securedrop-client/issues/648 is
-            # merged, we will want to pass the timeout to delete_source instead of setting
-            # it on the api object
-            api_client.default_request_timeout = 5
             api_client.delete_source(source_sdk_object)
 
             return self.source_uuid

--- a/securedrop_client/api_jobs/updatestar.py
+++ b/securedrop_client/api_jobs/updatestar.py
@@ -24,10 +24,6 @@ class UpdateStarJob(ApiJob):
         try:
             source_sdk_object = sdclientapi.Source(uuid=self.source_uuid)
 
-            # TODO: Once https://github.com/freedomofpress/securedrop-client/issues/648, we will
-            # want to pass the default request timeout to remove_star and add_star instead of
-            # setting it on the api object directly.
-            api_client.default_request_timeout = 5
             if self.is_starred:
                 api_client.remove_star(source_sdk_object)
             else:

--- a/securedrop_client/api_jobs/uploads.py
+++ b/securedrop_client/api_jobs/uploads.py
@@ -117,11 +117,6 @@ class SendReplyJob(ApiJob):
 
     def _make_call(self, encrypted_reply: str, api_client: API) -> sdclientapi.Reply:
         sdk_source = sdclientapi.Source(uuid=self.source_uuid)
-
-        # TODO: Once https://github.com/freedomofpress/securedrop-client/issues/648, we will want to
-        # pass the default request timeout to reply_source instead of setting it on the api object
-        # directly.
-        api_client.default_request_timeout = 5
         return api_client.reply_source(sdk_source, encrypted_reply, self.reply_uuid)
 
 


### PR DESCRIPTION
# Description

Increase the timeouts to rely on the sdk's default of 20 seconds for any requests that we agressively killed after 5 seconds until we gather more staging/prod data on how long each request takes, see https://github.com/freedomofpress/securedrop-client/issues/648. We also are continuing to discuss the value of increasing the timeout each time a job retries until it runs out of retries.

#### What the subprocess timeouts will be after https://github.com/freedomofpress/securedrop-client/pull/1055 and this PR are merged

|Endpoint|SDK subprocess timeout|
|:-|-:|
|`get_sources`| 60 |
|`get_all_replies`| 60 |
|`get_all_submissions`| 60 |
|`reply_source`| 20 |
|`add_star`| 20 |
|`remove_star`| 20 |
|`delete_source`| 20 |
|`authenticate`| 60 |
|`logout`| 60 |

# Test Plan

Make sure there are no regressions.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/master/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance
