### PR TITLE
Clear clipboard after login screen

### DIFF
--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -23,7 +23,8 @@ import logging
 
 from gettext import gettext as _
 from typing import Dict, List, Optional  # noqa: F401
-from PyQt5.QtWidgets import QMainWindow, QWidget, QHBoxLayout, QVBoxLayout, QDesktopWidget
+from PyQt5.QtWidgets import QApplication, QMainWindow, QWidget, QHBoxLayout, \
+    QVBoxLayout, QDesktopWidget
 
 from securedrop_client import __version__
 from securedrop_client.db import Source, User
@@ -197,3 +198,10 @@ class Window(QMainWindow):
         Clear any message currently in the error status bar.
         """
         self.top_pane.clear_error_status()
+
+    def clear_clipboard(self):
+        """
+        Purge any clipboard contents.
+        """
+        cb = QApplication.clipboard()
+        cb.clear()

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -437,6 +437,8 @@ class Controller(QObject):
             self.api.journalist_first_name,
             self.api.journalist_last_name,
             self.session)
+        # Clear clipboard contents in case of previously pasted creds
+        self.gui.clear_clipboard()
         self.gui.show_main_window(user)
         self.update_sources()
         self.api_job_queue.start(self.api)
@@ -456,6 +458,9 @@ class Controller(QObject):
         Allow user to view in offline mode without authentication.
         """
         self.gui.hide_login()
+        # Clear clipboard contents in case of previously pasted creds (user
+        # may have attempted online mode login, then switched to offline)
+        self.gui.clear_clipboard()
         self.gui.show_main_window()
         storage.mark_all_pending_drafts_as_failed(self.session)
         self.is_authenticated = False

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -283,3 +283,15 @@ def test_logout(mocker):
 
     w.left_pane.set_logged_out.assert_called_once_with()
     w.top_pane.set_logged_out.assert_called_once_with()
+
+
+def test_clear_clipboard(mocker):
+    """
+    Ensure we are clearing the system-level clipboard in the expected manner.
+    """
+    mock_clipboard = mocker.MagicMock()
+    mocker.patch('securedrop_client.gui.main.QApplication.clipboard',
+                 return_value=mock_clipboard)
+    w = Window()
+    w.clear_clipboard()
+    mock_clipboard.clear.assert_called_once_with()


### PR DESCRIPTION
# Description

Fixes #1051 by clearing the system clipboard contents after logging into online or offline mode.

# Status

Ready for review

## Test plan (online mode)

- Run the client from this branch, preferably in Qubes
- While the login screen is displayed, copy some string into the clipboard, e.g., "asdf" or your password
- [ ] Observe that the string you copied can be successfully pasted multiple times
- Log into the client
- [ ] Observe that the string you copied can no longer be pasted into the reply box

## Test plan (online mode)

- Run the client from this branch, preferably in Qubes
- Copy some string into the clipboard, e.g., "asdf"
- [ ] Observe that the string you copied can be successfully pasted multiple times
- Click the offline mode option
- [ ] Observe that the string you copied can no longer be pasted (you may have to pick another window to paste into, e.g., a terminal)

# Checklist
- [x] Tested in Qubes. Qubes testing required.
- [x] No AppArmor implications
- [x] No migrations