### PR TITLE
copy on speech bubble click

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1969,6 +1969,10 @@ class SpeechBubble(QWidget):
         if message_uuid == self.uuid:
             self.message.setText(text)
 
+    def mousePressEvent(self, e):
+        clippy = QApplication.clipboard()
+        clippy.setText(self.message.text())
+
 
 class MessageWidget(SpeechBubble):
     """


### PR DESCRIPTION
# Description

Adds copy on message bubble click.

Resolves #1052
Does not fix #815

After testing with some of the strings provided by https://github.com/minimaxir/big-list-of-naughty-strings/blob/master/blns.txt (thanks @redshiftzero for the link) I see that https://github.com/freedomofpress/securedrop-client/pull/1050 won't be ready for a while (just try with one of our test data strings, e.g. https://github.com/freedomofpress/securedrop-client/wiki/Message-Test-Data#105127-character-image-url), so I created this spike to implement message-copy by clicking on speech bubbles. This isn't a full-fledged feature. There is no current hover or active state when you click on a speech bubble, so there is no indicator that the text was copied to the clipboard.

I could add a popup that says "Copied!" or something, but I wanted to open up this PR so people like @eloquence could take a look and provide feedback about using this as an interim solution while we continue to investigate issues found in #1050.

# Test Plan

1. Click on a speech bubble
2. Ctrl-P in the ReplyBox to see that it was copied to the clipboard

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes
