### PR TITLE
app: make QLabel text selectable

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1957,6 +1957,9 @@ class SpeechBubble(QWidget):
         # Add widget to layout
         layout.addWidget(bubble_area)
 
+        # Make text selectable
+        self.message.setTextInteractionFlags(Qt.TextSelectableByMouse)
+
         # Connect signals to slots
         update_signal.connect(self._update_text)
 
@@ -3057,7 +3060,7 @@ class ConversationView(QWidget):
         self.current_messages = {}  # type: Dict[str, QWidget]
 
         # Set styles
-        self.setStyleSheet(self.CSS)
+        # self.setStyleSheet(self.CSS)
 
         # Set layout
         main_layout = QVBoxLayout()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3034,15 +3034,15 @@ class ConversationView(QWidget):
     Renders a conversation.
     """
 
-    CSS = '''
-    #container {
-        background: #f3f5f9;
+    CSS = {
+        'container': '''
+            background: #f3f5f9;
+        ''',
+        'scroll': '''
+            border: 0;
+            background: #f3f5f9;
+        '''
     }
-    #scroll {
-        border: 0;
-        background: #f3f5f9;
-    }
-    '''
 
     conversation_updated = pyqtSignal()
 
@@ -3059,9 +3059,6 @@ class ConversationView(QWidget):
         # To hold currently displayed messages.
         self.current_messages = {}  # type: Dict[str, QWidget]
 
-        # Set styles
-        # self.setStyleSheet(self.CSS)
-
         # Set layout
         main_layout = QVBoxLayout()
         self.setLayout(main_layout)
@@ -3077,12 +3074,14 @@ class ConversationView(QWidget):
         self.conversation_layout.setContentsMargins(self.MARGIN_LEFT, 0, self.MARGIN_RIGHT, 0)
         self.conversation_layout.setSpacing(0)
         self.container.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.container.setStyleSheet(self.CSS['container'])
 
         self.scroll = QScrollArea()
         self.scroll.setObjectName('scroll')
         self.scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.scroll.setWidget(self.container)
         self.scroll.setWidgetResizable(True)
+        self.scroll.setStyleSheet(self.CSS['scroll'])
 
         # Flag to show if the current user has sent a reply. See issue #61.
         self.reply_flag = False


### PR DESCRIPTION
# Description

Fixes #1052. 

Previously when adding text selectability to `QLabel`/`SecureQLabel` the application crashed with a segfault. After investigation this was due to [an upstream bug](https://bugreports.qt.io/browse/QTBUG-69204) that is fixed in qt 5.12.x but not in qt 5.11.x which we are currently using. There is a workaround (22e1b34) to handle this case until we are on a more recent version of qt. 

# Test Plan

- [x] Ensure that you can copy text from a reply
- [x] Ensure that you can copy text from a message
- [x] Ensure that text is only selectable in one message or reply at a time

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/master/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance
