### PR TITLE
app: disable context menu on SpeechBubble

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1957,8 +1957,9 @@ class SpeechBubble(QWidget):
         # Add widget to layout
         layout.addWidget(bubble_area)
 
-        # Make text selectable
+        # Make text selectable but disable the context menu
         self.message.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.message.setContextMenuPolicy(Qt.NoContextMenu)
 
         # Connect signals to slots
         update_signal.connect(self._update_text)


### PR DESCRIPTION
# Description

Fixes #1064 (removing context menu for now)

# Test Plan

- [ ] Ensure context menu does not appear for replies
- [ ] Ensure context menu does not appear for messages
- [ ] Ensure you can copy/paste text out of replies
- [ ] Ensure you can copy/paste text out of messages

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/master/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance
