### PR TITLE
Cryptoerror logs

### DIFF
--- a/securedrop_client/api_jobs/base.py
+++ b/securedrop_client/api_jobs/base.py
@@ -1,5 +1,4 @@
 import logging
-import traceback
 
 from PyQt5.QtCore import QObject, pyqtSignal
 from sdclientapi import API, AuthError, RequestTimeoutError, ServerConnectionError
@@ -78,11 +77,6 @@ class ApiJob(QueueJob):
                     raise
             except Exception as e:
                 self.failure_signal.emit(e)
-                logger.error(
-                    "%s API call error: %s",
-                    self.__class__.__name__,
-                    traceback.format_exc()
-                )
                 raise
             else:
                 self.success_signal.emit(result)

--- a/securedrop_client/api_jobs/downloads.py
+++ b/securedrop_client/api_jobs/downloads.py
@@ -265,21 +265,19 @@ class ReplyDownloadJob(DownloadJob):
         The return value is an empty string; replies have no original filename.
         '''
         with NamedTemporaryFile('w+') as plaintext_file:
-            self.gpg.decrypt_submission_or_reply(filepath, plaintext_file.name, is_doc=False)
             try:
+                self.gpg.decrypt_submission_or_reply(filepath, plaintext_file.name, is_doc=False)
                 set_message_or_reply_content(
                     model_type=Reply,
                     uuid=self.uuid,
                     session=session,
                     content=plaintext_file.read())
             finally:
-                # clean up directory where decryption happened
                 try:
                     os.rmdir(os.path.dirname(filepath))
-                except Exception as e:
-                    logger.warning(
-                        "Error deleting decryption directory of message %s: %s", self.uuid, e
-                    )
+                except OSError:
+                    msg = f'Could not delete decryption directory: {os.path.dirname(filepath)}'
+                    logger.debug(msg)
 
         return ""
 
@@ -330,13 +328,12 @@ class MessageDownloadJob(DownloadJob):
                     session=session,
                     content=plaintext_file.read())
             finally:
-                # clean up directory where decryption happened
                 try:
                     os.rmdir(os.path.dirname(filepath))
-                except Exception as e:
-                    logger.warning(
-                        "Error deleting decryption directory of message %s: %s", self.uuid, e
-                    )
+                except OSError:
+                    msg = f'Could not delete decryption directory: {os.path.dirname(filepath)}'
+                    logger.debug(msg)
+
         return ""
 
 

--- a/securedrop_client/api_jobs/downloads.py
+++ b/securedrop_client/api_jobs/downloads.py
@@ -181,7 +181,7 @@ class DownloadJob(ApiJob):
             db_object.download_error = None
             mark_as_decrypted(
                 type(db_object), db_object.uuid, session, original_filename=original_filename)
-            logger.info(f'File decrypted to {filepath}')
+            logger.info(f'File decrypted to {os.path.dirname(filepath)}')
         except CryptoError as e:
             mark_as_decrypted(type(db_object), db_object.uuid, session, is_decrypted=False)
             download_error = session.query(DownloadError).filter_by(

--- a/securedrop_client/crypto.py
+++ b/securedrop_client/crypto.py
@@ -109,7 +109,6 @@ class GpgHelper:
                 with open(err.name) as e:
                     msg = "GPG Error: {}".format(e.read())
 
-                logger.error(msg)
                 os.unlink(err.name)
 
                 raise CryptoError(msg)
@@ -173,8 +172,7 @@ class GpgHelper:
                 subprocess.check_call(cmd, stdout=stdout, stderr=stderr)
             except subprocess.CalledProcessError as e:
                 stderr.seek(0)
-                logger.error('Could not import key: {}\n{}'.format(e, stderr.read()))
-                raise CryptoError('Could not import key.')
+                raise CryptoError('Could not import key: {}\n{}'.format(e, stderr.read()))
 
     def encrypt_to_source(self, source_uuid: str, data: str) -> str:
         '''
@@ -220,9 +218,8 @@ class GpgHelper:
                 subprocess.check_call(cmd, stdout=stdout, stderr=stderr)
             except subprocess.CalledProcessError as e:
                 stderr.seek(0)
-                logger.error(
-                    'Could not encrypt to source {}: {}\n{}'.format(source_uuid, e, stderr.read()))
-                raise CryptoError('Could not encrypt to source: {}.'.format(source_uuid))
+                err = stderr.read()
+                raise CryptoError(f'Could not encrypt to source {source_uuid}: {e}\n{err}')
 
             stdout.seek(0)
             return stdout.read()

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -658,8 +658,6 @@ class Controller(QObject):
         """
         Called when a message fails to download.
         """
-        logger.info('Failed to download message: {}'.format(exception))
-
         if isinstance(exception, DownloadChecksumMismatchException):
             # Keep resubmitting the job if the download is corrupted.
             logger.warning('Failure due to checksum mismatch, retrying {}'.format(exception.uuid))
@@ -694,8 +692,6 @@ class Controller(QObject):
         """
         Called when a reply fails to download.
         """
-        logger.info('Failed to download reply: {}'.format(exception))
-
         if isinstance(exception, DownloadChecksumMismatchException):
             # Keep resubmitting the job if the download is corrupted.
             logger.warning('Failure due to checksum mismatch, retrying {}'.format(exception.uuid))
@@ -828,8 +824,6 @@ class Controller(QObject):
         """
         Called when a file fails to download.
         """
-        logger.info('Failed to download file: {}'.format(exception))
-
         # Keep resubmitting the job if the download is corrupted.
         if isinstance(exception, DownloadChecksumMismatchException):
             logger.warning('Failure due to checksum mismatch, retrying {}'.format(exception.uuid))

--- a/tests/api_jobs/test_downloads.py
+++ b/tests/api_jobs/test_downloads.py
@@ -520,13 +520,8 @@ def test_FileDownloadJob_decryption_error(
         gpg,
     )
 
-    mock_logger = mocker.patch('securedrop_client.api_jobs.downloads.logger')
-
     with pytest.raises(DownloadDecryptionException):
         job.call_api(api_client, session)
-
-    log_msg = mock_logger.debug.call_args_list[0][0][0]
-    assert log_msg.startswith('Failed to decrypt file')
 
     # ensure mocks aren't stale
     assert mock_decrypt.called

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1187,12 +1187,10 @@ def test_Controller_on_reply_downloaded_failure(mocker, homedir, session_maker):
     reply_ready = mocker.patch.object(co, 'reply_ready')
     reply = factory.Reply(source=factory.Source())
     mocker.patch('securedrop_client.storage.get_reply', return_value=reply)
-    info_logger = mocker.patch('securedrop_client.logic.logger.info')
     co._submit_download_job = mocker.MagicMock()
 
     co.on_reply_download_failure(Exception('mock_exception'))
 
-    info_logger.assert_called_once_with('Failed to download reply: mock_exception')
     reply_ready.emit.assert_not_called()
 
     # Job should not get automatically resubmitted if the failure was generic
@@ -1208,13 +1206,11 @@ def test_Controller_on_reply_downloaded_checksum_failure(mocker, homedir, sessio
     reply = factory.Reply(source=factory.Source())
     mocker.patch('securedrop_client.storage.get_reply', return_value=reply)
     warning_logger = mocker.patch('securedrop_client.logic.logger.warning')
-    info_logger = mocker.patch('securedrop_client.logic.logger.info')
     co._submit_download_job = mocker.MagicMock()
 
     co.on_reply_download_failure(DownloadChecksumMismatchException('bang!',
                                  type(reply), reply.uuid))
 
-    info_logger.call_args_list[0][0][0] == 'Failed to download reply: bang!'
     reply_ready.emit.assert_not_called()
 
     # Job should get resubmitted and we should log this is happening
@@ -1232,12 +1228,10 @@ def test_Controller_on_reply_downloaded_decryption_failure(mocker, homedir, sess
     reply_download_failed = mocker.patch.object(co, 'reply_download_failed')
     reply = factory.Reply(source=factory.Source())
     mocker.patch('securedrop_client.storage.get_reply', return_value=reply)
-    info_logger = mocker.patch('securedrop_client.logic.logger.info')
 
     decryption_exception = DownloadDecryptionException('bang!', type(reply), reply.uuid)
     co.on_reply_download_failure(decryption_exception)
 
-    info_logger.call_args_list[0][0][0] == 'Failed to download reply: bang!'
     reply_ready.emit.assert_not_called()
     reply_download_failed.emit.assert_called_with(reply.source.uuid, reply.uuid, str(reply))
 
@@ -1376,11 +1370,9 @@ def test_Controller_on_message_downloaded_failure(mocker, homedir, session_maker
     message = factory.Message(source=factory.Source())
     mocker.patch('securedrop_client.storage.get_message', return_value=message)
     co._submit_download_job = mocker.MagicMock()
-    info_logger = mocker.patch('securedrop_client.logic.logger.info')
 
     co.on_message_download_failure(Exception('mock_exception'))
 
-    info_logger.assert_called_once_with('Failed to download message: mock_exception')
     message_ready.emit.assert_not_called()
 
     # Job should not get automatically resubmitted if the failure was generic
@@ -1396,19 +1388,14 @@ def test_Controller_on_message_downloaded_checksum_failure(mocker, homedir, sess
     message = factory.Message(source=factory.Source())
     mocker.patch('securedrop_client.storage.get_message', return_value=message)
     co._submit_download_job = mocker.MagicMock()
-    warning_logger = mocker.patch('securedrop_client.logic.logger.warning')
-    info_logger = mocker.patch('securedrop_client.logic.logger.info')
 
     co.on_message_download_failure(DownloadChecksumMismatchException('bang!',
                                    type(message), message.uuid))
 
-    info_logger.call_args_list[0][0][0] == 'Failed to download message: bang!'
     message_ready.emit.assert_not_called()
 
     # Job should get resubmitted and we should log this is happening
     co._submit_download_job.call_count == 1
-    warning_logger.call_args_list[0][0][0] == \
-        'Failure due to checksum mismatch, retrying {}'.format(message.uuid)
 
 
 def test_Controller_on_message_downloaded_decryption_failure(mocker, homedir, session_maker):
@@ -1420,12 +1407,10 @@ def test_Controller_on_message_downloaded_decryption_failure(mocker, homedir, se
     message_download_failed = mocker.patch.object(co, 'message_download_failed')
     message = factory.Message(source=factory.Source())
     mocker.patch('securedrop_client.storage.get_message', return_value=message)
-    info_logger = mocker.patch('securedrop_client.logic.logger.info')
 
     decryption_exception = DownloadDecryptionException('bang!', type(message), message.uuid)
     co.on_message_download_failure(decryption_exception)
 
-    info_logger.call_args_list[0][0][0] == 'Failed to download message: bang!'
     message_ready.emit.assert_not_called()
     message_download_failed.emit.assert_called_with(message.source.uuid, message.uuid, str(message))
 


### PR DESCRIPTION
# Description

Clean up noisy logs around decryption errors: https://github.com/freedomofpress/securedrop-client/pull/1083#issuecomment-625668989

# Before
### Info level
```
2020-05-08 16:57:36,949 - securedrop_client.api_jobs.downloads:167(_download) INFO: File downloaded to /home/creviera/.securedrop_client/data/unlike_canvas/1-unlike_canvas-msg.txt
2020-05-08 16:57:36,957 - securedrop_client.crypto:112(decrypt_submission_or_reply) ERROR: GPG Error: gpg: encrypted with RSA key, ID C3E7C4C0A2201B2A
gpg: decryption failed: No secret key

2020-05-08 16:57:36,957 - securedrop_client.api_jobs.downloads:343(call_decrypt) WARNING: Error deleting decryption directory of message 4fe17e03-8196-4700-9d40-a41164cbeb90: [Errno 39] Directory not empty: '/home/creviera/.securedrop_client/data/unlike_canvas'
2020-05-08 16:57:36,979 - securedrop_client.logic:661(on_message_download_failure) INFO: Failed to download message: Downloaded file could not be decrypted.
2020-05-08 16:57:36,980 - securedrop_client.api_jobs.base:84(_do_call_api) ERROR: MessageDownloadJob API call error: Traceback (most recent call last):
  File "/home/creviera/workspace/freedomofpress/securedrop-client/securedrop_client/api_jobs/downloads.py", line 181, in _decrypt
    original_filename = self.call_decrypt(filepath, session)
  File "/home/creviera/workspace/freedomofpress/securedrop-client/securedrop_client/api_jobs/downloads.py", line 331, in call_decrypt
    self.gpg.decrypt_submission_or_reply(filepath, plaintext_file.name, is_doc=False)
  File "/home/creviera/workspace/freedomofpress/securedrop-client/securedrop_client/crypto.py", line 115, in decrypt_submission_or_reply
    raise CryptoError(msg)
securedrop_client.crypto.CryptoError: GPG Error: gpg: encrypted with RSA key, ID C3E7C4C0A2201B2A
gpg: decryption failed: No secret key


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/creviera/workspace/freedomofpress/securedrop-client/securedrop_client/api_jobs/base.py", line 72, in _do_call_api
    result = self.call_api(api_client, session)
  File "/home/creviera/workspace/freedomofpress/securedrop-client/securedrop_client/api_jobs/downloads.py", line 133, in call_api
    self._decrypt(destination, db_object, session)
  File "/home/creviera/workspace/freedomofpress/securedrop-client/securedrop_client/api_jobs/downloads.py", line 201, in _decrypt
    ) from e
securedrop_client.api_jobs.downloads.DownloadDecryptionException: Downloaded file could not be decrypted.

2020-05-08 16:57:36,980 - securedrop_client.queue:131(process) ERROR: DownloadDecryptionException: Downloaded file could not be decrypted.
```

### Debug level
```
2020-05-08 17:02:05,746 - securedrop_client.api_jobs.downloads:167(_download) INFO: File downloaded to /home/creviera/.securedrop_client/data/unsound_lateralization/1-unsound_lateralization-msg.txt
2020-05-08 17:02:05,753 - securedrop_client.crypto:112(decrypt_submission_or_reply) ERROR: GPG Error: gpg: encrypted with RSA key, ID C3E7C4C0A2201B2A
gpg: decryption failed: No secret key

2020-05-08 17:02:05,753 - securedrop_client.api_jobs.downloads:343(call_decrypt) WARNING: Error deleting decryption directory of message 457f75a1-fbcc-4116-8fbd-f35bc3dd4957: [Errno 39] Directory not empty: '/home/creviera/.securedrop_client/data/unsound_lateralization'
2020-05-08 17:02:05,772 - securedrop_client.api_jobs.downloads:196(_decrypt) DEBUG: Failed to decrypt file: 1-unsound_lateralization-msg.txt
2020-05-08 17:02:05,775 - securedrop_client.logic:661(on_message_download_failure) INFO: Failed to download message: Downloaded file could not be decrypted.
2020-05-08 17:02:05,776 - securedrop_client.api_jobs.base:84(_do_call_api) ERROR: MessageDownloadJob API call error: Traceback (most recent call last):
  File "/home/creviera/workspace/freedomofpress/securedrop-client/securedrop_client/api_jobs/downloads.py", line 181, in _decrypt
    original_filename = self.call_decrypt(filepath, session)
  File "/home/creviera/workspace/freedomofpress/securedrop-client/securedrop_client/api_jobs/downloads.py", line 331, in call_decrypt
    self.gpg.decrypt_submission_or_reply(filepath, plaintext_file.name, is_doc=False)
  File "/home/creviera/workspace/freedomofpress/securedrop-client/securedrop_client/crypto.py", line 115, in decrypt_submission_or_reply
    raise CryptoError(msg)
securedrop_client.crypto.CryptoError: GPG Error: gpg: encrypted with RSA key, ID C3E7C4C0A2201B2A
gpg: decryption failed: No secret key


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/creviera/workspace/freedomofpress/securedrop-client/securedrop_client/api_jobs/base.py", line 72, in _do_call_api
    result = self.call_api(api_client, session)
  File "/home/creviera/workspace/freedomofpress/securedrop-client/securedrop_client/api_jobs/downloads.py", line 133, in call_api
    self._decrypt(destination, db_object, session)
  File "/home/creviera/workspace/freedomofpress/securedrop-client/securedrop_client/api_jobs/downloads.py", line 201, in _decrypt
    ) from e
securedrop_client.api_jobs.downloads.DownloadDecryptionException: Downloaded file could not be decrypted.

2020-05-08 17:02:05,776 - securedrop_client.queue:131(process) ERROR: DownloadDecryptionException: Downloaded file could not be decrypted.
2020-05-08 17:02:05,778 - securedrop_client.queue:132(process) DEBUG: Skipping job
```

# After
### Info level
```
2020-05-08 16:37:56,812 - securedrop_client.api_jobs.downloads:167(_download) INFO: File downloaded to /home/creviera/.securedrop_client/data/condemnable_blowout/1-condemnable_blowout-msg.txt
2020-05-08 16:37:56,843 - securedrop_client.queue:131(process) ERROR: DownloadDecryptionException: Failed to decrypt file: 1-condemnable_blowout-msg.txt
```

### Debug level
```
2020-05-08 16:50:13,426 - securedrop_client.api_jobs.downloads:167(_download) INFO: File downloaded to /home/creviera/.securedrop_client/data/moral_persecution/1-moral_persecution-msg.txt
2020-05-08 16:50:13,435 - securedrop_client.api_jobs.downloads:335(call_decrypt) DEBUG: Could not delete decryption directory: /home/creviera/.securedrop_client/data/moral_persecution
2020-05-08 16:50:13,455 - securedrop_client.queue:131(process) ERROR: DownloadDecryptionException: Failed to decrypt file: 1-moral_persecution-msg.txt
2020-05-08 16:50:13,456 - securedrop_client.queue:132(process) DEBUG: Skipping job
```

# Test Plan

Follow test plan here: https://github.com/freedomofpress/securedrop-client/pull/1059#issue-402009029

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/master/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `master` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `master` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed
