### PR TITLE
reduce minimum size

### DIFF
--- a/securedrop_client/api_jobs/downloads.py
+++ b/securedrop_client/api_jobs/downloads.py
@@ -83,7 +83,7 @@ class DownloadJob(SingleObjectApiJob):
 
         * Minimum timeout allowed is 25 seconds
         """
-        TIMEOUT_BYTES_PER_SECOND = 100000.0
+        TIMEOUT_BYTES_PER_SECOND = 100_000.0
         TIMEOUT_ADJUSTMENT_FACTOR = 1.5
         TIMEOUT_BASE = 25
         timeout = math.ceil((size_in_bytes / TIMEOUT_BYTES_PER_SECOND) * TIMEOUT_ADJUSTMENT_FACTOR)

--- a/securedrop_client/config.py
+++ b/securedrop_client/config.py
@@ -27,7 +27,7 @@ class Config:
             logger.error("Error opening config file at {}: {}".format(full_path, e))
             json_config = {}
 
-        return cls(journalist_key_fingerprint=json_config.get("journalist_key_fingerprint", None),)
+        return cls(journalist_key_fingerprint=json_config.get("journalist_key_fingerprint", None))
 
     @property
     def is_valid(self) -> bool:

--- a/securedrop_client/export.py
+++ b/securedrop_client/export.py
@@ -59,9 +59,7 @@ class Export(QObject):
     DISK_TEST_METADATA = {"device": "disk-test"}
 
     PRINT_FN = "print_archive.sd-export"
-    PRINT_METADATA = {
-        "device": "printer",
-    }
+    PRINT_METADATA = {"device": "printer"}
 
     DISK_FN = "archive.sd-export"
     DISK_METADATA = {"device": "disk", "encryption_method": "luks"}

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -78,8 +78,8 @@ class Window(QMainWindow):
         self.main_pane.setLayout(layout)
         self.left_pane = LeftPane()
         self.main_view = MainView(self.main_pane)
-        layout.addWidget(self.left_pane, 1)
-        layout.addWidget(self.main_view, 8)
+        layout.addWidget(self.left_pane)
+        layout.addWidget(self.main_view)
 
         # Set the main window's central widget to show Top Pane and Main Pane
         self.central_widget = QWidget()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -177,7 +177,6 @@ class LeftPane(QWidget):
         layout.setSpacing(0)
         layout.setAlignment(Qt.AlignBottom)
         self.setFixedWidth(198)
-        self.setMinimumHeight(558)
 
         # Set background image
         self.logo = QWidget()
@@ -190,7 +189,6 @@ class LeftPane(QWidget):
         )
         self.logo.setPalette(self.offline_palette)
         self.logo.setAutoFillBackground(True)
-        self.logo.setMaximumHeight(884)
         self.logo.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.logo.setEnabled(False)
 
@@ -396,7 +394,6 @@ class UserProfile(QLabel):
         palette.setBrush(QPalette.Background, QBrush(QColor("#0096DC")))
         self.setPalette(palette)
         self.setAutoFillBackground(True)
-        self.setMinimumHeight(20)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
 
         # Set layout
@@ -426,13 +423,9 @@ class UserProfile(QLabel):
         self.user_icon.setCursor(QCursor(Qt.PointingHandCursor))
 
         # Add widgets to user auth layout
-        layout.addWidget(self.login_button, 1)
-        layout.addWidget(self.user_icon, 1)
-        layout.addWidget(self.user_button, 4)
-
-        # Align content to the top left
-        layout.addStretch()
-        layout.setAlignment(Qt.AlignTop)
+        layout.addWidget(self.login_button, alignment=Qt.AlignTop)
+        layout.addWidget(self.user_icon, alignment=Qt.AlignTop)
+        layout.addWidget(self.user_button, alignment=Qt.AlignTop)
 
     def setup(self, window, controller):
         self.user_button.setup(controller)
@@ -792,8 +785,7 @@ class SourceList(QListWidget):
     def __init__(self):
         super().__init__()
 
-        self.setObjectName("SourceList")
-        self.setFixedWidth(540)
+        self.setObjectName('SourceList')
         self.setUniformItemSizes(True)
 
         # Set layout.

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -784,7 +784,7 @@ class SourceList(QListWidget):
     def __init__(self):
         super().__init__()
 
-        self.setObjectName('SourceList')
+        self.setObjectName("SourceList")
         self.setUniformItemSizes(True)
 
         # Set layout.
@@ -1312,7 +1312,7 @@ class DeleteSourceMessageBox:
 
         message_tuple = (
             "<big>Deleting the Source account for",
-            "<b>{}</b> will also".format(source.journalist_designation,),
+            "<b>{}</b> will also".format(source.journalist_designation),
             "delete {} files, {} replies, and {} messages.</big>".format(files, replies, messages),
             "<br>",
             "<small>This Source will no longer be able to correspond",

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -419,7 +419,6 @@ class UserProfile(QLabel):
         self.user_icon_font.setLetterSpacing(QFont.AbsoluteSpacing, 0.58)
         self.user_icon.setFont(self.user_icon_font)
         self.user_icon.clicked.connect(self.user_button.click)
-        # Set cursor.
         self.user_icon.setCursor(QCursor(Qt.PointingHandCursor))
 
         # Add widgets to user auth layout
@@ -978,7 +977,7 @@ class SourceWidget(QWidget):
 
     SIDE_MARGIN = 10
     SOURCE_WIDGET_VERTICAL_MARGIN = 10
-    PREVIEW_WIDTH = 412
+    PREVIEW_WIDTH = 380
     PREVIEW_HEIGHT = 60
 
     def __init__(self, controller: Controller, source: Source):
@@ -1051,8 +1050,8 @@ class SourceWidget(QWidget):
         self.paperclip.setFixedSize(QSize(22, 22))
         self.timestamp = QLabel()
         self.timestamp.setObjectName("SourceWidget_timestamp")
-        metadata_layout.addWidget(self.paperclip, 0, Qt.AlignRight)
-        metadata_layout.addWidget(self.timestamp, 0, Qt.AlignRight)
+        metadata_layout.addWidget(self.paperclip, alignment=Qt.AlignRight)
+        metadata_layout.addWidget(self.timestamp, alignment=Qt.AlignRight)
         metadata_layout.addStretch()
 
         # Set up a source_widget

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -397,10 +397,7 @@ class Controller(QObject):
         new_api_thread.started.connect(new_api_runner.call_api)
 
         # Add the thread related objects to the api_threads dictionary.
-        self.api_threads[new_thread_id] = {
-            "thread": new_api_thread,
-            "runner": new_api_runner,
-        }
+        self.api_threads[new_thread_id] = {"thread": new_api_thread, "runner": new_api_runner}
 
         # Start the thread and related activity.
         new_api_thread.start()
@@ -834,7 +831,7 @@ class Controller(QObject):
 
     @login_required
     def on_submission_download(
-        self, submission_type: Union[Type[db.File], Type[db.Message]], submission_uuid: str,
+        self, submission_type: Union[Type[db.File], Type[db.Message]], submission_uuid: str
     ) -> None:
         """
         Download the file associated with the Submission (which may be a File or Message).

--- a/securedrop_client/resources/css/reply_message.css
+++ b/securedrop_client/resources/css/reply_message.css
@@ -1,6 +1,4 @@
 #ReplyWidget_message {
-    min-width: 508px;
-    max-width: 508px;
     font-family: 'Source Sans Pro';
     font-weight: 400;
     font-size: 15px;
@@ -10,8 +8,6 @@
 }
 
 #ReplyWidget_message_pending {
-    min-width: 508px;
-    max-width: 508px;
     font-family: 'Source Sans Pro';
     font-weight: 400;
     font-size: 15px;
@@ -21,8 +17,6 @@
 }
 
 #ReplyWidget_message_failed {
-    min-width: 508px;
-    max-width: 508px;
     font-family: 'Source Sans Pro';
     font-weight: 400;
     font-size: 15px;

--- a/securedrop_client/resources/css/sdclient.css
+++ b/securedrop_client/resources/css/sdclient.css
@@ -149,7 +149,7 @@
 }
 
 #MainView_view_holder {
-    min-width: 667;
+    min-width: 500;
     border: none;
     background-color: #f3f5f9;
 }
@@ -172,12 +172,10 @@
 }
 
 #EmptyConversationView_no_sources QLabel#EmptyConversationView_instructions {
-    min-width: 520px;
     max-width: 600px;
 }
 
 #EmptyConversationView_no_source_selected QLabel#EmptyConversationView_instructions {
-    min-width: 520px;
     max-width: 520px;
 }
 
@@ -185,7 +183,7 @@ QListView#SourceList {
     border: none;
     show-decoration-selected: 0;
     border-right: 3px solid #f3f5f9;
-    min-width: 540px;
+    min-width: 500px;
     max-width: 540px;
 }
 

--- a/securedrop_client/resources/css/sdclient.css
+++ b/securedrop_client/resources/css/sdclient.css
@@ -100,6 +100,7 @@
 
 #UserProfile {
     padding: 15px;
+    min-height: 200px
 }
 
 #UserProfile_icon {
@@ -184,6 +185,8 @@ QListView#SourceList {
     border: none;
     show-decoration-selected: 0;
     border-right: 3px solid #f3f5f9;
+    min-width: 540px;
+    max-width: 540px;
 }
 
 QListView#SourceList::item:selected {

--- a/securedrop_client/resources/css/speech_bubble_message.css
+++ b/securedrop_client/resources/css/speech_bubble_message.css
@@ -1,6 +1,4 @@
 #SpeechBubble_message {
-    min-width: 508px;
-    max-width: 508px;
     font-family: 'Source Sans Pro';
     font-weight: 400;
     font-size: 15px;
@@ -10,8 +8,6 @@
 }
 
 #SpeechBubble_message_decryption_error {
-    min-width: 508px;
-    max-width: 508px;
     font-family: 'Source Sans Pro';
     font-weight: 400;
     font-size: 15px;

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setuptools.setup(
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
     ),
-    entry_points={"console_scripts": ["sd-client = securedrop_client.app:run",],},
+    entry_points={"console_scripts": ["sd-client = securedrop_client.app:run"]},
 )

--- a/tests/api_jobs/test_downloads.py
+++ b/tests/api_jobs/test_downloads.py
@@ -364,7 +364,7 @@ def test_FileDownloadJob_happy_path_no_etag(mocker, homedir, session, session_ma
     api_client.default_request_timeout = mocker.MagicMock()
     api_client.download_submission = fake_download
 
-    job = FileDownloadJob(file_.uuid, os.path.join(homedir, "data"), gpg,)
+    job = FileDownloadJob(file_.uuid, os.path.join(homedir, "data"), gpg)
 
     mock_logger = mocker.patch("securedrop_client.api_jobs.downloads.logger")
 
@@ -407,7 +407,7 @@ def test_FileDownloadJob_happy_path_sha256_etag(
     api_client.default_request_timeout = mocker.MagicMock()
     api_client.download_submission = fake_download
 
-    job = FileDownloadJob(file_.uuid, os.path.join(homedir, "data"), gpg,)
+    job = FileDownloadJob(file_.uuid, os.path.join(homedir, "data"), gpg)
 
     job.call_api(api_client, session)
 
@@ -440,7 +440,7 @@ def test_FileDownloadJob_bad_sha256_etag(
     api_client.default_request_timeout = mocker.MagicMock()
     api_client.download_submission = fake_download
 
-    job = FileDownloadJob(file_.uuid, os.path.join(homedir, "data"), gpg,)
+    job = FileDownloadJob(file_.uuid, os.path.join(homedir, "data"), gpg)
 
     with pytest.raises(DownloadChecksumMismatchException):
         job.call_api(api_client, session)
@@ -468,7 +468,7 @@ def test_FileDownloadJob_happy_path_unknown_etag(mocker, homedir, session, sessi
     api_client.default_request_timeout = mocker.MagicMock()
     api_client.download_submission = fake_download
 
-    job = FileDownloadJob(file_.uuid, os.path.join(homedir, "data"), gpg,)
+    job = FileDownloadJob(file_.uuid, os.path.join(homedir, "data"), gpg)
 
     mock_decrypt = patch_decrypt(mocker, homedir, gpg, file_.filename)
     mock_logger = mocker.patch("securedrop_client.api_jobs.downloads.logger")
@@ -512,7 +512,7 @@ def test_FileDownloadJob_decryption_error(
     api_client.default_request_timeout = mocker.MagicMock()
     api_client.download_submission = fake_download
 
-    job = FileDownloadJob(file_.uuid, os.path.join(homedir, "data"), gpg,)
+    job = FileDownloadJob(file_.uuid, os.path.join(homedir, "data"), gpg)
 
     with pytest.raises(DownloadDecryptionException):
         job.call_api(api_client, session)

--- a/tests/api_jobs/test_sync.py
+++ b/tests/api_jobs/test_sync.py
@@ -11,7 +11,7 @@ def test_MetadataSyncJob_success(mocker, homedir, session, session_maker):
     job = MetadataSyncJob(homedir)
 
     mock_source = factory.RemoteSource(
-        key={"type": "PGP", "public": PUB_KEY, "fingerprint": "123456ABC",}
+        key={"type": "PGP", "public": PUB_KEY, "fingerprint": "123456ABC"}
     )
 
     mock_get_remote_data = mocker.patch(
@@ -33,7 +33,7 @@ def test_MetadataSyncJob_success_with_missing_key(mocker, homedir, session, sess
     """
     job = MetadataSyncJob(homedir)
 
-    mock_source = factory.RemoteSource(key={"type": "PGP", "public": "", "fingerprint": "",})
+    mock_source = factory.RemoteSource(key={"type": "PGP", "public": "", "fingerprint": ""})
 
     mock_get_remote_data = mocker.patch(
         "securedrop_client.api_jobs.sync.get_remote_data", return_value=([mock_source], [], [])

--- a/tests/api_jobs/test_uploads.py
+++ b/tests/api_jobs/test_uploads.py
@@ -48,7 +48,7 @@ def test_send_reply_success(homedir, mocker, session, session_maker, reply_statu
         "securedrop_client.logic.sdclientapi.Source", return_value=mock_sdk_source
     )
 
-    job = SendReplyJob(source.uuid, msg_uuid, msg, gpg,)
+    job = SendReplyJob(source.uuid, msg_uuid, msg, gpg)
 
     job.call_api(api_client, session)
 
@@ -114,7 +114,7 @@ def test_drafts_ordering(homedir, mocker, session, session_maker, reply_status_c
         "securedrop_client.logic.sdclientapi.Source", return_value=mock_sdk_source
     )
 
-    job = SendReplyJob(source.uuid, msg_uuid, msg, gpg,)
+    job = SendReplyJob(source.uuid, msg_uuid, msg, gpg)
 
     job.call_api(api_client, session)
 
@@ -175,7 +175,7 @@ def test_send_reply_failure_gpg_error(homedir, mocker, session, session_maker, r
         "securedrop_client.logic.sdclientapi.Source", return_value=mock_sdk_source
     )
 
-    job = SendReplyJob(source.uuid, msg_uuid, msg, gpg,)
+    job = SendReplyJob(source.uuid, msg_uuid, msg, gpg)
 
     with pytest.raises(SendReplyJobError):
         job.call_api(api_client, session)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,7 +126,7 @@ def config(homedir) -> str:
     full_path = os.path.join(homedir, Config.CONFIG_NAME)
     with open(full_path, "w") as f:
         f.write(
-            json.dumps({"journalist_key_fingerprint": "65A1B5FF195B56353CC63DFFCC40EF1228271441",})
+            json.dumps({"journalist_key_fingerprint": "65A1B5FF195B56353CC63DFFCC40EF1228271441"})
         )
     return full_path
 
@@ -186,10 +186,7 @@ def download_error_codes(session) -> None:
 
 @pytest.fixture(scope="function")
 def source(session) -> dict:
-    args = {
-        "uuid": str(uuid4()),
-        "public_key": PUB_KEY,
-    }
+    args = {"uuid": str(uuid4()), "public_key": PUB_KEY}
     source = Source(
         journalist_designation="foo-bar",
         is_flagged=False,

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -117,7 +117,7 @@ def DraftReply(**attrs):
 def ReplySendStatus(**attrs):
     global REPLY_SEND_STATUS_COUNT
     REPLY_SEND_STATUS_COUNT += 1
-    defaults = dict(name=db.ReplySendStatusCodes.PENDING.value,)
+    defaults = dict(name=db.ReplySendStatusCodes.PENDING.value)
 
     defaults.update(attrs)
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -814,11 +814,7 @@ def test_SourceList_update_adds_new_sources(mocker):
     mocker.patch("securedrop_client.gui.widgets.SourceWidget", mock_sw)
     mocker.patch("securedrop_client.gui.widgets.SourceListWidgetItem", mock_lwi)
 
-    sources = [
-        mocker.MagicMock(),
-        mocker.MagicMock(),
-        mocker.MagicMock(),
-    ]
+    sources = [mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock()]
     sl.update(sources)
 
     assert mock_sw.call_count == len(sources)
@@ -845,11 +841,7 @@ def test_SourceList_initial_update_adds_new_sources(mocker):
     sl.currentRow = mocker.MagicMock(return_value=0)
     sl.item = mocker.MagicMock()
     sl.item().isSelected.return_value = True
-    sources = [
-        mocker.MagicMock(),
-        mocker.MagicMock(),
-        mocker.MagicMock(),
-    ]
+    sources = [mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock()]
     sl.initial_update(sources)
     sl.add_source.assert_called_once_with(sources)
 
@@ -905,11 +897,7 @@ def test_SourceList_add_source_starts_timer(mocker, session_maker, homedir):
     to the source list via a single-shot QTimer.
     """
     sl = SourceList()
-    sources = [
-        mocker.MagicMock(),
-        mocker.MagicMock(),
-        mocker.MagicMock(),
-    ]
+    sources = [mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock()]
     mock_timer = mocker.MagicMock()
     with mocker.patch("securedrop_client.gui.widgets.QTimer", mock_timer):
         sl.add_source(sources)
@@ -1077,11 +1065,7 @@ def test_SourceList_add_source_closure_adds_sources(mocker):
     mock_lwi = mocker.MagicMock()
     mocker.patch("securedrop_client.gui.widgets.SourceWidget", mock_sw)
     mocker.patch("securedrop_client.gui.widgets.SourceListWidgetItem", mock_lwi)
-    sources = [
-        mocker.MagicMock(),
-        mocker.MagicMock(),
-        mocker.MagicMock(),
-    ]
+    sources = [mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock()]
     mock_timer = mocker.MagicMock()
     with mocker.patch("securedrop_client.gui.widgets.QTimer", mock_timer):
         sl.add_source(sources, 1)
@@ -1304,9 +1288,7 @@ def test_SourceWidget_update_truncate_latest_msg(mocker):
     controller = mocker.MagicMock()
     source = mocker.MagicMock()
     source.journalist_designation = "Testy McTestface"
-    source.collection = [
-        factory.Message(content="a" * 151),
-    ]
+    source.collection = [factory.Message(content="a" * 151)]
     sw = SourceWidget(controller, source)
 
     sw.update()
@@ -1322,9 +1304,7 @@ def test_SourceWidget_delete_source(mocker, session, source):
 
     sw = SourceWidget(mock_controller, source["source"])
 
-    mocker.patch(
-        "securedrop_client.gui.widgets.DeleteSourceMessageBox", mock_delete_source_message,
-    )
+    mocker.patch("securedrop_client.gui.widgets.DeleteSourceMessageBox", mock_delete_source_message)
 
     sw.delete_source(None)
     mock_delete_source_message_box_object.launch.assert_called_with()
@@ -1344,9 +1324,7 @@ def test_SourceWidget_delete_source_when_user_chooses_cancel(mocker, session, so
     mock_controller = mocker.MagicMock()
     sw = SourceWidget(mock_controller, source)
 
-    mocker.patch(
-        "securedrop_client.gui.widgets.QMessageBox.question", mock_message_box_question,
-    )
+    mocker.patch("securedrop_client.gui.widgets.QMessageBox.question", mock_message_box_question)
     sw.delete_source(None)
     sw.controller.delete_source.assert_not_called()
 
@@ -1404,9 +1382,7 @@ def test_SourceWidget_uses_SecureQLabel(mocker):
     controller = mocker.MagicMock()
     source = mocker.MagicMock()
     source.journalist_designation = "Testy McTestface"
-    source.collection = [
-        factory.Message(content="a" * 121),
-    ]
+    source.collection = [factory.Message(content="a" * 121)]
     sw = SourceWidget(controller, source)
 
     sw.update()
@@ -2533,7 +2509,7 @@ def test_FileWidget_filename_truncation(mocker, source, session):
 
 
 def test_FileWidget_on_file_download_updates_items_when_uuid_does_not_match(
-    mocker, homedir, session, source,
+    mocker, homedir, session, source
 ):
     """
     The _on_file_download method should clear and update the FileWidget
@@ -2590,7 +2566,7 @@ def test_FileWidget_on_file_missing_show_download_button_when_uuid_matches(
 
 
 def test_FileWidget_on_file_missing_does_not_show_download_button_when_uuid_does_not_match(
-    mocker, homedir, session, source,
+    mocker, homedir, session, source
 ):
     """
     The _on_file_missing method should not update the FileWidget when uuid doesn't match.
@@ -3817,9 +3793,7 @@ def test_DeleteSourceMessage_launch_when_user_chooses_cancel(mocker, source):
 
     delete_source_message_box = DeleteSourceMessageBox(source, mock_controller)
 
-    mocker.patch(
-        "securedrop_client.gui.widgets.QMessageBox.question", mock_message_box_question,
-    )
+    mocker.patch("securedrop_client.gui.widgets.QMessageBox.question", mock_message_box_question)
 
     delete_source_message_box.launch()
     mock_controller.delete_source.assert_not_called()
@@ -3843,9 +3817,7 @@ def test_DeleteSourceMssageBox_launch_when_user_chooses_yes(mocker, source, sess
 
     delete_source_message_box = DeleteSourceMessageBox(source, mock_controller)
 
-    mocker.patch(
-        "securedrop_client.gui.widgets.QMessageBox.question", mock_message_box_question,
-    )
+    mocker.patch("securedrop_client.gui.widgets.QMessageBox.question", mock_message_box_question)
 
     delete_source_message_box.launch()
     mock_controller.delete_source.assert_called_once_with(source)

--- a/tests/integration/test_styles_reply_message.py
+++ b/tests/integration/test_styles_reply_message.py
@@ -6,8 +6,6 @@ def test_styles(mocker, main_window):
     conversation_scrollarea = wrapper.conversation_view.scroll
     reply_widget = conversation_scrollarea.widget().layout().itemAt(2).widget()
 
-    assert 540 == reply_widget.message.minimumSize().width()  # 508px + 32px padding
-    assert 540 == reply_widget.message.maximumSize().width()  # 508px + 32px padding
     assert "Source Sans Pro" == reply_widget.message.font().family()
     assert QFont.Normal == reply_widget.message.font().weight()
     assert 15 == reply_widget.message.font().pixelSize()
@@ -16,8 +14,6 @@ def test_styles(mocker, main_window):
 
     reply_widget._set_reply_state("PENDING")
 
-    assert 540 == reply_widget.message.minimumSize().width()  # 508px + 32px padding
-    assert 540 == reply_widget.message.maximumSize().width()  # 508px + 32px padding
     assert "Source Sans Pro" == reply_widget.message.font().family()
     assert QFont.Normal == reply_widget.message.font().weight()
     assert 15 == reply_widget.message.font().pixelSize()
@@ -26,8 +22,6 @@ def test_styles(mocker, main_window):
 
     reply_widget._set_reply_state("FAILED")
 
-    assert 540 == reply_widget.message.minimumSize().width()  # 508px + 32px padding
-    assert 540 == reply_widget.message.maximumSize().width()  # 508px + 32px padding
     assert "Source Sans Pro" == reply_widget.message.font().family()
     assert QFont.Normal == reply_widget.message.font().weight()
     assert 15 == reply_widget.message.font().pixelSize()

--- a/tests/integration/test_styles_sdclient.py
+++ b/tests/integration/test_styles_sdclient.py
@@ -250,7 +250,7 @@ def test_styles_for_left_pane(mocker, main_window):
 def test_styles_for_main_view(mocker, main_window):
     main_view = main_window.main_view
     assert 558 == main_view.height()
-    assert 667 == main_view.view_holder.width()
+    assert 500 == main_view.view_holder.width()
     # assert 'border: none;' for view_holder
     assert "#f3f5f9" == main_view.view_holder.palette().color(QPalette.Background).name()
 
@@ -261,7 +261,6 @@ def test_styles_for_main_view(mocker, main_window):
     assert QFont.DemiBold - 1 == no_sources_instructions.font().weight()
     assert 35 == no_sources_instructions.font().pixelSize()
     assert "#a5b3e9" == no_sources_instructions.palette().color(QPalette.Foreground).name()
-    assert 520 == no_sources_instructions.minimumWidth()
     assert 600 == no_sources_instructions.maximumWidth()
     no_sources_spacer1 = no_sources.layout().itemAt(1)
     assert 35 == no_sources_spacer1.minimumSize().height()
@@ -287,7 +286,6 @@ def test_styles_for_main_view(mocker, main_window):
     assert QFont.DemiBold - 1 == no_source_selected_instructions.font().weight()
     assert 35 == no_source_selected_instructions.font().pixelSize()
     assert "#a5b3e9" == no_source_selected_instructions.palette().color(QPalette.Foreground).name()
-    assert 520 == no_source_selected_instructions.minimumWidth()
     assert 520 == no_source_selected_instructions.maximumWidth()
     no_source_selected_spacer1 = no_source_selected.layout().itemAt(1)
     assert 35 == no_source_selected_spacer1.minimumSize().height()

--- a/tests/integration/test_styles_speech_bubble_message.py
+++ b/tests/integration/test_styles_speech_bubble_message.py
@@ -6,8 +6,8 @@ def test_styles(mocker, main_window):
     conversation_scrollarea = wrapper.conversation_view.scroll
     speech_bubble = conversation_scrollarea.widget().layout().itemAt(1).widget()
 
-    assert 540 == speech_bubble.message.minimumSize().width()  # 508px + 32px padding
-    assert 540 == speech_bubble.message.maximumSize().width()  # 508px + 32px padding
+    assert 540 == speech_bubble.message.minimumSize().width()
+    assert 540 == speech_bubble.message.maximumSize().width()
     assert "Source Sans Pro" == speech_bubble.message.font().family()
     assert QFont.Normal == speech_bubble.message.font().weight()
     assert 15 == speech_bubble.message.font().pixelSize()
@@ -16,8 +16,8 @@ def test_styles(mocker, main_window):
 
     speech_bubble.set_error("123", speech_bubble.uuid, speech_bubble.message.text())
 
-    assert 540 == speech_bubble.message.minimumSize().width()  # 508px + 32px padding
-    assert 540 == speech_bubble.message.maximumSize().width()  # 508px + 32px padding
+    assert 540 == speech_bubble.message.minimumSize().width()
+    assert 540 == speech_bubble.message.maximumSize().width()
     assert "Source Sans Pro" == speech_bubble.message.font().family()
     assert QFont.Normal == speech_bubble.message.font().weight()
     assert 15 == speech_bubble.message.font().pixelSize()

--- a/tests/integration/test_styles_speech_bubble_message.py
+++ b/tests/integration/test_styles_speech_bubble_message.py
@@ -6,8 +6,8 @@ def test_styles(mocker, main_window):
     conversation_scrollarea = wrapper.conversation_view.scroll
     speech_bubble = conversation_scrollarea.widget().layout().itemAt(1).widget()
 
-    assert 540 == speech_bubble.message.minimumSize().width()
-    assert 540 == speech_bubble.message.maximumSize().width()
+    assert 540 == speech_bubble.speech_bubble.minimumSize().width()
+    assert 540 == speech_bubble.speech_bubble.maximumSize().width()
     assert "Source Sans Pro" == speech_bubble.message.font().family()
     assert QFont.Normal == speech_bubble.message.font().weight()
     assert 15 == speech_bubble.message.font().pixelSize()
@@ -16,8 +16,8 @@ def test_styles(mocker, main_window):
 
     speech_bubble.set_error("123", speech_bubble.uuid, speech_bubble.message.text())
 
-    assert 540 == speech_bubble.message.minimumSize().width()
-    assert 540 == speech_bubble.message.maximumSize().width()
+    assert 540 == speech_bubble.speech_bubble.minimumSize().width()
+    assert 540 == speech_bubble.speech_bubble.maximumSize().width()
     assert "Source Sans Pro" == speech_bubble.message.font().family()
     assert QFont.Normal == speech_bubble.message.font().weight()
     assert 15 == speech_bubble.message.font().pixelSize()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -149,12 +149,12 @@ def test_start_app(homedir, mocker):
 
 
 PERMISSIONS_CASES = [
-    {"should_pass": True, "home_perms": None, "sub_dirs": [],},
-    {"should_pass": True, "home_perms": 0o0700, "sub_dirs": [],},
-    {"should_pass": False, "home_perms": 0o0740, "sub_dirs": [],},
-    {"should_pass": False, "home_perms": 0o0704, "sub_dirs": [],},
-    {"should_pass": True, "home_perms": 0o0700, "sub_dirs": [("logs", 0o0700)],},
-    {"should_pass": False, "home_perms": 0o0700, "sub_dirs": [("logs", 0o0740)],},
+    {"should_pass": True, "home_perms": None, "sub_dirs": []},
+    {"should_pass": True, "home_perms": 0o0700, "sub_dirs": []},
+    {"should_pass": False, "home_perms": 0o0740, "sub_dirs": []},
+    {"should_pass": False, "home_perms": 0o0704, "sub_dirs": []},
+    {"should_pass": True, "home_perms": 0o0700, "sub_dirs": [("logs", 0o0700)]},
+    {"should_pass": False, "home_perms": 0o0700, "sub_dirs": [("logs", 0o0740)]},
 ]
 
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -136,7 +136,7 @@ def test__run_print(mocker):
 
     export._export_archive.assert_called_once_with("mock_archive_path")
     export._create_archive.assert_called_once_with(
-        "mock_archive_dir", "print_archive.sd-export", {"device": "printer",}, ["mock_filepath"]
+        "mock_archive_dir", "print_archive.sd-export", {"device": "printer"}, ["mock_filepath"]
     )
 
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -39,9 +39,7 @@ def test_APICallRunner_init(mocker):
     assert cr.api_call == mock_api_call
     assert cr.current_object == mock_current_object
     assert cr.args == ("foo",)
-    assert cr.kwargs == {
-        "bar": "baz",
-    }
+    assert cr.kwargs == {"bar": "baz"}
 
 
 def test_APICallRunner_call_api(mocker):
@@ -233,7 +231,7 @@ def test_Controller_on_authenticate_success(homedir, config, mocker, session_mak
 
 
 def test_Controller_completed_api_call_without_current_object(
-    homedir, config, mocker, session_maker,
+    homedir, config, mocker, session_maker
 ):
     """
     Ensure that cleanup is performed if an API call returns in the expected
@@ -250,7 +248,7 @@ def test_Controller_completed_api_call_without_current_object(
     mock_runner = mocker.MagicMock()
     mock_runner.result = result
     mock_runner.current_object = None
-    co.api_threads = {"thread_uuid": {"thread": mock_thread, "runner": mock_runner,}}
+    co.api_threads = {"thread_uuid": {"thread": mock_thread, "runner": mock_runner}}
     mock_user_callback = mocker.MagicMock()
 
     co.completed_api_call("thread_uuid", mock_user_callback)
@@ -275,7 +273,7 @@ def test_Controller_completed_api_call_with_current_object(homedir, config, mock
     mock_runner = mocker.MagicMock()
     mock_runner.result = result
     mock_runner.current_object = current_object
-    co.api_threads = {"thread_uuid": {"thread": mock_thread, "runner": mock_runner,}}
+    co.api_threads = {"thread_uuid": {"thread": mock_thread, "runner": mock_runner}}
     mock_user_callback = mocker.MagicMock()
 
     mock_arg_spec = mocker.MagicMock(args=["foo", "current_object"])
@@ -491,9 +489,7 @@ def test_Controller_on_sync_success(homedir, config, mocker):
     mock_storage = mocker.patch("securedrop_client.logic.storage")
     source = factory.Source()
     missing = factory.File(is_downloaded=None, is_decrypted=None, source=source)
-    mock_storage.update_missing_files.return_value = [
-        missing,
-    ]
+    mock_storage.update_missing_files.return_value = [missing]
 
     co.on_sync_success()
 
@@ -743,10 +739,10 @@ def test_Controller_set_activity_status(homedir, config, mocker, session_maker):
 
 
 PERMISSIONS_CASES = [
-    {"should_pass": True, "home_perms": None,},
-    {"should_pass": True, "home_perms": 0o0700,},
-    {"should_pass": False, "home_perms": 0o0740,},
-    {"should_pass": False, "home_perms": 0o0704,},
+    {"should_pass": True, "home_perms": None},
+    {"should_pass": True, "home_perms": 0o0700},
+    {"should_pass": False, "home_perms": 0o0740},
+    {"should_pass": False, "home_perms": 0o0704},
 ]
 
 
@@ -811,9 +807,7 @@ def test_Controller_on_file_download_Submission(homedir, config, session, mocker
 
     co.on_submission_download(db.File, file_.uuid)
 
-    mock_job_cls.assert_called_once_with(
-        file_.uuid, co.data_dir, co.gpg,
-    )
+    mock_job_cls.assert_called_once_with(file_.uuid, co.data_dir, co.gpg)
     co.add_job.emit.assert_called_once_with(mock_job)
     mock_success_signal.connect.assert_called_once_with(
         co.on_file_download_success, type=Qt.QueuedConnection
@@ -1506,9 +1500,7 @@ def test_Controller_send_reply_success(
 
     co.send_reply(source.uuid, "mock_user_uuid", "mock_msg")
 
-    mock_job_cls.assert_called_once_with(
-        source.uuid, "mock_user_uuid", "mock_msg", co.gpg,
-    )
+    mock_job_cls.assert_called_once_with(source.uuid, "mock_user_uuid", "mock_msg", co.gpg)
 
     co.add_job.emit.assert_called_once_with(mock_job)
     mock_success_signal.connect.assert_called_once_with(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -211,27 +211,15 @@ def test_get_remote_data(mocker):
     # Some source, submission and reply objects from the API.
     mock_api = mocker.MagicMock()
     source = factory.RemoteSource()
-    mock_api.get_sources.return_value = [
-        source,
-    ]
+    mock_api.get_sources.return_value = [source]
     submission = mocker.MagicMock()
-    mock_api.get_all_submissions.return_value = [
-        submission,
-    ]
+    mock_api.get_all_submissions.return_value = [submission]
     reply = mocker.MagicMock()
-    mock_api.get_all_replies.return_value = [
-        reply,
-    ]
+    mock_api.get_all_replies.return_value = [reply]
     sources, submissions, replies = get_remote_data(mock_api)
-    assert sources == [
-        source,
-    ]
-    assert submissions == [
-        submission,
-    ]
-    assert replies == [
-        reply,
-    ]
+    assert sources == [source]
+    assert submissions == [submission]
+    assert replies == [reply]
 
 
 def test_update_local_storage(homedir, mocker, session_maker):
@@ -453,9 +441,7 @@ def test_update_submissions_deletes_files_associated_with_the_submission(homedir
     local_source = mocker.MagicMock()
     local_source.uuid = "test-source-uuid"
     local_source.id = 666
-    mock_session.query().filter_by.return_value = [
-        local_source,
-    ]
+    mock_session.query().filter_by.return_value = [local_source]
     update_files(remote_submissions, local_submissions, mock_session, homedir)
 
     # Ensure the files associated with the submission are deleted on disk.
@@ -499,9 +485,7 @@ def test_update_replies_deletes_files_associated_with_the_reply(homedir, mocker)
     local_source = mocker.MagicMock()
     local_source.uuid = "test-source-uuid"
     local_source.id = 666
-    mock_session.query().filter_by.return_value = [
-        local_source,
-    ]
+    mock_session.query().filter_by.return_value = [local_source]
     update_replies(remote_replies, local_replies, mock_session, homedir)
 
     # Ensure the file associated with the reply are deleted on disk.
@@ -757,7 +741,7 @@ def test_update_replies(homedir, mocker, session):
     )
     session.add(local_reply_update)
 
-    local_reply_delete = factory.Reply(source_id=source.id, source=source,)
+    local_reply_delete = factory.Reply(source_id=source.id, source=source)
     session.add(local_reply_delete)
 
     local_replies = [local_reply_update, local_reply_delete]


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/1074, see what it currently looks like:

![Screenshot from 2020-06-23 23-08-14](https://user-images.githubusercontent.com/4522213/85507063-8b085880-b5a6-11ea-95c9-f294cfba50bc.png)

This PR makes it so the client fits within a 1280x1024 screen when it opens and adds support for a small variation in size in the sourcelist when you change the window size.

Also small fix to the sign-in button so that it no longer does this when you shrink the client to its smallest height. This is what it used to look like:

![Screenshot from 2020-06-23 23-06-28](https://user-images.githubusercontent.com/4522213/85506914-2fd66600-b5a6-11ea-9bb0-55ae10e68582.png)

Known issues that need to be addressed as follow-up or as part of this PR:

* journalist designations vary in size and sometimes don't fit within the smaller window with the current font size, see how the journalist designation gets cut off in the conversation header and reply box:
![Screenshot from 2020-06-23 22-48-35](https://user-images.githubusercontent.com/4522213/85506065-804cc400-b5a4-11ea-8d0a-fa18d995bade.png)
* speech bubbles don't yet vary in size, so you'll have to horizontal scroll, but my thinking is that we'll want to adjust the size of speech bubbles as the window size changes as well. for example, if the window is 1280x1024 then the speech bubbles could look like this: 
![Screenshot from 2020-06-23 22-49-43](https://user-images.githubusercontent.com/4522213/85506496-5fd13980-b5a5-11ea-8ea0-4e75dd19a0c8.png)

# Test Plan

1. Set your screen resolution to 1280 x 1024 and start the client
2. Check that all text, buttons, and widgets fit within the client window
3. Minimize to the client's smallest width and repeat step 2

#### Regression Test

Also check that the text, buttons, and widgets match what's on the `master` branch when the client is expanded for a larger screen resolution.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/master/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `master` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `master` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed
