### PR TITLE
functional tests: use named constants for wait times

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,14 @@ PASSWORD = "correct horse battery staple profanity oil chewy"
 # development.
 TOTP = "994892"
 
+# Time (in milliseconds) to wait for these GUI elements to render.
+TIME_APP_START = 1000
+TIME_CLICK_ACTION = 1000
+TIME_RENDER_SOURCE_LIST = 20000
+TIME_RENDER_CONV_VIEW = 1000
+TIME_SYNC = 10000
+TIME_FILE_DOWNLOAD = 5000
+
 
 @pytest.fixture(scope='function')
 def i18n():

--- a/tests/functional/test_delete_source.py
+++ b/tests/functional/test_delete_source.py
@@ -8,6 +8,8 @@ import pytest
 from flaky import flaky
 from PyQt5.QtCore import Qt
 
+from tests.conftest import TIME_APP_START, TIME_RENDER_CONV_VIEW, TIME_RENDER_SOURCE_LIST
+
 
 @flaky
 @pytest.mark.vcr()
@@ -16,18 +18,18 @@ def test_delete_source_and_their_docs(functional_test_logged_in_context, qtbot, 
     It's possible to delete a source and see it removed from the UI.
     """
     gui, controller, temmpdir = functional_test_logged_in_context
-    qtbot.wait(1000)
+    qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
         assert len(list(gui.main_view.source_list.source_widgets.keys()))
 
-    qtbot.waitUntil(check_for_sources, timeout=20000)
+    qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
     source_ids = list(gui.main_view.source_list.source_widgets.keys())
     assert len(source_ids) == 2
     first_source_id = source_ids[0]
     first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
     qtbot.mouseClick(first_source_widget, Qt.LeftButton)
-    qtbot.wait(1000)
+    qtbot.wait(TIME_RENDER_CONV_VIEW)
 
     assert gui.main_view.source_list.count() == 2
 
@@ -42,4 +44,4 @@ def test_delete_source_and_their_docs(functional_test_logged_in_context, qtbot, 
         # Confirm there is now only one source in the client list.
         assert gui.main_view.source_list.count() == 1
 
-    qtbot.waitUntil(check_source_list, timeout=20000)
+    qtbot.waitUntil(check_source_list, timeout=TIME_RENDER_SOURCE_LIST)

--- a/tests/functional/test_download_file.py
+++ b/tests/functional/test_download_file.py
@@ -9,6 +9,9 @@ from flaky import flaky
 from PyQt5.QtCore import Qt
 from securedrop_client.gui.widgets import FileWidget
 
+from tests.conftest import (TIME_APP_START, TIME_FILE_DOWNLOAD,
+                            TIME_RENDER_SOURCE_LIST, TIME_SYNC)
+
 
 @flaky
 @pytest.mark.vcr()
@@ -18,18 +21,18 @@ def test_download_file(functional_test_logged_in_context, qtbot, mocker):
     the conversation window.
     """
     gui, controller, tempdir = functional_test_logged_in_context
-    qtbot.wait(1000)
+    qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
         assert len(list(gui.main_view.source_list.source_widgets.keys()))
 
-    qtbot.waitUntil(check_for_sources, timeout=10000)
+    qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
     source_ids = list(gui.main_view.source_list.source_widgets.keys())
     first_source_id = source_ids[0]
     first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
     qtbot.mouseClick(first_source_widget, Qt.LeftButton)
 
-    qtbot.wait(10000)  # Wait for the client to sync.
+    qtbot.wait(TIME_SYNC)
     # Ensure the last widget in the conversation view contains the expected
     # text from the source.
     conversation = gui.main_view.view_layout.itemAt(0).widget()
@@ -45,7 +48,7 @@ def test_download_file(functional_test_logged_in_context, qtbot, mocker):
 
     # Let us download the file
     qtbot.mouseClick(file_msg.download_button, Qt.LeftButton)
-    qtbot.wait(5000)
+    qtbot.wait(TIME_FILE_DOWNLOAD)
     assert file_msg.export_button.isHidden() is False
     assert file_msg.file_name.text() == "hello.txt"
     assert file_msg.file_size.text() == "9B"

--- a/tests/functional/test_export_dialog.py
+++ b/tests/functional/test_export_dialog.py
@@ -9,6 +9,9 @@ from flaky import flaky
 from PyQt5.QtCore import Qt
 from securedrop_client.gui.widgets import FileWidget
 
+from tests.conftest import (TIME_APP_START, TIME_CLICK_ACTION, TIME_FILE_DOWNLOAD,
+                            TIME_RENDER_SOURCE_LIST, TIME_SYNC)
+
 
 @flaky
 @pytest.mark.vcr()
@@ -18,18 +21,18 @@ def test_export_dialog(functional_test_logged_in_context, qtbot, mocker):
     the conversation window.
     """
     gui, controller, tempdir = functional_test_logged_in_context
-    qtbot.wait(1000)
+    qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
         assert len(list(gui.main_view.source_list.source_widgets.keys()))
 
-    qtbot.waitUntil(check_for_sources, timeout=10000)
+    qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
     source_ids = list(gui.main_view.source_list.source_widgets.keys())
     first_source_id = source_ids[0]
     first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
     qtbot.mouseClick(first_source_widget, Qt.LeftButton)
 
-    qtbot.wait(10000)  # Wait for the client to sync.
+    qtbot.wait(TIME_SYNC)
     # Ensure the last widget in the conversation view contains the expected
     # text from the source.
     conversation = gui.main_view.view_layout.itemAt(0).widget()
@@ -45,7 +48,7 @@ def test_export_dialog(functional_test_logged_in_context, qtbot, mocker):
 
     # Let us download the file
     qtbot.mouseClick(file_msg.download_button, Qt.LeftButton)
-    qtbot.wait(5000)
+    qtbot.wait(TIME_FILE_DOWNLOAD)
     assert file_msg.export_button.isHidden() is False
     assert file_msg.file_name.text() == "hello.txt"
     assert file_msg.file_size.text() == "9B"
@@ -56,7 +59,7 @@ def test_export_dialog(functional_test_logged_in_context, qtbot, mocker):
     def check_for_export_dialog():
         assert file_msg.export_dialog
 
-    qtbot.waitUntil(check_for_export_dialog, timeout=1000)
+    qtbot.waitUntil(check_for_export_dialog, timeout=TIME_CLICK_ACTION)
 
     export_dialog = file_msg.export_dialog
     qtbot.mouseClick(export_dialog.continue_button, Qt.LeftButton)
@@ -64,17 +67,17 @@ def test_export_dialog(functional_test_logged_in_context, qtbot, mocker):
     def check_password_form():
         assert export_dialog.passphrase_form.isHidden() is False
 
-    qtbot.waitUntil(check_password_form, timeout=2000)
+    qtbot.waitUntil(check_password_form, timeout=TIME_CLICK_ACTION)
 
     message = "Use Tor Browser"
     # Focus on passphrase box text entry.
     qtbot.mouseClick(export_dialog.passphrase_field, Qt.LeftButton)
     # Type in a message to the passphrase box.
     qtbot.keyClicks(export_dialog.passphrase_field, message)
-    qtbot.wait(1000)
+    qtbot.wait(TIME_CLICK_ACTION)
 
     # click on the continue button
     qtbot.mouseClick(export_dialog.continue_button, Qt.LeftButton)
-    qtbot.wait(1000)
+    qtbot.wait(TIME_CLICK_ACTION)
 
     assert export_dialog.continue_button.text() == "DONE"

--- a/tests/functional/test_login.py
+++ b/tests/functional/test_login.py
@@ -11,7 +11,7 @@ from PyQt5.QtCore import Qt
 from securedrop_client.gui.main import Window
 from securedrop_client.gui.widgets import LoginDialog
 
-from tests.conftest import USERNAME, PASSWORD
+from tests.conftest import USERNAME, PASSWORD, TIME_RENDER_CONV_VIEW
 
 
 def test_login_ensure_errors_displayed(qtbot, mocker):
@@ -45,7 +45,7 @@ def test_login_as_journalist(functional_test_logged_out_context, qtbot, mocker):
     # and then (ultimately) emit the expected signal. This pattern will need to
     # be used with all API calls. For more information about this method, see:
     # https://pytest-qt.readthedocs.io/en/latest/signals.html
-    with qtbot.waitSignal(controller.authentication_state, timeout=10000):
+    with qtbot.waitSignal(controller.authentication_state, timeout=TIME_RENDER_CONV_VIEW):
         qtbot.mouseClick(gui.login_dialog.submit, Qt.LeftButton)
     # The main window is visible (indicating a successful login).
     assert gui.isVisible()

--- a/tests/functional/test_login_from_offline.py
+++ b/tests/functional/test_login_from_offline.py
@@ -5,7 +5,8 @@ import pytest
 from flaky import flaky
 from PyQt5.QtCore import Qt
 
-from tests.conftest import USERNAME, PASSWORD
+from tests.conftest import (TIME_APP_START, TIME_RENDER_CONV_VIEW,
+                            PASSWORD, USERNAME)
 
 
 @flaky
@@ -21,8 +22,7 @@ def test_login_from_offline(functional_test_logged_in_context, qtbot, mocker):
     A journalist can successfully log out of the application.
     """
     gui, controller, tempdir = functional_test_logged_in_context
-
-    qtbot.wait(2000)
+    qtbot.wait(TIME_APP_START)
 
     def check_login_button():
         assert gui.left_pane.user_profile.login_button.isVisible()
@@ -32,13 +32,13 @@ def test_login_from_offline(functional_test_logged_in_context, qtbot, mocker):
     # rather than pretend some sort of user interaction via the qtbot.
     gui.left_pane.user_profile.user_button.menu.logout.trigger()
     # Wait until the logout button is pressed.
-    qtbot.waitUntil(check_login_button, timeout=10000)
+    qtbot.waitUntil(check_login_button, timeout=TIME_RENDER_CONV_VIEW)
 
     def check_login_dialog():
         assert gui.login_dialog
 
     qtbot.mouseClick(gui.left_pane.user_profile.login_button, Qt.LeftButton)
-    qtbot.waitUntil(check_login_dialog, timeout=10000)
+    qtbot.waitUntil(check_login_dialog, timeout=TIME_RENDER_CONV_VIEW)
 
     qtbot.keyClicks(gui.login_dialog.username_field, USERNAME)
     qtbot.keyClicks(gui.login_dialog.password_field, PASSWORD)
@@ -49,4 +49,4 @@ def test_login_from_offline(functional_test_logged_in_context, qtbot, mocker):
     def wait_for_login():
         assert gui.login_dialog is None
 
-    qtbot.waitUntil(wait_for_login, timeout=10000)
+    qtbot.waitUntil(wait_for_login, timeout=TIME_RENDER_CONV_VIEW)

--- a/tests/functional/test_logout.py
+++ b/tests/functional/test_logout.py
@@ -7,6 +7,8 @@ https://github.com/freedomofpress/securedrop-client/wiki/Test-plan#basic-client-
 import pytest
 from flaky import flaky
 
+from tests.conftest import TIME_RENDER_CONV_VIEW
+
 
 @flaky
 @pytest.mark.vcr()
@@ -30,4 +32,4 @@ def test_logout_as_journalist(functional_test_logged_in_context, qtbot, mocker):
     # rather than pretend some sort of user interaction via the qtbot.
     gui.left_pane.user_profile.user_button.menu.logout.trigger()
     # Wait until the logout button is pressed.
-    qtbot.waitUntil(check_login_button, timeout=10000)
+    qtbot.waitUntil(check_login_button, timeout=TIME_RENDER_CONV_VIEW)

--- a/tests/functional/test_offline_delete_source.py
+++ b/tests/functional/test_offline_delete_source.py
@@ -8,6 +8,9 @@ import pytest
 from flaky import flaky
 from PyQt5.QtCore import Qt
 
+from tests.conftest import (TIME_APP_START, TIME_CLICK_ACTION,
+                            TIME_RENDER_CONV_VIEW, TIME_RENDER_SOURCE_LIST)
+
 
 @flaky
 @pytest.mark.vcr()
@@ -16,25 +19,25 @@ def test_offline_delete_source_and_their_docs(functional_test_logged_in_context,
     It's NOT possible to delete a source when the client is offline.
     """
     gui, controller, tempdir = functional_test_logged_in_context
-    qtbot.wait(1000)
+    qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
         assert len(list(gui.main_view.source_list.source_widgets.keys()))
 
-    qtbot.waitUntil(check_for_sources, timeout=10000)
+    qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
     source_ids = list(gui.main_view.source_list.source_widgets.keys())
     assert len(source_ids) == 2
     first_source_id = source_ids[0]
     first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
     qtbot.mouseClick(first_source_widget, Qt.LeftButton)
-    qtbot.wait(1000)
+    qtbot.wait(TIME_CLICK_ACTION)
 
     # Now logout.
     def check_login_button():
         assert gui.left_pane.user_profile.login_button.isVisible()
 
     gui.left_pane.user_profile.user_button.menu.logout.trigger()
-    qtbot.waitUntil(check_login_button, timeout=10000)
+    qtbot.waitUntil(check_login_button, timeout=TIME_RENDER_CONV_VIEW)
 
     # Delete the first source.
     # This is IMPOSSIBLE to trigger via either the qtbot or DeleteSourceAction
@@ -48,4 +51,4 @@ def test_offline_delete_source_and_their_docs(functional_test_logged_in_context,
         msg = gui.top_pane.error_status_bar.status_bar.currentMessage()
         assert msg == 'You must sign in to perform this action.'
 
-    qtbot.waitUntil(check_for_error, timeout=10000)
+    qtbot.waitUntil(check_for_error, timeout=TIME_CLICK_ACTION)

--- a/tests/functional/test_offline_read_conversations.py
+++ b/tests/functional/test_offline_read_conversations.py
@@ -8,6 +8,9 @@ import pytest
 from flaky import flaky
 from PyQt5.QtCore import Qt
 
+from tests.conftest import (TIME_APP_START, TIME_CLICK_ACTION,
+                            TIME_RENDER_CONV_VIEW, TIME_RENDER_SOURCE_LIST)
+
 
 @flaky
 @pytest.mark.vcr()
@@ -16,12 +19,12 @@ def test_offline_read_conversations(functional_test_logged_in_context, qtbot, mo
     It's possible to read downloaded conversations when offline.
     """
     gui, controller, tempdir = functional_test_logged_in_context
-    qtbot.wait(1000)
+    qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
         assert len(list(gui.main_view.source_list.source_widgets.keys()))
 
-    qtbot.waitUntil(check_for_sources, timeout=10000)
+    qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
     source_ids = list(gui.main_view.source_list.source_widgets.keys())
     first_source_id = source_ids[0]
     first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
@@ -29,14 +32,14 @@ def test_offline_read_conversations(functional_test_logged_in_context, qtbot, mo
 
     # Otherwise our test is running too fast to create all files/directories
     # as received via API call.
-    qtbot.wait(1000)
+    qtbot.wait(TIME_CLICK_ACTION)
 
     # Now logout.
     def check_login_button():
         assert gui.left_pane.user_profile.login_button.isVisible()
 
     gui.left_pane.user_profile.user_button.menu.logout.trigger()
-    qtbot.waitUntil(check_login_button, timeout=10000)
+    qtbot.waitUntil(check_login_button, timeout=TIME_RENDER_CONV_VIEW)
 
     # Ensure that clicking on a source shows a conversation that contains
     # activity.

--- a/tests/functional/test_offline_send_reply.py
+++ b/tests/functional/test_offline_send_reply.py
@@ -8,6 +8,9 @@ import pytest
 from flaky import flaky
 from PyQt5.QtCore import Qt
 
+from tests.conftest import (TIME_APP_START, TIME_RENDER_CONV_VIEW,
+                            TIME_RENDER_SOURCE_LIST)
+
 
 @flaky
 @pytest.mark.vcr()
@@ -16,12 +19,12 @@ def test_offline_send_reply_to_source(functional_test_logged_in_context, qtbot, 
     It's NOT possible to send a reply to a source when the client is offline.
     """
     gui, controller, tempdir = functional_test_logged_in_context
-    qtbot.wait(1000)
+    qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
         assert len(list(gui.main_view.source_list.source_widgets.keys()))
 
-    qtbot.waitUntil(check_for_sources, timeout=10000)
+    qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
     source_ids = list(gui.main_view.source_list.source_widgets.keys())
     first_source_id = source_ids[0]
     first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
@@ -32,7 +35,7 @@ def test_offline_send_reply_to_source(functional_test_logged_in_context, qtbot, 
         assert gui.left_pane.user_profile.login_button.isVisible()
 
     gui.left_pane.user_profile.user_button.menu.logout.trigger()
-    qtbot.waitUntil(check_login_button, timeout=10000)
+    qtbot.waitUntil(check_login_button, timeout=TIME_RENDER_CONV_VIEW)
 
     # Check UI won't let user send a reply.
     conversation = gui.main_view.view_layout.itemAt(0).widget()

--- a/tests/functional/test_offline_star_source.py
+++ b/tests/functional/test_offline_star_source.py
@@ -8,6 +8,9 @@ import pytest
 from flaky import flaky
 from PyQt5.QtCore import Qt
 
+from tests.conftest import (TIME_APP_START, TIME_RENDER_CONV_VIEW,
+                            TIME_RENDER_SOURCE_LIST)
+
 
 @flaky
 @pytest.mark.vcr()
@@ -17,12 +20,12 @@ def test_offline_star_source(functional_test_logged_in_context, qtbot):
     """
 
     gui, controller, homedir = functional_test_logged_in_context
-    qtbot.wait(1000)
+    qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
         assert len(list(gui.main_view.source_list.source_widgets.keys()))
 
-    qtbot.waitUntil(check_for_sources, timeout=10000)
+    qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
     source_ids = list(gui.main_view.source_list.source_widgets.keys())
     first_source_id = source_ids[0]
     first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
@@ -33,7 +36,7 @@ def test_offline_star_source(functional_test_logged_in_context, qtbot):
         assert gui.left_pane.user_profile.login_button.isVisible()
 
     gui.left_pane.user_profile.user_button.menu.logout.trigger()
-    qtbot.waitUntil(check_login_button, timeout=10000)
+    qtbot.waitUntil(check_login_button, timeout=TIME_RENDER_CONV_VIEW)
 
     # Check the source isn't checked.
     assert first_source_widget.star.isChecked() is False
@@ -45,4 +48,4 @@ def test_offline_star_source(functional_test_logged_in_context, qtbot):
         msg = gui.top_pane.error_status_bar.status_bar.currentMessage()
         assert msg == 'You must sign in to perform this action.'
 
-    qtbot.waitUntil(check_for_error, timeout=10000)
+    qtbot.waitUntil(check_for_error, timeout=TIME_RENDER_CONV_VIEW)

--- a/tests/functional/test_receive_message.py
+++ b/tests/functional/test_receive_message.py
@@ -9,6 +9,9 @@ from flaky import flaky
 from PyQt5.QtCore import Qt
 from securedrop_client.gui.widgets import FileWidget
 
+from tests.conftest import (TIME_APP_START, TIME_RENDER_SOURCE_LIST,
+                            TIME_SYNC)
+
 
 @flaky
 @pytest.mark.vcr()
@@ -18,18 +21,18 @@ def test_receive_message_from_source(functional_test_logged_in_context, qtbot, m
     the conversation window.
     """
     gui, controller, tempdir = functional_test_logged_in_context
-    qtbot.wait(1000)
+    qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
         assert len(list(gui.main_view.source_list.source_widgets.keys()))
 
-    qtbot.waitUntil(check_for_sources, timeout=10000)
+    qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
     source_ids = list(gui.main_view.source_list.source_widgets.keys())
     first_source_id = source_ids[0]
     first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
     qtbot.mouseClick(first_source_widget, Qt.LeftButton)
 
-    qtbot.wait(16000)  # Wait for the client to sync.
+    qtbot.wait(TIME_SYNC)
     # Ensure the last widget in the conversation view contains the expected
     # text from the source.
     conversation = gui.main_view.view_layout.itemAt(0).widget()

--- a/tests/functional/test_send_reply.py
+++ b/tests/functional/test_send_reply.py
@@ -8,6 +8,8 @@ import pytest
 from flaky import flaky
 from PyQt5.QtCore import Qt
 
+from tests.conftest import (TIME_APP_START, TIME_CLICK_ACTION, TIME_RENDER_SOURCE_LIST)
+
 
 @flaky
 @pytest.mark.vcr()
@@ -17,12 +19,12 @@ def test_send_reply_to_source(functional_test_logged_in_context, qtbot, mocker):
     conversation window.
     """
     gui, controller, tempdir = functional_test_logged_in_context
-    qtbot.wait(1000)
+    qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
         assert len(list(gui.main_view.source_list.source_widgets.keys()))
 
-    qtbot.waitUntil(check_for_sources, timeout=10000)
+    qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
     source_ids = list(gui.main_view.source_list.source_widgets.keys())
     first_source_id = source_ids[0]
     first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
@@ -34,12 +36,12 @@ def test_send_reply_to_source(functional_test_logged_in_context, qtbot, mocker):
     qtbot.mouseClick(conversation.reply_box.text_edit, Qt.LeftButton)
     # Type in a message to the reply box.
     qtbot.keyClicks(conversation.reply_box.text_edit, message)
-    qtbot.wait(1000)
+    qtbot.wait(TIME_CLICK_ACTION)
     # Wait until the result of the click on the send button has caused the
     # reply_sent signal to trigger.
     with qtbot.waitSignal(conversation.reply_box.reply_sent):
         qtbot.mouseClick(conversation.reply_box.send_button, Qt.LeftButton)
-    qtbot.wait(1000)
+    qtbot.wait(TIME_CLICK_ACTION)
     # Ensure the last widget in the conversation view contains the text we
     # just typed.
     last_msg_id = list(conversation.conversation_view.current_messages.keys())[-1]

--- a/tests/functional/test_star_source.py
+++ b/tests/functional/test_star_source.py
@@ -8,6 +8,9 @@ import pytest
 from flaky import flaky
 from PyQt5.QtCore import Qt
 
+from tests.conftest import (TIME_APP_START, TIME_CLICK_ACTION,
+                            TIME_RENDER_SOURCE_LIST)
+
 
 @flaky
 @pytest.mark.vcr()
@@ -16,12 +19,12 @@ def test_star_source(functional_test_logged_in_context, qtbot, mocker):
     It's possible to star a source and see its updated status.
     """
     gui, controller, tempdir = functional_test_logged_in_context
-    qtbot.wait(1000)
+    qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
         assert len(list(gui.main_view.source_list.source_widgets.keys()))
 
-    qtbot.waitUntil(check_for_sources, timeout=10000)
+    qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
     source_ids = list(gui.main_view.source_list.source_widgets.keys())
     first_source_id = source_ids[0]
     first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
@@ -31,6 +34,6 @@ def test_star_source(functional_test_logged_in_context, qtbot, mocker):
     assert first_source_widget.star.isChecked() is False
     # Click it.
     qtbot.mouseClick(first_source_widget.star, Qt.LeftButton)
-    qtbot.wait(1000)
+    qtbot.wait(TIME_CLICK_ACTION)
     # Check the source is now checked.
     assert first_source_widget.star.is_starred is True

--- a/tests/functional/test_unstar_source.py
+++ b/tests/functional/test_unstar_source.py
@@ -8,6 +8,9 @@ import pytest
 from flaky import flaky
 from PyQt5.QtCore import Qt
 
+from tests.conftest import (TIME_APP_START, TIME_CLICK_ACTION,
+                            TIME_RENDER_SOURCE_LIST)
+
 
 @flaky
 @pytest.mark.vcr()
@@ -16,12 +19,12 @@ def test_unstar_source(functional_test_logged_in_context, qtbot, mocker):
     It's possible to un-star a source and see its updated status.
     """
     gui, controller, tempdir = functional_test_logged_in_context
-    qtbot.wait(1000)
+    qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
         assert len(list(gui.main_view.source_list.source_widgets.keys()))
 
-    qtbot.waitUntil(check_for_sources, timeout=10000)
+    qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
     source_ids = list(gui.main_view.source_list.source_widgets.keys())
     first_source_id = source_ids[0]
     first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
@@ -31,6 +34,6 @@ def test_unstar_source(functional_test_logged_in_context, qtbot, mocker):
     assert first_source_widget.star.isChecked() is True
     # Click it again to toggle it off.
     qtbot.mouseClick(first_source_widget.star, Qt.LeftButton)
-    qtbot.wait(1000)
+    qtbot.wait(TIME_CLICK_ACTION)
     # Check the source isn't checked once more.
     assert first_source_widget.star.is_starred is False


### PR DESCRIPTION
# Description

Test only, addresses my comment [here](https://github.com/freedomofpress/securedrop-client/pull/1022#discussion_r404871812)

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/master/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `master` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `master` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
