### PR TITLE
Log intended folders instead of empty strings

### DIFF
--- a/securedrop_client/api_jobs/downloads.py
+++ b/securedrop_client/api_jobs/downloads.py
@@ -177,7 +177,7 @@ class DownloadJob(ApiJob):
                 type(db_object), db_object.uuid, session, original_filename=original_filename
             )
             logger.info("File decrypted: {} (decrypted file in: {})".format(
-                os.path.basename(filepath), os.path.dirname(original_filename))
+                os.path.basename(filepath), os.path.dirname(filepath))
             )
         except CryptoError as e:
             mark_as_decrypted(type(db_object), db_object.uuid, session, is_decrypted=False)
@@ -375,5 +375,5 @@ class FileDownloadJob(DownloadJob):
             filepath, plaintext_filepath, is_doc=True
         )
         logger.info("Decrypted file '{}' to folder '{}'".format(
-            filepath, os.path.dirname(original_filename)))
+            os.path.basename(filepath), os.path.dirname(filepath)))
         return original_filename


### PR DESCRIPTION
# Description

Fixes #1060. The changes in #965 switched to the wrong variable to get the folder name, so that we ended up logging empty strings instead of the intended (journalist designation) folders.

# Test Plan

1. Start the client from this branch (dev env should be fine) and sync with a server environment
2. - [ ] Observe that the logs for messages, replies and files no longer exhibit the behavior described in #1060, and the folder names are correct 
3. - [ ] Observe that the logs do not include sensitive original filenames (e.g., an uploaded file `moscow.avi` should not appear in the logs under that name after the file is downloaded in the client)

# Checklist

 - [x] These changes should not need testing in Qubes
 - [x] No update to the AppArmor profile is required for these changes