### PR TITLE
Make sure source fingerprint is updated on sync

### DIFF
--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -170,6 +170,7 @@ def update_sources(
             lazy_setattr(local_source, "is_starred", source.is_starred)
             lazy_setattr(local_source, "last_updated", parse(source.last_updated))
             lazy_setattr(local_source, "public_key", source.key['public'])
+            lazy_setattr(local_source, "fingerprint", source.key['fingerprint'])
 
             # Removing the UUID from local_sources_by_uuid ensures
             # this record won't be deleted at the end of this

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -4200,6 +4200,8 @@ def test_ReplyBoxWidget_enable_after_source_gets_key(mocker, session, session_ma
         # when the ReplyBoxWidget is constructed, the source has no key,
         # so the widget should be disabled
         rbw = ReplyBoxWidget(source, controller)
+        assert rbw.source.fingerprint is None
+        assert rbw.source.public_key is None
         assert rbw.replybox.isEnabled() is False
         assert rbw.text_edit.isEnabled() is False
 
@@ -4211,6 +4213,7 @@ def test_ReplyBoxWidget_enable_after_source_gets_key(mocker, session, session_ma
         rbw._on_synced("synced")
 
         # ... and the widget should be enabled
+        assert rbw.source.fingerprint
         assert rbw.source.public_key
         assert rbw.replybox.isEnabled()
         assert rbw.text_edit.isEnabled()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -311,7 +311,7 @@ def test_update_sources(homedir, mocker, session_maker, session):
     # This local source already exists in the API results and will be updated.
     local_source1 = factory.Source(
         journalist_designation=source_update.journalist_designation,
-        uuid=source_update.uuid,
+        uuid=source_update.uuid, public_key=None, fingerprint=None
     )
 
     # This local source does not exist in the API results and will be


### PR DESCRIPTION
# Description

It was missing from the list of attributes updated on existing sources during sync, so a source which had no key when first synced would never be completed, even once the keypair were generated on the server, and journalists would never be able to reply to them.

Fixes #1091.

# Test Plan

Tough to test manually, as the failure is dependent on a new source being synced before having its keypair generated. 

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/master/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `master` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `master` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
