### PR TITLE
Move CSS to CSS files and add new tests for stylesheets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,18 +29,26 @@ clean:  ## Clean the workspace of generated resources
 		find . -name __pycache__ -print0 | xargs -0 rm -rf
 
 TESTS ?= tests
+ITESTS ?= tests/integration
 FTESTS ?= tests/functional
 TESTOPTS ?= -v
 .PHONY: test
 test: ## Run the application tests in parallel (for rapid development)
-	@TEST_CMD="python -m pytest -v -n 4 --ignore=$(FTESTS) --cov-config .coveragerc --cov-report html --cov-report term-missing --cov=securedrop_client --cov-fail-under 100 $(TESTOPTS) $(TESTS)" ; \
+	@TEST_CMD="python -m pytest -v -n 4 --ignore=$(FTESTS) --ignore=$(ITESTS) --cov-config .coveragerc --cov-report html --cov-report term-missing --cov=securedrop_client --cov-fail-under 100 $(TESTOPTS) $(TESTS)" ; \
 		if command -v xvfb-run > /dev/null; then \
 		xvfb-run -a $$TEST_CMD ; else \
 		$$TEST_CMD ; fi
 
 .PHONY: test-random
 test-random: ## Run the application tests in random order
-	@TEST_CMD="python -m pytest -v --ignore=$(FTESTS) --random-order-bucket=global --cov-config .coveragerc --cov-report html --cov-report term-missing --cov=securedrop_client --cov-fail-under 100 $(TESTOPTS) $(TESTS)" ; \
+	@TEST_CMD="python -m pytest -v --ignore=$(FTESTS) --ignore=$(ITESTS) --random-order-bucket=global --cov-config .coveragerc --cov-report html --cov-report term-missing --cov=securedrop_client --cov-fail-under 100 $(TESTOPTS) $(TESTS)" ; \
+		if command -v xvfb-run > /dev/null; then \
+		xvfb-run -a $$TEST_CMD ; else \
+		$$TEST_CMD ; fi
+
+.PHONY: test-integration
+test-integration: ## Run the integration tests
+	@TEST_CMD="python -m pytest -v -n 4	 $(TESTOPTS) $(ITESTS)" ; \
 		if command -v xvfb-run > /dev/null; then \
 		xvfb-run -a $$TEST_CMD ; else \
 		$$TEST_CMD ; fi
@@ -72,7 +80,7 @@ bandit: ## Run bandit with medium level excluding test-related folders
 	bandit -ll --recursive . --exclude ./tests,./.venv
 
 .PHONY: check
-check: clean bandit lint mypy test-random test-functional ## Run the full CI test suite
+check: clean bandit lint mypy test-random test-integration test-functional ## Run the full CI test suite
 
 .PHONY: update-pip-requirements
 update-pip-requirements: ## Updates all Python requirements files via pip-compile for Linux.

--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -31,7 +31,6 @@ from logging.handlers import TimedRotatingFileHandler, SysLogHandler
 from securedrop_client import __version__
 from securedrop_client.logic import Controller
 from securedrop_client.gui.main import Window
-from securedrop_client.resources import load_icon, load_css, load_font
 from securedrop_client.db import make_session_maker
 from securedrop_client.utils import safe_mkdir
 
@@ -197,17 +196,11 @@ def start_app(args, qt_args) -> None:
     app.setApplicationVersion(__version__)
     app.setAttribute(Qt.AA_UseHighDpiPixmaps)
 
-    load_font('Montserrat')
-    load_font('Source_Sans_Pro')
-
     prevent_second_instance(app, args.sdc_home)
 
     session_maker = make_session_maker(args.sdc_home)
 
     gui = Window()
-
-    app.setWindowIcon(load_icon(gui.icon))
-    app.setStyleSheet(load_css('sdclient.css'))
 
     controller = Controller("http://localhost:8081/", gui, session_maker,
                             args.sdc_home, not args.no_proxy, not args.no_qubes)

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -30,7 +30,7 @@ from securedrop_client import __version__
 from securedrop_client.db import Source, User
 from securedrop_client.logic import Controller  # noqa: F401
 from securedrop_client.gui.widgets import TopPane, LeftPane, MainView, LoginDialog
-from securedrop_client.resources import load_icon
+from securedrop_client.resources import load_css, load_font, load_icon
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +55,9 @@ class Window(QMainWindow):
         """
         super().__init__()
 
+        load_font('Montserrat')
+        load_font('Source_Sans_Pro')
+        self.setStyleSheet(load_css('sdclient.css'))
         self.setWindowTitle(_("SecureDrop Client {}").format(__version__))
         self.setWindowIcon(load_icon(self.icon))
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1595,6 +1595,9 @@ class SpeechBubble(QWidget):
     and journalist.
     """
 
+    MESSAGE_CSS = load_css('speech_bubble_message.css')
+    STATUS_BAR_CSS = load_css('speech_bubble_status_bar.css')
+
     TOP_MARGIN = 28
     BOTTOM_MARGIN = 10
 
@@ -1615,10 +1618,12 @@ class SpeechBubble(QWidget):
         # Message box
         self.message = SecureQLabel(text)
         self.message.setObjectName('SpeechBubble_message')
+        self.message.setStyleSheet(self.MESSAGE_CSS)
 
         # Color bar
         self.color_bar = QWidget()
         self.color_bar.setObjectName('SpeechBubble_status_bar')
+        self.color_bar.setStyleSheet(self.STATUS_BAR_CSS)
 
         # Speech bubble
         self.speech_bubble = QWidget()
@@ -1674,16 +1679,20 @@ class SpeechBubble(QWidget):
             self.set_error_styles()
 
     def set_normal_styles(self):
-        self.setStyleSheet('')
+        self.message.setStyleSheet('')
         self.message.setObjectName('SpeechBubble_message')
+        self.message.setStyleSheet(self.MESSAGE_CSS)
+        self.color_bar.setStyleSheet('')
         self.color_bar.setObjectName('SpeechBubble_status_bar')
-        self.setStyleSheet(load_css('sdclient.css'))
+        self.color_bar.setStyleSheet(self.STATUS_BAR_CSS)
 
     def set_error_styles(self):
-        self.setStyleSheet('')
+        self.message.setStyleSheet('')
         self.message.setObjectName('SpeechBubble_message_decryption_error')
+        self.message.setStyleSheet(self.MESSAGE_CSS)
+        self.color_bar.setStyleSheet('')
         self.color_bar.setObjectName('SpeechBubble_status_bar_decryption_error')
-        self.setStyleSheet(load_css('sdclient.css'))
+        self.color_bar.setStyleSheet(self.STATUS_BAR_CSS)
 
 
 class MessageWidget(SpeechBubble):
@@ -1700,6 +1709,9 @@ class ReplyWidget(SpeechBubble):
     """
     Represents a reply to a source.
     """
+
+    MESSAGE_CSS = load_css('reply_message.css')
+    STATUS_BAR_CSS = load_css('reply_status_bar.css')
 
     def __init__(
         self,
@@ -1767,28 +1779,36 @@ class ReplyWidget(SpeechBubble):
             self._set_reply_state('FAILED')
 
     def set_normal_styles(self):
-        self.setStyleSheet('')
+        self.message.setStyleSheet('')
         self.message.setObjectName('ReplyWidget_message')
+        self.message.setStyleSheet(self.MESSAGE_CSS)
+        self.color_bar.setStyleSheet('')
         self.color_bar.setObjectName('ReplyWidget_status_bar')
-        self.setStyleSheet(load_css('sdclient.css'))
+        self.color_bar.setStyleSheet(self.STATUS_BAR_CSS)
 
     def set_failed_styles(self):
-        self.setStyleSheet('')
+        self.message.setStyleSheet('')
         self.message.setObjectName('ReplyWidget_message_failed')
+        self.message.setStyleSheet(self.MESSAGE_CSS)
+        self.color_bar.setStyleSheet('')
         self.color_bar.setObjectName('ReplyWidget_status_bar_failed')
-        self.setStyleSheet(load_css('sdclient.css'))
+        self.color_bar.setStyleSheet(self.STATUS_BAR_CSS)
 
     def set_pending_styles(self):
-        self.setStyleSheet('')
+        self.message.setStyleSheet('')
         self.message.setObjectName('ReplyWidget_message_pending')
+        self.message.setStyleSheet(self.MESSAGE_CSS)
+        self.color_bar.setStyleSheet('')
         self.color_bar.setObjectName('ReplyWidget_status_bar_pending')
-        self.setStyleSheet(load_css('sdclient.css'))
+        self.color_bar.setStyleSheet(self.STATUS_BAR_CSS)
 
 
 class FileWidget(QWidget):
     """
     Represents a file.
     """
+
+    DOWNLOAD_BUTTON_CSS = load_css('file_download_button.css')
 
     TOP_MARGIN = 4
     BOTTOM_MARGIN = 14
@@ -1841,6 +1861,7 @@ class FileWidget(QWidget):
         file_options_layout.setAlignment(Qt.AlignLeft)
         self.download_button = QPushButton(_(' DOWNLOAD'))
         self.download_button.setObjectName('FileWidget_download_button')
+        self.download_button.setStyleSheet(self.DOWNLOAD_BUTTON_CSS)
         self.download_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.download_button.setIcon(load_icon('download_file.svg'))
         self.download_button.setFont(self.file_buttons_font)
@@ -1949,9 +1970,9 @@ class FileWidget(QWidget):
             self.download_button.show()
 
             # Reset stylesheet
-            self.setStyleSheet('')
+            self.download_button.setStyleSheet('')
             self.download_button.setObjectName('FileWidget_download_button')
-            self.setStyleSheet(load_css('sdclient.css'))
+            self.download_button.setStyleSheet(self.DOWNLOAD_BUTTON_CSS)
 
             self.no_file_name.hide()
             self.export_button.hide()
@@ -2026,10 +2047,10 @@ class FileWidget(QWidget):
         self.download_animation.start()
         self.download_button.setText(_(" DOWNLOADING "))
 
-        # Reset stylesheet with new state so that the active color stays the same
-        self.setStyleSheet('')
+        # Reset widget stylesheet
+        self.download_button.setStyleSheet('')
         self.download_button.setObjectName('FileWidget_download_button_animating')
-        self.setStyleSheet(load_css('sdclient.css'))
+        self.download_button.setStyleSheet(self.DOWNLOAD_BUTTON_CSS)
 
     def set_button_animation_frame(self, frame_number):
         """
@@ -2049,6 +2070,9 @@ class FileWidget(QWidget):
 
 class ModalDialog(QDialog):
 
+    CONTINUE_BUTTON_CSS = load_css('modal_dialog_button.css')
+    ERROR_DETAILS_CSS = load_css('modal_dialog_error_details.css')
+
     MARGIN = 40
     NO_MARGIN = 0
 
@@ -2056,7 +2080,6 @@ class ModalDialog(QDialog):
         parent = QApplication.activeWindow()
         super().__init__(parent)
         self.setObjectName('ModalDialog')
-        self.setStyleSheet(load_css('sdclient.css'))
         self.setModal(True)
 
         # Header for icon and task title
@@ -2084,6 +2107,7 @@ class ModalDialog(QDialog):
         # Widget for displaying error messages
         self.error_details = QLabel()
         self.error_details.setObjectName('ModalDialog_error_details')
+        self.error_details.setStyleSheet(self.ERROR_DETAILS_CSS)
         self.error_details.setWordWrap(True)
         self.error_details.hide()
 
@@ -2108,6 +2132,7 @@ class ModalDialog(QDialog):
         self.cancel_button.setAutoDefault(False)
         self.continue_button = QPushButton(_('CONTINUE'))
         self.continue_button.setObjectName('ModalDialog_primary_button')
+        self.continue_button.setStyleSheet(self.CONTINUE_BUTTON_CSS)
         self.continue_button.setDefault(True)
         self.continue_button.setIconSize(QSize(21, 21))
         button_box = QDialogButtonBox(Qt.Horizontal)
@@ -2157,11 +2182,13 @@ class ModalDialog(QDialog):
         self.button_animation.start()
         self.continue_button.setText("")
         self.continue_button.setMinimumSize(QSize(142, 43))
-        # Reset stylesheet
-        self.setStyleSheet('')
+        # Reset widget stylesheets
+        self.continue_button.setStyleSheet('')
         self.continue_button.setObjectName('ModalDialog_primary_button_active')
+        self.continue_button.setStyleSheet(self.CONTINUE_BUTTON_CSS)
+        self.error_details.setStyleSheet('')
         self.error_details.setObjectName('ModalDialog_error_details_active')
-        self.setStyleSheet(load_css('sdclient.css'))
+        self.error_details.setStyleSheet(self.ERROR_DETAILS_CSS)
 
     def start_animate_header(self):
         self.header_icon.setVisible(False)
@@ -2172,11 +2199,13 @@ class ModalDialog(QDialog):
         self.continue_button.setIcon(QIcon())
         self.button_animation.stop()
         self.continue_button.setText(_('CONTINUE'))
-        # Reset stylesheet
-        self.setStyleSheet('')
+        # Reset widget stylesheets
+        self.continue_button.setStyleSheet('')
         self.continue_button.setObjectName('ModalDialog_primary_button')
+        self.continue_button.setStyleSheet(self.CONTINUE_BUTTON_CSS)
+        self.error_details.setStyleSheet('')
         self.error_details.setObjectName('ModalDialog_error_details')
-        self.setStyleSheet(load_css('sdclient.css'))
+        self.error_details.setStyleSheet(self.ERROR_DETAILS_CSS)
 
     def stop_animate_header(self):
         self.header_icon.setVisible(True)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2401,13 +2401,12 @@ class ExportDialog(ModalDialog):
 
         # Passphrase Form
         self.passphrase_form = QWidget()
-        self.passphrase_form.setObjectName('passphrase_form')
+        self.passphrase_form.setObjectName('ExportDialog_passphrase_form')
         passphrase_form_layout = QVBoxLayout()
         passphrase_form_layout.setContentsMargins(
             self.NO_MARGIN, self.NO_MARGIN, self.NO_MARGIN, self.NO_MARGIN)
         self.passphrase_form.setLayout(passphrase_form_layout)
         passphrase_label = SecureQLabel(_('Passphrase'))
-        passphrase_label.setObjectName('passphrase_label')
         font = QFont()
         font.setLetterSpacing(QFont.AbsoluteSpacing, self.PASSPHRASE_LABEL_SPACING)
         passphrase_label.setFont(font)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3045,13 +3045,11 @@ class ReplyTextEdit(QPlainTextEdit):
             msg = "<strong><font color=\"#24276d\">Awaiting encryption key</font></strong>"
             placeholder = msg + " from the server to enable replies."
         self.placeholder.setText(placeholder)
-        self.placeholder.adjustSize()
 
     def set_logged_out(self):
         text = "<strong><font color=\"#2a319d\">" + _("Sign in") + " </font></strong>" + \
             _("to compose or send a reply")
         self.placeholder.setText(text)
-        self.placeholder.adjustSize()
         self.setEnabled(False)
 
     def setText(self, text):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -201,7 +201,7 @@ class SyncIcon(QLabel):
     """
 
     CSS = '''
-    #sync_icon {
+    #SyncIcon {
         border: none;
         color: #fff;
     }
@@ -210,7 +210,7 @@ class SyncIcon(QLabel):
     def __init__(self):
         # Add svg images to button
         super().__init__()
-        self.setObjectName('sync_icon')
+        self.setObjectName('SyncIcon')
         self.setStyleSheet(self.CSS)
         self.setFixedSize(QSize(24, 20))
         self.sync_animation = load_movie("sync_disabled.gif")
@@ -257,7 +257,7 @@ class ActivityStatusBar(QStatusBar):
     """
 
     CSS = '''
-    #activity_status_bar {
+    #ActivityStatusBar {
         font-family: 'Source Sans Pro';
         font-weight: 600;
         font-size: 12px;
@@ -269,7 +269,7 @@ class ActivityStatusBar(QStatusBar):
         super().__init__()
 
         # Set css id
-        self.setObjectName('activity_status_bar')
+        self.setObjectName('ActivityStatusBar')
 
         # Set styles
         self.setStyleSheet(self.CSS)
@@ -291,10 +291,10 @@ class ErrorStatusBar(QWidget):
     """
 
     CSS = '''
-    #error_vertical_bar {
+    #ErrorStatusBar_vertical_bar {
         background-color: #ff3366;
     }
-    #error_icon {
+    #ErrorStatusBar_icon {
         background-color: qlineargradient(
             x1: 0,
             y1: 0,
@@ -305,7 +305,7 @@ class ErrorStatusBar(QWidget):
             stop: 1 #fff
         );
     }
-    #error_status_bar {
+    #ErrorStatusBar_status_bar {
         background-color: qlineargradient(
             x1: 0,
             y1: 0,
@@ -338,17 +338,17 @@ class ErrorStatusBar(QWidget):
 
         # Error vertical bar
         self.vertical_bar = QWidget()
-        self.vertical_bar.setObjectName('error_vertical_bar')  # Set css id
+        self.vertical_bar.setObjectName('ErrorStatusBar_vertical_bar')  # Set css id
         self.vertical_bar.setFixedWidth(10)
 
         # Error icon
         self.label = SvgLabel('error_icon.svg', svg_size=QSize(20, 20))
-        self.label.setObjectName('error_icon')  # Set css id
+        self.label.setObjectName('ErrorStatusBar_icon')  # Set css id
         self.label.setFixedWidth(42)
 
         # Error status bar
         self.status_bar = QStatusBar()
-        self.status_bar.setObjectName('error_status_bar')  # Set css id
+        self.status_bar.setObjectName('ErrorStatusBar_status_bar')  # Set css id
         self.status_bar.setSizeGripEnabled(False)
 
         # Add widgets to layout
@@ -413,10 +413,10 @@ class UserProfile(QLabel):
     """
 
     CSS = '''
-    QLabel#user_profile {
+    #UserProfile {
         padding: 15px;
     }
-    QLabel#user_icon {
+    #UserProfile_icon {
         border: none;
         background-color: #9211ff;
         padding-left: 3px;
@@ -432,7 +432,7 @@ class UserProfile(QLabel):
         super().__init__()
 
         # Set css id
-        self.setObjectName('user_profile')
+        self.setObjectName('UserProfile')
 
         # Set styles
         self.setStyleSheet(self.CSS)
@@ -461,7 +461,7 @@ class UserProfile(QLabel):
 
         # User icon
         self.user_icon = UserIconLabel()
-        self.user_icon.setObjectName('user_icon')  # Set css id
+        self.user_icon.setObjectName('UserProfile_icon')  # Set css id
         self.user_icon.setFixedSize(QSize(30, 30))
         self.user_icon.setAlignment(Qt.AlignCenter)
         self.user_icon_font = QFont()
@@ -517,10 +517,7 @@ class UserButton(SvgPushButton):
     """
 
     CSS = '''
-    SvgPushButton:focus {
-        outline: none;
-    }
-    SvgPushButton#user_button {
+    #UserButton {
         border: none;
         font-family: 'Source Sans Pro';
         font-weight: 700;
@@ -528,7 +525,10 @@ class UserButton(SvgPushButton):
         color: #fff;
         text-align: left;
     }
-    SvgPushButton::menu-indicator {
+    #UserButton:focus {
+        outline: none;
+    }
+    #UserButton::menu-indicator {
         image: none;
     }
     '''
@@ -537,7 +537,7 @@ class UserButton(SvgPushButton):
         super().__init__('dropdown_arrow.svg', svg_size=QSize(9, 6))
 
         # Set css id
-        self.setObjectName('user_button')
+        self.setObjectName('UserButton')
 
         # Set styles
         self.setStyleSheet(self.CSS)
@@ -595,7 +595,7 @@ class LoginButton(QPushButton):
     """
 
     CSS = '''
-    #login {
+    #LoginButton {
         border: none;
         background-color: #05edfe;
         font-family: 'Montserrat';
@@ -603,7 +603,7 @@ class LoginButton(QPushButton):
         font-size: 14px;
         color: #2a319d;
     }
-    #login:pressed {
+    #LoginButton:pressed {
         background-color: #85f6fe;
     }
     '''
@@ -612,7 +612,7 @@ class LoginButton(QPushButton):
         super().__init__(_('SIGN IN'))
 
         # Set css id
-        self.setObjectName('login')
+        self.setObjectName('LoginButton')
 
         # Set styles
         self.setStyleSheet(self.CSS)
@@ -641,20 +641,13 @@ class MainView(QWidget):
     """
 
     CSS = '''
-    #main_view {
+    #MainView {
         min-height: 558;
     }
-    #view_holder {
+    #MainView_view_holder {
         min-width: 667;
         border: none;
         background-color: #f3f5f9;
-    }
-    QLabel#no-source {
-        font-family: Montserrat-Regular;
-        font-size: 35px;
-        color: #a5b3e9;
-        padding: 100px;
-        qproperty-alignment: AlignLeft;
     }
     '''
 
@@ -662,7 +655,7 @@ class MainView(QWidget):
         super().__init__(parent)
 
         # Set id and styles
-        self.setObjectName('main_view')
+        self.setObjectName('MainView')
         self.setStyleSheet(self.CSS)
 
         # Set layout
@@ -679,7 +672,7 @@ class MainView(QWidget):
 
         # Create widgets
         self.view_holder = QWidget()
-        self.view_holder.setObjectName('view_holder')
+        self.view_holder.setObjectName('MainView_view_holder')
         self.view_layout = QVBoxLayout()
         self.view_holder.setLayout(self.view_layout)
         self.view_layout.setContentsMargins(0, 0, 0, 0)
@@ -779,29 +772,27 @@ class MainView(QWidget):
 class EmptyConversationView(QWidget):
 
     CSS = '''
-    #bullet {
-        margin: 4px 0px 0px 0px;
-        font-size: 35px;
-        font-weight: 600;
-    }
-    #no_sources {
-        min-width: 520px;
-        max-width: 600px;
-        text-align: left;
-    }
-    #no_source_selected {
-        min-width: 520px;
-        max-width: 520px;
-        text-align: left;
-    }
-    QLabel {
+    #EmptyConversationView QLabel {
         font-family: Montserrat;
         font-weight: 400;
         font-size: 35px;
         color: #a5b3e9;
     }
-    #instructions {
+    #EmptyConversationView QLabel#EmptyConversationView_instructions {
         font-weight: 500;
+    }
+    #EmptyConversationView QLabel#EmptyConversationView_bullet {
+        margin: 4px 0px 0px 0px;
+        font-size: 35px;
+        font-weight: 600;
+    }
+    #EmptyConversationView_no_sources {
+        min-width: 520px;
+        max-width: 600px;
+    }
+    #EmptyConversationView_no_source_selected {
+        min-width: 520px;
+        max-width: 520px;
     }
     '''
 
@@ -812,7 +803,7 @@ class EmptyConversationView(QWidget):
         super().__init__()
 
         # Set id and styles
-        self.setObjectName('view')
+        self.setObjectName('EmptyConversationView')
         self.setStyleSheet(self.CSS)
 
         # Set layout
@@ -822,11 +813,11 @@ class EmptyConversationView(QWidget):
 
         # Create widgets
         self.no_sources = QWidget()
-        self.no_sources.setObjectName('no_sources')
+        self.no_sources.setObjectName('EmptyConversationView_no_sources')
         no_sources_layout = QVBoxLayout()
         self.no_sources.setLayout(no_sources_layout)
         no_sources_instructions = QLabel(_('Nothing to see just yet!'))
-        no_sources_instructions.setObjectName('instructions')
+        no_sources_instructions.setObjectName('EmptyConversationView_instructions')
         no_sources_instructions.setWordWrap(True)
         no_sources_instruction_details1 = QLabel(
             _('Source submissions will be listed to the left, once downloaded and decrypted.'))
@@ -841,18 +832,18 @@ class EmptyConversationView(QWidget):
         no_sources_layout.addWidget(no_sources_instruction_details2)
 
         self.no_source_selected = QWidget()
-        self.no_sources.setObjectName('no_sources')
+        self.no_source_selected.setObjectName('EmptyConversationView_no_source_selected')
         no_source_selected_layout = QVBoxLayout()
         self.no_source_selected.setLayout(no_source_selected_layout)
         no_source_selected_instructions = QLabel(_('Select a source from the list, to:'))
-        no_source_selected_instructions.setObjectName('instructions')
+        no_source_selected_instructions.setObjectName('EmptyConversationView_instructions')
         no_source_selected_instructions.setWordWrap(True)
         bullet1 = QWidget()
         bullet1_layout = QHBoxLayout()
         bullet1_layout.setContentsMargins(0, 0, 0, 0)
         bullet1.setLayout(bullet1_layout)
         bullet1_bullet = QLabel('·')
-        bullet1_bullet.setObjectName('bullet')
+        bullet1_bullet.setObjectName('EmptyConversationView_bullet')
         bullet1_layout.addWidget(bullet1_bullet)
         bullet1_layout.addWidget(QLabel(_('Read a conversation')))
         bullet1_layout.addStretch()
@@ -861,7 +852,7 @@ class EmptyConversationView(QWidget):
         bullet2_layout.setContentsMargins(0, 0, 0, 0)
         bullet2.setLayout(bullet2_layout)
         bullet2_bullet = QLabel('·')
-        bullet2_bullet.setObjectName('bullet')
+        bullet2_bullet.setObjectName('EmptyConversationView_bullet')
         bullet2_layout.addWidget(bullet2_bullet)
         bullet2_layout.addWidget(QLabel(_('View or retrieve files')))
         bullet2_layout.addStretch()
@@ -870,7 +861,7 @@ class EmptyConversationView(QWidget):
         bullet3_layout.setContentsMargins(0, 0, 0, 0)
         bullet3.setLayout(bullet3_layout)
         bullet3_bullet = QLabel('·')
-        bullet3_bullet.setObjectName('bullet')
+        bullet3_bullet.setObjectName('EmptyConversationView_bullet')
         bullet3_layout.addWidget(bullet3_bullet)
         bullet3_layout.addWidget(QLabel(_('Send a response')))
         bullet3_layout.addStretch()
@@ -916,15 +907,15 @@ class SourceList(QListWidget):
     """
 
     CSS = '''
-    QListView {
+    QListView#SourceList {
         border: none;
         show-decoration-selected: 0;
         border-right: 3px solid #f3f5f9;
     }
-    QListView::item:selected {
+    QListView#SourceList::item:selected {
         background-color: #f3f5f9;
     }
-    QListView::item:hover{
+    QListView#SourceList::item:hover{
         border: 500px solid #f9f9f9;
     }
     '''
@@ -933,7 +924,7 @@ class SourceList(QListWidget):
         super().__init__()
 
         # Set id and styles.
-        self.setObjectName('sourcelist')
+        self.setObjectName('SourceList')
         self.setStyleSheet(self.CSS)
         self.setFixedWidth(540)
         self.setUniformItemSizes(True)
@@ -1114,35 +1105,35 @@ class SourceWidget(QWidget):
     """
 
     CSS = '''
-    QWidget#source_widget {
+    #SourceWidget_container {
         border-bottom: 1px solid #9b9b9b;
     }
-    QWidget#gutter {
+    #SourceWidget_gutter {
         min-width: 40px;
         max-width: 40px;
     }
-    QWidget#metadata {
+    #SourceWidget_metadata {
         max-width: 60px;
     }
-    QLabel#preview {
+    #SourceWidget_preview {
         font-family: 'Source Sans Pro';
         font-weight: 400;
         font-size: 13px;
         color: #383838;
     }
-    #source_deleted {
+    #SourceWidget_source_deleted {
         font-family: 'Source Sans Pro';
         font-weight: 400;
         font-size: 13px;
         color: #ff3366;
     }
-    QLabel#source_name {
+    #SourceWidget_name {
         font-family: 'Montserrat';
         font-weight: 500;
         font-size: 13px;
         color: #383838;
     }
-    QLabel#timestamp {
+    #SourceWidget_timestamp {
         font-family: 'Montserrat';
         font-weight: 500;
         font-size: 13px;
@@ -1185,7 +1176,7 @@ class SourceWidget(QWidget):
 
         # Set up gutter
         self.gutter = QWidget()
-        self.gutter.setObjectName('gutter')
+        self.gutter.setObjectName('SourceWidget_gutter')
         self.gutter.setSizePolicy(retain_space)
         gutter_layout = QVBoxLayout(self.gutter)
         gutter_layout.setContentsMargins(0, 0, 0, 0)
@@ -1196,17 +1187,17 @@ class SourceWidget(QWidget):
 
         # Set up summary
         self.summary = QWidget()
-        self.summary.setObjectName('summary')
+        self.summary.setObjectName('SourceWidget_summary')
         summary_layout = QVBoxLayout(self.summary)
         summary_layout.setContentsMargins(0, 0, 0, 0)
         summary_layout.setSpacing(0)
         self.name = QLabel()
-        self.name.setObjectName('source_name')
+        self.name.setObjectName('SourceWidget_name')
         self.preview = SecureQLabel(max_length=self.PREVIEW_WIDTH)
-        self.preview.setObjectName('preview')
+        self.preview.setObjectName('SourceWidget_preview')
         self.preview.setFixedSize(QSize(self.PREVIEW_WIDTH, self.PREVIEW_HEIGHT))
         self.waiting_delete_confirmation = QLabel('Deletion in progress')
-        self.waiting_delete_confirmation.setObjectName('source_deleted')
+        self.waiting_delete_confirmation.setObjectName('SourceWidget_source_deleted')
         self.waiting_delete_confirmation.setFixedSize(
             QSize(self.PREVIEW_WIDTH, self.PREVIEW_HEIGHT))
         self.waiting_delete_confirmation.hide()
@@ -1216,23 +1207,23 @@ class SourceWidget(QWidget):
 
         # Set up metadata
         self.metadata = QWidget()
-        self.metadata.setObjectName('metadata')
+        self.metadata.setObjectName('SourceWidget_metadata')
         self.metadata.setSizePolicy(retain_space)
         metadata_layout = QVBoxLayout(self.metadata)
         metadata_layout.setContentsMargins(0, 0, 0, 0)
         metadata_layout.setSpacing(0)
         self.paperclip = SvgLabel('paperclip.svg', QSize(18, 18))  # Set to size provided in the svg
-        self.paperclip.setObjectName('paperclip')
+        self.paperclip.setObjectName('SourceWidget_paperclip')
         self.paperclip.setFixedSize(QSize(22, 22))
         self.timestamp = QLabel()
-        self.timestamp.setObjectName('timestamp')
+        self.timestamp.setObjectName('SourceWidget_timestamp')
         metadata_layout.addWidget(self.paperclip, 0, Qt.AlignRight)
         metadata_layout.addWidget(self.timestamp, 0, Qt.AlignRight)
         metadata_layout.addStretch()
 
         # Set up a source_widget
         self.source_widget = QWidget()
-        self.source_widget.setObjectName('source_widget')
+        self.source_widget.setObjectName('SourceWidget_container')
         source_widget_layout = QHBoxLayout(self.source_widget)
         source_widget_layout.setContentsMargins(
             0, self.SOURCE_WIDGET_VERTICAL_MARGIN, 0, self.SOURCE_WIDGET_VERTICAL_MARGIN)
@@ -1308,7 +1299,7 @@ class StarToggleButton(SvgToggleButton):
     """
 
     css = '''
-    #star_button {
+    #StarToggleButton {
         border: none;
     }
     '''
@@ -1327,7 +1318,7 @@ class StarToggleButton(SvgToggleButton):
         self.controller.star_update_successful.connect(self.on_star_update_successful)
         self.installEventFilter(self)
 
-        self.setObjectName('star_button')
+        self.setObjectName('StarToggleButton')
         self.setStyleSheet(self.css)
         self.setFixedSize(QSize(20, 20))
 
@@ -1511,7 +1502,7 @@ class LoginOfflineLink(QLabel):
     clicked = pyqtSignal()
 
     CSS = '''
-    #offline_mode {
+    #LoginOfflineLink {
         border: none;
         color: #fff;
         text-decoration: underline;
@@ -1523,7 +1514,7 @@ class LoginOfflineLink(QLabel):
         super().__init__()
 
         # Set css id
-        self.setObjectName('offline_mode')
+        self.setObjectName('LoginOfflineLink')
 
         # Set styles
         self.setStyleSheet(self.CSS)
@@ -1541,7 +1532,7 @@ class SignInButton(QPushButton):
     """
 
     CSS = '''
-    #login {
+    #SignInButton {
         border: none;
         background-color: #05edfe;
         font-family: 'Montserrat';
@@ -1549,7 +1540,7 @@ class SignInButton(QPushButton):
         font-size: 14px;
         color: #2a319d;
     }
-    #login:pressed {
+    #SignInButton:pressed {
         background-color: #85f6fe;
     }
     '''
@@ -1558,7 +1549,7 @@ class SignInButton(QPushButton):
         super().__init__(_('SIGN IN'))
 
         # Set css id
-        self.setObjectName('login')
+        self.setObjectName('SignInButton')
 
         # Set styles
         self.setStyleSheet(self.CSS)
@@ -1583,13 +1574,13 @@ class LoginErrorBar(QWidget):
     """
 
     CSS = '''
-    QWidget {
+    #LoginErrorBar QWidget {
         background-color: #ce0083;
     }
-    #error_icon {
+    #LoginErrorBar_icon {
         color: #fff;
     }
-    #error_status_bar {
+    #LoginErrorBar_status_bar {
         font-family: 'Montserrat';
         font-weight: 500;
         font-size: 12px;
@@ -1600,7 +1591,7 @@ class LoginErrorBar(QWidget):
     def __init__(self):
         super().__init__()
 
-        self.setObjectName('error_bar')
+        self.setObjectName('LoginErrorBar')
 
         # Set styles
         self.setStyleSheet(self.CSS)
@@ -1620,12 +1611,12 @@ class LoginErrorBar(QWidget):
 
         # Error icon
         self.error_icon = SvgLabel('error_icon_white.svg', svg_size=QSize(18, 18))
-        self.error_icon.setObjectName('error_icon')
+        self.error_icon.setObjectName('LoginErrorBar_icon')
         self.error_icon.setFixedWidth(42)
 
         # Error status bar
         self.error_status_bar = SecureQLabel(wordwrap=False)
-        self.error_status_bar.setObjectName('error_status_bar')
+        self.error_status_bar.setObjectName('LoginErrorBar_status_bar')
         self.setFixedHeight(42)
 
         # Create space ths size of the error icon to keep the error message centered
@@ -1651,19 +1642,10 @@ class PasswordEdit(QLineEdit):
     """
     A LineEdit with icons to show/hide password entries
     """
-    CSS = '''QLineEdit {
-        border-radius: 0px;
-        height: 30px;
-        margin: 0px 0px 0px 0px;
-    }
-    '''
 
     def __init__(self, parent):
         self.parent = parent
         super().__init__(self.parent)
-
-        # Set styles
-        self.setStyleSheet(self.CSS)
 
         self.visibleIcon = load_icon("eye_visible.svg")
         self.hiddenIcon = load_icon("eye_hidden.svg")
@@ -1690,13 +1672,13 @@ class LoginDialog(QDialog):
     """
 
     CSS = '''
-    #login_form QLabel {
+    #LoginDialog_form QLabel {
         color: #fff;
         font-family: 'Montserrat';
         font-weight: 500;
         font-size: 13px;
     }
-    #login_form QLineEdit {
+    #LoginDialog_form QLineEdit {
         border-radius: 0px;
         height: 30px;
         margin: 0px 0px 0px 0px;
@@ -1714,9 +1696,6 @@ class LoginDialog(QDialog):
 
         # Set modal
         self.setModal(True)
-
-        # Set css id
-        self.setObjectName('login_dialog')
 
         # Set styles
         self.setStyleSheet(self.CSS)
@@ -1743,7 +1722,7 @@ class LoginDialog(QDialog):
         # Create form widget
         form = QWidget()
 
-        form.setObjectName('login_form')
+        form.setObjectName('LoginDialog_form')
 
         form_layout = QVBoxLayout()
         form.setLayout(form_layout)
@@ -1889,52 +1868,99 @@ class SpeechBubble(QWidget):
     and journalist.
     """
 
-    CSS = {
-        "speech_bubble": """
-            min-width: 540px;
-            max-width: 540px;
-            background-color: #fff;
-        """,
-        "message": """
-            min-width: 508px;
-            max-width: 508px;
-            font-family: 'Source Sans Pro';
-            font-weight: 400;
-            font-size: 15px;
-            background-color: #fff;
-            padding: 16px;
-        """,
-        "color_bar": """
-            min-height: 5px;
-            max-height: 5px;
-            background-color: #102781;
-            border: 0px;
-        """
+    CSS = '''
+    #SpeechBubble_container {
+        min-width: 540px;
+        max-width: 540px;
+        background-color: #fff;
     }
-
-    CSS_ERROR = {
-        "speech_bubble": """
-            min-width: 540px;
-            max-width: 540px;
-            background-color: #fff;
-        """,
-        "message": """
-            min-width: 508px;
-            max-width: 508px;
-            font-family: 'Source Sans Pro';
-            font-weight: 400;
-            font-size: 15px;
-            font-style: italic;
-            background-color: rgba(255, 255, 255, 0.6);
-            padding: 16px;
-        """,
-        "color_bar": """
-            min-height: 5px;
-            max-height: 5px;
-            background-color: #BCBFCD;
-            border: 0px;
-        """
+    #SpeechBubble_message {
+        min-width: 508px;
+        max-width: 508px;
+        font-family: 'Source Sans Pro';
+        font-weight: 400;
+        font-size: 15px;
+        background-color: #fff;
+        color: #3b3b3b;
+        padding: 16px;
     }
+    #SpeechBubble_status_bar {
+        min-height: 5px;
+        max-height: 5px;
+        background-color: #102781;
+        border: 0px;
+    }
+    #SpeechBubble_message_decryption_error {
+        min-width: 508px;
+        max-width: 508px;
+        font-family: 'Source Sans Pro';
+        font-weight: 400;
+        font-size: 15px;
+        font-style: italic;
+        background-color: rgba(255, 255, 255, 0.6);
+        padding: 16px;
+    }
+    #SpeechBubble_status_bar_decryption_error {
+        min-height: 5px;
+        max-height: 5px;
+        background-color: #bcbfcd;
+        border: 0px;
+    }
+    #ReplyWidget_message {
+        min-width: 508px;
+        max-width: 508px;
+        font-family: 'Source Sans Pro';
+        font-weight: 400;
+        font-size: 15px;
+        background-color: #fff;
+        color: #3b3b3b;
+        padding: 16px;
+    }
+    #ReplyWidget_status_bar {
+        min-height: 5px;
+        max-height: 5px;
+        background-color: #0065db;
+        border: 0px;
+    }
+    #ReplyWidget_failed_to_send_text {
+        font-family: 'Source Sans Pro';
+        font-weight: 500;
+        font-size: 13px;
+        color: #ff3366;
+    }
+    #ReplyWidget_message_failed {
+        min-width: 508px;
+        max-width: 508px;
+        font-family: 'Source Sans Pro';
+        font-weight: 400;
+        font-size: 15px;
+        background-color: #fff;
+        color: #3b3b3b;
+        padding: 16px;
+    }
+    #ReplyWidget_status_bar_failed {
+        min-height: 5px;
+        max-height: 5px;
+        background-color: #ff3366;
+        border: 0px;
+    }
+    #ReplyWidget_message_pending {
+        min-width: 508px;
+        max-width: 508px;
+        font-family: 'Source Sans Pro';
+        font-weight: 400;
+        font-size: 15px;
+        color: #a9aaad;
+        background-color: #F7F8FC;
+        padding: 16px;
+    }
+    #ReplyWidget_status_bar_pending {
+        min-height: 5px;
+        max-height: 5px;
+        background-color: #0065db;
+        border: 0px;
+    }
+    '''
 
     TOP_MARGIN = 28
     BOTTOM_MARGIN = 10
@@ -1953,17 +1979,20 @@ class SpeechBubble(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
+        # Set styles
+        self.setStyleSheet(self.CSS)
+
         # Message box
         self.message = SecureQLabel(text)
-        self.message.setObjectName('message')
+        self.message.setObjectName('SpeechBubble_message')
 
         # Color bar
         self.color_bar = QWidget()
-        self.color_bar.setObjectName('color_bar')
+        self.color_bar.setObjectName('SpeechBubble_status_bar')
 
         # Speech bubble
         self.speech_bubble = QWidget()
-        self.speech_bubble.setObjectName('speech_bubble')
+        self.speech_bubble.setObjectName('SpeechBubble_container')
         speech_bubble_layout = QVBoxLayout()
         self.speech_bubble.setLayout(speech_bubble_layout)
         speech_bubble_layout.addWidget(self.message)
@@ -1986,11 +2015,9 @@ class SpeechBubble(QWidget):
         self.message.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self.message.setContextMenuPolicy(Qt.NoContextMenu)
 
-        # Set styles
         if error:
             self.set_error_styles()
-        else:
-            self.set_normal_styles()
+
         self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
 
         # Connect signals to slots
@@ -2017,14 +2044,16 @@ class SpeechBubble(QWidget):
             self.set_error_styles()
 
     def set_normal_styles(self):
-        self.speech_bubble.setStyleSheet(self.CSS["speech_bubble"])
-        self.message.setStyleSheet(self.CSS["message"])
-        self.color_bar.setStyleSheet(self.CSS["color_bar"])
+        self.setStyleSheet('')
+        self.message.setObjectName('SpeechBubble_message')
+        self.color_bar.setObjectName('SpeechBubble_status_bar')
+        self.setStyleSheet(self.CSS)
 
     def set_error_styles(self):
-        self.speech_bubble.setStyleSheet(self.CSS_ERROR["speech_bubble"])
-        self.message.setStyleSheet(self.CSS_ERROR["message"])
-        self.color_bar.setStyleSheet(self.CSS_ERROR["color_bar"])
+        self.setStyleSheet('')
+        self.message.setObjectName('SpeechBubble_message_decryption_error')
+        self.color_bar.setObjectName('SpeechBubble_status_bar_decryption_error')
+        self.setStyleSheet(self.CSS)
 
 
 class MessageWidget(SpeechBubble):
@@ -2042,85 +2071,6 @@ class ReplyWidget(SpeechBubble):
     Represents a reply to a source.
     """
 
-    CSS = {
-        "color_bar": """
-            min-height: 5px;
-            max-height: 5px;
-            background-color: #0065db;
-            border: 0px;
-        """,
-        "message": """
-            min-width: 508px;
-            max-width: 508px;
-            font-family: 'Source Sans Pro';
-            font-weight: 400;
-            font-size: 15px;
-            background-color: #fff;
-            color: #3b3b3b;
-            padding: 16px;
-        """,
-        "speech_bubble": """
-            min-width: 540px;
-            max-width: 540px;
-            background-color: #fff;
-        """,
-    }
-
-    CSS_ERROR_MESSAGE = """
-        font-family: 'Source Sans Pro';
-        font-weight: 500;
-        font-size: 13px;
-        color: #ff3366;
-    """
-
-    CSS_REPLY_FAILED = {
-        "color_bar": """
-            min-height: 5px;
-            max-height: 5px;
-            background-color: #ff3366;
-            border: 0px;
-        """,
-        "message": """
-            min-width: 508px;
-            max-width: 508px;
-            font-family: 'Source Sans Pro';
-            font-weight: 400;
-            font-size: 15px;
-            background-color: #fff;
-            color: #3b3b3b;
-            padding: 16px;
-        """,
-        "speech_bubble": """
-            min-width: 540px;
-            max-width: 540px;
-            background-color: #fff;
-        """,
-    }
-
-    CSS_REPLY_PENDING = {
-        "color_bar": """
-            min-height: 5px;
-            max-height: 5px;
-            background-color: #0065db;
-            border: 0px;
-        """,
-        "message": """
-            min-width: 508px;
-            max-width: 508px;
-            font-family: 'Source Sans Pro';
-            font-weight: 400;
-            font-size: 15px;
-            color: #A9AAAD;
-            background-color: #F7F8FC;
-            padding: 16px;
-        """,
-        "speech_bubble": """
-            min-width: 540px;
-            max-width: 540px;
-            background-color: #fff;
-        """,
-    }
-
     def __init__(
         self,
         message_uuid: str,
@@ -2136,35 +2086,29 @@ class ReplyWidget(SpeechBubble):
         super().__init__(message_uuid, message, update_signal, download_error_signal, index, error)
         self.uuid = message_uuid
 
-        error_icon = SvgLabel('error_icon.svg', svg_size=QSize(12, 12))
-        error_icon.setObjectName('error_icon')  # Set css id
-        error_icon.setFixedWidth(12)
-        error_message = SecureQLabel('Failed to send', wordwrap=False)
-        error_message.setObjectName('error_message')
-        error_message.setStyleSheet(self.CSS_ERROR_MESSAGE)
-
         self.error = QWidget()
         error_layout = QHBoxLayout()
         error_layout.setContentsMargins(0, 0, 0, 0)
         error_layout.setSpacing(4)
         self.error.setLayout(error_layout)
+        error_message = SecureQLabel('Failed to send', wordwrap=False)
+        error_message.setObjectName('ReplyWidget_failed_to_send_text')
+        error_icon = SvgLabel('error_icon.svg', svg_size=QSize(12, 12))
+        error_icon.setFixedWidth(12)
         error_layout.addWidget(error_message)
         error_layout.addWidget(error_icon)
-
         self.error.hide()
+
         self.bubble_area_layout.addWidget(self.error)
 
         message_succeeded_signal.connect(self._on_reply_success)
         message_failed_signal.connect(self._on_reply_failure)
 
-        # Set styles
-        if error:
-            self.set_error_styles()
-        else:
-            self._set_reply_state(reply_status)
+        self._set_reply_state(reply_status)
 
     def _set_reply_state(self, status: str) -> None:
-        logger.debug("Setting ReplyWidget state: %s", status)
+        logger.debug(f'Setting ReplyWidget state: {status}')
+
         if status == 'SUCCEEDED':
             self.set_normal_styles()
             self.error.hide()
@@ -2192,15 +2136,23 @@ class ReplyWidget(SpeechBubble):
         if message_uuid == self.uuid:
             self._set_reply_state('FAILED')
 
+    def set_normal_styles(self):
+        self.setStyleSheet('')
+        self.message.setObjectName('ReplyWidget_message')
+        self.color_bar.setObjectName('ReplyWidget_status_bar')
+        self.setStyleSheet(self.CSS)
+
     def set_failed_styles(self):
-        self.speech_bubble.setStyleSheet(self.CSS_REPLY_FAILED["speech_bubble"])
-        self.message.setStyleSheet(self.CSS_REPLY_FAILED["message"])
-        self.color_bar.setStyleSheet(self.CSS_REPLY_FAILED["color_bar"])
+        self.setStyleSheet('')
+        self.message.setObjectName('ReplyWidget_message_failed')
+        self.color_bar.setObjectName('ReplyWidget_status_bar_failed')
+        self.setStyleSheet(self.CSS)
 
     def set_pending_styles(self):
-        self.speech_bubble.setStyleSheet(self.CSS_REPLY_PENDING["speech_bubble"])
-        self.message.setStyleSheet(self.CSS_REPLY_PENDING["message"])
-        self.color_bar.setStyleSheet(self.CSS_REPLY_PENDING["color_bar"])
+        self.setStyleSheet('')
+        self.message.setObjectName('ReplyWidget_message_pending')
+        self.color_bar.setObjectName('ReplyWidget_status_bar_pending')
+        self.setStyleSheet(self.CSS)
 
 
 class FileWidget(QWidget):
@@ -2209,49 +2161,59 @@ class FileWidget(QWidget):
     """
 
     CSS = '''
-    #file_widget {
+    #FileWidget {
         min-width: 540px;
         max-width: 540px;
     }
-    #file_options {
+    #FileWidget_file_options {
         min-width: 137px;
     }
-    QPushButton#export_print {
+    QPushButton#FileWidget_export_print {
         border: none;
         font-family: 'Source Sans Pro';
         font-weight: 500;
         font-size: 13px;
         color: #2A319D;
     }
-    QPushButton#export_print:hover {
+    QPushButton#FileWidget_export_print:hover {
         color: #05a6fe;
     }
-    QPushButton#download_button {
+    QPushButton#FileWidget_download_button {
         border: none;
         font-family: 'Source Sans Pro';
         font-weight: 600;
         font-size: 13px;
         color: #2a319d;
     }
-    QPushButton#download_button:hover {
+    QPushButton#FileWidget_download_button:hover {
         color: #05a6fe;
     }
-    QLabel#file_name {
+    QPushButton#FileWidget_download_button_animating {
+        border: none;
+        font-family: 'Source Sans Pro';
+        font-weight: 600;
+        font-size: 13px;
+        color: #05a6fe;
+    }
+    QPushButton#FileWidget_download_button_animating:hover {
+        color: #05a6fe;
+    }
+    QLabel#FileWidget_file_name {
         font-family: 'Source Sans Pro';
         font-weight: 600;
         font-size: 13px;
         color: #2a319d;
     }
-    QLabel#file_name:hover {
+    QLabel#FileWidget_file_name:hover {
         color: #05a6fe;
     }
-    QLabel#no_file_name {
+    QLabel#FileWidget_no_file_name {
         font-family: 'Source Sans Pro';
         font-weight: 300;
         font-size: 13px;
         color: #a5b3e9;
     }
-    QLabel#file_size {
+    QLabel#FileWidget_file_size {
         min-width: 48px;
         max-width: 48px;
         font-family: 'Source Sans Pro';
@@ -2259,26 +2221,13 @@ class FileWidget(QWidget):
         font-size: 13px;
         color: #2a319d;
     }
-    QWidget#horizontal_line {
+    QWidget#FileWidget_horizontal_line {
         min-height: 2px;
         max-height: 2px;
         background-color: rgba(211, 216, 234, 0.45);
         margin: 0px 8px 0px 8px;
     }
     '''
-
-    download_button_css = """
-    QPushButton#download_button {
-        border: none;
-        font-family: 'Source Sans Pro';
-        font-weight: 600;
-        font-size: 13px;
-        color: #2a319d;
-    }
-    QPushButton#download_button:hover {
-        color: #05a6fe;
-    }
-    """
 
     TOP_MARGIN = 4
     BOTTOM_MARGIN = 14
@@ -2307,7 +2256,7 @@ class FileWidget(QWidget):
         self.downloading = False
 
         # Set styles
-        self.setObjectName('file_widget')
+        self.setObjectName('FileWidget')
         self.setStyleSheet(self.CSS)
         file_description_font = QFont()
         file_description_font.setLetterSpacing(QFont.AbsoluteSpacing, self.FILE_FONT_SPACING)
@@ -2325,27 +2274,26 @@ class FileWidget(QWidget):
 
         # File options: download, export, print
         self.file_options = QWidget()
-        self.file_options.setObjectName('file_options')
+        self.file_options.setObjectName('FileWidget_file_options')
         file_options_layout = QHBoxLayout()
         self.file_options.setLayout(file_options_layout)
         file_options_layout.setContentsMargins(0, 0, 0, 0)
         file_options_layout.setSpacing(self.FILE_OPTIONS_LAYOUT_SPACING)
         file_options_layout.setAlignment(Qt.AlignLeft)
         self.download_button = QPushButton(_(' DOWNLOAD'))
-        self.download_button.setObjectName('download_button')
+        self.download_button.setObjectName('FileWidget_download_button')
         self.download_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.download_button.setIcon(load_icon('download_file.svg'))
         self.download_button.setFont(self.file_buttons_font)
         self.download_button.setCursor(QCursor(Qt.PointingHandCursor))
-        self.download_button.setStyleSheet(self.download_button_css)
         self.download_animation = load_movie("download_file.gif")
         self.export_button = QPushButton(_('EXPORT'))
-        self.export_button.setObjectName('export_print')
+        self.export_button.setObjectName('FileWidget_export_print')
         self.export_button.setFont(self.file_buttons_font)
         self.export_button.setCursor(QCursor(Qt.PointingHandCursor))
         self.middot = QLabel("·")
         self.print_button = QPushButton(_('PRINT'))
-        self.print_button.setObjectName('export_print')
+        self.print_button.setObjectName('FileWidget_export_print')
         self.print_button.setFont(self.file_buttons_font)
         self.print_button.setCursor(QCursor(Qt.PointingHandCursor))
         file_options_layout.addWidget(self.download_button)
@@ -2360,16 +2308,16 @@ class FileWidget(QWidget):
         self.file_name = SecureQLabel(
             wordwrap=False, max_length=self.FILENAME_WIDTH_PX, with_tooltip=True
         )
-        self.file_name.setObjectName('file_name')
+        self.file_name.setObjectName('FileWidget_file_name')
         self.file_name.installEventFilter(self)
         self.file_name.setCursor(QCursor(Qt.PointingHandCursor))
         self.no_file_name = SecureQLabel('ENCRYPTED FILE ON SERVER', wordwrap=False)
-        self.no_file_name.setObjectName('no_file_name')
+        self.no_file_name.setObjectName('FileWidget_no_file_name')
         self.no_file_name.setFont(file_description_font)
 
         # Line between file name and file size
         self.horizontal_line = QWidget()
-        self.horizontal_line.setObjectName('horizontal_line')
+        self.horizontal_line.setObjectName('FileWidget_horizontal_line')
         self.horizontal_line.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
         # Space between elided file name and file size when horizontal line is hidden
@@ -2379,7 +2327,7 @@ class FileWidget(QWidget):
 
         # File size
         self.file_size = SecureQLabel(humanize_filesize(self.file.size))
-        self.file_size.setObjectName('file_size')
+        self.file_size.setObjectName('FileWidget_file_size')
         self.file_size.setAlignment(Qt.AlignRight)
 
         # Decide what to show or hide based on whether or not the file's been downloaded
@@ -2431,14 +2379,21 @@ class FileWidget(QWidget):
         else:
             logger.debug('Changing file {} state to not downloaded'.format(self.uuid))
             self.download_button.setText(_('DOWNLOAD'))
+
             # Ensure correct icon depending on mouse hover state.
             if self.download_button.underMouse():
                 self.download_button.setIcon(load_icon('download_file_hover.svg'))
             else:
                 self.download_button.setIcon(load_icon('download_file.svg'))
+
             self.download_button.setFont(self.file_buttons_font)
             self.download_button.show()
-            self.download_button.setStyleSheet(self.download_button_css)
+
+            # Reset stylesheet
+            self.setStyleSheet('')
+            self.download_button.setObjectName('FileWidget_download_button')
+            self.setStyleSheet(self.CSS)
+
             self.no_file_name.hide()
             self.export_button.hide()
             self.middot.hide()
@@ -2511,7 +2466,11 @@ class FileWidget(QWidget):
         self.download_animation.frameChanged.connect(self.set_button_animation_frame)
         self.download_animation.start()
         self.download_button.setText(_(" DOWNLOADING "))
-        self.download_button.setStyleSheet("color: #05a6fe")
+
+        # Reset stylesheet with new state so that the active color stays the same
+        self.setStyleSheet('')
+        self.download_button.setObjectName('FileWidget_download_button_animating')
+        self.setStyleSheet(self.CSS)
 
     def set_button_animation_frame(self, frame_number):
         """
@@ -2532,21 +2491,21 @@ class FileWidget(QWidget):
 class ModalDialog(QDialog):
 
     CSS = '''
-    #modal {
+    #ModalDialog {
         min-width: 800px;
         max-width: 800px;
         min-height: 300px;
         max-height: 800px;
         background-color: #fff;
     }
-    #header_icon, #header_spinner {
+    #ModalDialog_header_icon, #ModalDialog_header_spinner {
         min-width: 80px;
         max-width: 80px;
         min-height: 64px;
         max-height: 64px;
         margin: 0px 0px 0px 30px;
     }
-    #header {
+    #ModalDialog_header {
         min-height: 68px;
         max-height: 68px;
         margin: 0px 0px 0px 4px;
@@ -2555,25 +2514,25 @@ class ModalDialog(QDialog):
         font-weight: 600;
         color: #2a319d;
     }
-    #header_line {
+    #ModalDialog_header_line {
         margin: 0px 40px 20px 40px;
         min-height: 2px;
         max-height: 2px;
         background-color: rgba(42, 49, 157, 0.15);
         border: none;
     }
-    #error_details {
+    #ModalDialog_error_details {
         margin: 0px 40px 0px 36px;
         font-family: 'Montserrat';
         font-size: 16px;
         color: #ff0064;
     }
-    #body {
+    #ModalDialog_body {
         font-family: 'Montserrat';
         font-size: 16px;
         color: #302aa3;
     }
-    #button_box QPushButton {
+    #ModalDialog_button_box QPushButton {
         margin: 0px 0px 0px 12px;
         height: 40px;
         padding-left: 20px;
@@ -2584,15 +2543,15 @@ class ModalDialog(QDialog):
         font-size: 15px;
         color: #2a319d;
     }
-    #button_box QPushButton::disabled {
+    #ModalDialog_button_box QPushButton::disabled {
         border: 2px solid rgba(42, 49, 157, 0.4);
         color: rgba(42, 49, 157, 0.4);
     }
-    #button_box QPushButton#primary_button {
+    #ModalDialog_button_box QPushButton#ModalDialog_primary_button {
         background-color: #2a319d;
         color: #fff;
     }
-    #button_box QPushButton#primary_button::disabled {
+    #ModalDialog_button_box QPushButton#ModalDialog_primary_button::disabled {
         border: 2px solid #C2C4E3;
         background-color: #C2C4E3;
         color: #E1E2F1;
@@ -2605,7 +2564,7 @@ class ModalDialog(QDialog):
     def __init__(self):
         parent = QApplication.activeWindow()
         super().__init__(parent)
-        self.setObjectName('modal')
+        self.setObjectName('ModalDialog')
         self.setStyleSheet(self.CSS)
         self.setModal(True)
 
@@ -2614,32 +2573,32 @@ class ModalDialog(QDialog):
         header_container_layout = QHBoxLayout()
         header_container.setLayout(header_container_layout)
         self.header_icon = SvgLabel('blank.svg', svg_size=QSize(64, 64))
-        self.header_icon.setObjectName('header_icon')
+        self.header_icon.setObjectName('ModalDialog_header_icon')
         self.header_spinner = QPixmap()
         self.header_spinner_label = QLabel()
-        self.header_spinner_label.setObjectName("header_spinner")
+        self.header_spinner_label.setObjectName("ModalDialog_header_spinner")
         self.header_spinner_label.setMinimumSize(64, 64)
         self.header_spinner_label.setVisible(False)
         self.header_spinner_label.setPixmap(self.header_spinner)
         self.header = QLabel()
-        self.header.setObjectName('header')
+        self.header.setObjectName('ModalDialog_header')
         header_container_layout.addWidget(self.header_icon)
         header_container_layout.addWidget(self.header_spinner_label)
         header_container_layout.addWidget(self.header, alignment=Qt.AlignCenter)
         header_container_layout.addStretch()
 
         self.header_line = QWidget()
-        self.header_line.setObjectName('header_line')
+        self.header_line.setObjectName('ModalDialog_header_line')
 
         # Widget for displaying error messages
         self.error_details = QLabel()
-        self.error_details.setObjectName('error_details')
+        self.error_details.setObjectName('ModalDialog_error_details')
         self.error_details.setWordWrap(True)
         self.error_details.hide()
 
         # Body to display instructions and forms
         self.body = QLabel()
-        self.body.setObjectName('body')
+        self.body.setObjectName('ModalDialog_body')
         self.body.setWordWrap(True)
         self.body.setScaledContents(True)
         body_container = QWidget()
@@ -2650,18 +2609,18 @@ class ModalDialog(QDialog):
 
         # Buttons to continue and cancel
         window_buttons = QWidget()
-        window_buttons.setObjectName('window_buttons')
+        window_buttons.setObjectName('ModalDialog_window_buttons')
         button_layout = QVBoxLayout()
         window_buttons.setLayout(button_layout)
         self.cancel_button = QPushButton(_('CANCEL'))
         self.cancel_button.clicked.connect(self.close)
         self.cancel_button.setAutoDefault(False)
         self.continue_button = QPushButton(_('CONTINUE'))
-        self.continue_button.setObjectName('primary_button')
+        self.continue_button.setObjectName('ModalDialog_primary_button')
         self.continue_button.setDefault(True)
         self.continue_button.setIconSize(QSize(21, 21))
         button_box = QDialogButtonBox(Qt.Horizontal)
-        button_box.setObjectName('button_box')
+        button_box.setObjectName('ModalDialog_button_box')
         button_box.addButton(self.cancel_button, QDialogButtonBox.ActionRole)
         button_box.addButton(self.continue_button, QDialogButtonBox.ActionRole)
         button_layout.addWidget(button_box, alignment=Qt.AlignRight)
@@ -3121,25 +3080,64 @@ class ExportDialog(ModalDialog):
                 self._show_generic_error_message()
 
 
+class ConversationScrollArea(QScrollArea):
+
+    CSS = '''
+    #ConversationScrollArea {
+        border: 0;
+        background: #f3f5f9;
+    }
+    #ConversationScrollArea_conversation {
+        background: #f3f5f9;
+    }
+    '''
+
+    MARGIN_LEFT = 38
+    MARGIN_RIGHT = 20
+
+    def __init__(self):
+        super().__init__()
+
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setWidgetResizable(True)
+
+        # Set styles
+        self.setObjectName('ConversationScrollArea')
+        self.setStyleSheet(self.CSS)
+
+        # Create the scroll area's widget
+        conversation = QWidget()
+        conversation.setObjectName('ConversationScrollArea_conversation')
+        conversation.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.conversation_layout = QVBoxLayout()
+        conversation.setLayout(self.conversation_layout)
+        self.conversation_layout.setContentsMargins(self.MARGIN_LEFT, 0, self.MARGIN_RIGHT, 0)
+        self.conversation_layout.setSpacing(0)
+
+        # `conversation` is a child of this scroll area
+        self.setWidget(conversation)
+
+    def add_widget_to_conversation(
+        self, index: int, widget: QWidget, alignment_flag: Qt.AlignmentFlag
+    ) -> None:
+        '''
+        Add `widget` to the scroll area's widget layout.
+        '''
+        self.conversation_layout.insertWidget(index, widget, alignment=alignment_flag)
+
+    def remove_widget_from_conversation(self, widget: QWidget) -> None:
+        '''
+        Remove `widget` from the scroll area's widget layout.
+        '''
+        self.conversation_layout.removeWidget(widget)
+
+
 class ConversationView(QWidget):
     """
     Renders a conversation.
     """
 
-    CSS = {
-        'container': '''
-            background: #f3f5f9;
-        ''',
-        'scroll': '''
-            border: 0;
-            background: #f3f5f9;
-        '''
-    }
-
     conversation_updated = pyqtSignal()
-
-    MARGIN_LEFT = 38
-    MARGIN_RIGHT = 20
 
     def __init__(self, source_db_object: Source, controller: Controller):
         super().__init__()
@@ -3159,21 +3157,7 @@ class ConversationView(QWidget):
         main_layout.setContentsMargins(0, 0, 0, 0)
         main_layout.setSpacing(0)
 
-        self.container = QWidget()
-        self.container.setObjectName('container')
-        self.conversation_layout = QVBoxLayout()
-        self.container.setLayout(self.conversation_layout)
-        self.conversation_layout.setContentsMargins(self.MARGIN_LEFT, 0, self.MARGIN_RIGHT, 0)
-        self.conversation_layout.setSpacing(0)
-        self.container.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-        self.container.setStyleSheet(self.CSS['container'])
-
-        self.scroll = QScrollArea()
-        self.scroll.setObjectName('scroll')
-        self.scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        self.scroll.setWidget(self.container)
-        self.scroll.setWidgetResizable(True)
-        self.scroll.setStyleSheet(self.CSS['scroll'])
+        self.scroll = ConversationScrollArea()
 
         # Flag to show if the current user has sent a reply. See issue #61.
         self.reply_flag = False
@@ -3218,14 +3202,12 @@ class ConversationView(QWidget):
                 if item_widget.index != index:
                     # The existing widget is out of order.
                     # Remove / re-add it and update index details.
-                    self.conversation_layout.removeWidget(item_widget)
+                    self.scroll.remove_widget_from_conversation(item_widget)
                     item_widget.index = index
                     if isinstance(item_widget, ReplyWidget):
-                        self.conversation_layout.insertWidget(index, item_widget,
-                                                              alignment=Qt.AlignRight)
+                        self.scroll.add_widget_to_conversation(index, item_widget, Qt.AlignRight)
                     else:
-                        self.conversation_layout.insertWidget(index, item_widget,
-                                                              alignment=Qt.AlignLeft)
+                        self.scroll.add_widget_to_conversation(index, item_widget, Qt.AlignLeft)
                 # Check if text in item has changed, then update the
                 # widget to reflect this change.
                 if not isinstance(item_widget, FileWidget):
@@ -3250,7 +3232,7 @@ class ConversationView(QWidget):
             logger.debug('Deleting item: {}'.format(item_widget.uuid))
             self.current_messages.pop(item_widget.uuid)
             item_widget.deleteLater()
-            self.conversation_layout.removeWidget(item_widget)
+            self.scroll.remove_widget_from_conversation(item_widget)
 
     def add_file(self, file: File, index):
         """
@@ -3264,7 +3246,7 @@ class ConversationView(QWidget):
             self.controller.file_missing,
             index,
         )
-        self.conversation_layout.insertWidget(index, conversation_item, alignment=Qt.AlignLeft)
+        self.scroll.add_widget_to_conversation(index, conversation_item, Qt.AlignLeft)
         self.current_messages[file.uuid] = conversation_item
         self.conversation_updated.emit()
 
@@ -3289,7 +3271,7 @@ class ConversationView(QWidget):
             index,
             message.download_error is not None,
         )
-        self.conversation_layout.insertWidget(index, conversation_item, alignment=Qt.AlignLeft)
+        self.scroll.add_widget_to_conversation(index, conversation_item, Qt.AlignLeft)
         self.current_messages[message.uuid] = conversation_item
         self.conversation_updated.emit()
 
@@ -3314,7 +3296,7 @@ class ConversationView(QWidget):
             index,
             getattr(reply, "download_error", None) is not None,
         )
-        self.conversation_layout.insertWidget(index, conversation_item, alignment=Qt.AlignRight)
+        self.scroll.add_widget_to_conversation(index, conversation_item, Qt.AlignRight)
         self.current_messages[reply.uuid] = conversation_item
 
     def add_reply_from_reply_box(self, uuid: str, content: str) -> None:
@@ -3331,7 +3313,7 @@ class ConversationView(QWidget):
             self.controller.reply_succeeded,
             self.controller.reply_failed,
             index)
-        self.conversation_layout.insertWidget(index, conversation_item, alignment=Qt.AlignRight)
+        self.scroll.add_widget_to_conversation(index, conversation_item, Qt.AlignRight)
         self.current_messages[uuid] = conversation_item
 
     def on_reply_sent(self, source_uuid: str, reply_uuid: str, reply_text: str) -> None:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2527,6 +2527,9 @@ class ModalDialog(QDialog):
         font-size: 16px;
         color: #ff0064;
     }
+    #ModalDialog_error_details_active {
+        color: #ff66C4;
+    }
     #ModalDialog_body {
         font-family: 'Montserrat';
         font-size: 16px;
@@ -2555,6 +2558,15 @@ class ModalDialog(QDialog):
         border: 2px solid #C2C4E3;
         background-color: #C2C4E3;
         color: #E1E2F1;
+    }
+    #ModalDialog_button_box QPushButton#ModalDialog_primary_button_active {
+        background-color: #f1f1f6;
+        color: #fff;
+        border: 2px solid #f1f1f6;
+        margin: 0px 0px 0px 12px;
+        height: 40px;
+        padding-left: 20px;
+        padding-right: 20px;
     }
     '''
 
@@ -2666,17 +2678,11 @@ class ModalDialog(QDialog):
         self.button_animation.start()
         self.continue_button.setText("")
         self.continue_button.setMinimumSize(QSize(142, 43))
-        css = """
-        background-color: #f1f1f6;
-        color: #fff;
-        border: 2px solid #f1f1f6;
-        margin: 0px 0px 0px 12px;
-        height: 40px;
-        padding-left: 20px;
-        padding-right: 20px;
-        """
-        self.continue_button.setStyleSheet(css)
-        self.error_details.setStyleSheet("color: #ff66C4")
+        # Reset stylesheet
+        self.setStyleSheet('')
+        self.continue_button.setObjectName('ModalDialog_primary_button_active')
+        self.error_details.setObjectName('ModalDialog_error_details_active')
+        self.setStyleSheet(self.CSS)
 
     def start_animate_header(self):
         self.header_icon.setVisible(False)
@@ -2687,9 +2693,11 @@ class ModalDialog(QDialog):
         self.continue_button.setIcon(QIcon())
         self.button_animation.stop()
         self.continue_button.setText(_('CONTINUE'))
-        css = "background-color: #2a319d; color: #fff; border: 2px solid #2a319d;"
-        self.continue_button.setStyleSheet(css)
-        self.error_details.setStyleSheet("color: #ff0064")
+        # Reset stylesheet
+        self.setStyleSheet('')
+        self.continue_button.setObjectName('ModalDialog_primary_button')
+        self.error_details.setObjectName('ModalDialog_error_details')
+        self.setStyleSheet(self.CSS)
 
     def stop_animate_header(self):
         self.header_icon.setVisible(True)
@@ -3332,7 +3340,7 @@ class SourceConversationWrapper(QWidget):
     """
 
     SOURCE_DELETED_CSS = '''
-    #source_deleted {
+    #SourceConversationWrapper_source_deleted {
         text-align: left;
         font-family: 'Montserrat';
         font-weight: 500;
@@ -3363,7 +3371,7 @@ class SourceConversationWrapper(QWidget):
         self.conversation_view = ConversationView(source, controller)
         self.reply_box = ReplyBoxWidget(source, controller)
         self.waiting_delete_confirmation = QLabel('Deleting...')
-        self.waiting_delete_confirmation.setObjectName('source_deleted')
+        self.waiting_delete_confirmation.setObjectName('SourceConversationWrapper_source_deleted')
         self.waiting_delete_confirmation.setStyleSheet(self.SOURCE_DELETED_CSS)
         self.waiting_delete_confirmation.hide()
 
@@ -3401,24 +3409,24 @@ class ReplyBoxWidget(QWidget):
     """
 
     CSS = '''
-    #replybox_holder {
+    #ReplyBoxWidget {
         min-height: 173px;
         max-height: 173px;
     }
-    #replybox {
+    #ReplyBoxWidget_replybox {
         background-color: #ffffff;
     }
-    #replybox::disabled {
+    #ReplyBoxWidget_replybox::disabled {
         background-color: #efefef;
     }
-    QPushButton {
+    #ReplyBoxWidget QPushButton {
         border: none;
     }
-    QPushButton:hover {
+    #ReplyBoxWidget QPushButton:hover {
         background: #D3D8EA;
         border-radius: 8px;
     }
-    QWidget#horizontal_line {
+    QWidget#ReplyBoxWidget_horizontal_line {
         min-height: 2px;
         max-height: 2px;
         background-color: rgba(42, 49, 157, 0.15);
@@ -3435,7 +3443,7 @@ class ReplyBoxWidget(QWidget):
         self.controller = controller
 
         # Set css id
-        self.setObjectName('replybox_holder')
+        self.setObjectName('ReplyBoxWidget')
 
         # Set styles
         self.setStyleSheet(self.CSS)
@@ -3450,11 +3458,11 @@ class ReplyBoxWidget(QWidget):
 
         # Create top horizontal line
         horizontal_line = QWidget()
-        horizontal_line.setObjectName('horizontal_line')
+        horizontal_line.setObjectName('ReplyBoxWidget_horizontal_line')
 
         # Create replybox
         self.replybox = QWidget()
-        self.replybox.setObjectName('replybox')
+        self.replybox.setObjectName('ReplyBoxWidget_replybox')
         replybox_layout = QHBoxLayout(self.replybox)
         replybox_layout.setContentsMargins(32.6, 19, 27.3, 18)
         replybox_layout.setSpacing(0)
@@ -3563,20 +3571,20 @@ class ReplyTextEdit(QPlainTextEdit):
     """
 
     CSS = '''
-    #reply_textedit {
+    #ReplyTextEdit {
         font-family: 'Montserrat';
         font-weight: 400;
         font-size: 18px;
         border: none;
         margin-right: 30.2px;
     }
-    #reply_placeholder {
+    #ReplyTextEdit_placeholder {
         font-family: 'Montserrat';
         font-weight: 400;
         font-size: 18px;
         color: #404040;
     }
-    #reply_placeholder::disabled {
+    #ReplyTextEdit_placeholder::disabled {
         color: rgba(42, 49, 157, 0.6);
     }
     '''
@@ -3586,13 +3594,13 @@ class ReplyTextEdit(QPlainTextEdit):
         self.controller = controller
         self.source = source
 
-        self.setObjectName('reply_textedit')
+        self.setObjectName('ReplyTextEdit')
         self.setStyleSheet(self.CSS)
 
         self.setTabChangesFocus(True)  # Needed so we can TAB to send button.
 
         self.placeholder = QLabel()
-        self.placeholder.setObjectName("reply_placeholder")
+        self.placeholder.setObjectName("ReplyTextEdit_placeholder")
         self.placeholder.setParent(self)
         self.placeholder.move(QPoint(3, 4))  # make label match text below
         self.set_logged_in()
@@ -3686,12 +3694,12 @@ class SourceMenuButton(QToolButton):
     """
 
     CSS = '''
-    #ellipsis_button {
+    #SourceMenuButton_ellipsis_button {
         border: none;
         margin: 5px 0px 0px 0px;
         padding-left: 8px;
     }
-    QToolButton::menu-indicator {
+    #SourceMenuButton QToolButton::menu-indicator {
         image: none;
     }
     '''
@@ -3701,7 +3709,7 @@ class SourceMenuButton(QToolButton):
         self.controller = controller
         self.source = source
 
-        self.setObjectName('ellipsis_button')
+        self.setObjectName('SourceMenuButton')
         self.setStyleSheet(self.CSS)
 
         self.setIcon(load_icon("ellipsis.svg"))
@@ -3719,7 +3727,7 @@ class TitleLabel(QLabel):
     """The title for a conversation."""
 
     CSS = '''
-    #conversation-title-source-name {
+    #TitleLabel {
         font-family: 'Montserrat';
         font-weight: 400;
         font-size: 24px;
@@ -3732,7 +3740,7 @@ class TitleLabel(QLabel):
         super().__init__(_(text))
 
         # Set css id
-        self.setObjectName('conversation-title-source-name')
+        self.setObjectName('TitleLabel')
 
         # Set styles
         self.setStyleSheet(self.CSS)
@@ -3742,7 +3750,7 @@ class LastUpdatedLabel(QLabel):
     """Time the conversation was last updated."""
 
     CSS = '''
-    #conversation-title-date {
+    #LastUpdatedLabel {
         font-family: 'Montserrat';
         font-weight: 200;
         font-size: 24px;
@@ -3754,7 +3762,7 @@ class LastUpdatedLabel(QLabel):
         super().__init__(last_updated)
 
         # Set css id
-        self.setObjectName('conversation-title-date')
+        self.setObjectName('LastUpdatedLabel')
 
         # Set styles
         self.setStyleSheet(self.CSS)
@@ -3769,7 +3777,7 @@ class SourceProfileShortWidget(QWidget):
     """
 
     CSS = '''
-    QWidget#horizontal_line {
+    QWidget#SourceProfileShortWidget_horizontal_line {
         min-height: 2px;
         max-height: 2px;
         background-color: rgba(42, 49, 157, 0.15);
@@ -3810,7 +3818,7 @@ class SourceProfileShortWidget(QWidget):
 
         # Create horizontal line
         horizontal_line = QWidget()
-        horizontal_line.setObjectName('horizontal_line')
+        horizontal_line.setObjectName('SourceProfileShortWidget_horizontal_line')
         horizontal_line.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
         # Add widgets

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -40,7 +40,7 @@ from securedrop_client.storage import source_exists
 from securedrop_client.export import ExportStatus, ExportError
 from securedrop_client.gui import SecureQLabel, SvgLabel, SvgPushButton, SvgToggleButton
 from securedrop_client.logic import Controller
-from securedrop_client.resources import load_icon, load_image, load_movie
+from securedrop_client.resources import load_css, load_icon, load_image, load_movie
 from securedrop_client.utils import humanize_filesize
 
 logger = logging.getLogger(__name__)
@@ -200,18 +200,10 @@ class SyncIcon(QLabel):
     An icon that shows sync state.
     """
 
-    CSS = '''
-    #SyncIcon {
-        border: none;
-        color: #fff;
-    }
-    '''
-
     def __init__(self):
         # Add svg images to button
         super().__init__()
         self.setObjectName('SyncIcon')
-        self.setStyleSheet(self.CSS)
         self.setFixedSize(QSize(24, 20))
         self.sync_animation = load_movie("sync_disabled.gif")
         self.sync_animation.setScaledSize(QSize(24, 20))
@@ -256,23 +248,11 @@ class ActivityStatusBar(QStatusBar):
     displayed for a given duration or until the message updated with a new message.
     """
 
-    CSS = '''
-    #ActivityStatusBar {
-        font-family: 'Source Sans Pro';
-        font-weight: 600;
-        font-size: 12px;
-        color: #d3d8ea;
-    }
-    '''
-
     def __init__(self):
         super().__init__()
 
         # Set css id
         self.setObjectName('ActivityStatusBar')
-
-        # Set styles
-        self.setStyleSheet(self.CSS)
 
         # Remove grip image at bottom right-hand corner
         self.setSizeGripEnabled(False)
@@ -290,43 +270,8 @@ class ErrorStatusBar(QWidget):
     be displayed for a given duration or until the message is cleared or updated with a new message.
     """
 
-    CSS = '''
-    #ErrorStatusBar_vertical_bar {
-        background-color: #ff3366;
-    }
-    #ErrorStatusBar_icon {
-        background-color: qlineargradient(
-            x1: 0,
-            y1: 0,
-            x2: 0,
-            y2: 1,
-            stop: 0 #fff,
-            stop: 0.2 #fff,
-            stop: 1 #fff
-        );
-    }
-    #ErrorStatusBar_status_bar {
-        background-color: qlineargradient(
-            x1: 0,
-            y1: 0,
-            x2: 0,
-            y2: 1,
-            stop: 0 #fff,
-            stop: 0.2 #fff,
-            stop: 1 #fff
-        );
-        font-family: 'Source Sans Pro';
-        font-weight: 400;
-        font-size: 14px;
-        color: #0c3e75;
-    }
-    '''
-
     def __init__(self):
         super().__init__()
-
-        # Set styles
-        self.setStyleSheet(self.CSS)
 
         # Set layout
         layout = QHBoxLayout(self)
@@ -412,30 +357,11 @@ class UserProfile(QLabel):
     button if the user is logged out.
     """
 
-    CSS = '''
-    #UserProfile {
-        padding: 15px;
-    }
-    #UserProfile_icon {
-        border: none;
-        background-color: #9211ff;
-        padding-left: 3px;
-        padding-bottom: 4px;
-        font-family: 'Source Sans Pro';
-        font-weight: 600;
-        font-size: 15px;
-        color: #fff;
-    }
-    '''
-
     def __init__(self):
         super().__init__()
 
         # Set css id
         self.setObjectName('UserProfile')
-
-        # Set styles
-        self.setStyleSheet(self.CSS)
 
         # Set background
         palette = QPalette()
@@ -516,31 +442,12 @@ class UserButton(SvgPushButton):
     This button is responsible for launching the journalist menu on click.
     """
 
-    CSS = '''
-    #UserButton {
-        border: none;
-        font-family: 'Source Sans Pro';
-        font-weight: 700;
-        font-size: 12px;
-        color: #fff;
-        text-align: left;
-    }
-    #UserButton:focus {
-        outline: none;
-    }
-    #UserButton::menu-indicator {
-        image: none;
-    }
-    '''
-
     def __init__(self):
         super().__init__('dropdown_arrow.svg', svg_size=QSize(9, 6))
 
         # Set css id
         self.setObjectName('UserButton')
 
-        # Set styles
-        self.setStyleSheet(self.CSS)
         self.setFixedHeight(30)
 
         self.setLayoutDirection(Qt.RightToLeft)
@@ -594,28 +501,12 @@ class LoginButton(QPushButton):
     A button that opens a login dialog when clicked.
     """
 
-    CSS = '''
-    #LoginButton {
-        border: none;
-        background-color: #05edfe;
-        font-family: 'Montserrat';
-        font-weight: 600;
-        font-size: 14px;
-        color: #2a319d;
-    }
-    #LoginButton:pressed {
-        background-color: #85f6fe;
-    }
-    '''
-
     def __init__(self):
         super().__init__(_('SIGN IN'))
 
         # Set css id
         self.setObjectName('LoginButton')
 
-        # Set styles
-        self.setStyleSheet(self.CSS)
         self.setFixedHeight(40)
 
         # Set click handler
@@ -640,23 +531,11 @@ class MainView(QWidget):
     and main context view).
     """
 
-    CSS = '''
-    #MainView {
-        min-height: 558;
-    }
-    #MainView_view_holder {
-        min-width: 667;
-        border: none;
-        background-color: #f3f5f9;
-    }
-    '''
-
     def __init__(self, parent: QObject):
         super().__init__(parent)
 
         # Set id and styles
         self.setObjectName('MainView')
-        self.setStyleSheet(self.CSS)
 
         # Set layout
         self.layout = QHBoxLayout(self)
@@ -771,40 +650,13 @@ class MainView(QWidget):
 
 class EmptyConversationView(QWidget):
 
-    CSS = '''
-    #EmptyConversationView QLabel {
-        font-family: Montserrat;
-        font-weight: 400;
-        font-size: 35px;
-        color: #a5b3e9;
-    }
-    #EmptyConversationView QLabel#EmptyConversationView_instructions {
-        font-weight: 500;
-    }
-    #EmptyConversationView QLabel#EmptyConversationView_bullet {
-        margin: 4px 0px 0px 0px;
-        font-size: 35px;
-        font-weight: 600;
-    }
-    #EmptyConversationView_no_sources {
-        min-width: 520px;
-        max-width: 600px;
-    }
-    #EmptyConversationView_no_source_selected {
-        min-width: 520px;
-        max-width: 520px;
-    }
-    '''
-
     MARGIN = 30
     NEWLINE_HEIGHT_PX = 35
 
     def __init__(self):
         super().__init__()
 
-        # Set id and styles
         self.setObjectName('EmptyConversationView')
-        self.setStyleSheet(self.CSS)
 
         # Set layout
         layout = QHBoxLayout()
@@ -906,26 +758,10 @@ class SourceList(QListWidget):
     Displays the list of sources.
     """
 
-    CSS = '''
-    QListView#SourceList {
-        border: none;
-        show-decoration-selected: 0;
-        border-right: 3px solid #f3f5f9;
-    }
-    QListView#SourceList::item:selected {
-        background-color: #f3f5f9;
-    }
-    QListView#SourceList::item:hover{
-        border: 500px solid #f9f9f9;
-    }
-    '''
-
     def __init__(self):
         super().__init__()
 
-        # Set id and styles.
         self.setObjectName('SourceList')
-        self.setStyleSheet(self.CSS)
         self.setFixedWidth(540)
         self.setUniformItemSizes(True)
 
@@ -1104,43 +940,6 @@ class SourceWidget(QWidget):
     -----------------------------------------------------------------------------
     """
 
-    CSS = '''
-    #SourceWidget_container {
-        border-bottom: 1px solid #9b9b9b;
-    }
-    #SourceWidget_gutter {
-        min-width: 40px;
-        max-width: 40px;
-    }
-    #SourceWidget_metadata {
-        max-width: 60px;
-    }
-    #SourceWidget_preview {
-        font-family: 'Source Sans Pro';
-        font-weight: 400;
-        font-size: 13px;
-        color: #383838;
-    }
-    #SourceWidget_source_deleted {
-        font-family: 'Source Sans Pro';
-        font-weight: 400;
-        font-size: 13px;
-        color: #ff3366;
-    }
-    #SourceWidget_name {
-        font-family: 'Montserrat';
-        font-weight: 500;
-        font-size: 13px;
-        color: #383838;
-    }
-    #SourceWidget_timestamp {
-        font-family: 'Montserrat';
-        font-weight: 500;
-        font-size: 13px;
-        color: #383838;
-    }
-    '''
-
     SIDE_MARGIN = 10
     SOURCE_WIDGET_VERTICAL_MARGIN = 10
     PREVIEW_WIDTH = 412
@@ -1156,9 +955,6 @@ class SourceWidget(QWidget):
         # Store source
         self.source_uuid = source.uuid
         self.source = source
-
-        # Set styles
-        self.setStyleSheet(self.CSS)
 
         # Set layout
         layout = QHBoxLayout(self)
@@ -1298,12 +1094,6 @@ class StarToggleButton(SvgToggleButton):
     A button that shows whether or not a source is starred
     """
 
-    css = '''
-    #StarToggleButton {
-        border: none;
-    }
-    '''
-
     def __init__(self, controller: Controller, source_uuid: str, is_starred: bool):
         super().__init__(on='star_on.svg', off='star_off.svg', svg_size=QSize(16, 16))
 
@@ -1319,7 +1109,6 @@ class StarToggleButton(SvgToggleButton):
         self.installEventFilter(self)
 
         self.setObjectName('StarToggleButton')
-        self.setStyleSheet(self.css)
         self.setFixedSize(QSize(20, 20))
 
         self.pressed.connect(self.on_pressed)
@@ -1501,14 +1290,6 @@ class LoginOfflineLink(QLabel):
 
     clicked = pyqtSignal()
 
-    CSS = '''
-    #LoginOfflineLink {
-        border: none;
-        color: #fff;
-        text-decoration: underline;
-    }
-    '''
-
     def __init__(self):
         # Add svg images to button
         super().__init__()
@@ -1516,8 +1297,6 @@ class LoginOfflineLink(QLabel):
         # Set css id
         self.setObjectName('LoginOfflineLink')
 
-        # Set styles
-        self.setStyleSheet(self.CSS)
         self.setFixedSize(QSize(120, 22))
 
         self.setText(_('USE OFFLINE'))
@@ -1531,28 +1310,12 @@ class SignInButton(QPushButton):
     A button that logs the user into application when clicked.
     """
 
-    CSS = '''
-    #SignInButton {
-        border: none;
-        background-color: #05edfe;
-        font-family: 'Montserrat';
-        font-weight: 600;
-        font-size: 14px;
-        color: #2a319d;
-    }
-    #SignInButton:pressed {
-        background-color: #85f6fe;
-    }
-    '''
-
     def __init__(self):
         super().__init__(_('SIGN IN'))
 
         # Set css id
         self.setObjectName('SignInButton')
 
-        # Set styles
-        self.setStyleSheet(self.CSS)
         self.setFixedHeight(40)
         self.setFixedWidth(140)
 
@@ -1573,28 +1336,10 @@ class LoginErrorBar(QWidget):
     A bar widget for displaying messages about login errors to the user.
     """
 
-    CSS = '''
-    #LoginErrorBar QWidget {
-        background-color: #ce0083;
-    }
-    #LoginErrorBar_icon {
-        color: #fff;
-    }
-    #LoginErrorBar_status_bar {
-        font-family: 'Montserrat';
-        font-weight: 500;
-        font-size: 12px;
-        color: #fff;
-    }
-    '''
-
     def __init__(self):
         super().__init__()
 
         self.setObjectName('LoginErrorBar')
-
-        # Set styles
-        self.setStyleSheet(self.CSS)
 
         # Set layout
         layout = QHBoxLayout(self)
@@ -1671,21 +1416,6 @@ class LoginDialog(QDialog):
     A dialog to display the login form.
     """
 
-    CSS = '''
-    #LoginDialog_form QLabel {
-        color: #fff;
-        font-family: 'Montserrat';
-        font-weight: 500;
-        font-size: 13px;
-    }
-    #LoginDialog_form QLineEdit {
-        border-radius: 0px;
-        height: 30px;
-        margin: 0px 0px 0px 0px;
-        padding-left: 5px;
-    }
-    '''
-
     MIN_PASSWORD_LEN = 14  # Journalist.MIN_PASSWORD_LEN on server
     MAX_PASSWORD_LEN = 128  # Journalist.MAX_PASSWORD_LEN on server
     MIN_JOURNALIST_USERNAME = 3  # Journalist.MIN_USERNAME_LEN on server
@@ -1696,9 +1426,6 @@ class LoginDialog(QDialog):
 
         # Set modal
         self.setModal(True)
-
-        # Set styles
-        self.setStyleSheet(self.CSS)
 
         # Set layout
         layout = QVBoxLayout(self)
@@ -1766,7 +1493,7 @@ class LoginDialog(QDialog):
         application_version.setLayout(application_version_layout)
         application_version_label = QLabel(_("SecureDrop Client v") + sd_version)
         application_version_label.setAlignment(Qt.AlignHCenter)
-        application_version_label.setStyleSheet("QLabel {color: #9fddff;}")
+        application_version_label.setObjectName('LoginDialog_app_version_label')
         application_version_layout.addWidget(application_version_label)
 
         # Add widgets
@@ -1868,100 +1595,6 @@ class SpeechBubble(QWidget):
     and journalist.
     """
 
-    CSS = '''
-    #SpeechBubble_container {
-        min-width: 540px;
-        max-width: 540px;
-        background-color: #fff;
-    }
-    #SpeechBubble_message {
-        min-width: 508px;
-        max-width: 508px;
-        font-family: 'Source Sans Pro';
-        font-weight: 400;
-        font-size: 15px;
-        background-color: #fff;
-        color: #3b3b3b;
-        padding: 16px;
-    }
-    #SpeechBubble_status_bar {
-        min-height: 5px;
-        max-height: 5px;
-        background-color: #102781;
-        border: 0px;
-    }
-    #SpeechBubble_message_decryption_error {
-        min-width: 508px;
-        max-width: 508px;
-        font-family: 'Source Sans Pro';
-        font-weight: 400;
-        font-size: 15px;
-        font-style: italic;
-        background-color: rgba(255, 255, 255, 0.6);
-        padding: 16px;
-    }
-    #SpeechBubble_status_bar_decryption_error {
-        min-height: 5px;
-        max-height: 5px;
-        background-color: #bcbfcd;
-        border: 0px;
-    }
-    #ReplyWidget_message {
-        min-width: 508px;
-        max-width: 508px;
-        font-family: 'Source Sans Pro';
-        font-weight: 400;
-        font-size: 15px;
-        background-color: #fff;
-        color: #3b3b3b;
-        padding: 16px;
-    }
-    #ReplyWidget_status_bar {
-        min-height: 5px;
-        max-height: 5px;
-        background-color: #0065db;
-        border: 0px;
-    }
-    #ReplyWidget_failed_to_send_text {
-        font-family: 'Source Sans Pro';
-        font-weight: 500;
-        font-size: 13px;
-        color: #ff3366;
-    }
-    #ReplyWidget_message_failed {
-        min-width: 508px;
-        max-width: 508px;
-        font-family: 'Source Sans Pro';
-        font-weight: 400;
-        font-size: 15px;
-        background-color: #fff;
-        color: #3b3b3b;
-        padding: 16px;
-    }
-    #ReplyWidget_status_bar_failed {
-        min-height: 5px;
-        max-height: 5px;
-        background-color: #ff3366;
-        border: 0px;
-    }
-    #ReplyWidget_message_pending {
-        min-width: 508px;
-        max-width: 508px;
-        font-family: 'Source Sans Pro';
-        font-weight: 400;
-        font-size: 15px;
-        color: #a9aaad;
-        background-color: #F7F8FC;
-        padding: 16px;
-    }
-    #ReplyWidget_status_bar_pending {
-        min-height: 5px;
-        max-height: 5px;
-        background-color: #0065db;
-        border: 0px;
-    }
-    '''
-
     TOP_MARGIN = 28
     BOTTOM_MARGIN = 10
 
@@ -1978,9 +1611,6 @@ class SpeechBubble(QWidget):
         # Set margins and spacing
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
-
-        # Set styles
-        self.setStyleSheet(self.CSS)
 
         # Message box
         self.message = SecureQLabel(text)
@@ -2047,13 +1677,13 @@ class SpeechBubble(QWidget):
         self.setStyleSheet('')
         self.message.setObjectName('SpeechBubble_message')
         self.color_bar.setObjectName('SpeechBubble_status_bar')
-        self.setStyleSheet(self.CSS)
+        self.setStyleSheet(load_css('sdclient.css'))
 
     def set_error_styles(self):
         self.setStyleSheet('')
         self.message.setObjectName('SpeechBubble_message_decryption_error')
         self.color_bar.setObjectName('SpeechBubble_status_bar_decryption_error')
-        self.setStyleSheet(self.CSS)
+        self.setStyleSheet(load_css('sdclient.css'))
 
 
 class MessageWidget(SpeechBubble):
@@ -2140,94 +1770,25 @@ class ReplyWidget(SpeechBubble):
         self.setStyleSheet('')
         self.message.setObjectName('ReplyWidget_message')
         self.color_bar.setObjectName('ReplyWidget_status_bar')
-        self.setStyleSheet(self.CSS)
+        self.setStyleSheet(load_css('sdclient.css'))
 
     def set_failed_styles(self):
         self.setStyleSheet('')
         self.message.setObjectName('ReplyWidget_message_failed')
         self.color_bar.setObjectName('ReplyWidget_status_bar_failed')
-        self.setStyleSheet(self.CSS)
+        self.setStyleSheet(load_css('sdclient.css'))
 
     def set_pending_styles(self):
         self.setStyleSheet('')
         self.message.setObjectName('ReplyWidget_message_pending')
         self.color_bar.setObjectName('ReplyWidget_status_bar_pending')
-        self.setStyleSheet(self.CSS)
+        self.setStyleSheet(load_css('sdclient.css'))
 
 
 class FileWidget(QWidget):
     """
     Represents a file.
     """
-
-    CSS = '''
-    #FileWidget {
-        min-width: 540px;
-        max-width: 540px;
-    }
-    #FileWidget_file_options {
-        min-width: 137px;
-    }
-    QPushButton#FileWidget_export_print {
-        border: none;
-        font-family: 'Source Sans Pro';
-        font-weight: 500;
-        font-size: 13px;
-        color: #2A319D;
-    }
-    QPushButton#FileWidget_export_print:hover {
-        color: #05a6fe;
-    }
-    QPushButton#FileWidget_download_button {
-        border: none;
-        font-family: 'Source Sans Pro';
-        font-weight: 600;
-        font-size: 13px;
-        color: #2a319d;
-    }
-    QPushButton#FileWidget_download_button:hover {
-        color: #05a6fe;
-    }
-    QPushButton#FileWidget_download_button_animating {
-        border: none;
-        font-family: 'Source Sans Pro';
-        font-weight: 600;
-        font-size: 13px;
-        color: #05a6fe;
-    }
-    QPushButton#FileWidget_download_button_animating:hover {
-        color: #05a6fe;
-    }
-    QLabel#FileWidget_file_name {
-        font-family: 'Source Sans Pro';
-        font-weight: 600;
-        font-size: 13px;
-        color: #2a319d;
-    }
-    QLabel#FileWidget_file_name:hover {
-        color: #05a6fe;
-    }
-    QLabel#FileWidget_no_file_name {
-        font-family: 'Source Sans Pro';
-        font-weight: 300;
-        font-size: 13px;
-        color: #a5b3e9;
-    }
-    QLabel#FileWidget_file_size {
-        min-width: 48px;
-        max-width: 48px;
-        font-family: 'Source Sans Pro';
-        font-weight: 400;
-        font-size: 13px;
-        color: #2a319d;
-    }
-    QWidget#FileWidget_horizontal_line {
-        min-height: 2px;
-        max-height: 2px;
-        background-color: rgba(211, 216, 234, 0.45);
-        margin: 0px 8px 0px 8px;
-    }
-    '''
 
     TOP_MARGIN = 4
     BOTTOM_MARGIN = 14
@@ -2255,9 +1816,7 @@ class FileWidget(QWidget):
         self.index = index
         self.downloading = False
 
-        # Set styles
         self.setObjectName('FileWidget')
-        self.setStyleSheet(self.CSS)
         file_description_font = QFont()
         file_description_font.setLetterSpacing(QFont.AbsoluteSpacing, self.FILE_FONT_SPACING)
         self.file_buttons_font = QFont()
@@ -2392,7 +1951,7 @@ class FileWidget(QWidget):
             # Reset stylesheet
             self.setStyleSheet('')
             self.download_button.setObjectName('FileWidget_download_button')
-            self.setStyleSheet(self.CSS)
+            self.setStyleSheet(load_css('sdclient.css'))
 
             self.no_file_name.hide()
             self.export_button.hide()
@@ -2470,7 +2029,7 @@ class FileWidget(QWidget):
         # Reset stylesheet with new state so that the active color stays the same
         self.setStyleSheet('')
         self.download_button.setObjectName('FileWidget_download_button_animating')
-        self.setStyleSheet(self.CSS)
+        self.setStyleSheet(load_css('sdclient.css'))
 
     def set_button_animation_frame(self, frame_number):
         """
@@ -2490,86 +2049,6 @@ class FileWidget(QWidget):
 
 class ModalDialog(QDialog):
 
-    CSS = '''
-    #ModalDialog {
-        min-width: 800px;
-        max-width: 800px;
-        min-height: 300px;
-        max-height: 800px;
-        background-color: #fff;
-    }
-    #ModalDialog_header_icon, #ModalDialog_header_spinner {
-        min-width: 80px;
-        max-width: 80px;
-        min-height: 64px;
-        max-height: 64px;
-        margin: 0px 0px 0px 30px;
-    }
-    #ModalDialog_header {
-        min-height: 68px;
-        max-height: 68px;
-        margin: 0px 0px 0px 4px;
-        font-family: 'Montserrat';
-        font-size: 24px;
-        font-weight: 600;
-        color: #2a319d;
-    }
-    #ModalDialog_header_line {
-        margin: 0px 40px 20px 40px;
-        min-height: 2px;
-        max-height: 2px;
-        background-color: rgba(42, 49, 157, 0.15);
-        border: none;
-    }
-    #ModalDialog_error_details {
-        margin: 0px 40px 0px 36px;
-        font-family: 'Montserrat';
-        font-size: 16px;
-        color: #ff0064;
-    }
-    #ModalDialog_error_details_active {
-        color: #ff66C4;
-    }
-    #ModalDialog_body {
-        font-family: 'Montserrat';
-        font-size: 16px;
-        color: #302aa3;
-    }
-    #ModalDialog_button_box QPushButton {
-        margin: 0px 0px 0px 12px;
-        height: 40px;
-        padding-left: 20px;
-        padding-right: 20px;
-        border: 2px solid #2a319d;
-        font-family: 'Montserrat';
-        font-weight: 500;
-        font-size: 15px;
-        color: #2a319d;
-    }
-    #ModalDialog_button_box QPushButton::disabled {
-        border: 2px solid rgba(42, 49, 157, 0.4);
-        color: rgba(42, 49, 157, 0.4);
-    }
-    #ModalDialog_button_box QPushButton#ModalDialog_primary_button {
-        background-color: #2a319d;
-        color: #fff;
-    }
-    #ModalDialog_button_box QPushButton#ModalDialog_primary_button::disabled {
-        border: 2px solid #C2C4E3;
-        background-color: #C2C4E3;
-        color: #E1E2F1;
-    }
-    #ModalDialog_button_box QPushButton#ModalDialog_primary_button_active {
-        background-color: #f1f1f6;
-        color: #fff;
-        border: 2px solid #f1f1f6;
-        margin: 0px 0px 0px 12px;
-        height: 40px;
-        padding-left: 20px;
-        padding-right: 20px;
-    }
-    '''
-
     MARGIN = 40
     NO_MARGIN = 0
 
@@ -2577,7 +2056,7 @@ class ModalDialog(QDialog):
         parent = QApplication.activeWindow()
         super().__init__(parent)
         self.setObjectName('ModalDialog')
-        self.setStyleSheet(self.CSS)
+        self.setStyleSheet(load_css('sdclient.css'))
         self.setModal(True)
 
         # Header for icon and task title
@@ -2682,7 +2161,7 @@ class ModalDialog(QDialog):
         self.setStyleSheet('')
         self.continue_button.setObjectName('ModalDialog_primary_button_active')
         self.error_details.setObjectName('ModalDialog_error_details_active')
-        self.setStyleSheet(self.CSS)
+        self.setStyleSheet(load_css('sdclient.css'))
 
     def start_animate_header(self):
         self.header_icon.setVisible(False)
@@ -2697,7 +2176,7 @@ class ModalDialog(QDialog):
         self.setStyleSheet('')
         self.continue_button.setObjectName('ModalDialog_primary_button')
         self.error_details.setObjectName('ModalDialog_error_details')
-        self.setStyleSheet(self.CSS)
+        self.setStyleSheet(load_css('sdclient.css'))
 
     def stop_animate_header(self):
         self.header_icon.setVisible(True)
@@ -2828,23 +2307,6 @@ class PrintDialog(ModalDialog):
 
 class ExportDialog(ModalDialog):
 
-    PASSPHRASE_FORM_CSS = '''
-    #passphrase_form QLabel {
-        font-family: 'Montserrat';
-        font-weight: 500;
-        font-size: 12px;
-        color: #2a319d;
-        padding-top: 6px;
-    }
-    #passphrase_form QLineEdit {
-        border-radius: 0px;
-        min-height: 30px;
-        max-height: 30px;
-        background-color: #f8f8f8;
-        padding-bottom: 2px;
-    }
-    '''
-
     PASSPHRASE_LABEL_SPACING = 0.5
     NO_MARGIN = 0
     FILENAME_WIDTH_PX = 260
@@ -2910,7 +2372,6 @@ class ExportDialog(ModalDialog):
 
         # Passphrase Form
         self.passphrase_form = QWidget()
-        self.passphrase_form.setStyleSheet(self.PASSPHRASE_FORM_CSS)
         self.passphrase_form.setObjectName('passphrase_form')
         passphrase_form_layout = QVBoxLayout()
         passphrase_form_layout.setContentsMargins(
@@ -3090,16 +2551,6 @@ class ExportDialog(ModalDialog):
 
 class ConversationScrollArea(QScrollArea):
 
-    CSS = '''
-    #ConversationScrollArea {
-        border: 0;
-        background: #f3f5f9;
-    }
-    #ConversationScrollArea_conversation {
-        background: #f3f5f9;
-    }
-    '''
-
     MARGIN_LEFT = 38
     MARGIN_RIGHT = 20
 
@@ -3109,9 +2560,7 @@ class ConversationScrollArea(QScrollArea):
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setWidgetResizable(True)
 
-        # Set styles
         self.setObjectName('ConversationScrollArea')
-        self.setStyleSheet(self.CSS)
 
         # Create the scroll area's widget
         conversation = QWidget()
@@ -3339,18 +2788,6 @@ class SourceConversationWrapper(QWidget):
     per-source resources.
     """
 
-    SOURCE_DELETED_CSS = '''
-    #SourceConversationWrapper_source_deleted {
-        text-align: left;
-        font-family: 'Montserrat';
-        font-weight: 500;
-        font-size: 40px;
-        color: #a5b3e9;
-        padding-bottom: 264px;
-        padding-right: 195px;
-    }
-    '''
-
     def __init__(self, source: Source, controller: Controller) -> None:
         super().__init__()
 
@@ -3372,7 +2809,6 @@ class SourceConversationWrapper(QWidget):
         self.reply_box = ReplyBoxWidget(source, controller)
         self.waiting_delete_confirmation = QLabel('Deleting...')
         self.waiting_delete_confirmation.setObjectName('SourceConversationWrapper_source_deleted')
-        self.waiting_delete_confirmation.setStyleSheet(self.SOURCE_DELETED_CSS)
         self.waiting_delete_confirmation.hide()
 
         # Add widgets
@@ -3408,32 +2844,6 @@ class ReplyBoxWidget(QWidget):
     A textbox where a journalist can enter a reply.
     """
 
-    CSS = '''
-    #ReplyBoxWidget {
-        min-height: 173px;
-        max-height: 173px;
-    }
-    #ReplyBoxWidget_replybox {
-        background-color: #ffffff;
-    }
-    #ReplyBoxWidget_replybox::disabled {
-        background-color: #efefef;
-    }
-    #ReplyBoxWidget QPushButton {
-        border: none;
-    }
-    #ReplyBoxWidget QPushButton:hover {
-        background: #D3D8EA;
-        border-radius: 8px;
-    }
-    QWidget#ReplyBoxWidget_horizontal_line {
-        min-height: 2px;
-        max-height: 2px;
-        background-color: rgba(42, 49, 157, 0.15);
-        border: none;
-    }
-    '''
-
     reply_sent = pyqtSignal(str, str, str)
 
     def __init__(self, source: Source, controller: Controller) -> None:
@@ -3444,9 +2854,6 @@ class ReplyBoxWidget(QWidget):
 
         # Set css id
         self.setObjectName('ReplyBoxWidget')
-
-        # Set styles
-        self.setStyleSheet(self.CSS)
 
         # Set layout
         main_layout = QVBoxLayout()
@@ -3570,32 +2977,12 @@ class ReplyTextEdit(QPlainTextEdit):
     a richtext lable on top to replace the placeholder functionality
     """
 
-    CSS = '''
-    #ReplyTextEdit {
-        font-family: 'Montserrat';
-        font-weight: 400;
-        font-size: 18px;
-        border: none;
-        margin-right: 30.2px;
-    }
-    #ReplyTextEdit_placeholder {
-        font-family: 'Montserrat';
-        font-weight: 400;
-        font-size: 18px;
-        color: #404040;
-    }
-    #ReplyTextEdit_placeholder::disabled {
-        color: rgba(42, 49, 157, 0.6);
-    }
-    '''
-
     def __init__(self, source, controller):
         super().__init__()
         self.controller = controller
         self.source = source
 
         self.setObjectName('ReplyTextEdit')
-        self.setStyleSheet(self.CSS)
 
         self.setTabChangesFocus(True)  # Needed so we can TAB to send button.
 
@@ -3693,24 +3080,12 @@ class SourceMenuButton(QToolButton):
     This button is responsible for launching the source menu on click.
     """
 
-    CSS = '''
-    #SourceMenuButton_ellipsis_button {
-        border: none;
-        margin: 5px 0px 0px 0px;
-        padding-left: 8px;
-    }
-    #SourceMenuButton QToolButton::menu-indicator {
-        image: none;
-    }
-    '''
-
     def __init__(self, source, controller):
         super().__init__()
         self.controller = controller
         self.source = source
 
         self.setObjectName('SourceMenuButton')
-        self.setStyleSheet(self.CSS)
 
         self.setIcon(load_icon("ellipsis.svg"))
         self.setIconSize(QSize(22, 4))  # Set to the size of the svg viewBox
@@ -3726,46 +3101,21 @@ class SourceMenuButton(QToolButton):
 class TitleLabel(QLabel):
     """The title for a conversation."""
 
-    CSS = '''
-    #TitleLabel {
-        font-family: 'Montserrat';
-        font-weight: 400;
-        font-size: 24px;
-        color: #2a319d;
-        padding-left: 4px;
-    }
-    '''
-
     def __init__(self, text):
         super().__init__(_(text))
 
         # Set css id
         self.setObjectName('TitleLabel')
 
-        # Set styles
-        self.setStyleSheet(self.CSS)
-
 
 class LastUpdatedLabel(QLabel):
     """Time the conversation was last updated."""
-
-    CSS = '''
-    #LastUpdatedLabel {
-        font-family: 'Montserrat';
-        font-weight: 200;
-        font-size: 24px;
-        color: #2a319d;
-    }
-    '''
 
     def __init__(self, last_updated):
         super().__init__(last_updated)
 
         # Set css id
         self.setObjectName('LastUpdatedLabel')
-
-        # Set styles
-        self.setStyleSheet(self.CSS)
 
 
 class SourceProfileShortWidget(QWidget):
@@ -3776,16 +3126,6 @@ class SourceProfileShortWidget(QWidget):
     2. A menu to perform various operations on Source.
     """
 
-    CSS = '''
-    QWidget#SourceProfileShortWidget_horizontal_line {
-        min-height: 2px;
-        max-height: 2px;
-        background-color: rgba(42, 49, 157, 0.15);
-        padding-left: 12px;
-        padding-right: 12px;
-    }
-    '''
-
     MARGIN_LEFT = 25
     MARGIN_RIGHT = 17
     VERTICAL_MARGIN = 14
@@ -3795,9 +3135,6 @@ class SourceProfileShortWidget(QWidget):
 
         self.source = source
         self.controller = controller
-
-        # Set styles
-        self.setStyleSheet(self.CSS)
 
         # Set layout
         layout = QVBoxLayout()

--- a/securedrop_client/resources/css/file_download_button.css
+++ b/securedrop_client/resources/css/file_download_button.css
@@ -1,0 +1,23 @@
+QPushButton#FileWidget_download_button {
+    border: none;
+    font-family: 'Source Sans Pro';
+    font-weight: 600;
+    font-size: 13px;
+    color: #2a319d;
+}
+
+QPushButton#FileWidget_download_button:hover {
+    color: #05a6fe;
+}
+
+QPushButton#FileWidget_download_button_animating {
+    border: none;
+    font-family: 'Source Sans Pro';
+    font-weight: 600;
+    font-size: 13px;
+    color: #05a6fe;
+}
+
+QPushButton#FileWidget_download_button_animating:hover {
+    color: #05a6fe;
+}

--- a/securedrop_client/resources/css/modal_dialog_button.css
+++ b/securedrop_client/resources/css/modal_dialog_button.css
@@ -1,0 +1,20 @@
+#ModalDialog_button_box QPushButton#ModalDialog_primary_button {
+    background-color: #2a319d;
+    color: #fff;
+}
+
+#ModalDialog_button_box QPushButton#ModalDialog_primary_button::disabled {
+    border: 2px solid #C2C4E3;
+    background-color: #C2C4E3;
+    color: #E1E2F1;
+}
+
+#ModalDialog_button_box QPushButton#ModalDialog_primary_button_active {
+    background-color: #f1f1f6;
+    color: #fff;
+    border: 2px solid #f1f1f6;
+    margin: 0px 0px 0px 12px;
+    height: 40px;
+    padding-left: 20px;
+    padding-right: 20px;
+}

--- a/securedrop_client/resources/css/modal_dialog_button.css
+++ b/securedrop_client/resources/css/modal_dialog_button.css
@@ -4,9 +4,9 @@
 }
 
 #ModalDialog_button_box QPushButton#ModalDialog_primary_button::disabled {
-    border: 2px solid #C2C4E3;
-    background-color: #C2C4E3;
-    color: #E1E2F1;
+    border: 2px solid #c2c4e3;
+    background-color: #c2c4e3;
+    color: #e1e2f1;
 }
 
 #ModalDialog_button_box QPushButton#ModalDialog_primary_button_active {

--- a/securedrop_client/resources/css/modal_dialog_error_details.css
+++ b/securedrop_client/resources/css/modal_dialog_error_details.css
@@ -1,0 +1,10 @@
+#ModalDialog_error_details {
+    margin: 0px 40px 0px 36px;
+    font-family: 'Montserrat';
+    font-size: 16px;
+    color: #ff0064;
+}
+
+#ModalDialog_error_details_active {
+    color: #ff66C4;
+}

--- a/securedrop_client/resources/css/modal_dialog_error_details.css
+++ b/securedrop_client/resources/css/modal_dialog_error_details.css
@@ -6,5 +6,8 @@
 }
 
 #ModalDialog_error_details_active {
-    color: #ff66C4;
+    margin: 0px 40px 0px 36px;
+    font-family: 'Montserrat';
+    font-size: 16px;
+    color: #ff66c4;
 }

--- a/securedrop_client/resources/css/reply_message.css
+++ b/securedrop_client/resources/css/reply_message.css
@@ -1,0 +1,32 @@
+#ReplyWidget_message {
+    min-width: 508px;
+    max-width: 508px;
+    font-family: 'Source Sans Pro';
+    font-weight: 400;
+    font-size: 15px;
+    background-color: #fff;
+    color: #3b3b3b;
+    padding: 16px;
+}
+
+#ReplyWidget_message_pending {
+    min-width: 508px;
+    max-width: 508px;
+    font-family: 'Source Sans Pro';
+    font-weight: 400;
+    font-size: 15px;
+    color: #a9aaad;
+    background-color: #F7F8FC;
+    padding: 16px;
+}
+
+#ReplyWidget_message_failed {
+    min-width: 508px;
+    max-width: 508px;
+    font-family: 'Source Sans Pro';
+    font-weight: 400;
+    font-size: 15px;
+    background-color: #fff;
+    color: #3b3b3b;
+    padding: 16px;
+}

--- a/securedrop_client/resources/css/reply_message.css
+++ b/securedrop_client/resources/css/reply_message.css
@@ -16,7 +16,7 @@
     font-weight: 400;
     font-size: 15px;
     color: #a9aaad;
-    background-color: #F7F8FC;
+    background-color: #f7f8fc;
     padding: 16px;
 }
 

--- a/securedrop_client/resources/css/reply_status_bar.css
+++ b/securedrop_client/resources/css/reply_status_bar.css
@@ -1,0 +1,20 @@
+#ReplyWidget_status_bar {
+    min-height: 5px;
+    max-height: 5px;
+    background-color: #0065db;
+    border: 0px;
+}
+
+#ReplyWidget_status_bar_pending {
+    min-height: 5px;
+    max-height: 5px;
+    background-color: #0065db;
+    border: 0px;
+}
+
+#ReplyWidget_status_bar_failed {
+    min-height: 5px;
+    max-height: 5px;
+    background-color: #ff3366;
+    border: 0px;
+}

--- a/securedrop_client/resources/css/sdclient.css
+++ b/securedrop_client/resources/css/sdclient.css
@@ -1,7 +1,623 @@
-QLabel#error_label {
-    color: #FF0000;
+#SyncIcon {
+    border: none;
+    color: #fff;
 }
 
-ConversationView {
-    background-color: white;
+#ActivityStatusBar {
+    font-family: 'Source Sans Pro';
+    font-weight: 600;
+    font-size: 12px;
+    color: #d3d8ea;
+}
+
+#ErrorStatusBar_vertical_bar {
+    background-color: #ff3366;
+}
+
+#ErrorStatusBar_icon {
+    background-color: qlineargradient(
+        x1: 0,
+        y1: 0,
+        x2: 0,
+        y2: 1,
+        stop: 0 #fff,
+        stop: 0.2 #fff,
+        stop: 1 #fff
+    );
+}
+
+#ErrorStatusBar_status_bar {
+    background-color: qlineargradient(
+        x1: 0,
+        y1: 0,
+        x2: 0,
+        y2: 1,
+        stop: 0 #fff,
+        stop: 0.2 #fff,
+        stop: 1 #fff
+    );
+    font-family: 'Source Sans Pro';
+    font-weight: 400;
+    font-size: 14px;
+    color: #0c3e75;
+}
+
+#UserProfile {
+    padding: 15px;
+}
+
+#UserProfile_icon {
+    border: none;
+    background-color: #9211ff;
+    padding-left: 3px;
+    padding-bottom: 4px;
+    font-family: 'Source Sans Pro';
+    font-weight: 600;
+    font-size: 15px;
+    color: #fff;
+}
+
+#UserButton {
+    border: none;
+    font-family: 'Source Sans Pro';
+    font-weight: 700;
+    font-size: 12px;
+    color: #fff;
+    text-align: left;
+}
+
+#UserButton:focus {
+    outline: none;
+}
+
+#UserButton::menu-indicator {
+    image: none;
+}
+
+#LoginButton {
+    border: none;
+    background-color: #05edfe;
+    font-family: 'Montserrat';
+    font-weight: 600;
+    font-size: 14px;
+    color: #2a319d;
+}
+
+#LoginButton:pressed {
+    background-color: #85f6fe;
+}
+
+#MainView {
+    min-height: 558;
+}
+
+#MainView_view_holder {
+    min-width: 667;
+    border: none;
+    background-color: #f3f5f9;
+}
+
+#EmptyConversationView QLabel {
+    font-family: Montserrat;
+    font-weight: 400;
+    font-size: 35px;
+    color: #a5b3e9;
+}
+
+#EmptyConversationView QLabel#EmptyConversationView_instructions {
+    font-weight: 500;
+}
+
+#EmptyConversationView QLabel#EmptyConversationView_bullet {
+    margin: 4px 0px 0px 0px;
+    font-size: 35px;
+    font-weight: 600;
+}
+
+#EmptyConversationView_no_sources {
+    min-width: 520px;
+    max-width: 600px;
+}
+
+#EmptyConversationView_no_source_selected {
+    min-width: 520px;
+    max-width: 520px;
+}
+
+QListView#SourceList {
+    border: none;
+    show-decoration-selected: 0;
+    border-right: 3px solid #f3f5f9;
+}
+
+QListView#SourceList::item:selected {
+    background-color: #f3f5f9;
+}
+
+QListView#SourceList::item:hover{
+    border: 500px solid #f9f9f9;
+}
+
+#SourceWidget_container {
+    border-bottom: 1px solid #9b9b9b;
+}
+
+#SourceWidget_gutter {
+    min-width: 40px;
+    max-width: 40px;
+}
+
+#SourceWidget_metadata {
+    max-width: 60px;
+}
+
+#SourceWidget_preview {
+    font-family: 'Source Sans Pro';
+    font-weight: 400;
+    font-size: 13px;
+    color: #383838;
+}
+
+#SourceWidget_source_deleted {
+    font-family: 'Source Sans Pro';
+    font-weight: 400;
+    font-size: 13px;
+    color: #ff3366;
+}
+
+#SourceWidget_name {
+    font-family: 'Montserrat';
+    font-weight: 500;
+    font-size: 13px;
+    color: #383838;
+}
+
+#SourceWidget_timestamp {
+    font-family: 'Montserrat';
+    font-weight: 500;
+    font-size: 13px;
+    color: #383838;
+}
+
+#StarToggleButton {
+    border: none;
+}
+
+#LoginOfflineLink {
+    border: none;
+    color: #fff;
+    text-decoration: underline;
+}
+
+#SignInButton {
+    border: none;
+    background-color: #05edfe;
+    font-family: 'Montserrat';
+    font-weight: 600;
+    font-size: 14px;
+    color: #2a319d;
+}
+
+#SignInButton:pressed {
+    background-color: #85f6fe;
+}
+
+#LoginErrorBar QWidget {
+    background-color: #ce0083;
+}
+
+#LoginErrorBar_icon {
+    color: #fff;
+}
+
+#LoginErrorBar_status_bar {
+    font-family: 'Montserrat';
+    font-weight: 500;
+    font-size: 12px;
+    color: #fff;
+}
+
+#LoginDialog_form QLabel {
+    color: #fff;
+    font-family: 'Montserrat';
+    font-weight: 500;
+    font-size: 13px;
+}
+
+#LoginDialog_form QLineEdit {
+    border-radius: 0px;
+    height: 30px;
+    margin: 0px 0px 0px 0px;
+    padding-left: 5px;
+}
+
+#LoginDialog_app_version_label {
+    color: #9fddff;
+}
+
+#SpeechBubble_container {
+    min-width: 540px;
+    max-width: 540px;
+    background-color: #fff;
+}
+
+#SpeechBubble_message {
+    min-width: 508px;
+    max-width: 508px;
+    font-family: 'Source Sans Pro';
+    font-weight: 400;
+    font-size: 15px;
+    background-color: #fff;
+    color: #3b3b3b;
+    padding: 16px;
+}
+
+#SpeechBubble_status_bar {
+    min-height: 5px;
+    max-height: 5px;
+    background-color: #102781;
+    border: 0px;
+}
+
+#SpeechBubble_message_decryption_error {
+    min-width: 508px;
+    max-width: 508px;
+    font-family: 'Source Sans Pro';
+    font-weight: 400;
+    font-size: 15px;
+    font-style: italic;
+    background-color: rgba(255, 255, 255, 0.6);
+    padding: 16px;
+}
+
+#SpeechBubble_status_bar_decryption_error {
+    min-height: 5px;
+    max-height: 5px;
+    background-color: #bcbfcd;
+    border: 0px;
+}
+
+#ReplyWidget_message {
+    min-width: 508px;
+    max-width: 508px;
+    font-family: 'Source Sans Pro';
+    font-weight: 400;
+    font-size: 15px;
+    background-color: #fff;
+    color: #3b3b3b;
+    padding: 16px;
+}
+
+#ReplyWidget_status_bar {
+    min-height: 5px;
+    max-height: 5px;
+    background-color: #0065db;
+    border: 0px;
+}
+
+#ReplyWidget_failed_to_send_text {
+    font-family: 'Source Sans Pro';
+    font-weight: 500;
+    font-size: 13px;
+    color: #ff3366;
+}
+
+#ReplyWidget_message_failed {
+    min-width: 508px;
+    max-width: 508px;
+    font-family: 'Source Sans Pro';
+    font-weight: 400;
+    font-size: 15px;
+    background-color: #fff;
+    color: #3b3b3b;
+    padding: 16px;
+}
+
+#ReplyWidget_status_bar_failed {
+    min-height: 5px;
+    max-height: 5px;
+    background-color: #ff3366;
+    border: 0px;
+}
+
+#ReplyWidget_message_pending {
+    min-width: 508px;
+    max-width: 508px;
+    font-family: 'Source Sans Pro';
+    font-weight: 400;
+    font-size: 15px;
+    color: #a9aaad;
+    background-color: #F7F8FC;
+    padding: 16px;
+}
+
+#ReplyWidget_status_bar_pending {
+    min-height: 5px;
+    max-height: 5px;
+    background-color: #0065db;
+    border: 0px;
+}
+
+#FileWidget {
+    min-width: 540px;
+    max-width: 540px;
+}
+
+#FileWidget_file_options {
+    min-width: 137px;
+}
+
+QPushButton#FileWidget_export_print {
+    border: none;
+    font-family: 'Source Sans Pro';
+    font-weight: 500;
+    font-size: 13px;
+    color: #2A319D;
+}
+
+QPushButton#FileWidget_export_print:hover {
+    color: #05a6fe;
+}
+
+QPushButton#FileWidget_download_button {
+    border: none;
+    font-family: 'Source Sans Pro';
+    font-weight: 600;
+    font-size: 13px;
+    color: #2a319d;
+}
+
+QPushButton#FileWidget_download_button:hover {
+    color: #05a6fe;
+}
+
+QPushButton#FileWidget_download_button_animating {
+    border: none;
+    font-family: 'Source Sans Pro';
+    font-weight: 600;
+    font-size: 13px;
+    color: #05a6fe;
+}
+
+QPushButton#FileWidget_download_button_animating:hover {
+    color: #05a6fe;
+}
+
+QLabel#FileWidget_file_name {
+    font-family: 'Source Sans Pro';
+    font-weight: 600;
+    font-size: 13px;
+    color: #2a319d;
+}
+
+QLabel#FileWidget_file_name:hover {
+    color: #05a6fe;
+}
+
+QLabel#FileWidget_no_file_name {
+    font-family: 'Source Sans Pro';
+    font-weight: 300;
+    font-size: 13px;
+    color: #a5b3e9;
+}
+
+QLabel#FileWidget_file_size {
+    min-width: 48px;
+    max-width: 48px;
+    font-family: 'Source Sans Pro';
+    font-weight: 400;
+    font-size: 13px;
+    color: #2a319d;
+}
+
+QWidget#FileWidget_horizontal_line {
+    min-height: 2px;
+    max-height: 2px;
+    background-color: rgba(211, 216, 234, 0.45);
+    margin: 0px 8px 0px 8px;
+}
+
+#ModalDialog {
+    min-width: 800px;
+    max-width: 800px;
+    min-height: 300px;
+    max-height: 800px;
+    background-color: #fff;
+}
+
+#ModalDialog_header_icon, #ModalDialog_header_spinner {
+    min-width: 80px;
+    max-width: 80px;
+    min-height: 64px;
+    max-height: 64px;
+    margin: 0px 0px 0px 30px;
+}
+
+#ModalDialog_header {
+    min-height: 68px;
+    max-height: 68px;
+    margin: 0px 0px 0px 4px;
+    font-family: 'Montserrat';
+    font-size: 24px;
+    font-weight: 600;
+    color: #2a319d;
+}
+
+#ModalDialog_header_line {
+    margin: 0px 40px 20px 40px;
+    min-height: 2px;
+    max-height: 2px;
+    background-color: rgba(42, 49, 157, 0.15);
+    border: none;
+}
+
+#ModalDialog_error_details {
+    margin: 0px 40px 0px 36px;
+    font-family: 'Montserrat';
+    font-size: 16px;
+    color: #ff0064;
+}
+
+#ModalDialog_error_details_active {
+    color: #ff66C4;
+}
+
+#ModalDialog_body {
+    font-family: 'Montserrat';
+    font-size: 16px;
+    color: #302aa3;
+}
+
+#ModalDialog_button_box QPushButton {
+    margin: 0px 0px 0px 12px;
+    height: 40px;
+    padding-left: 20px;
+    padding-right: 20px;
+    border: 2px solid #2a319d;
+    font-family: 'Montserrat';
+    font-weight: 500;
+    font-size: 15px;
+    color: #2a319d;
+}
+
+#ModalDialog_button_box QPushButton::disabled {
+    border: 2px solid rgba(42, 49, 157, 0.4);
+    color: rgba(42, 49, 157, 0.4);
+}
+
+#ModalDialog_button_box QPushButton#ModalDialog_primary_button {
+    background-color: #2a319d;
+    color: #fff;
+}
+
+#ModalDialog_button_box QPushButton#ModalDialog_primary_button::disabled {
+    border: 2px solid #C2C4E3;
+    background-color: #C2C4E3;
+    color: #E1E2F1;
+}
+
+#ModalDialog_button_box QPushButton#ModalDialog_primary_button_active {
+    background-color: #f1f1f6;
+    color: #fff;
+    border: 2px solid #f1f1f6;
+    margin: 0px 0px 0px 12px;
+    height: 40px;
+    padding-left: 20px;
+    padding-right: 20px;
+}
+
+#passphrase_form QLabel {
+    font-family: 'Montserrat';
+    font-weight: 500;
+    font-size: 12px;
+    color: #2a319d;
+    padding-top: 6px;
+}
+
+#passphrase_form QLineEdit {
+    border-radius: 0px;
+    min-height: 30px;
+    max-height: 30px;
+    background-color: #f8f8f8;
+    padding-bottom: 2px;
+}
+
+#ConversationScrollArea {
+    border: 0;
+    background: #f3f5f9;
+}
+
+#ConversationScrollArea_conversation {
+    background: #f3f5f9;
+}
+
+#SourceConversationWrapper_source_deleted {
+    text-align: left;
+    font-family: 'Montserrat';
+    font-weight: 500;
+    font-size: 40px;
+    color: #a5b3e9;
+    padding-bottom: 264px;
+    padding-right: 195px;
+}
+
+#ReplyBoxWidget {
+    min-height: 173px;
+    max-height: 173px;
+}
+
+#ReplyBoxWidget_replybox {
+    background-color: #ffffff;
+}
+
+#ReplyBoxWidget_replybox::disabled {
+    background-color: #efefef;
+}
+
+#ReplyBoxWidget QPushButton {
+    border: none;
+}
+
+#ReplyBoxWidget QPushButton:hover {
+    background: #D3D8EA;
+    border-radius: 8px;
+}
+
+QWidget#ReplyBoxWidget_horizontal_line {
+    min-height: 2px;
+    max-height: 2px;
+    background-color: rgba(42, 49, 157, 0.15);
+    border: none;
+}
+
+#ReplyTextEdit {
+    font-family: 'Montserrat';
+    font-weight: 400;
+    font-size: 18px;
+    border: none;
+    margin-right: 30.2px;
+}
+
+#ReplyTextEdit_placeholder {
+    font-family: 'Montserrat';
+    font-weight: 400;
+    font-size: 18px;
+    color: #404040;
+}
+
+#ReplyTextEdit_placeholder::disabled {
+    color: rgba(42, 49, 157, 0.6);
+}
+
+#SourceMenuButton_ellipsis_button {
+    border: none;
+    margin: 5px 0px 0px 0px;
+    padding-left: 8px;
+}
+
+#SourceMenuButton QToolButton::menu-indicator {
+    image: none;
+}
+
+#TitleLabel {
+    font-family: 'Montserrat';
+    font-weight: 400;
+    font-size: 24px;
+    color: #2a319d;
+    padding-left: 4px;
+}
+
+#LastUpdatedLabel {
+    font-family: 'Montserrat';
+    font-weight: 200;
+    font-size: 24px;
+    color: #2a319d;
+}
+
+QWidget#SourceProfileShortWidget_horizontal_line {
+    min-height: 2px;
+    max-height: 2px;
+    background-color: rgba(42, 49, 157, 0.15);
+    padding-left: 12px;
+    padding-right: 12px;
 }

--- a/securedrop_client/resources/css/sdclient.css
+++ b/securedrop_client/resources/css/sdclient.css
@@ -283,18 +283,20 @@ QWidget#ReplyBoxWidget_horizontal_line {
     font-weight: 400;
     font-size: 18px;
     border: none;
-    margin-right: 30.2px;
 }
 
-#ReplyTextEdit_placeholder {
+#ReplyTextEditPlaceholder_text {
     font-family: 'Montserrat';
     font-weight: 400;
     font-size: 18px;
     color: #404040;
 }
 
-#ReplyTextEdit_placeholder::disabled {
-    color: rgba(42, 49, 157, 0.6);
+#ReplyTextEditPlaceholder_bold_blue {
+    font-family: 'Montserrat';
+    font-weight: 600;
+    font-size: 18px;
+    color: #2a319d;
 }
 
 QWidget#SourceProfileShortWidget_horizontal_line {

--- a/securedrop_client/resources/css/sdclient.css
+++ b/securedrop_client/resources/css/sdclient.css
@@ -1,3 +1,59 @@
+/**
+ * The main stylesheet for the SecureDrop Client application
+ */
+
+#LoginDialog_form QLabel {
+    color: #fff;
+    font-family: 'Montserrat';
+    font-weight: 500;
+    font-size: 13px;
+}
+
+#LoginDialog_form QLineEdit {
+    border-radius: 0px;
+    height: 30px;
+    margin: 0px 0px 0px 0px;
+    padding-left: 5px;
+}
+
+#LoginDialog_app_version_label {
+    color: #9fddff;
+}
+
+#LoginOfflineLink {
+    border: none;
+    color: #fff;
+    text-decoration: underline;
+}
+
+#SignInButton {
+    border: none;
+    background-color: #05edfe;
+    font-family: 'Montserrat';
+    font-weight: 600;
+    font-size: 14px;
+    color: #2a319d;
+}
+
+#SignInButton:pressed {
+    background-color: #85f6fe;
+}
+
+#LoginErrorBar QWidget {
+    background-color: #ce0083;
+}
+
+#LoginErrorBar_icon {
+    color: #fff;
+}
+
+#LoginErrorBar_status_bar {
+    font-family: 'Montserrat';
+    font-weight: 500;
+    font-size: 12px;
+    color: #fff;
+}
+
 #SyncIcon {
     border: none;
     color: #fff;
@@ -114,12 +170,12 @@
     font-weight: 600;
 }
 
-#EmptyConversationView_no_sources {
+#EmptyConversationView_no_sources QLabel#EmptyConversationView_instructions {
     min-width: 520px;
     max-width: 600px;
 }
 
-#EmptyConversationView_no_source_selected {
+#EmptyConversationView_no_source_selected QLabel#EmptyConversationView_instructions {
     min-width: 520px;
     max-width: 520px;
 }
@@ -183,69 +239,104 @@ QListView#SourceList::item:hover{
     border: none;
 }
 
-#LoginOfflineLink {
-    border: none;
-    color: #fff;
-    text-decoration: underline;
+#SourceConversationWrapper_source_deleted {
+    text-align: left;
+    font-family: 'Montserrat';
+    font-weight: 500;
+    font-size: 40px;
+    color: #a5b3e9;
+    padding-bottom: 264px;
+    padding-right: 195px;
 }
 
-#SignInButton {
+#ReplyBoxWidget {
+    min-height: 173px;
+    max-height: 173px;
+}
+
+#ReplyBoxWidget_replybox {
+    background-color: #ffffff;
+}
+
+#ReplyBoxWidget_replybox::disabled {
+    background-color: #efefef;
+}
+
+#ReplyBoxWidget QPushButton {
     border: none;
-    background-color: #05edfe;
+}
+
+#ReplyBoxWidget QPushButton:hover {
+    background: #D3D8EA;
+    border-radius: 8px;
+}
+
+QWidget#ReplyBoxWidget_horizontal_line {
+    min-height: 2px;
+    max-height: 2px;
+    background-color: rgba(42, 49, 157, 0.15);
+    border: none;
+}
+
+#ReplyTextEdit {
     font-family: 'Montserrat';
-    font-weight: 600;
-    font-size: 14px;
+    font-weight: 400;
+    font-size: 18px;
+    border: none;
+    margin-right: 30.2px;
+}
+
+#ReplyTextEdit_placeholder {
+    font-family: 'Montserrat';
+    font-weight: 400;
+    font-size: 18px;
+    color: #404040;
+}
+
+#ReplyTextEdit_placeholder::disabled {
+    color: rgba(42, 49, 157, 0.6);
+}
+
+QWidget#SourceProfileShortWidget_horizontal_line {
+    min-height: 2px;
+    max-height: 2px;
+    background-color: rgba(42, 49, 157, 0.15);
+    padding-left: 12px;
+    padding-right: 12px;
+}
+
+#SourceMenuButton {
+    border: none;
+    margin: 5px 0px 0px 0px;
+    padding-left: 8px;
+}
+
+QToolButton#SourceMenuButton::menu-indicator {
+    image: none;
+}
+
+#LastUpdatedLabel {
+    font-family: 'Montserrat';
+    font-weight: 200;
+    font-size: 24px;
     color: #2a319d;
 }
 
-#SignInButton:pressed {
-    background-color: #85f6fe;
-}
-
-#LoginErrorBar QWidget {
-    background-color: #ce0083;
-}
-
-#LoginErrorBar_icon {
-    color: #fff;
-}
-
-#LoginErrorBar_status_bar {
+#TitleLabel {
     font-family: 'Montserrat';
-    font-weight: 500;
-    font-size: 12px;
-    color: #fff;
+    font-weight: 400;
+    font-size: 24px;
+    color: #2a319d;
+    padding-left: 4px;
 }
 
-#LoginDialog_form QLabel {
-    color: #fff;
-    font-family: 'Montserrat';
-    font-weight: 500;
-    font-size: 13px;
+#ConversationScrollArea {
+    border: 0;
+    background: #f3f5f9;
 }
 
-#LoginDialog_form QLineEdit {
-    border-radius: 0px;
-    height: 30px;
-    margin: 0px 0px 0px 0px;
-    padding-left: 5px;
-}
-
-#LoginDialog_app_version_label {
-    color: #9fddff;
-}
-
-#SpeechBubble_container {
-    min-width: 540px;
-    max-width: 540px;
-    background-color: #fff;
-}
-
-#ReplyWidget_failed_to_send_text {
-    font-family: 'Source Sans Pro';
-    font-weight: 500;
-    font-size: 13px;
-    color: #ff3366;
+#ConversationScrollArea_conversation {
+    background: #f3f5f9;
 }
 
 #FileWidget {
@@ -262,7 +353,7 @@ QPushButton#FileWidget_export_print {
     font-family: 'Source Sans Pro';
     font-weight: 500;
     font-size: 13px;
-    color: #2A319D;
+    color: #2a319d;
 }
 
 QPushButton#FileWidget_export_print:hover {
@@ -301,6 +392,19 @@ QWidget#FileWidget_horizontal_line {
     max-height: 2px;
     background-color: rgba(211, 216, 234, 0.45);
     margin: 0px 8px 0px 8px;
+}
+
+#SpeechBubble_container {
+    min-width: 540px;
+    max-width: 540px;
+    background-color: #fff;
+}
+
+#ReplyWidget_failed_to_send_text {
+    font-family: 'Source Sans Pro';
+    font-weight: 500;
+    font-size: 13px;
+    color: #ff3366;
 }
 
 #ModalDialog {
@@ -360,7 +464,7 @@ QWidget#FileWidget_horizontal_line {
     color: rgba(42, 49, 157, 0.4);
 }
 
-#passphrase_form QLabel {
+#ExportDialog_passphrase_form QLabel {
     font-family: 'Montserrat';
     font-weight: 500;
     font-size: 12px;
@@ -368,110 +472,10 @@ QWidget#FileWidget_horizontal_line {
     padding-top: 6px;
 }
 
-#passphrase_form QLineEdit {
+#ExportDialog_passphrase_form QLineEdit {
     border-radius: 0px;
     min-height: 30px;
     max-height: 30px;
     background-color: #f8f8f8;
     padding-bottom: 2px;
-}
-
-#ConversationScrollArea {
-    border: 0;
-    background: #f3f5f9;
-}
-
-#ConversationScrollArea_conversation {
-    background: #f3f5f9;
-}
-
-#SourceConversationWrapper_source_deleted {
-    text-align: left;
-    font-family: 'Montserrat';
-    font-weight: 500;
-    font-size: 40px;
-    color: #a5b3e9;
-    padding-bottom: 264px;
-    padding-right: 195px;
-}
-
-#ReplyBoxWidget {
-    min-height: 173px;
-    max-height: 173px;
-}
-
-#ReplyBoxWidget_replybox {
-    background-color: #ffffff;
-}
-
-#ReplyBoxWidget_replybox::disabled {
-    background-color: #efefef;
-}
-
-#ReplyBoxWidget QPushButton {
-    border: none;
-}
-
-#ReplyBoxWidget QPushButton:hover {
-    background: #D3D8EA;
-    border-radius: 8px;
-}
-
-QWidget#ReplyBoxWidget_horizontal_line {
-    min-height: 2px;
-    max-height: 2px;
-    background-color: rgba(42, 49, 157, 0.15);
-    border: none;
-}
-
-#ReplyTextEdit {
-    font-family: 'Montserrat';
-    font-weight: 400;
-    font-size: 18px;
-    border: none;
-    margin-right: 30.2px;
-}
-
-#ReplyTextEdit_placeholder {
-    font-family: 'Montserrat';
-    font-weight: 400;
-    font-size: 18px;
-    color: #404040;
-}
-
-#ReplyTextEdit_placeholder::disabled {
-    color: rgba(42, 49, 157, 0.6);
-}
-
-#SourceMenuButton {
-    border: none;
-    margin: 5px 0px 0px 0px;
-    padding-left: 8px;
-}
-
-QToolButton#SourceMenuButton::menu-indicator {
-    image: none;
-}
-
-#TitleLabel {
-    font-family: 'Montserrat';
-    font-weight: 400;
-    font-size: 24px;
-    color: #2a319d;
-    padding-left: 4px;
-}
-
-#LastUpdatedLabel {
-    font-family: 'Montserrat';
-    font-weight: 200;
-    font-size: 24px;
-    color: #2a319d;
-}
-
-QWidget#SourceProfileShortWidget_horizontal_line {
-    min-height: 2px;
-    max-height: 2px;
-    background-color: rgba(42, 49, 157, 0.15);
-    padding-left: 12px;
-    padding-right: 12px;
 }

--- a/securedrop_client/resources/css/sdclient.css
+++ b/securedrop_client/resources/css/sdclient.css
@@ -241,101 +241,11 @@ QListView#SourceList::item:hover{
     background-color: #fff;
 }
 
-#SpeechBubble_message {
-    min-width: 508px;
-    max-width: 508px;
-    font-family: 'Source Sans Pro';
-    font-weight: 400;
-    font-size: 15px;
-    background-color: #fff;
-    color: #3b3b3b;
-    padding: 16px;
-}
-
-#SpeechBubble_status_bar {
-    min-height: 5px;
-    max-height: 5px;
-    background-color: #102781;
-    border: 0px;
-}
-
-#SpeechBubble_message_decryption_error {
-    min-width: 508px;
-    max-width: 508px;
-    font-family: 'Source Sans Pro';
-    font-weight: 400;
-    font-size: 15px;
-    font-style: italic;
-    background-color: rgba(255, 255, 255, 0.6);
-    padding: 16px;
-}
-
-#SpeechBubble_status_bar_decryption_error {
-    min-height: 5px;
-    max-height: 5px;
-    background-color: #bcbfcd;
-    border: 0px;
-}
-
-#ReplyWidget_message {
-    min-width: 508px;
-    max-width: 508px;
-    font-family: 'Source Sans Pro';
-    font-weight: 400;
-    font-size: 15px;
-    background-color: #fff;
-    color: #3b3b3b;
-    padding: 16px;
-}
-
-#ReplyWidget_status_bar {
-    min-height: 5px;
-    max-height: 5px;
-    background-color: #0065db;
-    border: 0px;
-}
-
 #ReplyWidget_failed_to_send_text {
     font-family: 'Source Sans Pro';
     font-weight: 500;
     font-size: 13px;
     color: #ff3366;
-}
-
-#ReplyWidget_message_failed {
-    min-width: 508px;
-    max-width: 508px;
-    font-family: 'Source Sans Pro';
-    font-weight: 400;
-    font-size: 15px;
-    background-color: #fff;
-    color: #3b3b3b;
-    padding: 16px;
-}
-
-#ReplyWidget_status_bar_failed {
-    min-height: 5px;
-    max-height: 5px;
-    background-color: #ff3366;
-    border: 0px;
-}
-
-#ReplyWidget_message_pending {
-    min-width: 508px;
-    max-width: 508px;
-    font-family: 'Source Sans Pro';
-    font-weight: 400;
-    font-size: 15px;
-    color: #a9aaad;
-    background-color: #F7F8FC;
-    padding: 16px;
-}
-
-#ReplyWidget_status_bar_pending {
-    min-height: 5px;
-    max-height: 5px;
-    background-color: #0065db;
-    border: 0px;
 }
 
 #FileWidget {
@@ -356,30 +266,6 @@ QPushButton#FileWidget_export_print {
 }
 
 QPushButton#FileWidget_export_print:hover {
-    color: #05a6fe;
-}
-
-QPushButton#FileWidget_download_button {
-    border: none;
-    font-family: 'Source Sans Pro';
-    font-weight: 600;
-    font-size: 13px;
-    color: #2a319d;
-}
-
-QPushButton#FileWidget_download_button:hover {
-    color: #05a6fe;
-}
-
-QPushButton#FileWidget_download_button_animating {
-    border: none;
-    font-family: 'Source Sans Pro';
-    font-weight: 600;
-    font-size: 13px;
-    color: #05a6fe;
-}
-
-QPushButton#FileWidget_download_button_animating:hover {
     color: #05a6fe;
 }
 
@@ -451,17 +337,6 @@ QWidget#FileWidget_horizontal_line {
     border: none;
 }
 
-#ModalDialog_error_details {
-    margin: 0px 40px 0px 36px;
-    font-family: 'Montserrat';
-    font-size: 16px;
-    color: #ff0064;
-}
-
-#ModalDialog_error_details_active {
-    color: #ff66C4;
-}
-
 #ModalDialog_body {
     font-family: 'Montserrat';
     font-size: 16px;
@@ -483,27 +358,6 @@ QWidget#FileWidget_horizontal_line {
 #ModalDialog_button_box QPushButton::disabled {
     border: 2px solid rgba(42, 49, 157, 0.4);
     color: rgba(42, 49, 157, 0.4);
-}
-
-#ModalDialog_button_box QPushButton#ModalDialog_primary_button {
-    background-color: #2a319d;
-    color: #fff;
-}
-
-#ModalDialog_button_box QPushButton#ModalDialog_primary_button::disabled {
-    border: 2px solid #C2C4E3;
-    background-color: #C2C4E3;
-    color: #E1E2F1;
-}
-
-#ModalDialog_button_box QPushButton#ModalDialog_primary_button_active {
-    background-color: #f1f1f6;
-    color: #fff;
-    border: 2px solid #f1f1f6;
-    margin: 0px 0px 0px 12px;
-    height: 40px;
-    padding-left: 20px;
-    padding-right: 20px;
 }
 
 #passphrase_form QLabel {
@@ -589,13 +443,13 @@ QWidget#ReplyBoxWidget_horizontal_line {
     color: rgba(42, 49, 157, 0.6);
 }
 
-#SourceMenuButton_ellipsis_button {
+#SourceMenuButton {
     border: none;
     margin: 5px 0px 0px 0px;
     padding-left: 8px;
 }
 
-#SourceMenuButton QToolButton::menu-indicator {
+QToolButton#SourceMenuButton::menu-indicator {
     image: none;
 }
 

--- a/securedrop_client/resources/css/speech_bubble_message.css
+++ b/securedrop_client/resources/css/speech_bubble_message.css
@@ -1,0 +1,21 @@
+#SpeechBubble_message {
+    min-width: 508px;
+    max-width: 508px;
+    font-family: 'Source Sans Pro';
+    font-weight: 400;
+    font-size: 15px;
+    background-color: #fff;
+    color: #3b3b3b;
+    padding: 16px;
+}
+
+#SpeechBubble_message_decryption_error {
+    min-width: 508px;
+    max-width: 508px;
+    font-family: 'Source Sans Pro';
+    font-weight: 400;
+    font-size: 15px;
+    font-style: italic;
+    background-color: rgba(255, 255, 255, 0.6);
+    padding: 16px;
+}

--- a/securedrop_client/resources/css/speech_bubble_message.css
+++ b/securedrop_client/resources/css/speech_bubble_message.css
@@ -17,5 +17,6 @@
     font-size: 15px;
     font-style: italic;
     background-color: rgba(255, 255, 255, 0.6);
+    color: #3b3b3b;
     padding: 16px;
 }

--- a/securedrop_client/resources/css/speech_bubble_status_bar.css
+++ b/securedrop_client/resources/css/speech_bubble_status_bar.css
@@ -1,0 +1,13 @@
+#SpeechBubble_status_bar {
+    min-height: 5px;
+    max-height: 5px;
+    background-color: #102781;
+    border: 0px;
+}
+
+#SpeechBubble_status_bar_decryption_error {
+    min-height: 5px;
+    max-height: 5px;
+    background-color: #bcbfcd;
+    border: 0px;
+}

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -22,6 +22,8 @@ def test_init(mocker):
     mock_mv = mocker.patch('securedrop_client.gui.main.MainView')
     mocker.patch('securedrop_client.gui.main.QHBoxLayout', mock_lo)
     mocker.patch('securedrop_client.gui.main.QMainWindow')
+    mocker.patch('securedrop_client.gui.main.Window.setStyleSheet')
+    load_css = mocker.patch('securedrop_client.gui.main.load_css')
 
     w = Window()
 
@@ -29,6 +31,7 @@ def test_init(mocker):
     mock_lp.assert_called_once_with()
     mock_mv.assert_called_once_with(w.main_pane)
     assert mock_lo().addWidget.call_count == 2
+    load_css.assert_called_once_with('sdclient.css')
 
 
 def test_setup(mocker):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -3900,7 +3900,7 @@ def test_ReplyBoxWidget_init(mocker):
     """
     Ensure reply box set up properly.
     """
-    rb = ReplyBoxWidget(mocker.MagicMock(), mocker.MagicMock())
+    rb = ReplyBoxWidget(factory.Source(), mocker.MagicMock())
     assert rb.text_edit.isEnabled()
     assert not rb.send_button.isHidden()
     assert rb.send_button.isDefault() is True  # Needed for "Enter" to work.
@@ -3913,7 +3913,7 @@ def test_ReplyBoxWidget_init_no_auth(mocker):
     """
     controller = mocker.MagicMock()
     controller.is_authenticated = False
-    rb = ReplyBoxWidget(mocker.MagicMock(), controller)
+    rb = ReplyBoxWidget(factory.Source(), controller)
     assert not rb.text_edit.isEnabled()
     assert rb.send_button.isHidden()
 
@@ -3928,7 +3928,9 @@ def test_ReplyBoxWidget_placeholder_show_currently_selected_source(mocker):
     source.journalist_designation = "source name"
 
     rb = ReplyBoxWidget(source, controller)
-    assert rb.text_edit.placeholder.text().find(source.journalist_designation) != -1
+
+    source_name = rb.text_edit.placeholder.signed_in.layout().itemAt(1).widget()
+    assert -1 != source_name.text()
 
 
 def test_ReplyBoxWidget_send_reply(mocker):
@@ -3936,9 +3938,7 @@ def test_ReplyBoxWidget_send_reply(mocker):
     Ensure sending a reply from the reply box emits signal, clears text box, and sends the reply
     details to the controller.
     """
-    source = mocker.Mock()
-    source.uuid = 'abc123'
-    source.collection = []
+    source = factory.Source(uuid='abc123')
     reply_uuid = '456xyz'
     mocker.patch('securedrop_client.gui.widgets.uuid4', return_value=reply_uuid)
     controller = mocker.MagicMock()
@@ -3980,7 +3980,7 @@ def test_ReplyBoxWidget_send_reply_does_not_send_empty_string(mocker):
     """
     Ensure sending a reply from the reply box does not send empty string.
     """
-    source = mocker.MagicMock()
+    source = factory.Source()
     controller = mocker.MagicMock()
     rb = ReplyBoxWidget(source, controller)
     rb.text_edit = ReplyTextEdit(source, controller)
@@ -3999,7 +3999,7 @@ def test_ReplyBoxWidget_send_reply_does_not_send_empty_string(mocker):
 
 
 def test_ReplyBoxWidget_on_synced(mocker):
-    source = mocker.MagicMock()
+    source = factory.Source()
     controller = mocker.MagicMock()
     rb = ReplyBoxWidget(source, controller)
     rb.text_edit.hasFocus = mocker.MagicMock(return_value=True)
@@ -4076,7 +4076,7 @@ def test_ReplyBoxWidget__on_authentication_changed(mocker, homedir):
     """
     When the client is authenticated, enable reply box.
     """
-    source = mocker.MagicMock()
+    source = factory.Source()
     controller = mocker.MagicMock()
     rb = ReplyBoxWidget(source, controller)
     rb.set_logged_in = mocker.MagicMock()
@@ -4110,7 +4110,7 @@ def test_ReplyBoxWidget__on_authentication_changed_offline(mocker, homedir):
     """
     When the client goes offline, disable reply box.
     """
-    source = mocker.MagicMock()
+    source = factory.Source()
     controller = mocker.MagicMock()
     rb = ReplyBoxWidget(source, controller)
     rb.set_logged_out = mocker.MagicMock()
@@ -4124,7 +4124,6 @@ def test_ReplyBoxWidget_auth_signals(mocker, homedir):
     """
     Ensure we connect to the auth signal and set the intial state on update
     """
-    source = mocker.Mock(collection=[])
     connect = mocker.MagicMock()
     signal = mocker.MagicMock(connect=connect)
     controller = mocker.MagicMock(authentication_state=signal)
@@ -4133,13 +4132,13 @@ def test_ReplyBoxWidget_auth_signals(mocker, homedir):
     _on_authentication_changed_fn = mocker.patch.object(
         ReplyBoxWidget, '_on_authentication_changed')
 
-    ReplyBoxWidget(source, controller)
+    ReplyBoxWidget(factory.Source(), controller)
 
     connect.assert_called_once_with(_on_authentication_changed_fn)
 
 
 def test_ReplyBoxWidget_enable(mocker):
-    source = mocker.MagicMock()
+    source = factory.Source()
     controller = mocker.MagicMock()
     rb = ReplyBoxWidget(source, controller)
     rb.text_edit = ReplyTextEdit(source, controller)
@@ -4154,7 +4153,7 @@ def test_ReplyBoxWidget_enable(mocker):
 
 
 def test_ReplyBoxWidget_disable(mocker):
-    source = mocker.MagicMock()
+    source = factory.Source()
     controller = mocker.MagicMock()
     rb = ReplyBoxWidget(source, controller)
     rb.text_edit = ReplyTextEdit(source, controller)
@@ -4210,7 +4209,7 @@ def test_ReplyTextEdit_focus_change_no_text(mocker):
     Tests if placeholder text in reply box disappears when it's focused (clicked)
     and reappears when it's no longer on focus
     """
-    source = mocker.MagicMock()
+    source = factory.Source()
     controller = mocker.MagicMock()
     rt = ReplyTextEdit(source, controller)
 
@@ -4231,9 +4230,8 @@ def test_ReplyTextEdit_focus_change_with_text_typed(mocker):
     Test that the placeholder does not appear when there is text in the ReplyTextEdit widget and
     that the text remains in the ReplyTextEdit regardless of focus.
     """
-    source = mocker.MagicMock()
     controller = mocker.MagicMock()
-    rt = ReplyTextEdit(source, controller)
+    rt = ReplyTextEdit(factory.Source(), controller)
     reply_text = 'mocked reply text'
     rt.setText(reply_text)
 
@@ -4254,7 +4252,7 @@ def test_ReplyTextEdit_setText(mocker):
     Checks that a non-empty string parameter causes placeholder to hide and that super's
     setPlainText method is called (to ensure cursor is hidden).
     """
-    rt = ReplyTextEdit(mocker.MagicMock(), mocker.MagicMock())
+    rt = ReplyTextEdit(factory.Source(), mocker.MagicMock())
     mocker.patch('securedrop_client.gui.widgets.QPlainTextEdit.setPlainText')
 
     rt.setText('mocked reply text')
@@ -4268,7 +4266,7 @@ def test_ReplyTextEdit_setText_empty_string(mocker):
     Checks that plain string parameter causes placeholder to show and that super's setPlainText
     method is called (to ensure cursor is hidden).
     """
-    rt = ReplyTextEdit(mocker.MagicMock(), mocker.MagicMock())
+    rt = ReplyTextEdit(factory.Source(), mocker.MagicMock())
     mocker.patch('securedrop_client.gui.widgets.QPlainTextEdit.setPlainText')
 
     rt.setText('')
@@ -4281,29 +4279,33 @@ def test_ReplyTextEdit_set_logged_out(mocker):
     """
     Checks the placeholder text for reply box is correct for offline mode
     """
-    source = mocker.MagicMock()
+    source = factory.Source()
     controller = mocker.MagicMock()
     rt = ReplyTextEdit(source, controller)
 
     rt.set_logged_out()
 
-    assert 'Sign in' in rt.placeholder.text()
-    assert 'to compose or send a reply' in rt.placeholder.text()
+    sign_in = rt.placeholder.signed_out.layout().itemAt(0).widget()
+    to_compose_reply = rt.placeholder.signed_out.layout().itemAt(1).widget()
+
+    assert 'Sign in' == sign_in.text()
+    assert ' to compose or send a reply' in to_compose_reply.text()
 
 
 def test_ReplyTextEdit_set_logged_in(mocker):
     """
     Checks the placeholder text for reply box is correct for online mode
     """
-    source = mocker.MagicMock()
-    source.journalist_designation = 'journalist designation'
+    source = factory.Source()
     controller = mocker.MagicMock()
     rt = ReplyTextEdit(source, controller)
 
     rt.set_logged_in()
 
-    assert 'Compose a reply to' in rt.placeholder.text()
-    assert source.journalist_designation in rt.placeholder.text()
+    compose_a_reply_to = rt.placeholder.signed_in.layout().itemAt(0).widget()
+    source_name = rt.placeholder.signed_in.layout().itemAt(1).widget()
+    assert 'Compose a reply to ' == compose_a_reply_to.text()
+    assert source.journalist_designation == source_name.text()
 
 
 def test_ReplyBox_set_logged_in_no_public_key(mocker):
@@ -4311,15 +4313,18 @@ def test_ReplyBox_set_logged_in_no_public_key(mocker):
     If the selected source has no public key, ensure a warning message is
     shown and the user is unable to send a reply.
     """
-    source = mocker.MagicMock()
-    source.journalist_designation = 'journalist designation'
+    source = factory.Source()
     source.public_key = None
     controller = mocker.MagicMock()
     rb = ReplyBoxWidget(source, controller)
 
     rb.set_logged_in()
 
-    assert 'Awaiting encryption key' in rb.text_edit.placeholder.text()
+    awaiting_key = rb.text_edit.placeholder.signed_in_no_key.layout().itemAt(0).widget()
+    from_server = rb.text_edit.placeholder.signed_in_no_key.layout().itemAt(1).widget()
+
+    assert 'Awaiting encryption key' == awaiting_key.text()
+    assert ' from server to enable replies' == from_server.text()
 
     # Both the reply box and the text editor must be disabled for the widget
     # to be rendered correctly.

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -2037,8 +2037,6 @@ def test_SpeechBubble_init(mocker):
     sb.message.text() == 'hello'
     assert mock_update_connect.called
     assert mock_download_error_connect.called
-    assert 'background-color: #102781;' in sb.color_bar.styleSheet()
-    assert 'background-color: #fff;' in sb.speech_bubble.styleSheet()
 
 
 def test_SpeechBubble_init_with_error(mocker):
@@ -2060,9 +2058,6 @@ def test_SpeechBubble_init_with_error(mocker):
     sb.message.text() == 'hello'
     assert mock_update_connect.called
     assert mock_download_error_connect.called
-    assert 'background-color: #BCBFCD;' in sb.color_bar.styleSheet()
-    assert 'background-color: rgba(255, 255, 255, 0.6);' in sb.message.styleSheet()
-    assert 'font-style: italic;' in sb.message.styleSheet()
 
 
 def test_SpeechBubble_update_text(mocker):
@@ -2114,9 +2109,6 @@ def test_SpeechBubble_set_error(mocker):
     error_message = "Oh no."
     bubble.set_error("source id", message_uuid, error_message)
     assert bubble.message.text() == error_message
-    assert "font-style: italic;" in bubble.message.styleSheet()
-    assert "background-color: rgba(255, 255, 255, 0.6);" in bubble.message.styleSheet()
-    assert "background-color: #BCBFCD;" in bubble.color_bar.styleSheet()
 
 
 def test_MessageWidget_init(mocker):
@@ -2188,7 +2180,7 @@ def test_ReplyWidget_init_with_error(mocker):
     mock_failure_connected = mocker.Mock()
     mock_failure_signal.connect = mock_failure_connected
 
-    rw = ReplyWidget(
+    ReplyWidget(
         'mock id',
         'hello',
         'dummy',
@@ -2203,10 +2195,6 @@ def test_ReplyWidget_init_with_error(mocker):
     assert mock_update_connected.called
     assert mock_success_connected.called
     assert mock_failure_connected.called
-
-    assert "font-style: italic;" in rw.message.styleSheet()
-    assert "background-color: rgba(255, 255, 255, 0.6);" in rw.message.styleSheet()
-    assert "background-color: #BCBFCD;" in rw.color_bar.styleSheet()
 
 
 def test_FileWidget_init_file_not_downloaded(mocker, source, session):
@@ -2395,8 +2383,6 @@ def test_FileWidget_start_button_animation(mocker, session, source):
     fw.start_button_animation()
     # Check indicators of activity have been updated.
     assert fw.download_button.setIcon.call_count == 1
-    fw.download_button.setText.assert_called_once_with(" DOWNLOADING ")
-    fw.download_button.setStyleSheet.assert_called_once_with("color: #05a6fe")
 
 
 def test_FileWidget_on_left_click_open(mocker, session, source):
@@ -2761,7 +2747,7 @@ def test_ModalDialog_animation_of_activestate(mocker):
     dialog.button_animation.start.assert_called_once_with()
     dialog.continue_button.setText.assert_called_once_with("")
     assert dialog.continue_button.setMinimumSize.call_count == 1
-    assert dialog.continue_button.setStyleSheet.call_count == 1
+    assert dialog.continue_button.setStyleSheet.call_count == 2  # also called once for reset
 
     dialog.continue_button.reset_mock()
 
@@ -2770,7 +2756,7 @@ def test_ModalDialog_animation_of_activestate(mocker):
     dialog.button_animation.stop.assert_called_once_with()
     dialog.continue_button.setText.assert_called_once_with("CONTINUE")
     assert dialog.continue_button.setIcon.call_count == 1
-    assert dialog.continue_button.setStyleSheet.call_count == 1
+    assert dialog.continue_button.setStyleSheet.call_count == 2  # also called once for reset
 
 
 def test_ModalDialog_animation_of_header(mocker):
@@ -3380,7 +3366,7 @@ def test_ConversationView_init(mocker, homedir):
     mocked_source = mocker.MagicMock()
     mocked_controller = mocker.MagicMock()
     cv = ConversationView(mocked_source, mocked_controller)
-    assert isinstance(cv.conversation_layout, QVBoxLayout)
+    assert isinstance(cv.scroll.conversation_layout, QVBoxLayout)
 
 
 def test_ConversationView_update_conversation_position_follow(mocker, homedir):
@@ -3446,7 +3432,7 @@ def test_ConversationView_add_message(mocker, session, source):
     session.commit()
 
     cv = ConversationView(source, mocked_controller)
-    cv.conversation_layout = mocker.MagicMock()
+    cv.scroll.conversation_layout = mocker.MagicMock()
     cv.conversation_updated = mocker.MagicMock()
     # this is the MessageWidget that __init__() would return
     mock_msg_widget_res = mocker.MagicMock()
@@ -3467,7 +3453,7 @@ def test_ConversationView_add_message(mocker, session, source):
     )
 
     # check that we added the correct widget to the layout
-    cv.conversation_layout.insertWidget.assert_called_once_with(
+    cv.scroll.conversation_layout.insertWidget.assert_called_once_with(
         0, mock_msg_widget_res, alignment=Qt.AlignLeft)
 
     # Check the signal is emitted to say the message has been added (and thus
@@ -3496,7 +3482,7 @@ def test_ConversationView_add_message_no_content(mocker, session, source):
     session.commit()
 
     cv = ConversationView(source, mocked_controller)
-    cv.conversation_layout = mocker.MagicMock()
+    cv.scroll.conversation_layout = mocker.MagicMock()
     # this is the MessageWidget that __init__() would return
     mock_msg_widget_res = mocker.MagicMock()
     # mock the actual MessageWidget so we can inspect the __init__ call
@@ -3512,7 +3498,7 @@ def test_ConversationView_add_message_no_content(mocker, session, source):
     )
 
     # check that we added the correct widget to the layout
-    cv.conversation_layout.insertWidget.assert_called_once_with(
+    cv.scroll.conversation_layout.insertWidget.assert_called_once_with(
         0, mock_msg_widget_res, alignment=Qt.AlignLeft)
 
 
@@ -3563,7 +3549,7 @@ def test_ConversationView_add_reply_from_reply_box(mocker):
         reply_failed=reply_failed
     )
     cv = ConversationView(source, controller)
-    cv.conversation_layout = mocker.MagicMock()
+    cv.scroll.conversation_layout = mocker.MagicMock()
     reply_widget_res = mocker.MagicMock()
     reply_widget = mocker.patch(
         'securedrop_client.gui.widgets.ReplyWidget', return_value=reply_widget_res)
@@ -3574,7 +3560,7 @@ def test_ConversationView_add_reply_from_reply_box(mocker):
         'abc123', 'test message', 'PENDING', reply_ready, reply_download_failed,
         reply_succeeded, reply_failed, 0
     )
-    cv.conversation_layout.insertWidget.assert_called_once_with(
+    cv.scroll.conversation_layout.insertWidget.assert_called_once_with(
         0, reply_widget_res, alignment=Qt.AlignRight)
 
 
@@ -3602,7 +3588,7 @@ def test_ConversationView_add_reply(mocker, session, source):
     session.commit()
 
     cv = ConversationView(source, mocked_controller)
-    cv.conversation_layout = mocker.MagicMock()
+    cv.scroll.conversation_layout = mocker.MagicMock()
     # this is the Reply that __init__() would return
     reply_widget_res = mocker.MagicMock()
     # mock the actual MessageWidget so we can inspect the __init__ call
@@ -3625,7 +3611,7 @@ def test_ConversationView_add_reply(mocker, session, source):
     )
 
     # check that we added the correct widget to the layout
-    cv.conversation_layout.insertWidget.assert_called_once_with(
+    cv.scroll.conversation_layout.insertWidget.assert_called_once_with(
         0, reply_widget_res, alignment=Qt.AlignRight)
 
 
@@ -3652,7 +3638,7 @@ def test_ConversationView_add_reply_no_content(mocker, session, source):
     session.commit()
 
     cv = ConversationView(source, mocked_controller)
-    cv.conversation_layout = mocker.MagicMock()
+    cv.scroll.conversation_layout = mocker.MagicMock()
     # this is the Reply that __init__() would return
     reply_widget_res = mocker.MagicMock()
     # mock the actual MessageWidget so we can inspect the __init__ call
@@ -3675,7 +3661,7 @@ def test_ConversationView_add_reply_no_content(mocker, session, source):
     )
 
     # check that we added the correct widget to the layout
-    cv.conversation_layout.insertWidget.assert_called_once_with(
+    cv.scroll.conversation_layout.insertWidget.assert_called_once_with(
         0, reply_widget_res, alignment=Qt.AlignRight)
 
 
@@ -3693,7 +3679,7 @@ def test_ConversationView_add_downloaded_file(mocker, homedir, source, session):
     mocked_controller = mocker.MagicMock(get_file=mock_get_file)
 
     cv = ConversationView(source['source'], mocked_controller)
-    cv.conversation_layout = mocker.MagicMock()
+    cv.scroll.conversation_layout = mocker.MagicMock()
     cv.conversation_updated = mocker.MagicMock()
 
     mock_label = mocker.patch('securedrop_client.gui.widgets.SecureQLabel')
@@ -3703,10 +3689,10 @@ def test_ConversationView_add_downloaded_file(mocker, homedir, source, session):
     cv.add_file(file, 0)
 
     mock_label.assert_called_with('123B')  # default factory filesize
-    assert cv.conversation_layout.insertWidget.call_count == 1
+    assert cv.scroll.conversation_layout.insertWidget.call_count == 1
     assert cv.conversation_updated.emit.call_count == 1
 
-    cal = cv.conversation_layout.insertWidget.call_args_list
+    cal = cv.scroll.conversation_layout.insertWidget.call_args_list
     assert isinstance(cal[0][0][1], FileWidget)
 
 
@@ -3723,15 +3709,15 @@ def test_ConversationView_add_not_downloaded_file(mocker, homedir, source, sessi
     mocked_controller = mocker.MagicMock(get_file=mock_get_file)
 
     cv = ConversationView(source['source'], mocked_controller)
-    cv.conversation_layout = mocker.MagicMock()
+    cv.scroll.conversation_layout = mocker.MagicMock()
 
     mocker.patch('securedrop_client.gui.widgets.QHBoxLayout.addWidget')
     mocker.patch('securedrop_client.gui.widgets.FileWidget.setLayout')
 
     cv.add_file(file, 0)
-    assert cv.conversation_layout.insertWidget.call_count == 1
+    assert cv.scroll.conversation_layout.insertWidget.call_count == 1
 
-    cal = cv.conversation_layout.insertWidget.call_args_list
+    cal = cv.scroll.conversation_layout.insertWidget.call_args_list
     assert isinstance(cal[0][0][1], FileWidget)
 
 
@@ -4362,11 +4348,11 @@ def test_update_conversation_maintains_old_items(mocker, session):
     mock_controller = mocker.MagicMock(get_file=mock_get_file)
 
     cv = ConversationView(source, mock_controller)
-    assert cv.conversation_layout.count() == 3
+    assert cv.scroll.conversation_layout.count() == 3
 
     cv.update_conversation(cv.source.collection)
 
-    assert cv.conversation_layout.count() == 3
+    assert cv.scroll.conversation_layout.count() == 3
 
 
 def test_update_conversation_does_not_remove_pending_draft_items(mocker, session):
@@ -4392,7 +4378,7 @@ def test_update_conversation_does_not_remove_pending_draft_items(mocker, session
     mock_controller = mocker.MagicMock(get_file=mock_get_file)
 
     cv = ConversationView(source, mock_controller)
-    assert cv.conversation_layout.count() == 3  # precondition with draft
+    assert cv.scroll.conversation_layout.count() == 3  # precondition with draft
 
     # add the new message and persist
     new_message = factory.Message(filename='4-source-msg.gpg', source=source)
@@ -4401,7 +4387,7 @@ def test_update_conversation_does_not_remove_pending_draft_items(mocker, session
 
     # New message added, draft message persists.
     cv.update_conversation(cv.source.collection)
-    assert cv.conversation_layout.count() == 4
+    assert cv.scroll.conversation_layout.count() == 4
 
 
 def test_update_conversation_does_remove_successful_draft_items(mocker, session):
@@ -4427,7 +4413,7 @@ def test_update_conversation_does_remove_successful_draft_items(mocker, session)
     mock_controller = mocker.MagicMock(get_file=mock_get_file)
 
     cv = ConversationView(source, mock_controller)
-    assert cv.conversation_layout.count() == 3  # precondition with draft
+    assert cv.scroll.conversation_layout.count() == 3  # precondition with draft
 
     # add the new message and persist
     new_message = factory.Message(filename='4-source-msg.gpg', source=source)
@@ -4440,7 +4426,7 @@ def test_update_conversation_does_remove_successful_draft_items(mocker, session)
 
     # New message added, draft message is gone.
     cv.update_conversation(cv.source.collection)
-    assert cv.conversation_layout.count() == 3
+    assert cv.scroll.conversation_layout.count() == 3
 
 
 def test_update_conversation_keeps_failed_draft_items(mocker, session):
@@ -4466,7 +4452,7 @@ def test_update_conversation_keeps_failed_draft_items(mocker, session):
     mock_controller = mocker.MagicMock(get_file=mock_get_file)
 
     cv = ConversationView(source, mock_controller)
-    assert cv.conversation_layout.count() == 3  # precondition with draft
+    assert cv.scroll.conversation_layout.count() == 3  # precondition with draft
 
     # add the new message and persist
     new_message = factory.Message(filename='4-source-msg.gpg', source=source)
@@ -4475,7 +4461,7 @@ def test_update_conversation_keeps_failed_draft_items(mocker, session):
 
     # New message added, draft message retained.
     cv.update_conversation(cv.source.collection)
-    assert cv.conversation_layout.count() == 4
+    assert cv.scroll.conversation_layout.count() == 4
 
 
 def test_update_conversation_adds_new_items(mocker, session):
@@ -4498,7 +4484,7 @@ def test_update_conversation_adds_new_items(mocker, session):
     mock_controller = mocker.MagicMock(get_file=mock_get_file)
 
     cv = ConversationView(source, mock_controller)
-    assert cv.conversation_layout.count() == 3  # precondition
+    assert cv.scroll.conversation_layout.count() == 3  # precondition
 
     # add the new message and persist
     new_message = factory.Message(filename='4-source-msg.gpg', source=source)
@@ -4506,7 +4492,7 @@ def test_update_conversation_adds_new_items(mocker, session):
     session.commit()
 
     cv.update_conversation(cv.source.collection)
-    assert cv.conversation_layout.count() == 4
+    assert cv.scroll.conversation_layout.count() == 4
 
 
 def test_update_conversation_position_updates(mocker, session):
@@ -4529,7 +4515,7 @@ def test_update_conversation_position_updates(mocker, session):
     mock_controller = mocker.MagicMock(get_file=mock_get_file)
 
     cv = ConversationView(source, mock_controller)
-    assert cv.conversation_layout.count() == 3  # precondition
+    assert cv.scroll.conversation_layout.count() == 3  # precondition
 
     # Change the position of the Reply.
     reply_widget = cv.current_messages[reply.uuid]
@@ -4541,7 +4527,7 @@ def test_update_conversation_position_updates(mocker, session):
     session.commit()
 
     cv.update_conversation(cv.source.collection)
-    assert cv.conversation_layout.count() == 4
+    assert cv.scroll.conversation_layout.count() == 4
     assert reply_widget.index == 2  # re-ordered.
 
 
@@ -4564,8 +4550,8 @@ def test_update_conversation_content_updates(mocker, session):
     cv = ConversationView(source, mock_controller)
     cv.current_messages = {}  # Reset!
 
-    cv.conversation_layout.insertWidget = mocker.MagicMock()
-    cv.conversation_layout.removeWidget = mocker.MagicMock()
+    cv.scroll.conversation_layout.insertWidget = mocker.MagicMock()
+    cv.scroll.conversation_layout.removeWidget = mocker.MagicMock()
     # this is the MessageWidget that __init__() would return
     mock_msg_widget_res = mocker.MagicMock()
     # mock MessageWidget so we can inspect the __init__ call to see what content

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -43,6 +43,40 @@ def main_window(mocker, homedir):
 
 
 @pytest.fixture(scope='function')
+def main_window_no_key(mocker, homedir):
+    # Setup
+    app = QApplication([])
+    gui = Window()
+    app.setActiveWindow(gui)
+    gui.show()
+    controller = Controller('http://localhost', gui, mocker.MagicMock(), homedir, proxy=False)
+    controller.qubes = False
+    gui.setup(controller)
+
+    # Create a source widget
+    source_list = gui.main_view.source_list
+    source = factory.Source(public_key=None)
+    source_list.update([source])
+
+    # Create a file widget, message widget, and reply widget
+    mocker.patch('securedrop_client.gui.widgets.humanize_filesize', return_value='100')
+    mocker.patch(
+        'securedrop_client.gui.SecureQLabel.get_elided_text', return_value='1-yellow-doc.gz.gpg')
+    source.collection.append([
+        factory.File(source=source, filename='1-yellow-doc.gz.gpg'),
+        factory.Message(source=source, filename='2-yellow-msg.gpg'),
+        factory.Reply(source=source, filename='3-yellow-reply.gpg')])
+    source_list.setCurrentItem(source_list.item(0))
+    gui.main_view.on_source_changed()
+
+    yield gui
+
+    # Teardown
+    gui.login_dialog.close()
+    app.exit()
+
+
+@pytest.fixture(scope='function')
 def modal_dialog(mocker, homedir):
     app = QApplication([])
     gui = Window()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,97 @@
+import pytest
+from PyQt5.QtWidgets import QApplication
+
+from securedrop_client.logic import Controller
+from securedrop_client.gui.main import Window
+from securedrop_client.gui.widgets import ExportDialog, ModalDialog, PrintDialog
+
+from tests import factory
+
+
+@pytest.fixture(scope='function')
+def main_window(mocker, homedir):
+    # Setup
+    app = QApplication([])
+    gui = Window()
+    app.setActiveWindow(gui)
+    gui.show()
+    controller = Controller('http://localhost', gui, mocker.MagicMock(), homedir, proxy=False)
+    controller.qubes = False
+    gui.setup(controller)
+
+    # Create a source widget
+    source_list = gui.main_view.source_list
+    source = factory.Source()
+    source_list.update([source])
+
+    # Create a file widget, message widget, and reply widget
+    mocker.patch('securedrop_client.gui.widgets.humanize_filesize', return_value='100')
+    mocker.patch(
+        'securedrop_client.gui.SecureQLabel.get_elided_text', return_value='1-yellow-doc.gz.gpg')
+    source.collection.append([
+        factory.File(source=source, filename='1-yellow-doc.gz.gpg'),
+        factory.Message(source=source, filename='2-yellow-msg.gpg'),
+        factory.Reply(source=source, filename='3-yellow-reply.gpg')])
+    source_list.setCurrentItem(source_list.item(0))
+    gui.main_view.on_source_changed()
+
+    yield gui
+
+    # Teardown
+    gui.login_dialog.close()
+    app.exit()
+
+
+@pytest.fixture(scope='function')
+def modal_dialog(mocker, homedir):
+    app = QApplication([])
+    gui = Window()
+    gui.show()
+    controller = Controller('http://localhost', gui, mocker.MagicMock(), homedir, proxy=False)
+    controller.qubes = False
+    gui.setup(controller)
+    gui.login_dialog.close()
+    app.setActiveWindow(gui)
+    dialog = ModalDialog()
+
+    yield dialog
+
+    dialog.close()
+    app.exit()
+
+
+@pytest.fixture(scope='function')
+def print_dialog(mocker, homedir):
+    app = QApplication([])
+    gui = Window()
+    gui.show()
+    controller = Controller('http://localhost', gui, mocker.MagicMock(), homedir, proxy=False)
+    controller.qubes = False
+    gui.setup(controller)
+    gui.login_dialog.close()
+    app.setActiveWindow(gui)
+    dialog = PrintDialog(controller, 'file_uuid', 'file_name')
+
+    yield dialog
+
+    dialog.close()
+    app.exit()
+
+
+@pytest.fixture(scope='function')
+def export_dialog(mocker, homedir):
+    app = QApplication([])
+    gui = Window()
+    gui.show()
+    controller = Controller('http://localhost', gui, mocker.MagicMock(), homedir, proxy=False)
+    controller.qubes = False
+    gui.setup(controller)
+    gui.login_dialog.close()
+    app.setActiveWindow(gui)
+    dialog = ExportDialog(controller, 'file_uuid', 'file_name')
+    dialog.show()
+
+    yield dialog
+
+    dialog.close()
+    gui.close()

--- a/tests/integration/test_placeholder.py
+++ b/tests/integration/test_placeholder.py
@@ -1,0 +1,14 @@
+def test_styles_for_placeholder(main_window):
+    wrapper = main_window.main_view.view_layout.itemAt(0).widget()
+    reply_box = wrapper.reply_box
+    reply_text_edit = reply_box.text_edit
+    reply_placeholder_logged_out = '' \
+        '<strong><font color="#2a319d">Sign in </font></strong>to compose or send a reply'
+    reply_placeholder_logged_in = '' \
+        'Compose a reply to <strong><font color="#24276d">testy-mctestface</font></strong>'
+
+    assert reply_placeholder_logged_out == reply_text_edit.placeholder.text()
+
+    reply_box.set_logged_in()
+
+    assert reply_placeholder_logged_in == reply_text_edit.placeholder.text()

--- a/tests/integration/test_placeholder.py
+++ b/tests/integration/test_placeholder.py
@@ -1,14 +1,53 @@
+from PyQt5.QtGui import QFont, QPalette
+
+
 def test_styles_for_placeholder(main_window):
     wrapper = main_window.main_view.view_layout.itemAt(0).widget()
     reply_box = wrapper.reply_box
     reply_text_edit = reply_box.text_edit
-    reply_placeholder_logged_out = '' \
-        '<strong><font color="#2a319d">Sign in </font></strong>to compose or send a reply'
-    reply_placeholder_logged_in = '' \
-        'Compose a reply to <strong><font color="#24276d">testy-mctestface</font></strong>'
 
-    assert reply_placeholder_logged_out == reply_text_edit.placeholder.text()
+    sign_in = reply_text_edit.placeholder.signed_out.layout().itemAt(0).widget()
+    assert 'Montserrat' == sign_in.font().family()
+    assert QFont.Bold == sign_in.font().weight()
+    assert 18 == sign_in.font().pixelSize()
+    assert '#2a319d' == sign_in.palette().color(QPalette.Foreground).name()
+
+    to_compose_reply = reply_text_edit.placeholder.signed_out.layout().itemAt(1).widget()
+    assert 'Montserrat' == to_compose_reply.font().family()
+    assert QFont.Normal == to_compose_reply.font().weight()
+    assert 18 == to_compose_reply.font().pixelSize()
+    assert '#404040' == to_compose_reply.palette().color(QPalette.Foreground).name()
 
     reply_box.set_logged_in()
 
-    assert reply_placeholder_logged_in == reply_text_edit.placeholder.text()
+    compose_a_reply_to = reply_text_edit.placeholder.signed_in.layout().itemAt(0).widget()
+    assert 'Montserrat' == compose_a_reply_to.font().family()
+    assert QFont.Normal == compose_a_reply_to.font().weight()
+    assert 18 == compose_a_reply_to.font().pixelSize()
+    assert '#404040' == compose_a_reply_to.palette().color(QPalette.Foreground).name()
+
+    source_name = reply_text_edit.placeholder.signed_in.layout().itemAt(1).widget()
+    assert 'Montserrat' == source_name.font().family()
+    assert QFont.Bold == source_name.font().weight()
+    assert 18 == source_name.font().pixelSize()
+    assert '#2a319d' == source_name.palette().color(QPalette.Foreground).name()
+
+
+def test_styles_for_placeholder_no_key(main_window_no_key):
+    wrapper = main_window_no_key.main_view.view_layout.itemAt(0).widget()
+    reply_box = wrapper.reply_box
+    reply_text_edit = reply_box.text_edit
+
+    reply_box.set_logged_in()
+
+    awaiting_key = reply_text_edit.placeholder.signed_in_no_key.layout().itemAt(0).widget()
+    assert 'Montserrat' == awaiting_key.font().family()
+    assert QFont.Bold == awaiting_key.font().weight()
+    assert 18 == awaiting_key.font().pixelSize()
+    assert '#2a319d' == awaiting_key.palette().color(QPalette.Foreground).name()
+
+    from_server = reply_text_edit.placeholder.signed_in_no_key.layout().itemAt(1).widget()
+    assert 'Montserrat' == from_server.font().family()
+    assert QFont.Normal == from_server.font().weight()
+    assert 18 == from_server.font().pixelSize()
+    assert '#404040' == from_server.palette().color(QPalette.Foreground).name()

--- a/tests/integration/test_styles_file_download_button.py
+++ b/tests/integration/test_styles_file_download_button.py
@@ -1,0 +1,25 @@
+from PyQt5.QtGui import QFont, QPalette
+
+
+def test_styles_for_conversation_view(mocker, main_window):
+    wrapper = main_window.main_view.view_layout.itemAt(0).widget()
+    conversation_scrollarea = wrapper.conversation_view.scroll
+    file_widget = conversation_scrollarea.widget().layout().itemAt(0).widget()
+    download_button = file_widget.download_button
+    assert 'Source Sans Pro' == download_button.font().family()
+    assert QFont.Bold == download_button.font().weight()
+    assert 13 == download_button.font().pixelSize()
+    assert '#2a319d' == download_button.palette().color(QPalette.Foreground).name()
+    # assert 'border: none;' for download_button
+    # hover = QEvent(QEvent.HoverEnter)
+    # download_button.eventFilter(download_button, hover)
+    # assert '#05a6fe' == download_button.palette().color(QPalette.Foreground).name()
+    file_widget.start_button_animation()
+    assert 'Source Sans Pro' == download_button.font().family()
+    assert QFont.Bold == download_button.font().weight()
+    assert 13 == download_button.font().pixelSize()
+    assert '#05a6fe' == download_button.palette().color(QPalette.Foreground).name()
+    # assert 'border: none;' for download_button
+    # hover = QEvent(QEvent.HoverEnter)
+    # download_button.eventFilter(download_button, hover)
+    # assert '#05a6fe' == download_button.palette().color(QPalette.Foreground).name()

--- a/tests/integration/test_styles_file_download_button.py
+++ b/tests/integration/test_styles_file_download_button.py
@@ -1,25 +1,56 @@
+from PyQt5.QtCore import QEvent
 from PyQt5.QtGui import QFont, QPalette
 
+from securedrop_client.resources import load_icon
 
-def test_styles_for_conversation_view(mocker, main_window):
+
+def test_styles(mocker, main_window):
     wrapper = main_window.main_view.view_layout.itemAt(0).widget()
     conversation_scrollarea = wrapper.conversation_view.scroll
     file_widget = conversation_scrollarea.widget().layout().itemAt(0).widget()
     download_button = file_widget.download_button
+
+    expected_image = load_icon('download_file.svg').pixmap(20, 20).toImage()
+    assert download_button.icon().pixmap(20, 20).toImage() == expected_image
     assert 'Source Sans Pro' == download_button.font().family()
     assert QFont.Bold == download_button.font().weight()
     assert 13 == download_button.font().pixelSize()
     assert '#2a319d' == download_button.palette().color(QPalette.Foreground).name()
     # assert 'border: none;' for download_button
-    # hover = QEvent(QEvent.HoverEnter)
-    # download_button.eventFilter(download_button, hover)
+
+    file_widget.eventFilter(download_button, QEvent(QEvent.HoverEnter))
+    expected_image = load_icon('download_file_hover.svg').pixmap(20, 20).toImage()
+    assert download_button.icon().pixmap(20, 20).toImage() == expected_image
     # assert '#05a6fe' == download_button.palette().color(QPalette.Foreground).name()
+
+    file_widget.eventFilter(download_button, QEvent(QEvent.HoverLeave))
+    expected_image = load_icon('download_file.svg').pixmap(20, 20).toImage()
+    assert download_button.icon().pixmap(20, 20).toImage() == expected_image
+    assert '#2a319d' == download_button.palette().color(QPalette.Foreground).name()
+
+
+def test_styles_animated(mocker, main_window):
+    wrapper = main_window.main_view.view_layout.itemAt(0).widget()
+    conversation_scrollarea = wrapper.conversation_view.scroll
+    file_widget = conversation_scrollarea.widget().layout().itemAt(0).widget()
+    download_button = file_widget.download_button
+
     file_widget.start_button_animation()
+
+    expected_image = load_icon('download_file.gif').pixmap(20, 20).toImage()
+    assert download_button.icon().pixmap(20, 20).toImage() == expected_image
     assert 'Source Sans Pro' == download_button.font().family()
     assert QFont.Bold == download_button.font().weight()
     assert 13 == download_button.font().pixelSize()
     assert '#05a6fe' == download_button.palette().color(QPalette.Foreground).name()
     # assert 'border: none;' for download_button
-    # hover = QEvent(QEvent.HoverEnter)
-    # download_button.eventFilter(download_button, hover)
-    # assert '#05a6fe' == download_button.palette().color(QPalette.Foreground).name()
+
+    file_widget.eventFilter(download_button, QEvent(QEvent.HoverEnter))
+    expected_image = load_icon('download_file.gif').pixmap(20, 20).toImage()
+    assert download_button.icon().pixmap(20, 20).toImage() == expected_image
+    assert '#05a6fe' == download_button.palette().color(QPalette.Foreground).name()
+
+    file_widget.eventFilter(download_button, QEvent(QEvent.HoverLeave))
+    expected_image = load_icon('download_file.gif').pixmap(20, 20).toImage()
+    assert download_button.icon().pixmap(20, 20).toImage() == expected_image
+    assert '#05a6fe' == download_button.palette().color(QPalette.Foreground).name()

--- a/tests/integration/test_styles_modal_dialog_button.py
+++ b/tests/integration/test_styles_modal_dialog_button.py
@@ -1,0 +1,18 @@
+from PyQt5.QtGui import QPalette
+
+
+def test_styles_for_modal_dialog(modal_dialog):
+    continue_button = modal_dialog.continue_button
+    assert '#ffffff' == continue_button.palette().color(QPalette.Foreground).name()
+    assert '#2a319d' == continue_button.palette().color(QPalette.Background).name()
+    continue_button.setEnabled(False)
+    assert '#e1e2f1' == continue_button.palette().color(QPalette.Foreground).name()
+    assert '#c2c4e3' == continue_button.palette().color(QPalette.Background).name()
+    modal_dialog.start_animate_activestate()
+    assert '#ffffff' == continue_button.palette().color(QPalette.Foreground).name()
+    assert '#f1f1f6' == continue_button.palette().color(QPalette.Background).name()
+    # assert border: 2px solid #f1f1f6;
+    # assert margin: 0px 0px 0px 12px;
+    # assert height: 40px;
+    # assert padding-left: 20px;
+    # assert padding-right: 20px;

--- a/tests/integration/test_styles_modal_dialog_button.py
+++ b/tests/integration/test_styles_modal_dialog_button.py
@@ -1,18 +1,23 @@
 from PyQt5.QtGui import QPalette
 
 
-def test_styles_for_modal_dialog(modal_dialog):
+def test_styles(modal_dialog):
     continue_button = modal_dialog.continue_button
+
     assert '#ffffff' == continue_button.palette().color(QPalette.Foreground).name()
     assert '#2a319d' == continue_button.palette().color(QPalette.Background).name()
+
     continue_button.setEnabled(False)
+
     assert '#e1e2f1' == continue_button.palette().color(QPalette.Foreground).name()
     assert '#c2c4e3' == continue_button.palette().color(QPalette.Background).name()
+
     modal_dialog.start_animate_activestate()
+
     assert '#ffffff' == continue_button.palette().color(QPalette.Foreground).name()
     assert '#f1f1f6' == continue_button.palette().color(QPalette.Background).name()
     # assert border: 2px solid #f1f1f6;
-    # assert margin: 0px 0px 0px 12px;
-    # assert height: 40px;
+    # assert (12, 0, 0, 0) == continue_button.getContentsMargins()
+    # assert 40 == continue_button.height()
     # assert padding-left: 20px;
     # assert padding-right: 20px;

--- a/tests/integration/test_styles_modal_dialog_error_details.py
+++ b/tests/integration/test_styles_modal_dialog_error_details.py
@@ -1,14 +1,17 @@
 from PyQt5.QtGui import QPalette
 
 
-def test_styles_for_modal_dialog(modal_dialog):
+def test_styles(modal_dialog):
     error_details = modal_dialog.error_details
-    # assert margin: 0px 40px 0px 36px;
+
+    assert (36, 0, 40, 0) == error_details.getContentsMargins()
     assert '#ff0064' == error_details.palette().color(QPalette.Foreground).name()
     assert 'Montserrat' == error_details.font().family()
     assert 16 == error_details.font().pixelSize()
+
     modal_dialog.start_animate_activestate()
-    # assert margin: 0px 40px 0px 36px;
+
+    assert (36, 0, 40, 0) == error_details.getContentsMargins()
     assert '#ff66c4' == error_details.palette().color(QPalette.Foreground).name()
     assert 'Montserrat' == error_details.font().family()
     assert 16 == error_details.font().pixelSize()

--- a/tests/integration/test_styles_modal_dialog_error_details.py
+++ b/tests/integration/test_styles_modal_dialog_error_details.py
@@ -1,0 +1,14 @@
+from PyQt5.QtGui import QPalette
+
+
+def test_styles_for_modal_dialog(modal_dialog):
+    error_details = modal_dialog.error_details
+    # assert margin: 0px 40px 0px 36px;
+    assert '#ff0064' == error_details.palette().color(QPalette.Foreground).name()
+    assert 'Montserrat' == error_details.font().family()
+    assert 16 == error_details.font().pixelSize()
+    modal_dialog.start_animate_activestate()
+    # assert margin: 0px 40px 0px 36px;
+    assert '#ff66c4' == error_details.palette().color(QPalette.Foreground).name()
+    assert 'Montserrat' == error_details.font().family()
+    assert 16 == error_details.font().pixelSize()

--- a/tests/integration/test_styles_reply_message.py
+++ b/tests/integration/test_styles_reply_message.py
@@ -1,0 +1,32 @@
+from PyQt5.QtGui import QFont, QPalette
+
+
+def test_styles_for_conversation_view(mocker, main_window):
+    wrapper = main_window.main_view.view_layout.itemAt(0).widget()
+    conversation_scrollarea = wrapper.conversation_view.scroll
+    reply_widget = conversation_scrollarea.widget().layout().itemAt(2).widget()
+    assert 540 == reply_widget.message.minimumSize().width()  # 508px + 32px padding
+    assert 540 == reply_widget.message.maximumSize().width()  # 508px + 32px padding
+    assert 'Source Sans Pro' == reply_widget.message.font().family()
+    assert QFont.Normal == reply_widget.message.font().weight()
+    assert 15 == reply_widget.message.font().pixelSize()
+    assert '#3b3b3b' == reply_widget.message.palette().color(QPalette.Foreground).name()
+    assert '#ffffff' == reply_widget.message.palette().color(QPalette.Background).name()
+
+    reply_widget._set_reply_state('PENDING')
+    assert 540 == reply_widget.message.minimumSize().width()  # 508px + 32px padding
+    assert 540 == reply_widget.message.maximumSize().width()  # 508px + 32px padding
+    assert 'Source Sans Pro' == reply_widget.message.font().family()
+    assert QFont.Normal == reply_widget.message.font().weight()
+    assert 15 == reply_widget.message.font().pixelSize()
+    assert '#a9aaad' == reply_widget.message.palette().color(QPalette.Foreground).name()
+    assert '#f7f8fc' == reply_widget.message.palette().color(QPalette.Background).name()
+
+    reply_widget._set_reply_state('FAILED')
+    assert 540 == reply_widget.message.minimumSize().width()  # 508px + 32px padding
+    assert 540 == reply_widget.message.maximumSize().width()  # 508px + 32px padding
+    assert 'Source Sans Pro' == reply_widget.message.font().family()
+    assert QFont.Normal == reply_widget.message.font().weight()
+    assert 15 == reply_widget.message.font().pixelSize()
+    assert '#3b3b3b' == reply_widget.message.palette().color(QPalette.Foreground).name()
+    assert '#ffffff' == reply_widget.message.palette().color(QPalette.Background).name()

--- a/tests/integration/test_styles_reply_message.py
+++ b/tests/integration/test_styles_reply_message.py
@@ -1,10 +1,11 @@
 from PyQt5.QtGui import QFont, QPalette
 
 
-def test_styles_for_conversation_view(mocker, main_window):
+def test_styles(mocker, main_window):
     wrapper = main_window.main_view.view_layout.itemAt(0).widget()
     conversation_scrollarea = wrapper.conversation_view.scroll
     reply_widget = conversation_scrollarea.widget().layout().itemAt(2).widget()
+
     assert 540 == reply_widget.message.minimumSize().width()  # 508px + 32px padding
     assert 540 == reply_widget.message.maximumSize().width()  # 508px + 32px padding
     assert 'Source Sans Pro' == reply_widget.message.font().family()
@@ -14,6 +15,7 @@ def test_styles_for_conversation_view(mocker, main_window):
     assert '#ffffff' == reply_widget.message.palette().color(QPalette.Background).name()
 
     reply_widget._set_reply_state('PENDING')
+
     assert 540 == reply_widget.message.minimumSize().width()  # 508px + 32px padding
     assert 540 == reply_widget.message.maximumSize().width()  # 508px + 32px padding
     assert 'Source Sans Pro' == reply_widget.message.font().family()
@@ -23,6 +25,7 @@ def test_styles_for_conversation_view(mocker, main_window):
     assert '#f7f8fc' == reply_widget.message.palette().color(QPalette.Background).name()
 
     reply_widget._set_reply_state('FAILED')
+
     assert 540 == reply_widget.message.minimumSize().width()  # 508px + 32px padding
     assert 540 == reply_widget.message.maximumSize().width()  # 508px + 32px padding
     assert 'Source Sans Pro' == reply_widget.message.font().family()

--- a/tests/integration/test_styles_reply_status_bar.py
+++ b/tests/integration/test_styles_reply_status_bar.py
@@ -1,22 +1,25 @@
 from PyQt5.QtGui import QPalette
 
 
-def test_styles_for_conversation_view(mocker, main_window):
+def test_styles(mocker, main_window):
     wrapper = main_window.main_view.view_layout.itemAt(0).widget()
     conversation_scrollarea = wrapper.conversation_view.scroll
     reply_widget = conversation_scrollarea.widget().layout().itemAt(2).widget()
+
     assert 5 == reply_widget.color_bar.minimumSize().height()
     assert 5 == reply_widget.color_bar.maximumSize().height()
     assert '#0065db' == reply_widget.color_bar.palette().color(QPalette.Background).name()
     # assert border: 0px;
 
     reply_widget._set_reply_state('PENDING')
+
     assert 5 == reply_widget.color_bar.minimumSize().height()
     assert 5 == reply_widget.color_bar.maximumSize().height()
     assert '#0065db' == reply_widget.color_bar.palette().color(QPalette.Background).name()
     # assert border: 0px;
 
     reply_widget._set_reply_state('FAILED')
+
     assert 5 == reply_widget.color_bar.minimumSize().height()
     assert 5 == reply_widget.color_bar.maximumSize().height()
     assert '#ff3366' == reply_widget.color_bar.palette().color(QPalette.Background).name()

--- a/tests/integration/test_styles_reply_status_bar.py
+++ b/tests/integration/test_styles_reply_status_bar.py
@@ -1,0 +1,23 @@
+from PyQt5.QtGui import QPalette
+
+
+def test_styles_for_conversation_view(mocker, main_window):
+    wrapper = main_window.main_view.view_layout.itemAt(0).widget()
+    conversation_scrollarea = wrapper.conversation_view.scroll
+    reply_widget = conversation_scrollarea.widget().layout().itemAt(2).widget()
+    assert 5 == reply_widget.color_bar.minimumSize().height()
+    assert 5 == reply_widget.color_bar.maximumSize().height()
+    assert '#0065db' == reply_widget.color_bar.palette().color(QPalette.Background).name()
+    # assert border: 0px;
+
+    reply_widget._set_reply_state('PENDING')
+    assert 5 == reply_widget.color_bar.minimumSize().height()
+    assert 5 == reply_widget.color_bar.maximumSize().height()
+    assert '#0065db' == reply_widget.color_bar.palette().color(QPalette.Background).name()
+    # assert border: 0px;
+
+    reply_widget._set_reply_state('FAILED')
+    assert 5 == reply_widget.color_bar.minimumSize().height()
+    assert 5 == reply_widget.color_bar.maximumSize().height()
+    assert '#ff3366' == reply_widget.color_bar.palette().color(QPalette.Background).name()
+    # assert border: 0px;

--- a/tests/integration/test_styles_sdclient.py
+++ b/tests/integration/test_styles_sdclient.py
@@ -1,0 +1,612 @@
+from PyQt5.QtCore import QEvent
+from PyQt5.QtGui import QFont, QPalette
+from PyQt5.QtWidgets import QLabel, QLineEdit, QPushButton, QWidget
+
+
+def test_css(main_window):
+    assert 'LoginDialog_form' in main_window.styleSheet()
+
+
+def test_class_name_matches_css_object_name(mocker, main_window):
+    # Login Dialog
+    login_dialog = main_window.login_dialog
+    assert 'LoginDialog' == login_dialog.__class__.__name__
+    form = login_dialog.layout().itemAt(2).widget()
+    assert 'LoginDialog' in form.objectName()
+    app_version_label = login_dialog.layout().itemAt(4).widget().layout().itemAt(0).widget()
+    assert 'LoginDialog' in app_version_label.objectName()
+    login_offline_link = login_dialog.offline_mode
+    assert 'LoginOfflineLink' == login_offline_link.__class__.__name__
+    assert 'LoginOfflineLink' == login_offline_link.objectName()
+    login_button = login_dialog.submit
+    assert 'SignInButton' == login_button.__class__.__name__
+    assert 'SignInButton' in login_button.objectName()
+    login_error_bar = login_dialog.error_bar
+    assert 'LoginErrorBar' == login_error_bar.__class__.__name__
+    assert 'LoginErrorBar' in login_error_bar.objectName()
+    assert 'LoginErrorBar' in login_error_bar.error_icon.objectName()
+    assert 'LoginErrorBar' in login_error_bar.error_status_bar.objectName()
+
+    # Top Pane
+    sync_icon = main_window.top_pane.sync_icon
+    assert 'SyncIcon' == sync_icon.__class__.__name__
+    assert 'SyncIcon' == sync_icon.objectName()
+    activity_status_bar = main_window.top_pane.activity_status_bar
+    assert 'ActivityStatusBar' == activity_status_bar.__class__.__name__
+    assert 'ActivityStatusBar' == activity_status_bar.objectName()
+    error_status_bar = main_window.top_pane.error_status_bar
+    assert 'ErrorStatusBar' == error_status_bar.__class__.__name__
+    assert 'ErrorStatusBar' in error_status_bar.vertical_bar.objectName()
+    assert 'ErrorStatusBar' in error_status_bar.label.objectName()
+    assert 'ErrorStatusBar' in error_status_bar.status_bar.objectName()
+
+    # Left Pane
+    user_profile = main_window.left_pane.user_profile
+    assert 'UserProfile' == user_profile.__class__.__name__
+    assert 'UserProfile' == user_profile.objectName()
+    assert 'UserProfile' in user_profile.user_icon.objectName()
+    user_button = user_profile.user_button
+    assert 'UserButton' == user_button.__class__.__name__
+    assert 'UserButton' == user_button.objectName()
+    login_button = user_profile.login_button
+    assert 'LoginButton' == login_button.__class__.__name__
+    assert 'LoginButton' == login_button.objectName()
+
+    # Main View
+    main_view = main_window.main_view
+    assert 'MainView' == main_view.__class__.__name__
+    assert 'MainView' == main_view.objectName()
+    assert 'MainView' in main_view.view_holder.objectName()
+    empty_conversation_view = main_view.empty_conversation_view
+    'EmptyConversationView' == empty_conversation_view.__class__.__name__
+    'EmptyConversationView' == empty_conversation_view.objectName()
+    'EmptyConversationView' in empty_conversation_view.no_sources.objectName()
+    'EmptyConversationView' in empty_conversation_view.no_source_selected.objectName()
+    source_list = main_view.source_list
+    'SourceList' == source_list.__class__.__name__
+    'SourceList' == source_list.objectName()
+
+    source_widget = source_list.itemWidget(source_list.item(0))
+    assert 'SourceWidget' == source_widget.__class__.__name__
+    assert 'SourceWidget' in source_widget.gutter.objectName()
+    assert 'SourceWidget' in source_widget.summary.objectName()
+    assert 'SourceWidget' in source_widget.name.objectName()
+    assert 'SourceWidget' in source_widget.preview.objectName()
+    assert 'SourceWidget' in source_widget.waiting_delete_confirmation.objectName()
+    assert 'SourceWidget' in source_widget.metadata.objectName()
+    assert 'SourceWidget' in source_widget.paperclip.objectName()
+    assert 'SourceWidget' in source_widget.timestamp.objectName()
+    assert 'SourceWidget' in source_widget.source_widget.objectName()
+    star = source_widget.star
+    assert 'StarToggleButton' == star.__class__.__name__
+    assert 'StarToggleButton' in star.objectName()
+
+    wrapper = main_view.view_layout.itemAt(0).widget()
+    assert 'SourceConversationWrapper' == wrapper.__class__.__name__
+    assert 'SourceConversationWrapper' in wrapper.waiting_delete_confirmation.objectName()
+    reply_box = wrapper.reply_box
+    assert 'ReplyBoxWidget' == reply_box.__class__.__name__
+    assert 'ReplyBoxWidget' == reply_box.objectName()
+    horizontal_line = reply_box.layout().itemAt(0).widget()
+    assert 'ReplyBoxWidget' in horizontal_line.objectName()
+    assert 'ReplyBoxWidget' in reply_box.replybox.objectName()
+    reply_text_edit = reply_box.text_edit
+    assert 'ReplyTextEdit' == reply_text_edit.__class__.__name__
+    assert 'ReplyTextEdit' == reply_text_edit.objectName()
+    assert 'ReplyTextEdit' in reply_text_edit.placeholder.objectName()
+    conversation_title_bar = wrapper.conversation_title_bar
+    assert 'SourceProfileShortWidget' == conversation_title_bar.__class__.__name__
+    horizontal_line = conversation_title_bar.layout().itemAt(1).widget()
+    assert 'SourceProfileShortWidget' in horizontal_line.objectName()
+    menu = conversation_title_bar.layout().itemAt(0).widget().layout().itemAt(3).widget()
+    assert 'SourceMenuButton' in menu.objectName()
+    last_updated_label = conversation_title_bar.updated
+    assert 'LastUpdatedLabel' in last_updated_label.objectName()
+    title = conversation_title_bar.layout().itemAt(0).widget().layout().itemAt(0).widget()
+    assert 'TitleLabel' in title.objectName()
+    conversation_scroll_area = wrapper.conversation_view.scroll
+    assert 'ConversationScrollArea' == conversation_scroll_area.__class__.__name__
+    assert 'ConversationScrollArea' in conversation_scroll_area.widget().objectName()
+    file_widget = conversation_scroll_area.widget().layout().itemAt(0).widget()
+    assert 'FileWidget' == file_widget.__class__.__name__
+    message_widget = conversation_scroll_area.widget().layout().itemAt(1).widget()
+    assert 'MessageWidget' == message_widget.__class__.__name__
+    assert 'SpeechBubble' in message_widget.speech_bubble.objectName()
+    reply_widget = conversation_scroll_area.widget().layout().itemAt(2).widget()
+    assert 'ReplyWidget' == reply_widget.__class__.__name__
+    assert 'SpeechBubble' in reply_widget.speech_bubble.objectName()
+    error_message = reply_widget.error.layout().itemAt(0).widget()
+    assert 'ReplyWidget' in error_message.objectName()
+
+
+def test_class_name_matches_css_object_name_for_print_dialog(print_dialog):
+    assert 'PrintDialog' == print_dialog.__class__.__name__
+
+
+def test_class_name_matches_css_object_name_for_export_dialog(export_dialog):
+    assert 'ExportDialog' == export_dialog.__class__.__name__
+    assert 'ExportDialog' in export_dialog.passphrase_form.objectName()
+
+
+def test_class_name_matches_css_object_name_for_modal_dialog(modal_dialog):
+    assert 'ModalDialog' in modal_dialog.header_icon.objectName()
+    assert 'ModalDialog' in modal_dialog.header_spinner_label.objectName()
+    assert 'ModalDialog' in modal_dialog.header.objectName()
+    assert 'ModalDialog' in modal_dialog.header_line.objectName()
+    assert 'ModalDialog' in modal_dialog.error_details.objectName()
+    assert 'ModalDialog' in modal_dialog.body.objectName()
+    assert 'ModalDialog' in modal_dialog.body.objectName()
+    assert 'ModalDialog' in modal_dialog.continue_button.objectName()
+    window_buttons = modal_dialog.layout().itemAt(5).widget()
+    assert 'ModalDialog' in window_buttons.objectName()
+    button_box = window_buttons.layout().itemAt(0).widget()
+    assert 'ModalDialog' in button_box.objectName()
+
+
+def test_styles_for_login_dialog(mocker, main_window):
+    login_dialog = main_window.login_dialog
+    form = login_dialog.layout().itemAt(2).widget()
+    form_children_qlabel = form.findChildren(QLabel)
+    for c in form_children_qlabel:
+        assert 'Montserrat' == c.font().family()
+        # TODO: Figure out why font size is QFont.DemiBold - 1
+        assert QFont.DemiBold - 1 == c.font().weight()
+        assert 13 == c.font().pixelSize()
+        assert '#ffffff' == c.palette().color(QPalette.Foreground).name()
+    form_children_qlineedit = form.findChildren(QLineEdit)
+    for c in form_children_qlineedit:
+        assert 30 == c.height()  # 30px + 0px margin
+        # assert `border-radius: 0px;`
+        # assert `padding-left: 5px;`
+    app_version_label = login_dialog.layout().itemAt(4).widget().layout().itemAt(0).widget()
+    assert '#9fddff' == app_version_label.palette().color(QPalette.Foreground).name()
+
+    login_offline_link = login_dialog.offline_mode
+    assert '#ffffff' == login_offline_link.palette().color(QPalette.Foreground).name()
+    # assert `border: none;`
+    # assert `text-decoration: underline;
+
+    login_button = login_dialog.submit
+    # assert `border: none;`
+    assert 'Montserrat' == login_button.font().family()
+    assert QFont.Bold == login_button.font().weight()
+    assert 14 == login_button.font().pixelSize()
+    assert '#2a319d' == login_button.palette().color(QPalette.Foreground).name()
+    assert '#05edfe' == login_button.palette().color(QPalette.Background).name()
+    # assert `background-color: #85f6fe;` when button is pressed
+
+    login_error_bar = login_dialog.error_bar
+    login_error_bar_children = login_error_bar.findChildren(QWidget)
+    for c in login_error_bar_children:
+        assert '#ce0083' == c.palette().color(QPalette.Background).name()
+    assert '#ffffff' == login_error_bar.error_icon.palette().color(QPalette.Foreground).name()
+    assert '#ffffff' == login_error_bar.error_status_bar.palette().color(QPalette.Foreground).name()
+
+
+def test_styles_for_top_pane(mocker, main_window):
+    sync_icon = main_window.top_pane.sync_icon
+    assert '#ffffff' == sync_icon.palette().color(QPalette.Base).name()
+    # assert 'border: none;' for sync_icon
+    activity_status_bar = main_window.top_pane.activity_status_bar
+    assert 'Source Sans Pro' == activity_status_bar.font().family()
+    assert QFont.Bold == activity_status_bar.font().weight()
+    assert 12 == activity_status_bar.font().pixelSize()
+    assert '#ffffff' == activity_status_bar.palette().color(QPalette.Base).name()
+    assert '#d3d8ea' == activity_status_bar.palette().color(QPalette.Foreground).name()
+    error_status_bar = main_window.top_pane.error_status_bar
+    assert '#ff3366' == error_status_bar.vertical_bar.palette().color(QPalette.Background).name()
+    # assert 'background-color: qlineargradient(...' for vertical_bar
+    # assert 'background-color: qlineargradient(...'' for status_bar
+    assert 'Source Sans Pro' == error_status_bar.status_bar.font().family()
+    assert QFont.Normal == error_status_bar.status_bar.font().weight()
+    assert 14 == error_status_bar.status_bar.font().pixelSize()
+    assert '#0c3e75' == error_status_bar.status_bar.palette().color(QPalette.Foreground).name()
+
+
+def test_styles_for_left_pane(mocker, main_window):
+    user_profile = main_window.left_pane.user_profile
+    # assert 'padding: 15px;'
+    assert '#9211ff' == user_profile.user_icon.palette().color(QPalette.Background).name()
+    # assert 'border: none;' for user_icon
+    # assert 'padding-left: 3px;' for user_icon
+    # assert 'padding-bottom: 4px;' for user_icon
+    assert 'Source Sans Pro' == user_profile.user_icon.font().family()
+    assert QFont.Bold == user_profile.user_icon.font().weight()
+    assert 15 == user_profile.user_icon.font().pixelSize()
+    assert '#ffffff' == user_profile.user_icon.palette().color(QPalette.Foreground).name()
+    user_button = user_profile.user_button
+    # assert 'border: none;'
+    assert 'Source Sans Pro' == user_button.font().family()
+    assert QFont.Black == user_button.font().weight()
+    assert 12 == user_button.font().pixelSize()
+    assert '#ffffff' == user_button.palette().color(QPalette.Foreground).name()
+    # assert 'text-align: left;'
+    # assert 'outline: none;' for focus
+    # assert 'image: none;' for menu-indicator
+    login_button = user_profile.login_button
+    # assert 'border: none;'
+    assert '#05edfe' == login_button.palette().color(QPalette.Background).name()
+    assert 'Montserrat' == login_button.font().family()
+    assert QFont.Bold == login_button.font().weight()
+    assert 14 == login_button.font().pixelSize()
+    assert '#2a319d' == login_button.palette().color(QPalette.Foreground).name()
+    # assert 'background-color: #85f6fe;' for pressed
+
+
+def test_styles_for_main_view(mocker, main_window):
+    main_view = main_window.main_view
+    assert 558 == main_view.height()
+    assert 667 == main_view.view_holder.width()
+    # assert 'border: none;' for view_holder
+    assert '#f3f5f9' == main_view.view_holder.palette().color(QPalette.Background).name()
+
+    no_sources = main_view.empty_conversation_view.no_sources
+    assert 5 == no_sources.layout().count()
+    no_sources_instructions = no_sources.layout().itemAt(0).widget()
+    assert 'Montserrat' == no_sources_instructions.font().family()
+    assert QFont.DemiBold - 1 == no_sources_instructions.font().weight()
+    assert 35 == no_sources_instructions.font().pixelSize()
+    assert '#a5b3e9' == no_sources_instructions.palette().color(QPalette.Foreground).name()
+    assert 520 == no_sources_instructions.minimumWidth()
+    assert 600 == no_sources_instructions.maximumWidth()
+    no_sources_spacer1 = no_sources.layout().itemAt(1)
+    assert 35 == no_sources_spacer1.minimumSize().height()
+    assert 35 == no_sources_spacer1.maximumSize().height()
+    no_sources_instruction_details1 = no_sources.layout().itemAt(2).widget()
+    assert 'Montserrat' == no_sources_instruction_details1.font().family()
+    assert QFont.Normal == no_sources_instruction_details1.font().weight()
+    assert 35 == no_sources_instruction_details1.font().pixelSize()
+    assert '#a5b3e9' == no_sources_instruction_details1.palette().color(QPalette.Foreground).name()
+    no_sources_spacer2 = no_sources.layout().itemAt(3)
+    assert 35 == no_sources_spacer2.minimumSize().height()
+    assert 35 == no_sources_spacer2.maximumSize().height()
+    no_sources_instruction_details2 = no_sources.layout().itemAt(4).widget()
+    assert 'Montserrat' == no_sources_instruction_details2.font().family()
+    assert QFont.Normal == no_sources_instruction_details2.font().weight()
+    assert 35 == no_sources_instruction_details2.font().pixelSize()
+    assert '#a5b3e9' == no_sources_instruction_details2.palette().color(QPalette.Foreground).name()
+
+    no_source_selected = main_view.empty_conversation_view.no_source_selected
+    assert 6 == no_source_selected.layout().count()
+    no_source_selected_instructions = no_source_selected.layout().itemAt(0).widget()
+    assert 'Montserrat' == no_source_selected_instructions.font().family()
+    assert QFont.DemiBold - 1 == no_source_selected_instructions.font().weight()
+    assert 35 == no_source_selected_instructions.font().pixelSize()
+    assert '#a5b3e9' == no_source_selected_instructions.palette().color(QPalette.Foreground).name()
+    assert 520 == no_source_selected_instructions.minimumWidth()
+    assert 520 == no_source_selected_instructions.maximumWidth()
+    no_source_selected_spacer1 = no_source_selected.layout().itemAt(1)
+    assert 35 == no_source_selected_spacer1.minimumSize().height()
+    assert 35 == no_source_selected_spacer1.maximumSize().height()
+    bullet1_bullet = no_source_selected.layout().itemAt(2).widget().layout().itemAt(0).widget()
+    # assert 'margin: 4px 0px 0px 0px;'
+    35 == bullet1_bullet.font().pixelSize()
+    QFont.Bold == bullet1_bullet.font().weight()
+    assert 'Montserrat' == bullet1_bullet.font().family()
+    assert '#a5b3e9' == bullet1_bullet.palette().color(QPalette.Foreground).name()
+    bullet2_bullet = no_source_selected.layout().itemAt(3).widget().layout().itemAt(0).widget()
+    # assert 'margin: 4px 0px 0px 0px;'
+    35 == bullet2_bullet.font().pixelSize()
+    QFont.Bold == bullet2_bullet.font().weight()
+    assert 'Montserrat' == bullet2_bullet.font().family()
+    assert '#a5b3e9' == bullet2_bullet.palette().color(QPalette.Foreground).name()
+    bullet3_bullet = no_source_selected.layout().itemAt(4).widget().layout().itemAt(0).widget()
+    # assert 'margin: 4px 0px 0px 0px;'
+    35 == bullet3_bullet.font().pixelSize()
+    QFont.Bold == bullet3_bullet.font().weight()
+    assert 'Montserrat' == bullet3_bullet.font().family()
+    assert '#a5b3e9' == bullet3_bullet.palette().color(QPalette.Foreground).name()
+    no_source_selected_spacer2 = no_source_selected.layout().itemAt(5)
+    assert (35 * 4) == no_source_selected_spacer2.minimumSize().height()
+    assert (35 * 4) == no_source_selected_spacer2.maximumSize().height()
+
+
+def test_styles_source_list(mocker, main_window):
+    source_list = main_window.main_view.source_list
+    # assert 'border: none;'
+    # assert 'show-decoration-selected: 0;'
+    # assert 'border-right: 3px solid #f3f5f9;'
+    source_widget = source_list.itemWidget(source_list.item(0))
+    # source_list.setCurrentItem(source_list.item(0))
+    # assert '#f3f5f9' == source_list.item(0).palette().color(QPalette.Background).name()
+    # assert 'border: 500px solid #f9f9f9;' on item hover
+    # assert 'border-bottom: 1px solid #9b9b9b;' on source_widget (SourceWidget_container)
+    assert 40 == source_widget.gutter.minimumSize().width()
+    assert 40 == source_widget.gutter.maximumSize().width()
+    assert 60 == source_widget.metadata.maximumSize().width()
+    preview = source_widget.preview
+    assert 'Source Sans Pro' == preview.font().family()
+    QFont.Normal == preview.font().weight()
+    13 == preview.font().pixelSize()
+    assert '#383838' == preview.palette().color(QPalette.Foreground).name()
+    waiting_delete_confirmation = source_widget.waiting_delete_confirmation
+    assert 'Source Sans Pro' == waiting_delete_confirmation.font().family()
+    QFont.Normal == waiting_delete_confirmation.font().weight()
+    13 == waiting_delete_confirmation.font().pixelSize()
+    assert '#ff3366' == waiting_delete_confirmation.palette().color(QPalette.Foreground).name()
+    name = source_widget.name
+    assert 'Montserrat' == name.font().family()
+    QFont.Normal == name.font().weight()
+    13 == name.font().pixelSize()
+    assert '#383838' == name.palette().color(QPalette.Foreground).name()
+    timestamp = source_widget.timestamp
+    assert 'Montserrat' == timestamp.font().family()
+    QFont.Normal == timestamp.font().weight()
+    13 == timestamp.font().pixelSize()
+    assert '#383838' == timestamp.palette().color(QPalette.Foreground).name()
+    # star = source_widget.star
+    # assert 'border: none;'
+
+
+def test_styles_for_conversation_view(mocker, main_window):
+    wrapper = main_window.main_view.view_layout.itemAt(0).widget()
+    waiting_delete_confirmation = wrapper.waiting_delete_confirmation
+    assert 'Montserrat' == waiting_delete_confirmation.font().family()
+    assert QFont.DemiBold - 1 == waiting_delete_confirmation.font().weight()
+    assert 40 == waiting_delete_confirmation.font().pixelSize()
+    assert '#a5b3e9' == waiting_delete_confirmation.palette().color(QPalette.Foreground).name()
+    # assert 'text-align: left;'
+    # assert 'padding-bottom: 264px;'
+    # assert 'padding-right: 195px;'
+    reply_box = wrapper.reply_box
+    assert 173 == reply_box.minimumSize().height()
+    assert 173 == reply_box.maximumSize().height()
+    assert '#efefef' == reply_box.replybox.palette().color(QPalette.Background).name()
+    reply_box.set_logged_in()
+    assert '#ffffff' == reply_box.replybox.palette().color(QPalette.Background).name()
+    reply_box_children = reply_box.findChildren(QPushButton)
+    hover = QEvent(QEvent.HoverEnter)
+    for c in reply_box_children:
+        # assert 'border: none;' for QPushButton
+        c.eventFilter(c, hover)
+        # assert '#d3d8ea'== c.palette().color(QPalette.Background).name()
+        # assert 'border-radius: 8px; for QPushButton on hover
+    horizontal_line = reply_box.layout().itemAt(0).widget()
+    assert 2 == horizontal_line.minimumSize().height()
+    assert 2 == horizontal_line.maximumSize().height()
+    # assert 'background-color: rgba(42, 49, 157, 0.15);' for horizontal_line
+    # assert 'border: none;' for horizontal line
+    reply_text_edit = reply_box.text_edit
+    assert 'Montserrat' == reply_text_edit.font().family()
+    assert QFont.Normal == reply_text_edit.font().weight()
+    assert 18 == reply_text_edit.font().pixelSize()
+    # assert 'border: none;'
+    # assert 'margin-right: 30.2px;'
+    assert 'Montserrat' == reply_text_edit.placeholder.font().family()
+    assert QFont.Normal == reply_text_edit.placeholder.font().weight()
+    assert 18 == reply_text_edit.placeholder.font().pixelSize()
+    '#404040' == reply_text_edit.placeholder.palette().color(QPalette.Foreground).name()
+    # assert 'color: rgba(42, 49, 157, 0.6);' when placeholder disabled
+
+    conversation_title_bar = wrapper.conversation_title_bar
+    horizontal_line = conversation_title_bar.layout().itemAt(1).widget()
+    assert 2 == horizontal_line.minimumSize().height()
+    assert 2 == horizontal_line.maximumSize().height()
+    # assert 'background-color: rgba(42, 49, 157, 0.15);'
+    # assert 'padding-left: 12px;'
+    # assert 'padding-right: 12px;'
+    # menu = conversation_title_bar.layout().itemAt(0).widget().layout().itemAt(3).widget()
+    # assert 'border: none;'
+    # assert 'margin: 5px 0px 0px 0px;'
+    # assert 'padding-left: 8px;'
+    # assert 'image: none;' for 'menu-indicator'
+    last_updated_label = conversation_title_bar.updated
+    assert 'Montserrat' == last_updated_label.font().family()
+    assert QFont.Light == last_updated_label.font().weight()
+    assert 24 == last_updated_label.font().pixelSize()
+    assert '#2a319d' == last_updated_label.palette().color(QPalette.Foreground).name()
+
+    title = conversation_title_bar.layout().itemAt(0).widget().layout().itemAt(0).widget()
+    assert 'Montserrat' == title.font().family()
+    assert QFont.Normal == title.font().weight()
+    assert 24 == title.font().pixelSize()
+    assert '#2a319d' == title.palette().color(QPalette.Foreground).name()
+    # assert 'padding-left: 4px;' for title
+
+    conversation_scrollarea = wrapper.conversation_view.scroll
+    assert '#f3f5f9' == conversation_scrollarea.palette().color(QPalette.Background).name()
+    # assert 'border: none;' for conversation_scrollarea
+    assert '#f3f5f9' == conversation_scrollarea.widget().palette().color(QPalette.Background).name()
+    file_widget = conversation_scrollarea.widget().layout().itemAt(0).widget()
+    assert 540 == file_widget.minimumSize().width()
+    assert 540 == file_widget.maximumSize().width()
+    assert 137 == file_widget.file_options.minimumSize().width()
+    assert 'Source Sans Pro' == file_widget.export_button.font().family()
+    assert QFont.DemiBold - 1 == file_widget.export_button.font().weight()
+    assert 13 == file_widget.export_button.font().pixelSize()
+    assert '#2a319d' == file_widget.export_button.palette().color(QPalette.Foreground).name()
+    # assert 'border: none;' for export_print
+    assert 'Source Sans Pro' == file_widget.file_name.font().family()
+    assert QFont.Bold == file_widget.file_name.font().weight()
+    assert 13 == file_widget.file_name.font().pixelSize()
+    assert '#2a319d' == file_widget.file_name.palette().color(QPalette.Foreground).name()
+    # hover = QEvent(QEvent.HoverEnter)
+    # file_widget.file_name.eventFilter(file_widget.file_name, hover)
+    # assert '#05a6fe'== file_widget.file_name.palette().color(QPalette.Foreground).name()
+    assert 'Source Sans Pro' == file_widget.no_file_name.font().family()
+    # TODO: Figure out why font size is QFont.Light + 12
+    assert QFont.Light + 12 == file_widget.no_file_name.font().weight()
+    assert 13 == file_widget.no_file_name.font().pixelSize()
+    assert '#a5b3e9' == file_widget.no_file_name.palette().color(QPalette.Foreground).name()
+
+    assert 48 == file_widget.file_size.minimumSize().width()
+    assert 48 == file_widget.file_size.maximumSize().width()
+    assert 'Source Sans Pro' == file_widget.file_size.font().family()
+    assert QFont.Normal == file_widget.file_size.font().weight()
+    assert 13 == file_widget.file_size.font().pixelSize()
+    assert '#2a319d' == file_widget.file_size.palette().color(QPalette.Foreground).name()
+
+    assert 2 == file_widget.horizontal_line.minimumSize().height()  # 2px + 0px margin
+    assert 2 == file_widget.horizontal_line.maximumSize().height()  # 2px + 0px margin
+    # assert 'background-color: rgba(211, 216, 234, 0.45);' for horizontal_line'
+    # assert 8px left-margin and right-margin for horizontal_line
+
+    message_widget = conversation_scrollarea.widget().layout().itemAt(1).widget()
+    assert 540 == message_widget.speech_bubble.minimumSize().width()
+    assert 540 == message_widget.speech_bubble.maximumSize().width()
+    assert '#ffffff' == message_widget.speech_bubble.palette().color(QPalette.Background).name()
+    reply_widget = conversation_scrollarea.widget().layout().itemAt(2).widget()
+    assert 540 == reply_widget.speech_bubble.minimumSize().width()
+    assert 540 == reply_widget.speech_bubble.maximumSize().width()
+    assert '#ffffff' == reply_widget.speech_bubble.palette().color(QPalette.Background).name()
+    reply_widget_error_message = reply_widget.error.layout().itemAt(0).widget()
+    assert 'Source Sans Pro' == reply_widget_error_message.font().family()
+    assert QFont.DemiBold - 1 == reply_widget_error_message.font().weight()
+    assert 13 == reply_widget_error_message.font().pixelSize()
+    assert '#ff3366' == reply_widget_error_message.palette().color(QPalette.Foreground).name()
+
+
+def test_styles_for_modal_dialog(modal_dialog):
+    assert 800 == modal_dialog.minimumSize().width()
+    assert 800 == modal_dialog.maximumSize().width()
+    assert 300 == modal_dialog.minimumSize().height()
+    assert 800 == modal_dialog.maximumSize().height()
+    assert '#ffffff' == modal_dialog.palette().color(QPalette.Background).name()
+    assert 110 == modal_dialog.header_icon.minimumSize().width()  # 80px + 30px margin
+    assert 110 == modal_dialog.header_icon.maximumSize().width()  # 80px + 30px margin
+    assert 64 == modal_dialog.header_icon.minimumSize().height()  # 64px + 0px margin
+    assert 64 == modal_dialog.header_icon.maximumSize().height()  # 64px + 0px margin
+    assert 110 == modal_dialog.header_spinner_label.minimumSize().width()  # 80px + 30px margin
+    assert 110 == modal_dialog.header_spinner_label.maximumSize().width()  # 80px + 30px margin
+    assert 64 == modal_dialog.header_spinner_label.minimumSize().height()  # 64px + 0px margin
+    assert 64 == modal_dialog.header_spinner_label.maximumSize().height()  # 64px + 0px margin
+    assert 68 == modal_dialog.header.minimumSize().height()  # 68px + 0px margin
+    assert 68 == modal_dialog.header.maximumSize().height()  # 68px + 0px margin
+    assert 'Montserrat' == modal_dialog.header.font().family()
+    assert QFont.Bold == modal_dialog.header.font().weight()
+    assert 24 == modal_dialog.header.font().pixelSize()
+    assert '#2a319d' == modal_dialog.header.palette().color(QPalette.Foreground).name()
+    # assert 4px left-margin for header
+    assert 22 == modal_dialog.header_line.minimumSize().height()  # 2px + 20px margin
+    assert 22 == modal_dialog.header_line.maximumSize().height()  # 2px + 20px margin
+    # assert 40px left-margin and 40px right-margin for header_line
+    # assert 'background-color: rgba(42, 49, 157, 0.15);' for header_line
+    # assert 'border: none;' for header_line
+
+    assert 'Montserrat' == modal_dialog.body.font().family()
+    assert 16 == modal_dialog.body.font().pixelSize()
+    assert '#302aa3' == modal_dialog.body.palette().color(QPalette.Foreground).name()
+    window_buttons = modal_dialog.layout().itemAt(5).widget()
+    button_box = window_buttons.layout().itemAt(0).widget()
+    button_box_children = button_box.findChildren(QPushButton)
+    for c in button_box_children:
+        # BUG??? assert 44 == c.height()  # 40px + 4px of border
+        assert 'Montserrat' == c.font().family()
+        assert QFont.DemiBold - 1 == c.font().weight()
+        assert 15 == c.font().pixelSize()
+        # BUG??? assert '#2a319d' == c.palette().color(QPalette.Foreground).name()
+        # assert 'margin: 0px 0px 0px 12px;'
+        # assert 'padding-left: 20px;'
+        # assert 'padding-right: 20px;'
+        # assert 'border: 2px solid #2a319d;'
+        # assert 'border: 2px solid rgba(42, 49, 157, 0.4);' for button_box when disabled
+        # assert 'color: rgba(42, 49, 157, 0.4);' for button_box when disabled
+
+
+def test_styles_for_print_dialog(print_dialog):
+    assert 800 == print_dialog.minimumSize().width()
+    assert 800 == print_dialog.maximumSize().width()
+    assert 300 == print_dialog.minimumSize().height()
+    assert 800 == print_dialog.maximumSize().height()
+    assert '#ffffff' == print_dialog.palette().color(QPalette.Background).name()
+    assert 110 == print_dialog.header_icon.minimumSize().width()  # 80px + 30px margin
+    assert 110 == print_dialog.header_icon.maximumSize().width()  # 80px + 30px margin
+    assert 64 == print_dialog.header_icon.minimumSize().height()  # 64px + 0px margin
+    assert 64 == print_dialog.header_icon.maximumSize().height()  # 64px + 0px margin
+    assert 110 == print_dialog.header_spinner_label.minimumSize().width()  # 80px + 30px margin
+    assert 110 == print_dialog.header_spinner_label.maximumSize().width()  # 80px + 30px margin
+    assert 64 == print_dialog.header_spinner_label.minimumSize().height()  # 64px + 0px margin
+    assert 64 == print_dialog.header_spinner_label.maximumSize().height()  # 64px + 0px margin
+    assert 68 == print_dialog.header.minimumSize().height()  # 68px + 0px margin
+    assert 68 == print_dialog.header.maximumSize().height()  # 68px + 0px margin
+    assert 'Montserrat' == print_dialog.header.font().family()
+    assert QFont.Bold == print_dialog.header.font().weight()
+    assert 24 == print_dialog.header.font().pixelSize()
+    assert '#2a319d' == print_dialog.header.palette().color(QPalette.Foreground).name()
+    # assert 4px left-margin for header
+    assert 22 == print_dialog.header_line.minimumSize().height()  # 2px + 20px margin
+    assert 22 == print_dialog.header_line.maximumSize().height()  # 2px + 20px margin
+    # assert 40px left-margin and 40px right-margin for header_line
+    # assert 'background-color: rgba(42, 49, 157, 0.15);' for header_line
+    # assert 'border: none;' for header_line
+
+    assert 'Montserrat' == print_dialog.body.font().family()
+    assert 16 == print_dialog.body.font().pixelSize()
+    assert '#302aa3' == print_dialog.body.palette().color(QPalette.Foreground).name()
+    window_buttons = print_dialog.layout().itemAt(5).widget()
+    button_box = window_buttons.layout().itemAt(0).widget()
+    button_box_children = button_box.findChildren(QPushButton)
+    for c in button_box_children:
+        # BUG??? assert 44 == c.height()  # 40px + 4px of border
+        assert 'Montserrat' == c.font().family()
+        assert QFont.DemiBold - 1 == c.font().weight()
+        assert 15 == c.font().pixelSize()
+        # BUG??? assert '#2a319d' == c.palette().color(QPalette.Foreground).name()
+        # assert 'margin: 0px 0px 0px 12px;'
+        # assert 'padding-left: 20px;'
+        # assert 'padding-right: 20px;'
+        # assert 'border: 2px solid #2a319d;'
+        # assert 'border: 2px solid rgba(42, 49, 157, 0.4);' for button_box when disabled
+        # assert 'color: rgba(42, 49, 157, 0.4);' for button_box when disabled
+
+
+def test_styles_for_export_dialog(export_dialog):
+    assert 800 == export_dialog.minimumSize().width()
+    assert 800 == export_dialog.maximumSize().width()
+    assert 300 == export_dialog.minimumSize().height()
+    assert 800 == export_dialog.maximumSize().height()
+    assert '#ffffff' == export_dialog.palette().color(QPalette.Background).name()
+    assert 110 == export_dialog.header_icon.minimumSize().width()  # 80px + 30px margin
+    assert 110 == export_dialog.header_icon.maximumSize().width()  # 80px + 30px margin
+    assert 64 == export_dialog.header_icon.minimumSize().height()  # 64px + 0px margin
+    assert 64 == export_dialog.header_icon.maximumSize().height()  # 64px + 0px margin
+    assert 110 == export_dialog.header_spinner_label.minimumSize().width()  # 80px + 30px margin
+    assert 110 == export_dialog.header_spinner_label.maximumSize().width()  # 80px + 30px margin
+    assert 64 == export_dialog.header_spinner_label.minimumSize().height()  # 64px + 0px margin
+    assert 64 == export_dialog.header_spinner_label.maximumSize().height()  # 64px + 0px margin
+    assert 68 == export_dialog.header.minimumSize().height()  # 68px + 0px margin
+    assert 68 == export_dialog.header.maximumSize().height()  # 68px + 0px margin
+    assert 'Montserrat' == export_dialog.header.font().family()
+    assert QFont.Bold == export_dialog.header.font().weight()
+    assert 24 == export_dialog.header.font().pixelSize()
+    assert '#2a319d' == export_dialog.header.palette().color(QPalette.Foreground).name()
+    # assert 4px left-margin for header
+    assert 22 == export_dialog.header_line.minimumSize().height()  # 2px + 20px margin
+    assert 22 == export_dialog.header_line.maximumSize().height()  # 2px + 20px margin
+    # assert 40px left-margin and 40px right-margin for header_line
+    # assert 'background-color: rgba(42, 49, 157, 0.15);' for header_line
+    # assert 'border: none;' for header_line
+
+    assert 'Montserrat' == export_dialog.body.font().family()
+    assert 16 == export_dialog.body.font().pixelSize()
+    assert '#302aa3' == export_dialog.body.palette().color(QPalette.Foreground).name()
+    window_buttons = export_dialog.layout().itemAt(5).widget()
+    button_box = window_buttons.layout().itemAt(0).widget()
+    button_box_children = button_box.findChildren(QPushButton)
+    for c in button_box_children:
+        assert 44 == c.height()  # 40px + 4px of border
+        assert 'Montserrat' == c.font().family()
+        assert QFont.DemiBold - 1 == c.font().weight()
+        assert 15 == c.font().pixelSize()
+        # BUG??? assert '#2a319d' == c.palette().color(QPalette.Foreground).name()
+        # assert 'margin: 0px 0px 0px 12px;'
+        # assert 'padding-left: 20px;'
+        # assert 'padding-right: 20px;'
+        # assert 'border: 2px solid #2a319d;'
+        # assert 'border: 2px solid rgba(42, 49, 157, 0.4);' for button_box when disabled
+        # assert 'color: rgba(42, 49, 157, 0.4);' for button_box when disabled
+
+    passphrase_children_qlabel = export_dialog.passphrase_form.findChildren(QLabel)
+    for c in passphrase_children_qlabel:
+        assert 'Montserrat' == c.font().family()
+        assert QFont.DemiBold - 1 == c.font().weight()
+        assert 12 == c.font().pixelSize()
+        assert '#2a319d' == c.palette().color(QPalette.Foreground).name()
+        # assert 'padding-top: 6px;'
+
+    form_children_qlineedit = export_dialog.passphrase_form.findChildren(QLineEdit)
+    for c in form_children_qlineedit:
+        assert 32 == c.minimumSize().height()  # 30px + 2px padding-bottom
+        assert 32 == c.maximumSize().height()  # 30px + 2px padding-bottom
+        assert '#f8f8f8' == c.palette().color(QPalette.Background).name()
+        # assert 'border-radius: 0px;'

--- a/tests/integration/test_styles_sdclient.py
+++ b/tests/integration/test_styles_sdclient.py
@@ -1,3 +1,5 @@
+import math
+
 from PyQt5.QtCore import QEvent
 from PyQt5.QtGui import QFont, QPalette
 from PyQt5.QtWidgets import QLabel, QLineEdit, QPushButton, QWidget
@@ -156,6 +158,7 @@ def test_styles_for_login_dialog(mocker, main_window):
     form_children_qlineedit = form.findChildren(QLineEdit)
     for c in form_children_qlineedit:
         assert 30 == c.height()  # 30px + 0px margin
+        assert (0, 0, 0, 0) == c.getContentsMargins()
         # assert `border-radius: 0px;`
         # assert `padding-left: 5px;`
     app_version_label = login_dialog.layout().itemAt(4).widget().layout().itemAt(0).widget()
@@ -279,19 +282,19 @@ def test_styles_for_main_view(mocker, main_window):
     assert 35 == no_source_selected_spacer1.minimumSize().height()
     assert 35 == no_source_selected_spacer1.maximumSize().height()
     bullet1_bullet = no_source_selected.layout().itemAt(2).widget().layout().itemAt(0).widget()
-    # assert 'margin: 4px 0px 0px 0px;'
+    assert (0, 4, 0, 0) == bullet1_bullet.getContentsMargins()
     35 == bullet1_bullet.font().pixelSize()
     QFont.Bold == bullet1_bullet.font().weight()
     assert 'Montserrat' == bullet1_bullet.font().family()
     assert '#a5b3e9' == bullet1_bullet.palette().color(QPalette.Foreground).name()
     bullet2_bullet = no_source_selected.layout().itemAt(3).widget().layout().itemAt(0).widget()
-    # assert 'margin: 4px 0px 0px 0px;'
+    assert (0, 4, 0, 0) == bullet2_bullet.getContentsMargins()
     35 == bullet2_bullet.font().pixelSize()
     QFont.Bold == bullet2_bullet.font().weight()
     assert 'Montserrat' == bullet2_bullet.font().family()
     assert '#a5b3e9' == bullet2_bullet.palette().color(QPalette.Foreground).name()
     bullet3_bullet = no_source_selected.layout().itemAt(4).widget().layout().itemAt(0).widget()
-    # assert 'margin: 4px 0px 0px 0px;'
+    assert (0, 4, 0, 0) == bullet3_bullet.getContentsMargins()
     35 == bullet3_bullet.font().pixelSize()
     QFont.Bold == bullet3_bullet.font().weight()
     assert 'Montserrat' == bullet3_bullet.font().family()
@@ -311,6 +314,7 @@ def test_styles_source_list(mocker, main_window):
     # assert '#f3f5f9' == source_list.item(0).palette().color(QPalette.Background).name()
     # assert 'border: 500px solid #f9f9f9;' on item hover
     # assert 'border-bottom: 1px solid #9b9b9b;' on source_widget (SourceWidget_container)
+    # assert 1 == source_widget.frame()
     assert 40 == source_widget.gutter.minimumSize().width()
     assert 40 == source_widget.gutter.maximumSize().width()
     assert 60 == source_widget.metadata.maximumSize().width()
@@ -364,30 +368,44 @@ def test_styles_for_conversation_view(mocker, main_window):
     horizontal_line = reply_box.layout().itemAt(0).widget()
     assert 2 == horizontal_line.minimumSize().height()
     assert 2 == horizontal_line.maximumSize().height()
-    # assert 'background-color: rgba(42, 49, 157, 0.15);' for horizontal_line
+    assert 38 == math.floor(255 * 0.15)  # sanity check
+    assert 38 == horizontal_line.palette().color(QPalette.Background).rgba64().alpha8()
+    assert 42 == horizontal_line.palette().color(QPalette.Background).red()
+    assert 49 == horizontal_line.palette().color(QPalette.Background).green()
+    assert 157 == horizontal_line.palette().color(QPalette.Background).blue()
     # assert 'border: none;' for horizontal line
     reply_text_edit = reply_box.text_edit
     assert 'Montserrat' == reply_text_edit.font().family()
     assert QFont.Normal == reply_text_edit.font().weight()
     assert 18 == reply_text_edit.font().pixelSize()
     # assert 'border: none;'
-    # assert 'margin-right: 30.2px;'
+    assert (0, 0, 30, 0) == reply_text_edit.getContentsMargins()
     assert 'Montserrat' == reply_text_edit.placeholder.font().family()
     assert QFont.Normal == reply_text_edit.placeholder.font().weight()
     assert 18 == reply_text_edit.placeholder.font().pixelSize()
     '#404040' == reply_text_edit.placeholder.palette().color(QPalette.Foreground).name()
-    # assert 'color: rgba(42, 49, 157, 0.6);' when placeholder disabled
+
+    reply_text_edit.setEnabled(False)
+    assert 153 == math.floor(255 * 0.6)  # sanity check
+    assert 153 == reply_text_edit.placeholder.palette().color(QPalette.Foreground).rgba64().alpha8()
+    assert 42 == reply_text_edit.placeholder.palette().color(QPalette.Foreground).red()
+    assert 49 == reply_text_edit.placeholder.palette().color(QPalette.Foreground).green()
+    assert 157 == reply_text_edit.placeholder.palette().color(QPalette.Foreground).blue()
 
     conversation_title_bar = wrapper.conversation_title_bar
     horizontal_line = conversation_title_bar.layout().itemAt(1).widget()
     assert 2 == horizontal_line.minimumSize().height()
     assert 2 == horizontal_line.maximumSize().height()
-    # assert 'background-color: rgba(42, 49, 157, 0.15);'
-    # assert 'padding-left: 12px;'
+    assert 38 == math.floor(255 * 0.15)  # sanity check
+    assert 38 == horizontal_line.palette().color(QPalette.Background).rgba64().alpha8()
+    assert 42 == horizontal_line.palette().color(QPalette.Background).red()
+    assert 49 == horizontal_line.palette().color(QPalette.Background).green()
+    assert 157 == horizontal_line.palette().color(QPalette.Background).blue()
+    # # assert 'padding-left: 12px;'
     # assert 'padding-right: 12px;'
     # menu = conversation_title_bar.layout().itemAt(0).widget().layout().itemAt(3).widget()
+    # assert (0, 5, 0, 0) == menu.getContentsMargins()
     # assert 'border: none;'
-    # assert 'margin: 5px 0px 0px 0px;'
     # assert 'padding-left: 8px;'
     # assert 'image: none;' for 'menu-indicator'
     last_updated_label = conversation_title_bar.updated
@@ -438,8 +456,12 @@ def test_styles_for_conversation_view(mocker, main_window):
 
     assert 2 == file_widget.horizontal_line.minimumSize().height()  # 2px + 0px margin
     assert 2 == file_widget.horizontal_line.maximumSize().height()  # 2px + 0px margin
-    # assert 'background-color: rgba(211, 216, 234, 0.45);' for horizontal_line'
-    # assert 8px left-margin and right-margin for horizontal_line
+    # assert (8, 0, 8, 0) == file_widget.horizontal_line.getContentsMargins()
+    assert 114 == math.floor(255 * 0.45)  # sanity check
+    assert 114 == file_widget.horizontal_line.palette().color(QPalette.Background).rgba64().alpha8()
+    assert 211 == file_widget.horizontal_line.palette().color(QPalette.Background).red()
+    assert 216 == file_widget.horizontal_line.palette().color(QPalette.Background).green()
+    assert 234 == file_widget.horizontal_line.palette().color(QPalette.Background).blue()
 
     message_widget = conversation_scrollarea.widget().layout().itemAt(1).widget()
     assert 540 == message_widget.speech_bubble.minimumSize().width()
@@ -476,12 +498,16 @@ def test_styles_for_modal_dialog(modal_dialog):
     assert QFont.Bold == modal_dialog.header.font().weight()
     assert 24 == modal_dialog.header.font().pixelSize()
     assert '#2a319d' == modal_dialog.header.palette().color(QPalette.Foreground).name()
-    # assert 4px left-margin for header
+    assert (4, 0, 0, 0) == modal_dialog.header.getContentsMargins()
     assert 22 == modal_dialog.header_line.minimumSize().height()  # 2px + 20px margin
     assert 22 == modal_dialog.header_line.maximumSize().height()  # 2px + 20px margin
-    # assert 40px left-margin and 40px right-margin for header_line
-    # assert 'background-color: rgba(42, 49, 157, 0.15);' for header_line
+    # assert (40, 0, 40, 0) == modal_dialog.header_line.getContentsMargins()
     # assert 'border: none;' for header_line
+    assert 38 == math.floor(255 * 0.15)  # sanity check
+    assert 38 == modal_dialog.header_line.palette().color(QPalette.Background).rgba64().alpha8()
+    assert 42 == modal_dialog.header_line.palette().color(QPalette.Background).red()
+    assert 49 == modal_dialog.header_line.palette().color(QPalette.Background).green()
+    assert 157 == modal_dialog.header_line.palette().color(QPalette.Background).blue()
 
     assert 'Montserrat' == modal_dialog.body.font().family()
     assert 16 == modal_dialog.body.font().pixelSize()
@@ -490,17 +516,22 @@ def test_styles_for_modal_dialog(modal_dialog):
     button_box = window_buttons.layout().itemAt(0).widget()
     button_box_children = button_box.findChildren(QPushButton)
     for c in button_box_children:
-        # BUG??? assert 44 == c.height()  # 40px + 4px of border
+        # assert 44 == c.height()  # 40px + 4px of border
         assert 'Montserrat' == c.font().family()
         assert QFont.DemiBold - 1 == c.font().weight()
         assert 15 == c.font().pixelSize()
-        # BUG??? assert '#2a319d' == c.palette().color(QPalette.Foreground).name()
-        # assert 'margin: 0px 0px 0px 12px;'
+        # assert '#2a319d' == c.palette().color(QPalette.Foreground).name()
+        # assert (12, 0, 0, 0) == c.getContentsMargins()
         # assert 'padding-left: 20px;'
         # assert 'padding-right: 20px;'
         # assert 'border: 2px solid #2a319d;'
         # assert 'border: 2px solid rgba(42, 49, 157, 0.4);' for button_box when disabled
-        # assert 'color: rgba(42, 49, 157, 0.4);' for button_box when disabled
+        # c.setEnabled(False)
+        # assert 102 == math.floor(255 * 0.4)  # sanity check
+        # assert 102 == c.palette().color(QPalette.Background).rgba64().alpha8()
+        # assert 42 == c.palette().color(QPalette.Background).red()
+        # assert 49 == c.palette().color(QPalette.Background).green()
+        # assert 157 == c.palette().color(QPalette.Background).blue()
 
 
 def test_styles_for_print_dialog(print_dialog):
@@ -523,12 +554,16 @@ def test_styles_for_print_dialog(print_dialog):
     assert QFont.Bold == print_dialog.header.font().weight()
     assert 24 == print_dialog.header.font().pixelSize()
     assert '#2a319d' == print_dialog.header.palette().color(QPalette.Foreground).name()
-    # assert 4px left-margin for header
+    assert (4, 0, 0, 0) == print_dialog.header.getContentsMargins()
     assert 22 == print_dialog.header_line.minimumSize().height()  # 2px + 20px margin
     assert 22 == print_dialog.header_line.maximumSize().height()  # 2px + 20px margin
-    # assert 40px left-margin and 40px right-margin for header_line
-    # assert 'background-color: rgba(42, 49, 157, 0.15);' for header_line
+    # assert (40, 0, 40, 0) == print_dialog.header_line.getContentsMargins()
     # assert 'border: none;' for header_line
+    assert 38 == math.floor(255 * 0.15)  # sanity check
+    assert 38 == print_dialog.header_line.palette().color(QPalette.Background).rgba64().alpha8()
+    assert 42 == print_dialog.header_line.palette().color(QPalette.Background).red()
+    assert 49 == print_dialog.header_line.palette().color(QPalette.Background).green()
+    assert 157 == print_dialog.header_line.palette().color(QPalette.Background).blue()
 
     assert 'Montserrat' == print_dialog.body.font().family()
     assert 16 == print_dialog.body.font().pixelSize()
@@ -537,17 +572,22 @@ def test_styles_for_print_dialog(print_dialog):
     button_box = window_buttons.layout().itemAt(0).widget()
     button_box_children = button_box.findChildren(QPushButton)
     for c in button_box_children:
-        # BUG??? assert 44 == c.height()  # 40px + 4px of border
+        # assert 44 == c.height()  # 40px + 4px of border
         assert 'Montserrat' == c.font().family()
         assert QFont.DemiBold - 1 == c.font().weight()
         assert 15 == c.font().pixelSize()
-        # BUG??? assert '#2a319d' == c.palette().color(QPalette.Foreground).name()
-        # assert 'margin: 0px 0px 0px 12px;'
+        # assert '#2a319d' == c.palette().color(QPalette.Foreground).name()
+        # assert (12, 0, 0, 0) == c.getContentsMargins()
         # assert 'padding-left: 20px;'
         # assert 'padding-right: 20px;'
         # assert 'border: 2px solid #2a319d;'
         # assert 'border: 2px solid rgba(42, 49, 157, 0.4);' for button_box when disabled
-        # assert 'color: rgba(42, 49, 157, 0.4);' for button_box when disabled
+        # c.setEnabled(False)
+        # assert 102 == math.floor(255 * 0.4)  # sanity check
+        # assert 102 == c.palette().color(QPalette.Background).rgba64().alpha8()
+        # assert 42 == c.palette().color(QPalette.Background).red()
+        # assert 49 == c.palette().color(QPalette.Background).green()
+        # assert 157 == c.palette().color(QPalette.Background).blue()
 
 
 def test_styles_for_export_dialog(export_dialog):
@@ -570,12 +610,16 @@ def test_styles_for_export_dialog(export_dialog):
     assert QFont.Bold == export_dialog.header.font().weight()
     assert 24 == export_dialog.header.font().pixelSize()
     assert '#2a319d' == export_dialog.header.palette().color(QPalette.Foreground).name()
-    # assert 4px left-margin for header
+    assert (4, 0, 0, 0) == export_dialog.header.getContentsMargins()
     assert 22 == export_dialog.header_line.minimumSize().height()  # 2px + 20px margin
     assert 22 == export_dialog.header_line.maximumSize().height()  # 2px + 20px margin
-    # assert 40px left-margin and 40px right-margin for header_line
-    # assert 'background-color: rgba(42, 49, 157, 0.15);' for header_line
+    # assert (40, 0, 40, 0) == export_dialog.header_line.getContentsMargins()
     # assert 'border: none;' for header_line
+    assert 38 == math.floor(255 * 0.15)  # sanity check
+    assert 38 == export_dialog.header_line.palette().color(QPalette.Background).rgba64().alpha8()
+    assert 42 == export_dialog.header_line.palette().color(QPalette.Background).red()
+    assert 49 == export_dialog.header_line.palette().color(QPalette.Background).green()
+    assert 157 == export_dialog.header_line.palette().color(QPalette.Background).blue()
 
     assert 'Montserrat' == export_dialog.body.font().family()
     assert 16 == export_dialog.body.font().pixelSize()
@@ -588,13 +632,18 @@ def test_styles_for_export_dialog(export_dialog):
         assert 'Montserrat' == c.font().family()
         assert QFont.DemiBold - 1 == c.font().weight()
         assert 15 == c.font().pixelSize()
-        # BUG??? assert '#2a319d' == c.palette().color(QPalette.Foreground).name()
-        # assert 'margin: 0px 0px 0px 12px;'
+        # assert '#2a319d' == c.palette().color(QPalette.Foreground).name()
+        # assert (12, 0, 0, 0) == c.getContentsMargins()
         # assert 'padding-left: 20px;'
         # assert 'padding-right: 20px;'
         # assert 'border: 2px solid #2a319d;'
         # assert 'border: 2px solid rgba(42, 49, 157, 0.4);' for button_box when disabled
-        # assert 'color: rgba(42, 49, 157, 0.4);' for button_box when disabled
+        # c.setEnabled(False)
+        # assert 102 == math.floor(255 * 0.4)  # sanity check
+        # assert 102 == c.palette().color(QPalette.Background).rgba64().alpha8()
+        # assert 42 == c.palette().color(QPalette.Background).red()
+        # assert 49 == c.palette().color(QPalette.Background).green()
+        # assert 157 == c.palette().color(QPalette.Background).blue()
 
     passphrase_children_qlabel = export_dialog.passphrase_form.findChildren(QLabel)
     for c in passphrase_children_qlabel:

--- a/tests/integration/test_styles_sdclient.py
+++ b/tests/integration/test_styles_sdclient.py
@@ -95,7 +95,18 @@ def test_class_name_matches_css_object_name(mocker, main_window):
     reply_text_edit = reply_box.text_edit
     assert 'ReplyTextEdit' == reply_text_edit.__class__.__name__
     assert 'ReplyTextEdit' == reply_text_edit.objectName()
-    assert 'ReplyTextEdit' in reply_text_edit.placeholder.objectName()
+    compose_a_reply_to = reply_text_edit.placeholder.signed_in.layout().itemAt(0).widget()
+    source_name = reply_text_edit.placeholder.signed_in.layout().itemAt(1).widget()
+    sign_in = reply_text_edit.placeholder.signed_out.layout().itemAt(0).widget()
+    to_compose_reply = reply_text_edit.placeholder.signed_in.layout().itemAt(1).widget()
+    awaiting_key = reply_text_edit.placeholder.signed_out.layout().itemAt(0).widget()
+    from_server = reply_text_edit.placeholder.signed_in.layout().itemAt(1).widget()
+    assert 'ReplyTextEditPlaceholder' in compose_a_reply_to.objectName()
+    assert 'ReplyTextEditPlaceholder' in source_name.objectName()
+    assert 'ReplyTextEditPlaceholder' in sign_in.objectName()
+    assert 'ReplyTextEditPlaceholder' in to_compose_reply.objectName()
+    assert 'ReplyTextEditPlaceholder' in awaiting_key.objectName()
+    assert 'ReplyTextEditPlaceholder' in from_server.objectName()
     conversation_title_bar = wrapper.conversation_title_bar
     assert 'SourceProfileShortWidget' == conversation_title_bar.__class__.__name__
     horizontal_line = conversation_title_bar.layout().itemAt(1).widget()
@@ -379,18 +390,8 @@ def test_styles_for_conversation_view(mocker, main_window):
     assert QFont.Normal == reply_text_edit.font().weight()
     assert 18 == reply_text_edit.font().pixelSize()
     # assert 'border: none;'
-    assert (0, 0, 30, 0) == reply_text_edit.getContentsMargins()
-    assert 'Montserrat' == reply_text_edit.placeholder.font().family()
-    assert QFont.Normal == reply_text_edit.placeholder.font().weight()
-    assert 18 == reply_text_edit.placeholder.font().pixelSize()
-    '#404040' == reply_text_edit.placeholder.palette().color(QPalette.Foreground).name()
-
-    reply_text_edit.setEnabled(False)
-    assert 153 == math.floor(255 * 0.6)  # sanity check
-    assert 153 == reply_text_edit.placeholder.palette().color(QPalette.Foreground).rgba64().alpha8()
-    assert 42 == reply_text_edit.placeholder.palette().color(QPalette.Foreground).red()
-    assert 49 == reply_text_edit.placeholder.palette().color(QPalette.Foreground).green()
-    assert 157 == reply_text_edit.placeholder.palette().color(QPalette.Foreground).blue()
+    assert (0, 0, 0, 0) == reply_text_edit.getContentsMargins()
+    # See test_placeholder.py for placeholder tests
 
     conversation_title_bar = wrapper.conversation_title_bar
     horizontal_line = conversation_title_bar.layout().itemAt(1).widget()

--- a/tests/integration/test_styles_speech_bubble_message.py
+++ b/tests/integration/test_styles_speech_bubble_message.py
@@ -1,0 +1,23 @@
+from PyQt5.QtGui import QFont, QPalette
+
+
+def test_styles(mocker, main_window):
+    wrapper = main_window.main_view.view_layout.itemAt(0).widget()
+    conversation_scrollarea = wrapper.conversation_view.scroll
+    speech_bubble = conversation_scrollarea.widget().layout().itemAt(1).widget()
+    assert 540 == speech_bubble.message.minimumSize().width()  # 508px + 32px padding
+    assert 540 == speech_bubble.message.maximumSize().width()  # 508px + 32px padding
+    assert 'Source Sans Pro' == speech_bubble.message.font().family()
+    assert QFont.Normal == speech_bubble.message.font().weight()
+    assert 15 == speech_bubble.message.font().pixelSize()
+    assert '#3b3b3b' == speech_bubble.message.palette().color(QPalette.Foreground).name()
+    assert '#ffffff' == speech_bubble.message.palette().color(QPalette.Background).name()
+    speech_bubble.set_error('123', speech_bubble.uuid, speech_bubble.message.text())
+    assert 540 == speech_bubble.message.minimumSize().width()  # 508px + 32px padding
+    assert 540 == speech_bubble.message.maximumSize().width()  # 508px + 32px padding
+    assert 'Source Sans Pro' == speech_bubble.message.font().family()
+    assert QFont.Normal == speech_bubble.message.font().weight()
+    assert 15 == speech_bubble.message.font().pixelSize()
+    assert '#3b3b3b' == speech_bubble.message.palette().color(QPalette.Foreground).name()
+    # font-style: italic;
+    # background-color: rgba(255, 255, 255, 0.6);

--- a/tests/integration/test_styles_speech_bubble_message.py
+++ b/tests/integration/test_styles_speech_bubble_message.py
@@ -5,6 +5,7 @@ def test_styles(mocker, main_window):
     wrapper = main_window.main_view.view_layout.itemAt(0).widget()
     conversation_scrollarea = wrapper.conversation_view.scroll
     speech_bubble = conversation_scrollarea.widget().layout().itemAt(1).widget()
+
     assert 540 == speech_bubble.message.minimumSize().width()  # 508px + 32px padding
     assert 540 == speech_bubble.message.maximumSize().width()  # 508px + 32px padding
     assert 'Source Sans Pro' == speech_bubble.message.font().family()
@@ -12,12 +13,18 @@ def test_styles(mocker, main_window):
     assert 15 == speech_bubble.message.font().pixelSize()
     assert '#3b3b3b' == speech_bubble.message.palette().color(QPalette.Foreground).name()
     assert '#ffffff' == speech_bubble.message.palette().color(QPalette.Background).name()
+
     speech_bubble.set_error('123', speech_bubble.uuid, speech_bubble.message.text())
+
     assert 540 == speech_bubble.message.minimumSize().width()  # 508px + 32px padding
     assert 540 == speech_bubble.message.maximumSize().width()  # 508px + 32px padding
     assert 'Source Sans Pro' == speech_bubble.message.font().family()
     assert QFont.Normal == speech_bubble.message.font().weight()
     assert 15 == speech_bubble.message.font().pixelSize()
     assert '#3b3b3b' == speech_bubble.message.palette().color(QPalette.Foreground).name()
-    # font-style: italic;
-    # background-color: rgba(255, 255, 255, 0.6);
+    assert speech_bubble.message.font().italic()
+    assert 153 == round(255 * 0.6)  # sanity check
+    assert 153 == speech_bubble.message.palette().color(QPalette.Background).rgba64().alpha8()
+    assert 255 == speech_bubble.message.palette().color(QPalette.Background).red()
+    assert 255 == speech_bubble.message.palette().color(QPalette.Background).green()
+    assert 255 == speech_bubble.message.palette().color(QPalette.Background).blue()

--- a/tests/integration/test_styles_speech_bubble_status_bar.py
+++ b/tests/integration/test_styles_speech_bubble_status_bar.py
@@ -1,0 +1,16 @@
+from PyQt5.QtGui import QPalette
+
+
+def test_styles(mocker, main_window):
+    wrapper = main_window.main_view.view_layout.itemAt(0).widget()
+    conversation_scrollarea = wrapper.conversation_view.scroll
+    speech_bubble = conversation_scrollarea.widget().layout().itemAt(1).widget()
+    assert 5 == speech_bubble.color_bar.minimumSize().height()
+    assert 5 == speech_bubble.color_bar.maximumSize().height()
+    assert '#102781' == speech_bubble.color_bar.palette().color(QPalette.Background).name()
+    # assert border: 0px;
+    speech_bubble.set_error('123', speech_bubble.uuid, speech_bubble.message.text())
+    assert 5 == speech_bubble.color_bar.minimumSize().height()
+    assert 5 == speech_bubble.color_bar.maximumSize().height()
+    assert '#bcbfcd' == speech_bubble.color_bar.palette().color(QPalette.Background).name()
+    # assert border: 0px;

--- a/tests/integration/test_styles_speech_bubble_status_bar.py
+++ b/tests/integration/test_styles_speech_bubble_status_bar.py
@@ -5,11 +5,14 @@ def test_styles(mocker, main_window):
     wrapper = main_window.main_view.view_layout.itemAt(0).widget()
     conversation_scrollarea = wrapper.conversation_view.scroll
     speech_bubble = conversation_scrollarea.widget().layout().itemAt(1).widget()
+
     assert 5 == speech_bubble.color_bar.minimumSize().height()
     assert 5 == speech_bubble.color_bar.maximumSize().height()
     assert '#102781' == speech_bubble.color_bar.palette().color(QPalette.Background).name()
     # assert border: 0px;
+
     speech_bubble.set_error('123', speech_bubble.uuid, speech_bubble.message.text())
+
     assert 5 == speech_bubble.color_bar.minimumSize().height()
     assert 5 == speech_bubble.color_bar.maximumSize().height()
     assert '#bcbfcd' == speech_bubble.color_bar.palette().color(QPalette.Background).name()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -130,6 +130,7 @@ def test_start_app(homedir, mocker):
     mocker.patch('securedrop_client.app.make_session_maker', return_value=mock_session_maker)
 
     start_app(mock_args, mock_qt_args)
+
     mock_app.assert_called_once_with(mock_qt_args)
     mock_win.assert_called_once_with()
     mock_controller.assert_called_once_with('http://localhost:8081/',


### PR DESCRIPTION
# Description

Towards https://github.com/freedomofpress/securedrop-client/issues/1078

Goals behind this PR:
* Start using `.css` files instead of strings or dictionaries of strings or dictionaries of dictionaries of strings
* Separate css stylesheets from Qt application logic
* Use standard CSS object names that correspond to Qt Widget class names
* Set the stylesheet for the application once, except for when we need to change the CSS of an object based on an action.
* Add integration tests to make sure the styles are what we expect
* Add regression tests to make sure if a class name changes then the CSS object name needs to be updated and vice versa

# Test Plan

There are many integration tests that you'll see check to see that the widget styles are what we expect them to be. We are almost at 100% UI style coverage now. Since it's difficult to keep track of where we have coverage for stylesheets, I left comments in the test code for assertions that will get us to 100% coverage. The comments all relate to the following types of tests:

* border tests, including border-radius tests, see https://code.woboq.org/qt5/qtbase/src/widgets/styles/qstylesheetstyle.cpp.html#_ZN21QStyleSheetBorderDataC1EPiP6QBrushPN4QCss11BorderStyleEP5QSize
* padding tests
* text alignment tests
* `menu-indicator` tests
* `image: none;` and `show-decoration-selected: 0;`  tests

There are also comments in the test code for unexpected test failures, e.g. a background color of a disabled button should return gray but instead returns white. There aren't that many of these and it could be because of test writing fatigue that these are broken, however, in order to make sure the client looks like what we expect it to look like, the test plan is to compare master to this pr branch by following this plan:

1. Run the client from `master` and take screenshots
2. Run the client from this PR branch and take screenshots
3. Use a tool to compare the screenshots or manually compare and pay close attention to borders, colors, and layout spacing/ margins.
4. Run the client from qubes and repeat steps 1-3 

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/master/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `master` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `master` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed
