### PR TITLE
Spike 2

### DIFF
--- a/create_dev_data.py
+++ b/create_dev_data.py
@@ -2,11 +2,15 @@
 import json
 import os
 import sys
+
 from securedrop_client.config import Config
-from securedrop_client.db import Base, make_session_maker
+from securedrop_client.db import Base, Session, make_engine
+
 
 sdc_home = sys.argv[1]
-session = make_session_maker(sdc_home)()
+
+engine = make_engine(sdc_home)
+session = Session(bind=engine)
 Base.metadata.create_all(bind=session.get_bind())
 
 with open(os.path.join(sdc_home, Config.CONFIG_NAME), 'w') as f:

--- a/create_dev_data.py
+++ b/create_dev_data.py
@@ -4,13 +4,13 @@ import os
 import sys
 
 from securedrop_client.config import Config
-from securedrop_client.db import Base, Session, make_engine
+from securedrop_client.db import Base, SessionFactory, make_engine
 
 
 sdc_home = sys.argv[1]
 
 engine = make_engine(sdc_home)
-session = Session(bind=engine)
+session = SessionFactory(bind=engine)
 Base.metadata.create_all(bind=session.get_bind())
 
 with open(os.path.join(sdc_home, Config.CONFIG_NAME), 'w') as f:

--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -25,14 +25,16 @@ import signal
 import sys
 import socket
 from argparse import ArgumentParser
+
 from PyQt5.QtWidgets import QApplication, QMessageBox
 from PyQt5.QtCore import Qt, QTimer
 from logging.handlers import TimedRotatingFileHandler
+
 from securedrop_client import __version__
 from securedrop_client.logic import Controller
 from securedrop_client.gui.main import Window
 from securedrop_client.resources import load_icon, load_css
-from securedrop_client.db import make_session_maker
+from securedrop_client.db import Session, make_engine
 from securedrop_client.utils import safe_mkdir
 
 DEFAULT_SDC_HOME = '~/.securedrop_client'
@@ -184,15 +186,15 @@ def start_app(args, qt_args) -> None:
 
     prevent_second_instance(app, args.sdc_home)
 
-    session_maker = make_session_maker(args.sdc_home)
-
     gui = Window()
 
     app.setWindowIcon(load_icon(gui.icon))
     app.setStyleSheet(load_css('sdclient.css'))
 
-    controller = Controller("http://localhost:8081/", gui, session_maker,
-                            args.sdc_home, not args.no_proxy)
+    engine = make_engine(args.sdc_home)
+    Session.configure(bind=engine)
+
+    controller = Controller("http://localhost:8081/", gui, args.sdc_home, not args.no_proxy)
     controller.setup()
 
     configure_signal_handlers(app)

--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -34,7 +34,7 @@ from securedrop_client import __version__
 from securedrop_client.logic import Controller
 from securedrop_client.gui.main import Window
 from securedrop_client.resources import load_icon, load_css
-from securedrop_client.db import Session, make_engine
+from securedrop_client.db import SessionFactory, make_engine
 from securedrop_client.utils import safe_mkdir
 
 DEFAULT_SDC_HOME = '~/.securedrop_client'
@@ -192,7 +192,7 @@ def start_app(args, qt_args) -> None:
     app.setStyleSheet(load_css('sdclient.css'))
 
     engine = make_engine(args.sdc_home)
-    Session.configure(bind=engine)
+    SessionFactory.configure(bind=engine)
 
     controller = Controller("http://localhost:8081/", gui, args.sdc_home, not args.no_proxy)
     controller.setup()

--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -6,8 +6,7 @@ from sqlalchemy import Boolean, Column, create_engine, DateTime, ForeignKey, Int
     Text, MetaData, CheckConstraint, text, UniqueConstraint
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship, backref, scoped_session, sessionmaker
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import relationship, backref, sessionmaker
 
 
 Session = sessionmaker()

--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, backref, sessionmaker
 
 
-Session = sessionmaker()
+SessionFactory = sessionmaker()
 
 convention = {
     "ix": 'ix_%(column_0_label)s',

--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -11,6 +11,23 @@ from sqlalchemy.orm import relationship, backref, sessionmaker
 
 SessionFactory = sessionmaker()
 
+from contextlib import contextmanager
+
+@contextmanager
+def session_scope():
+    """Provide a transactional scope around a series of operations."""
+    session = SessionFactory()
+    try:
+        yield session
+        session.commit()
+        print('committed changes')
+    except:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+        print('closed session')
+
 convention = {
     "ix": 'ix_%(column_0_label)s',
     "uq": "uq_%(table_name)s_%(column_0_name)s",

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1382,7 +1382,6 @@ class ConversationView(QWidget):
         self.clear_conversation()
         # add new items
         for conversation_item in collection:
-            self.controller.session.refresh(conversation_item)
             if conversation_item.filename.endswith('msg.gpg'):
                 self.add_message(conversation_item)
             elif conversation_item.filename.endswith('reply.gpg'):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -31,7 +31,6 @@ from PyQt5.QtWidgets import QListWidget, QLabel, QWidget, QListWidgetItem, QHBox
     QToolButton, QSizePolicy, QTextEdit, QStatusBar, QGraphicsDropShadowEffect
 
 from securedrop_client.db import Source, Message, File, Reply
-from securedrop_client.storage import source_exists
 from securedrop_client.gui import SvgLabel, SvgPushButton, SvgToggleButton
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_icon, load_image
@@ -713,7 +712,7 @@ class SourceList(QListWidget):
     def get_current_source(self):
         source_item = self.currentItem()
         source_widget = self.itemWidget(source_item)
-        if source_widget and source_exists(self.controller.session, source_widget.source.uuid):
+        if source_widget:
             return source_widget.source
 
 
@@ -1250,23 +1249,23 @@ class ReplyWidget(ConversationWidget):
         message_succeeded_signal.connect(self._on_reply_success)
         message_failed_signal.connect(self._on_reply_failure)
 
-    @pyqtSlot(str)
-    def _on_reply_success(self, message_id: str) -> None:
+    @pyqtSlot(str, str)
+    def _on_reply_success(self, message_id: str, source_uuid: str) -> None:
         """
         Conditionally update this ReplyWidget's state if and only if the message_id of the emitted
         signal matches the message_id of this widget.
         """
         if message_id == self.message_id:
-            logger.debug('Message {} succeeded'.format(message_id))
+            logger.debug('Reply {} succeeded'.format(message_id))
 
-    @pyqtSlot(str)
-    def _on_reply_failure(self, message_id: str) -> None:
+    @pyqtSlot(str, str)
+    def _on_reply_failure(self, message_id: str, source_uuid: str) -> None:
         """
         Conditionally update this ReplyWidget's state if and only if the message_id of the emitted
         signal matches the message_id of this widget.
         """
         if message_id == self.message_id:
-            logger.debug('Message {} failed'.format(message_id))
+            logger.debug('Reply {} failed'.format(message_id))
 
 
 class FileWidget(QWidget):
@@ -1276,7 +1275,7 @@ class FileWidget(QWidget):
 
     def __init__(
         self,
-        file_uuid: str,
+        file: File,
         controller: Controller,
         file_ready_signal: pyqtBoundSignal,
     ) -> None:
@@ -1285,7 +1284,7 @@ class FileWidget(QWidget):
         """
         super().__init__()
         self.controller = controller
-        self.file = self.controller.get_file(file_uuid)
+        self.file = file
 
         self.layout = QHBoxLayout()
         self.update()
@@ -1316,10 +1315,7 @@ class FileWidget(QWidget):
     @pyqtSlot(str)
     def _on_file_downloaded(self, file_uuid: str) -> None:
         if file_uuid == self.file.uuid:
-            # update state
-            self.file = self.controller.get_file(self.file.uuid)
-
-            # update gui
+            self.file.is_downloaded = True
             self.clear()  # delete existing icon and label
             self.update()  # draw modified widget
 
@@ -1328,12 +1324,9 @@ class FileWidget(QWidget):
         Handle a completed click via the program logic. The download state
         of the file distinguishes which function in the logic layer to call.
         """
-        # update state
-        self.file = self.controller.get_file(self.file.uuid)
-
         if self.file.is_downloaded:
             # Open the already downloaded file.
-            self.controller.on_file_open(self.file.uuid)
+            self.controller.on_file_open(self.file)
         else:
             # Download the file.
             self.controller.on_submission_download(File, self.file.uuid)
@@ -1348,11 +1341,7 @@ class ConversationView(QWidget):
     https://github.com/freedomofpress/securedrop-client/issues/273
     """
 
-    def __init__(
-        self,
-        source_db_object: Source,
-        controller: Controller,
-    ):
+    def __init__(self, source_db_object: Source, controller: Controller):
         super().__init__()
         self.source = source_db_object
         self.controller = controller
@@ -1379,6 +1368,10 @@ class ConversationView(QWidget):
         main_layout.setContentsMargins(0, 0, 0, 0)
         main_layout.addWidget(self.scroll)
         self.setLayout(main_layout)
+
+        self.controller.reply_succeeded.connect(self.on_reply_succeeded)
+        self.controller.reply_failed.connect(self.on_reply_failed)
+
         self.update_conversation(self.source.collection)
 
     def clear_conversation(self):
@@ -1406,7 +1399,7 @@ class ConversationView(QWidget):
         """
         self.conversation_layout.addWidget(
             FileWidget(
-                submission_db_object.uuid,
+                submission_db_object,
                 self.controller,
                 self.controller.file_ready,
             ),
@@ -1471,6 +1464,14 @@ class ConversationView(QWidget):
         if source_uuid == self.source.uuid:
             self.add_reply_from_reply_box(reply_uuid, reply_text)
 
+    def on_reply_succeeded(self, reply_uuid: str, source_uuid: str) -> None:
+        if source_uuid == self.source.uuid:
+            pass
+
+    def on_reply_failed(self, reply_uuid: str, source_uuid: str) -> None:
+        if source_uuid == self.source.uuid:
+            pass
+
 
 class SourceConversationWrapper(QWidget):
     """
@@ -1478,11 +1479,7 @@ class SourceConversationWrapper(QWidget):
     per-source resources.
     """
 
-    def __init__(
-        self,
-        source: Source,
-        controller: Controller,
-    ) -> None:
+    def __init__(self, source: Source, controller: Controller) -> None:
         super().__init__()
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1250,7 +1250,7 @@ class ReplyWidget(ConversationWidget):
         message_failed_signal.connect(self._on_reply_failure)
 
     @pyqtSlot(str, str)
-    def _on_reply_success(self, message_id: str, source_uuid: str) -> None:
+    def _on_reply_success(self, source_uuid: str, message_id: str) -> None:
         """
         Conditionally update this ReplyWidget's state if and only if the message_id of the emitted
         signal matches the message_id of this widget.
@@ -1259,7 +1259,7 @@ class ReplyWidget(ConversationWidget):
             logger.debug('Reply {} succeeded'.format(message_id))
 
     @pyqtSlot(str, str)
-    def _on_reply_failure(self, message_id: str, source_uuid: str) -> None:
+    def _on_reply_failure(self, source_uuid: str, message_id: str) -> None:
         """
         Conditionally update this ReplyWidget's state if and only if the message_id of the emitted
         signal matches the message_id of this widget.
@@ -1369,9 +1369,6 @@ class ConversationView(QWidget):
         main_layout.addWidget(self.scroll)
         self.setLayout(main_layout)
 
-        self.controller.reply_succeeded.connect(self.on_reply_succeeded)
-        self.controller.reply_failed.connect(self.on_reply_failed)
-
         self.update_conversation(self.source.collection)
 
     def clear_conversation(self):
@@ -1463,14 +1460,6 @@ class ConversationView(QWidget):
         """
         if source_uuid == self.source.uuid:
             self.add_reply_from_reply_box(reply_uuid, reply_text)
-
-    def on_reply_succeeded(self, reply_uuid: str, source_uuid: str) -> None:
-        if source_uuid == self.source.uuid:
-            pass
-
-    def on_reply_failed(self, reply_uuid: str, source_uuid: str) -> None:
-        if source_uuid == self.source.uuid:
-            pass
 
 
 class SourceConversationWrapper(QWidget):

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -201,7 +201,7 @@ class Controller(QObject):
         # Automagically sync with the API every 5 minutes.
         self.sync_update = QTimer()
         self.sync_update.timeout.connect(self.sync_api)
-        self.sync_update.start(1000 * 60 * 5)  # every 5 minutes.
+        self.sync_update.start(1000 * 10 * 1)  # every 5 minutes.
 
     def call_api(self,
                  api_call_func,
@@ -426,9 +426,7 @@ class Controller(QObject):
         """
         Display the updated list of sources with those found in local storage.
         """
-        session = db.Session()
-        sources = list(storage.get_local_sources(session))
-        session.close()
+        sources = list(storage.get_local_sources())
         if sources:
             sources.sort(key=lambda x: x.last_updated, reverse=True)
         self.gui.show_sources(sources)

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -601,8 +601,8 @@ class Controller(QObject):
     def on_reply_success(self, result, current_object: Tuple[str, str]) -> None:
         source_uuid, reply_uuid = current_object
         storage.add_reply(reply_uuid, source_uuid, self.api.token_journalist_uuid, result.filename)
-        self.reply_succeeded.emit(reply_uuid, source_uuid)
+        self.reply_succeeded.emit(source_uuid, reply_uuid)
 
     def on_reply_failure(self, result, current_object: Tuple[str, str]) -> None:
         source_uuid, reply_uuid = current_object
-        self.reply_failed.emit(reply_uuid, source_uuid)
+        self.reply_failed.emit(source_uuid, reply_uuid)

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -427,8 +427,8 @@ class Controller(QObject):
         Display the updated list of sources with those found in local storage.
         """
         sources = list(storage.get_local_sources())
-        if sources:
-            sources.sort(key=lambda x: x.last_updated, reverse=True)
+        # if sources:
+        #     sources.sort(key=lambda x: x.last_updated, reverse=True)
         self.gui.show_sources(sources)
         self.update_sync()
 
@@ -579,7 +579,7 @@ class Controller(QObject):
         except Exception:
             tb = traceback.format_exc()
             logger.error('Failed to encrypt to source {}:\n'.format(source_uuid, tb))
-            self.reply_failed.emit(msg_uuid)
+            self.reply_failed.emit(source_uuid, msg_uuid)
         else:
             # Guard against calling the API if we're not logged in
             if self.api:
@@ -594,7 +594,7 @@ class Controller(QObject):
                 )
             else:  # pragma: no cover
                 logger.error('not logged in - not implemented!')
-                self.reply_failed.emit(msg_uuid)
+                self.reply_failed.emit(source_uuid, msg_uuid)
 
     def on_reply_success(self, result, current_object: Tuple[str, str]) -> None:
         source_uuid, reply_uuid = current_object

--- a/securedrop_client/message_sync.py
+++ b/securedrop_client/message_sync.py
@@ -28,9 +28,7 @@ from typing import Callable, Union
 from PyQt5.QtCore import QObject, pyqtSignal
 from securedrop_client import storage
 from securedrop_client.crypto import GpgHelper, CryptoError
-from securedrop_client.db import File, Message, Reply
-from sqlalchemy.orm import scoped_session
-from sqlalchemy.orm.session import Session
+from securedrop_client.db import Session, File, Message, Reply
 from tempfile import NamedTemporaryFile
 
 
@@ -43,12 +41,10 @@ class APISyncObject(QObject):
         self,
         api: API,
         gpg: GpgHelper,
-        session_maker: scoped_session,
     ) -> None:
         super().__init__()
         self.api = api
         self.gpg = gpg
-        self.session_maker = session_maker
 
     def decrypt_the_thing(
         self,
@@ -93,7 +89,7 @@ class MessageSync(APISyncObject):
     message_ready = pyqtSignal([str, str])
 
     def run(self, loop: bool = True) -> None:
-        session = self.session_maker()
+        session = Session()
         while True:
             submissions = storage.find_new_messages(session)
 
@@ -149,7 +145,7 @@ class ReplySync(APISyncObject):
     reply_ready = pyqtSignal([str, str])
 
     def run(self, loop: bool = True) -> None:
-        session = self.session_maker()
+        session = Session()
         while True:
             replies = storage.find_new_replies(session)
 

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -27,7 +27,6 @@ from typing import List, Tuple, Type, Union
 
 from sqlalchemy import or_
 from sqlalchemy.orm import scoped_session
-from sqlalchemy.orm.exc import NoResultFound
 
 from securedrop_client.db import Session, Source, Message, File, Reply, User
 from sdclientapi import API
@@ -136,8 +135,11 @@ def update_local_storage(remote_sources: List[SDKSource],
 
     session.close()
 
+
 def update_sources(remote_sources: List[SDKSource],
-                   local_sources: List[Source], session: scoped_session, data_dir: str) -> None:
+                   local_sources: List[Source],
+                   session: scoped_session,
+                   data_dir: str) -> None:
     """
     Given collections of remote sources, the current local sources and a
     session to the local database, ensure the state of the local database
@@ -385,8 +387,10 @@ def mark_message_as_downloaded(uuid: str, session: scoped_session) -> None:
     session.commit()
 
 
-def set_object_decryption_status_with_content(obj: Union[File, Message, Reply], session: scoped_session,
-                                              is_successful: bool, content: str = None) -> None:
+def set_object_decryption_status_with_content(obj: Union[File, Message, Reply],
+                                              session: scoped_session,
+                                              is_successful: bool,
+                                              content: str = None) -> None:
     """Mark object as decrypted or not in the database."""
 
     model = type(obj)

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -26,9 +26,7 @@ from dateutil.parser import parse
 from typing import List, Tuple, Type, Union
 
 from sqlalchemy import or_
-from sqlalchemy.orm import scoped_session
-
-from securedrop_client.db import Message, File, Reply, SessionFactory, Source, User
+from securedrop_client.db import session_scope, Source, Message, File, Reply, User
 from sdclientapi import API
 from sdclientapi import Source as SDKSource
 from sdclientapi import Submission as SDKSubmission
@@ -41,61 +39,24 @@ def get_local_sources() -> List[Source]:
     """
     Return all source objects from the local database.
     """
-    session = SessionFactory()
-    sources = session.query(Source).all()
-    session.close()
-    return sources
+    with session_scope() as session:
+        sources = session.query(Source).all()
+        session.close()
+        return sources
 
-def get_local_source(uuid: str) -> Source:
-    """
-    Return local source that matches given uuid.
-    """
-    session = SessionFactory()
-    source = session.query(Source).filter_by(uuid=uuid).one_or_none()
-    session.close()
-    return source
-
-def get_local_messages() -> List[Message]:
-    """
-    Return all submission objects from the local database.
-    """
-    session = SessionFactory()
-    messages = session.query(Message).all()
-    session.close()
-    return messages
-
-def get_local_files() -> List[File]:
-    """
-    Return all file (a submitted file) objects from the local database.
-    """
-    session = SessionFactory()
-    files = session.query(File).all()
-    session.close()
-    return files
-
-def get_local_replies() -> List[Reply]:
-    """
-    Return all reply objects from the local database.
-    """
-    session = SessionFactory()
-    replies = session.query(Reply).all()
-    session.close()
-    return replies
 
 def add_reply(reply_uuid, source_uuid, journalist_uuid, filename):
     """
     Add a reply to the database.
     """
-    session = SessionFactory()
-    source = session.query(Source).filter_by(uuid=source_uuid).one_or_none()
-    reply = Reply(
-        uuid=reply_uuid,
-        source_id=source.id,
-        journalist_id=journalist_uuid,
-        filename=filename)
-    session.add(reply)
-    session.commit()
-    session.close()
+    with session_scope() as session:
+        source = session.query(Source).filter_by(uuid=source_uuid).one_or_none()
+        reply = Reply(
+            uuid=reply_uuid,
+            source_id=source.id,
+            journalist_id=journalist_uuid,
+            filename=filename)
+        session.add(reply)
 
 
 def get_remote_data(api: API) -> Tuple[List[SDKSource], List[SDKSubmission], List[SDKReply]]:
@@ -133,29 +94,16 @@ def update_local_storage(remote_sources: List[SDKSource],
     replies from the SecureDrop API, ensures the local database is updated
     with this data.
     """
-
-    session = SessionFactory()
-
-    local_sources = get_local_sources()
-    local_files = get_local_files()
-    local_messages = get_local_messages()
-    local_replies = get_local_replies()
-
     remote_messages = [x for x in remote_submissions if x.filename.endswith('msg.gpg')]
     remote_files = [x for x in remote_submissions if not x.filename.endswith('msg.gpg')]
 
-    update_sources(remote_sources, local_sources, data_dir)
-    update_files(remote_files, local_files, data_dir)
-    update_messages(remote_messages, local_messages, data_dir)
-    update_replies(remote_replies, local_replies, data_dir)
-
-    session.commit()
-    session.close()
+    update_sources(remote_sources, data_dir)
+    update_files(remote_files, data_dir)
+    update_messages(remote_messages, data_dir)
+    update_replies(remote_replies, data_dir)
 
 
-def update_sources(remote_sources: List[SDKSource],
-                   local_sources: List[Source],
-                   data_dir: str) -> None:
+def update_sources(remote_sources: List[SDKSource], data_dir: str) -> None:
     """
     Given collections of remote sources, the current local sources and a
     session to the local database, ensure the state of the local database
@@ -166,66 +114,58 @@ def update_sources(remote_sources: List[SDKSource],
     * Local items not returned in the remote sources are deleted from the
       local database.
     """
-    session = SessionFactory()
+    with session_scope() as session:
+        local_sources = session.query(Source).all()
+        local_uuids = {source.uuid for source in local_sources}
+        for source in remote_sources:
+            if source.uuid in local_uuids:
+                # Update an existing record.
+                local_source = [s for s in local_sources if s.uuid == source.uuid][0]
+                local_source.journalist_designation = source.journalist_designation
+                local_source.is_flagged = source.is_flagged
+                local_source.public_key = source.key['public']
+                local_source.interaction_count = source.interaction_count
+                local_source.document_count = source.number_of_documents
+                local_source.is_starred = source.is_starred
+                local_source.last_updated = parse(source.last_updated)
 
-    local_uuids = {source.uuid for source in local_sources}
-    for source in remote_sources:
-        if source.uuid in local_uuids:
-            # Update an existing record.
-            local_source = [s for s in local_sources
-                            if s.uuid == source.uuid][0]
-            local_source.journalist_designation = source.journalist_designation
-            local_source.is_flagged = source.is_flagged
-            local_source.public_key = source.key['public']
-            local_source.interaction_count = source.interaction_count
-            local_source.document_count = source.number_of_documents
-            local_source.is_starred = source.is_starred
-            local_source.last_updated = parse(source.last_updated)
+                # Removing the UUID from local_uuids ensures this record won't be
+                # deleted at the end of this function.
+                local_uuids.remove(source.uuid)
+                logger.debug('Updated source {}'.format(source.uuid))
+            else:
+                # A new source to be added to the database.
+                ns = Source(uuid=source.uuid,
+                            journalist_designation=source.journalist_designation,
+                            is_flagged=source.is_flagged,
+                            public_key=source.key['public'],
+                            interaction_count=source.interaction_count,
+                            is_starred=source.is_starred,
+                            last_updated=parse(source.last_updated),
+                            document_count=source.number_of_documents)
+                session.add(ns)
+                logger.debug('Added new source {}'.format(source.uuid))
 
-            # Removing the UUID from local_uuids ensures this record won't be
-            # deleted at the end of this function.
-            local_uuids.remove(source.uuid)
-            logger.debug('Updated source {}'.format(source.uuid))
-        else:
-            # A new source to be added to the database.
-            ns = Source(uuid=source.uuid,
-                        journalist_designation=source.journalist_designation,
-                        is_flagged=source.is_flagged,
-                        public_key=source.key['public'],
-                        interaction_count=source.interaction_count,
-                        is_starred=source.is_starred,
-                        last_updated=parse(source.last_updated),
-                        document_count=source.number_of_documents)
-            session.add(ns)
-            logger.debug('Added new source {}'.format(source.uuid))
+        # The uuids remaining in local_uuids do not exist on the remote server, so
+        # delete the related records.
+        for deleted_source in [s for s in local_sources if s.uuid in local_uuids]:
+            for document in deleted_source.collection:
+                delete_single_submission_or_reply_on_disk(document, data_dir)
 
-    # The uuids remaining in local_uuids do not exist on the remote server, so
-    # delete the related records.
-    for deleted_source in [s for s in local_sources if s.uuid in local_uuids]:
-        for document in deleted_source.collection:
-            delete_single_submission_or_reply_on_disk(document, data_dir)
-
-        session.delete(deleted_source)
-        logger.debug('Deleted source {}'.format(deleted_source.uuid))
-
-    session.commit()
+            session.delete(deleted_source)
+            logger.debug('Deleted source {}'.format(deleted_source.uuid))
 
 
-def update_files(remote_submissions: List[SDKSubmission],
-                 local_submissions: List[File],
-                 data_dir: str) -> None:
-    __update_submissions(File, remote_submissions, local_submissions, data_dir)
+def update_files(remote_submissions: List[SDKSubmission], data_dir: str) -> None:
+    __update_submissions(File, remote_submissions, data_dir)
 
 
-def update_messages(remote_submissions: List[SDKSubmission],
-                    local_submissions: List[Message],
-                    data_dir: str) -> None:
-    __update_submissions(Message, remote_submissions, local_submissions, data_dir)
+def update_messages(remote_submissions: List[SDKSubmission], data_dir: str) -> None:
+    __update_submissions(Message, remote_submissions, data_dir)
 
 
 def __update_submissions(model: Union[Type[File], Type[Message]],
                          remote_submissions: List[SDKSubmission],
-                         local_submissions: Union[List[Message], List[File]],
                          data_dir: str) -> None:
     """
     The logic for updating files and messages is effectively the same, so this function is somewhat
@@ -236,53 +176,49 @@ def __update_submissions(model: Union[Type[File], Type[Message]],
     * Local submissions not returned in the remote submissions are deleted
       from the local database.
     """
-    session = SessionFactory()
+    with session_scope() as session:
+        local_submissions = session.query(model).all()
+        local_uuids = {submission.uuid for submission in local_submissions}
+        for submission in remote_submissions:
+            if submission.uuid in local_uuids:
+                local_submission = [s for s in local_submissions
+                                    if s.uuid == submission.uuid][0]
 
-    local_uuids = {submission.uuid for submission in local_submissions}
-    for submission in remote_submissions:
-        if submission.uuid in local_uuids:
-            local_submission = [s for s in local_submissions
-                                if s.uuid == submission.uuid][0]
+                # Update files on disk to match new filename.
+                if (local_submission.filename != submission.filename):
+                    rename_file(data_dir, local_submission.filename,
+                                submission.filename)
 
-            # Update files on disk to match new filename.
-            if (local_submission.filename != submission.filename):
-                rename_file(data_dir, local_submission.filename,
-                            submission.filename)
+                # Update an existing record.
+                local_submission.filename = submission.filename
+                local_submission.size = submission.size
+                local_submission.is_read = submission.is_read
+                local_submission.download_url = submission.download_url
 
-            # Update an existing record.
-            local_submission.filename = submission.filename
-            local_submission.size = submission.size
-            local_submission.is_read = submission.is_read
-            local_submission.download_url = submission.download_url
+                # Removing the UUID from local_uuids ensures this record won't be
+                # deleted at the end of this function.
+                local_uuids.remove(submission.uuid)
+                logger.debug('Updated submission {}'.format(submission.uuid))
+            else:
+                # A new submission to be added to the database.
+                _, source_uuid = submission.source_url.rsplit('/', 1)
 
-            # Removing the UUID from local_uuids ensures this record won't be
-            # deleted at the end of this function.
-            local_uuids.remove(submission.uuid)
-            logger.debug('Updated submission {}'.format(submission.uuid))
-        else:
-            # A new submission to be added to the database.
-            _, source_uuid = submission.source_url.rsplit('/', 1)
+                source = session.query(Source).filter_by(uuid=source_uuid)[0]
+                ns = model(source_id=source.id, uuid=submission.uuid, size=submission.size,
+                           filename=submission.filename, download_url=submission.download_url)
+                session.add(ns)
+                logger.debug('Added new submission {}'.format(submission.uuid))
 
-            source = session.query(Source).filter_by(uuid=source_uuid)[0]
-            ns = model(source_id=source.id, uuid=submission.uuid, size=submission.size,
-                       filename=submission.filename, download_url=submission.download_url)
-            session.add(ns)
-            logger.debug('Added new submission {}'.format(submission.uuid))
-
-    # The uuids remaining in local_uuids do not exist on the remote server, so
-    # delete the related records.
-    for deleted_submission in [s for s in local_submissions
-                               if s.uuid in local_uuids]:
-        delete_single_submission_or_reply_on_disk(deleted_submission, data_dir)
-        session.delete(deleted_submission)
-        logger.debug('Deleted submission {}'.format(deleted_submission.uuid))
-
-    session.commit()
+        # The uuids remaining in local_uuids do not exist on the remote server, so
+        # delete the related records.
+        for deleted_submission in [s for s in local_submissions
+                                   if s.uuid in local_uuids]:
+            delete_single_submission_or_reply_on_disk(deleted_submission, data_dir)
+            session.delete(deleted_submission)
+            logger.debug('Deleted submission {}'.format(deleted_submission.uuid))
 
 
-def update_replies(remote_replies: List[SDKReply],
-                   local_replies: List[Reply],
-                   data_dir: str) -> None:
+def update_replies(remote_replies: List[SDKReply], data_dir: str) -> None:
     """
     * Existing replies are updated in the local database.
     * New replies have an entry created in the local database.
@@ -292,71 +228,68 @@ def update_replies(remote_replies: List[SDKReply],
     If a reply references a new journalist username, add them to the database
     as a new user.
     """
-    session = SessionFactory()
+    with session_scope() as session:
+        local_replies = session.query(Reply).all()
+        local_uuids = {reply.uuid for reply in local_replies}
+        for reply in remote_replies:
+            if reply.uuid in local_uuids:
+                local_reply = [r for r in local_replies if r.uuid == reply.uuid][0]
+                # Update files on disk to match new filename.
+                if (local_reply.filename != reply.filename):
+                    rename_file(data_dir, local_reply.filename, reply.filename)
+                # Update an existing record.
+                jid = get_journalist_id(reply.journalist_uuid, reply.journalist_username)
+                local_reply.journalist_id = jid
+                local_reply.filename = reply.filename
+                local_reply.size = reply.size
 
-    local_uuids = {reply.uuid for reply in local_replies}
-    for reply in remote_replies:
-        if reply.uuid in local_uuids:
-            local_reply = [r for r in local_replies if r.uuid == reply.uuid][0]
-            # Update files on disk to match new filename.
-            if (local_reply.filename != reply.filename):
-                rename_file(data_dir, local_reply.filename, reply.filename)
-            # Update an existing record.
-            user = find_or_create_user(reply.journalist_uuid, reply.journalist_username)
-            local_reply.journalist_id = user.id
-            local_reply.filename = reply.filename
-            local_reply.size = reply.size
+                local_uuids.remove(reply.uuid)
+                logger.debug('Updated reply {}'.format(reply.uuid))
+            else:
+                # A new reply to be added to the database.
+                source_uuid = reply.source_uuid
+                source = session.query(Source).filter_by(uuid=source_uuid)[0]
+                jid = get_journalist_id(reply.journalist_uuid, reply.journalist_username)
+                nr = Reply(uuid=reply.uuid,
+                           journalist_id=jid,
+                           source_id=source.id,
+                           filename=reply.filename,
+                           size=reply.size)
+                session.add(nr)
+                logger.debug('Added new reply {}'.format(reply.uuid))
 
-            local_uuids.remove(reply.uuid)
-            logger.debug('Updated reply {}'.format(reply.uuid))
-        else:
-            # A new reply to be added to the database.
-            source_uuid = reply.source_uuid
-            source = session.query(Source).filter_by(uuid=source_uuid)[0]
-            user = find_or_create_user(reply.journalist_uuid, reply.journalist_username)
-            nr = Reply(uuid=reply.uuid,
-                       journalist_id=user.id,
-                       source_id=source.id,
-                       filename=reply.filename,
-                       size=reply.size)
-            session.add(nr)
-            logger.debug('Added new reply {}'.format(reply.uuid))
+        # The uuids remaining in local_uuids do not exist on the remote server, so
+        # delete the related records.
+        for deleted_reply in [r for r in local_replies if r.uuid in local_uuids]:
+            delete_single_submission_or_reply_on_disk(deleted_reply, data_dir)
+            session.delete(deleted_reply)
+            logger.debug('Deleted reply {}'.format(deleted_reply.uuid))
 
-    # The uuids remaining in local_uuids do not exist on the remote server, so
-    # delete the related records.
-    for deleted_reply in [r for r in local_replies if r.uuid in local_uuids]:
-        delete_single_submission_or_reply_on_disk(deleted_reply, data_dir)
-        session.delete(deleted_reply)
-        logger.debug('Deleted reply {}'.format(deleted_reply.uuid))
 
-    session.commit()
-    session.close()
-
-def find_or_create_user(uuid: str, username: str) -> User:
+def get_journalist_id(uuid: str, username: str) -> str:
     """
     Returns a user object representing the referenced journalist UUID.
     If the user does not already exist in the data, a new instance is created.
     If the user exists but the username has changed, the username is updated.
     """
-    session = SessionFactory()
-
-    user = session.query(User).filter_by(uuid=uuid).one_or_none()
-    if user and user.username == username:
-        # User exists in the local database and the username is unchanged.
-        return user
-    elif user and user.username != username:
-        # User exists in the local database but the username is changed.
-        user.username = username
-        session.add(user)
-        session.commit()
-        return user
-    else:
-        # User does not exist in the local database.
-        new_user = User(username=username)
-        new_user.uuid = uuid
-        session.add(new_user)
-        session.commit()
-        return new_user
+    with session_scope() as session:
+        user = session.query(User).filter_by(uuid=uuid).one_or_none()
+        if user and user.username == username:
+            # User exists in the local database and the username is unchanged.
+            user_id = user.id
+        elif user and user.username != username:
+            # User exists in the local database but the username is changed.
+            user.username = username
+            session.add(user)
+            user_id = user.id
+        else:
+            # User does not exist in the local database.
+            new_user = User(username=username)
+            new_user.uuid = uuid
+            session.add(new_user)
+            user_id = new_user.id
+        session.close()
+        return user_id
 
 
 def find_new_messages() -> List[Message]:
@@ -368,15 +301,20 @@ def find_new_messages() -> List[Message]:
     * The message has not yet had decryption attempted.
     * Decryption previously failed on a message.
     """
-    return SessionFactory().query(Message).filter(
-        or_(Message.is_downloaded == False,
-            Message.is_decrypted == False,
-            Message.is_decrypted == None)).all()  # noqa: E711
+    with session_scope() as session:
+        messages = session.query(Message).filter(
+            or_(Message.is_downloaded == False,
+                Message.is_decrypted == False,
+                Message.is_decrypted == None)).all()  # noqa: E711
+        session.close()
+        return messages
 
 
 def find_new_files() -> List[File]:
-    return SessionFactory().query(File).filter_by(is_downloaded=False).all()
-
+    with session_scope() as session:
+        files = session.query(File).filter_by(is_downloaded=False).all()
+        session.close()
+        return files
 
 def find_new_replies() -> List[Reply]:
     """
@@ -387,57 +325,55 @@ def find_new_replies() -> List[Reply]:
     * The reply has not yet had decryption attempted.
     * Decryption previously failed on a reply.
     """
-    return SessionFactory().query(Reply).filter(
-        or_(Reply.is_downloaded == False,
-            Reply.is_decrypted == False,
-            Reply.is_decrypted == None)).all()  # noqa: E711
+    with session_scope() as session:
+        replies = session.query(Reply).filter(
+            or_(Reply.is_downloaded == False,
+                Reply.is_decrypted == False,
+                Reply.is_decrypted == None)).all()  # noqa: E711
+        return replies
 
 
 def mark_file_as_downloaded(uuid: str) -> None:
     """
     Mark file as downloaded in the database.
     """
-    session = SessionFactory()
-    file_db_object = session.query(File).filter_by(uuid=uuid).one()
-    file_db_object.is_downloaded = True
-    session.add(file_db_object)
-    session.commit()
+    with session_scope() as session:
+        file_db_object = session.query(File).filter_by(uuid=uuid).one()
+        file_db_object.is_downloaded = True
+        session.add(file_db_object)
 
 
 def mark_message_as_downloaded(uuid: str) -> None:
     """
     Mark message as downloaded in the database.
     """
-    session = SessionFactory()
-    message_db_object = session.query(Message).filter_by(uuid=uuid).one()
-    message_db_object.is_downloaded = True
-    session.add(message_db_object)
-    session.commit()
+    with session_scope() as session:
+        message_db_object = session.query(Message).filter_by(uuid=uuid).one()
+        message_db_object.is_downloaded = True
+        session.add(message_db_object)
 
 
 def set_object_decryption_status_with_content(obj: Union[File, Message, Reply],
                                               is_successful: bool,
                                               content: str = None) -> None:
     """Mark object as decrypted or not in the database."""
-    session = SessionFactory()
-    model = type(obj)
-    db_object = session.query(model).filter_by(uuid=obj.uuid).one_or_none()
-    db_object.is_decrypted = is_successful
-    if content is not None:
-        db_object.content = content
-    session.add(db_object)
-    session.commit()
+    with session_scope() as session:
+        model = type(obj)
+        db_object = session.query(model).filter_by(uuid=obj.uuid).one_or_none()
+        db_object.is_decrypted = is_successful
+        if content is not None:
+            db_object.content = content
+        session.add(db_object)
 
 
 def mark_reply_as_downloaded(uuid: str) -> None:
     """
     Mark reply as downloaded in the database.
     """
-    session = SessionFactory()
-    reply_db_object = session.query(Reply).filter_by(uuid=uuid).one()
-    reply_db_object.is_downloaded = True
-    session.add(reply_db_object)
-    session.commit()
+    with session_scope() as session:
+        reply_db_object = session.query(Reply).filter_by(uuid=uuid).one()
+        reply_db_object.is_downloaded = True
+        session.add(reply_db_object)
 
 
 def delete_single_submission_or_reply_on_disk(obj_db: Union[File, Message, Reply],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 from securedrop_client.config import Config
 from securedrop_client.app import configure_locale_and_language
-from securedrop_client.db import Base, Session, Source, make_engine
+from securedrop_client.db import Base, SessionFactory, Source, make_engine
 
 
 with open(os.path.join(os.path.dirname(__file__), 'files', 'test-key.gpg.pub.asc')) as f:
@@ -82,21 +82,14 @@ def _alembic_config(homedir):
 
 
 @pytest.fixture(scope='function')
-def SessionFactory(homedir):
-    engine = make_engine(homedir)
-    Session = sessionmaker(bind=engine)
-    return Session
-
-
-@pytest.fixture(scope='function')
 def session(homedir):
     """
     This fixture recreates the test db every time it is used
     """
     engine = make_engine(homedir)
-    Session.configure(bind=engine)
+    SessionFactory.configure(bind=engine)
     Base.metadata.create_all(bind=engine, checkfirst=False)
-    session = Session()
+    session = SessionFactory()
     yield session
     # teardown
     session.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,13 @@ def _alembic_config(homedir):
 
 
 @pytest.fixture(scope='function')
+def SessionFactory(homedir):
+    engine = make_engine(homedir)
+    Session = sessionmaker(bind=engine)
+    return Session
+
+
+@pytest.fixture(scope='function')
 def session(homedir):
     """
     This fixture recreates the test db every time it is used

--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -12,7 +12,7 @@ from os import path
 from sqlalchemy import text
 
 from . import conftest
-from securedrop_client.db import Base, Session, convention, make_engine
+from securedrop_client.db import Base, SessionFactory, convention, make_engine
 
 MIGRATION_PATH = path.join(path.dirname(__file__), '..', 'alembic', 'versions')
 
@@ -99,12 +99,12 @@ def test_alembic_head_matches_db_models(tmpdir):
     models_homedir = str(tmpdir.mkdir('models'))
     subprocess.check_call(['sqlite3', os.path.join(models_homedir, 'svs.sqlite'), '.databases'])
     engine = make_engine(models_homedir)
-    Session.configure(bind=engine)
+    SessionFactory.configure(bind=engine)
     Base.metadata.create_all(bind=engine, checkfirst=False)
     # Base.metadata.create_all(bind=session.get_bind(), checkfirst=False)
     assert Base.metadata.naming_convention == convention
 
-    session = Session()
+    session = SessionFactory()
     models_schema = get_schema(session)
     Base.metadata.drop_all(bind=engine)
     session.close()
@@ -112,13 +112,13 @@ def test_alembic_head_matches_db_models(tmpdir):
     alembic_homedir = str(tmpdir.mkdir('alembic'))
     subprocess.check_call(['sqlite3', os.path.join(alembic_homedir, 'svs.sqlite'), '.databases'])
     engine = make_engine(alembic_homedir)
-    Session.configure(bind=engine)
+    SessionFactory.configure(bind=engine)
     Base.metadata.create_all(bind=engine, checkfirst=False)
 
     alembic_config = conftest._alembic_config(alembic_homedir)
     upgrade(alembic_config, 'head')
 
-    session = Session()
+    session = SessionFactory()
     alembic_schema = get_schema(session)
     Base.metadata.drop_all(bind=engine)
     session.close()
@@ -166,8 +166,8 @@ def test_schema_unchanged_after_up_then_downgrade(alembic_config,
         pass
 
     engine = make_engine(str(tmpdir.mkdir('original')))
-    Session.configure(bind=engine)
-    session = Session()
+    SessionFactory.configure(bind=engine)
+    session = SessionFactory()
 
     original_schema = get_schema(session)
 
@@ -175,8 +175,8 @@ def test_schema_unchanged_after_up_then_downgrade(alembic_config,
     downgrade(alembic_config, '-1')
 
     engine = make_engine(str(tmpdir.mkdir('reverted')))
-    Session.configure(bind=engine)
-    session = Session()
+    SessionFactory.configure(bind=engine)
+    session = SessionFactory()
 
     reverted_schema = get_schema(session)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -111,7 +111,6 @@ def test_start_app(homedir, mocker):
     """
     Ensure the expected things are configured and the application is started.
     """
-    mock_session_maker = mocker.MagicMock()
     mock_args = mocker.MagicMock()
     mock_qt_args = mocker.MagicMock()
     mock_args.sdc_home = str(homedir)
@@ -123,14 +122,11 @@ def test_start_app(homedir, mocker):
     mock_controller = mocker.patch('securedrop_client.app.Controller')
     mocker.patch('securedrop_client.app.prevent_second_instance')
     mocker.patch('securedrop_client.app.sys')
-    mocker.patch('securedrop_client.app.make_session_maker', return_value=mock_session_maker)
 
     start_app(mock_args, mock_qt_args)
     mock_app.assert_called_once_with(mock_qt_args)
     mock_win.assert_called_once_with()
-    mock_controller.assert_called_once_with('http://localhost:8081/',
-                                            mock_win(), mock_session_maker,
-                                            homedir, False)
+    mock_controller.assert_called_once_with('http://localhost:8081/', mock_win(), homedir, False)
 
 
 PERMISSIONS_CASES = [
@@ -170,7 +166,6 @@ PERMISSIONS_CASES = [
 def test_create_app_dir_permissions(tmpdir, mocker):
 
     for idx, case in enumerate(PERMISSIONS_CASES):
-        mock_session_maker = mocker.MagicMock()
         mock_args = mocker.MagicMock()
         mock_qt_args = mocker.MagicMock()
 
@@ -192,7 +187,6 @@ def test_create_app_dir_permissions(tmpdir, mocker):
         mocker.patch('securedrop_client.app.Controller')
         mocker.patch('securedrop_client.app.sys')
         mocker.patch('securedrop_client.app.prevent_second_instance')
-        mocker.patch('securedrop_client.app.make_session_maker', return_value=mock_session_maker)
 
         def func():
             start_app(mock_args, mock_qt_args)
@@ -245,7 +239,7 @@ def test_signal_interception(mocker, homedir):
     mocker.patch('securedrop_client.app.QApplication')
     mocker.patch('securedrop_client.app.prevent_second_instance')
     mocker.patch('sys.exit')
-    mocker.patch('securedrop_client.db.make_session_maker')
+    mocker.patch('securedrop_client.db.make_engine')
     mocker.patch('securedrop_client.app.init')
     mocker.patch('securedrop_client.logic.Controller.setup')
     mocker.patch('securedrop_client.logic.GpgHelper')

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -13,12 +13,12 @@ with open(os.path.join(os.path.dirname(__file__), 'files', 'securedrop.gpg.asc')
     JOURNO_KEY = f.read()
 
 
-def test_message_logic(homedir, config, mocker, session_maker):
+def test_message_logic(homedir, config, mocker):
     """
     Ensure that messages are handled.
     Using the `config` fixture to ensure the config is written to disk.
     """
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    gpg = GpgHelper(homedir, is_qubes=False)
 
     test_msg = 'tests/files/test-msg.gpg'
     expected_output_filename = 'test-msg'
@@ -32,12 +32,12 @@ def test_message_logic(homedir, config, mocker, session_maker):
     assert dest == os.path.join(homedir, 'data', expected_output_filename)
 
 
-def test_gunzip_logic(homedir, config, mocker, session_maker):
+def test_gunzip_logic(homedir, config, mocker):
     """
     Ensure that gzipped documents/files are handled
     Using the `config` fixture to ensure the config is written to disk.
     """
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    gpg = GpgHelper(homedir, is_qubes=False)
 
     test_gzip = 'tests/files/test-doc.gz.gpg'
     expected_output_filename = 'test-doc'
@@ -52,12 +52,12 @@ def test_gunzip_logic(homedir, config, mocker, session_maker):
     assert mock_unlink.call_count == 2
 
 
-def test_subprocess_raises_exception(homedir, config, mocker, session_maker):
+def test_subprocess_raises_exception(homedir, config, mocker):
     """
     Ensure that failed GPG commands raise an exception.
     Using the `config` fixture to ensure the config is written to disk.
     """
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    gpg = GpgHelper(homedir, is_qubes=False)
 
     test_gzip = 'tests/files/test-doc.gz.gpg'
     output_filename = 'test-doc'
@@ -73,21 +73,21 @@ def test_subprocess_raises_exception(homedir, config, mocker, session_maker):
     assert mock_unlink.call_count == 1
 
 
-def test_import_key(homedir, config, source, session_maker):
+def test_import_key(homedir, config, source):
     '''
     Check the happy path that we can import a single PGP key.
     Using the `config` fixture to ensure the config is written to disk.
     '''
-    helper = GpgHelper(homedir, session_maker, is_qubes=False)
+    helper = GpgHelper(homedir, is_qubes=False)
     helper.import_key(source['uuid'], source['public_key'], source['fingerprint'])
 
 
-def test_import_key_gpg_call_fail(homedir, config, mocker, session_maker):
+def test_import_key_gpg_call_fail(homedir, config, mocker):
     '''
     Check that a `CryptoError` is raised if calling `gpg` fails.
     Using the `config` fixture to ensure the config is written to disk.
     '''
-    helper = GpgHelper(homedir, session_maker, is_qubes=False)
+    helper = GpgHelper(homedir, is_qubes=False)
     err = CalledProcessError(cmd=['foo'], returncode=1)
     mock_call = mocker.patch('securedrop_client.crypto.subprocess.check_call',
                              side_effect=err)
@@ -99,12 +99,12 @@ def test_import_key_gpg_call_fail(homedir, config, mocker, session_maker):
     assert mock_call.called
 
 
-def test_encrypt(homedir, source, config, mocker, session_maker):
+def test_encrypt(homedir, source, config, mocker):
     '''
     Check that calling `encrypt` encrypts the message.
     Using the `config` fixture to ensure the config is written to disk.
     '''
-    helper = GpgHelper(homedir, session_maker, is_qubes=False)
+    helper = GpgHelper(homedir, is_qubes=False)
 
     # first we have to ensure the pubkeys are available
     helper._import(PUB_KEY)
@@ -134,12 +134,12 @@ def test_encrypt(homedir, source, config, mocker, session_maker):
     assert decrypted == plaintext
 
 
-def test_encrypt_fail(homedir, source, config, mocker, session_maker):
+def test_encrypt_fail(homedir, source, config, mocker):
     '''
     Check that a `CryptoError` is raised if the call to `gpg` fails.
     Using the `config` fixture to ensure the config is written to disk.
     '''
-    helper = GpgHelper(homedir, session_maker, is_qubes=False)
+    helper = GpgHelper(homedir, is_qubes=False)
 
     # first we have to ensure the pubkeys are available
     helper._import(PUB_KEY)

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -609,7 +609,7 @@ def test_Controller_update_sources(homedir, config, mocker, session):
     store.
     Using the `config` fixture to ensure the config is written to disk.
     """
-    mocker.patch('securedrop_client.logic.db.Session', return_value=session)
+    mocker.patch('securedrop_client.logic.db.SessionFactory', return_value=session)
     mock_gui = mocker.MagicMock()
     co = Controller('http://localhost', mock_gui, homedir)
     mock_storage = mocker.patch('securedrop_client.logic.storage')

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -62,7 +62,7 @@ def test_APICallRunner_with_exception(mocker):
     cr.call_failed.emit.assert_called_once_with()
 
 
-def test_Controller_init(homedir, config, mocker, session_maker):
+def test_Controller_init(homedir, config, mocker):
     """
     The passed in gui, app and session instances are correctly referenced and,
     where appropriate, have a reference back to the client.
@@ -70,19 +70,18 @@ def test_Controller_init(homedir, config, mocker, session_maker):
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost/', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost/', mock_gui, homedir)
     assert co.hostname == 'http://localhost/'
     assert co.gui == mock_gui
-    assert co.session_maker == session_maker
     assert co.api_threads == {}
 
 
-def test_Controller_setup(homedir, config, mocker, session_maker):
+def test_Controller_setup(homedir, config, mocker):
     """
     Ensure the application is set up with the following default state:
     Using the `config` fixture to ensure the config is written to disk.
     """
-    co = Controller('http://localhost', mocker.MagicMock(), session_maker, homedir)
+    co = Controller('http://localhost', mocker.MagicMock(), homedir)
     co.update_sources = mocker.MagicMock()
 
     co.setup()
@@ -90,14 +89,14 @@ def test_Controller_setup(homedir, config, mocker, session_maker):
     co.gui.setup.assert_called_once_with(co)
 
 
-def test_Controller_start_message_thread(homedir, config, mocker, session_maker):
+def test_Controller_start_message_thread(homedir, config, mocker):
     """
     When starting message-fetching thread, make sure we do a few things.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     mock_qthread = mocker.patch('securedrop_client.logic.QThread')
     mocker.patch('securedrop_client.logic.MessageSync')
@@ -110,7 +109,7 @@ def test_Controller_start_message_thread(homedir, config, mocker, session_maker)
     co.message_thread.start.assert_called_once_with()
 
 
-def test_Controller_start_message_thread_if_already_running(homedir, config, mocker, session_maker):
+def test_Controller_start_message_thread_if_already_running(homedir, config, mocker):
     """
     Ensure that when starting the message thread, we don't start another thread
     if it's already running. Instead, we just authenticate the existing thread.
@@ -118,7 +117,7 @@ def test_Controller_start_message_thread_if_already_running(homedir, config, moc
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.api = 'api object'
     co.message_sync = mocker.MagicMock()
     co.message_thread = mocker.MagicMock()
@@ -129,14 +128,14 @@ def test_Controller_start_message_thread_if_already_running(homedir, config, moc
     co.message_thread.start.assert_not_called()
 
 
-def test_Controller_start_reply_thread(homedir, config, mocker, session_maker):
+def test_Controller_start_reply_thread(homedir, config, mocker):
     """
     When starting reply-fetching thread, make sure we do a few things.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     mock_qthread = mocker.patch('securedrop_client.logic.QThread')
     mocker.patch('securedrop_client.logic.ReplySync')
@@ -149,7 +148,7 @@ def test_Controller_start_reply_thread(homedir, config, mocker, session_maker):
     co.reply_thread.start.assert_called_once_with()
 
 
-def test_Controller_start_reply_thread_if_already_running(homedir, config, mocker, session_maker):
+def test_Controller_start_reply_thread_if_already_running(homedir, config, mocker):
     """
     Ensure that when starting the reply thread, we don't start another thread
     if it's already running. Instead, we just authenticate the existing thread.
@@ -157,7 +156,7 @@ def test_Controller_start_reply_thread_if_already_running(homedir, config, mocke
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     co.api = 'api object'
     co.reply_sync = mocker.MagicMock()
@@ -169,14 +168,14 @@ def test_Controller_start_reply_thread_if_already_running(homedir, config, mocke
     co.reply_thread.start.assert_not_called()
 
 
-def test_Controller_call_api(homedir, config, mocker, session_maker):
+def test_Controller_call_api(homedir, config, mocker):
     """
     A new thread and APICallRunner is created / setup.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     co.finish_api_call = mocker.MagicMock()
     mocker.patch('securedrop_client.logic.QThread')
@@ -200,7 +199,7 @@ def test_Controller_call_api(homedir, config, mocker, session_maker):
     runner.call_timed_out.connect.call_count == 1
 
 
-def test_Controller_login(homedir, config, mocker, session_maker):
+def test_Controller_login(homedir, config, mocker):
     """
     Ensures the API is called in the expected manner for logging in the user
     given the username, password and 2fa token.
@@ -209,7 +208,7 @@ def test_Controller_login(homedir, config, mocker, session_maker):
     mock_gui = mocker.MagicMock()
     mock_api = mocker.patch('securedrop_client.logic.sdclientapi.API')
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.call_api = mocker.MagicMock()
 
     co.login('username', 'password', '123456')
@@ -224,7 +223,7 @@ def test_Controller_login_offline_mode(homedir, config, mocker):
     Ensures user is not authenticated when logging in in offline mode and that the correct windows
     are displayed.
     """
-    co = Controller('http://localhost', mocker.MagicMock(), mocker.MagicMock(), homedir)
+    co = Controller('http://localhost', mocker.MagicMock(), homedir)
     co.call_api = mocker.MagicMock()
     co.gui = mocker.MagicMock()
     co.gui.show_main_window = mocker.MagicMock()
@@ -243,7 +242,7 @@ def test_Controller_login_offline_mode(homedir, config, mocker):
     co.update_sources.assert_called_once_with()
 
 
-def test_Controller_on_authenticate_failure(homedir, config, mocker, session_maker):
+def test_Controller_on_authenticate_failure(homedir, config, mocker):
     """
     If the server responds with a negative to the request to authenticate, make
     sure the user knows.
@@ -251,7 +250,7 @@ def test_Controller_on_authenticate_failure(homedir, config, mocker, session_mak
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     result_data = Exception('oh no')
     co.on_authenticate_failure(result_data)
@@ -261,7 +260,7 @@ def test_Controller_on_authenticate_failure(homedir, config, mocker, session_mak
                                 'verify your credentials and try again.')
 
 
-def test_Controller_on_authenticate_success(homedir, config, mocker, session_maker):
+def test_Controller_on_authenticate_success(homedir, config, mocker):
     """
     Ensure the client syncs when the user successfully logs in.
     Using the `config` fixture to ensure the config is written to disk.
@@ -269,7 +268,7 @@ def test_Controller_on_authenticate_success(homedir, config, mocker, session_mak
     mock_gui = mocker.MagicMock()
     mock_api_job_queue = mocker.patch("securedrop_client.logic.ApiJobQueue")
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.sync_api = mocker.MagicMock()
     co.api = mocker.MagicMock()
     co.start_message_thread = mocker.MagicMock()
@@ -287,12 +286,7 @@ def test_Controller_on_authenticate_success(homedir, config, mocker, session_mak
     assert mock_api_job_queue.called
 
 
-def test_Controller_completed_api_call_without_current_object(
-    homedir,
-    config,
-    mocker,
-    session_maker,
-):
+def test_Controller_completed_api_call_without_current_object(homedir, config, mocker):
     """
     Ensure that cleanup is performed if an API call returns in the expected
     time.
@@ -300,7 +294,7 @@ def test_Controller_completed_api_call_without_current_object(
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     result = 'result'
 
@@ -321,7 +315,7 @@ def test_Controller_completed_api_call_without_current_object(
     mock_user_callback.assert_called_once_with(result)
 
 
-def test_Controller_completed_api_call_with_current_object(homedir, config, mocker, session_maker):
+def test_Controller_completed_api_call_with_current_object(homedir, config, mocker):
     """
     Ensure that cleanup is performed if an API call returns in the expected
     time.
@@ -329,7 +323,7 @@ def test_Controller_completed_api_call_with_current_object(homedir, config, mock
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     result = 'result'
     current_object = 'current_object'
@@ -354,7 +348,7 @@ def test_Controller_completed_api_call_with_current_object(homedir, config, mock
                                                current_object=current_object)
 
 
-def test_Controller_on_action_requiring_login(homedir, config, mocker, session_maker):
+def test_Controller_on_action_requiring_login(homedir, config, mocker):
     """
     Ensure that when on_action_requiring_login is called, an error
     is shown in the GUI status area.
@@ -362,7 +356,7 @@ def test_Controller_on_action_requiring_login(homedir, config, mocker, session_m
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     co.on_action_requiring_login()
 
@@ -370,28 +364,28 @@ def test_Controller_on_action_requiring_login(homedir, config, mocker, session_m
         'You must sign in to perform this action.')
 
 
-def test_Controller_authenticated_yes(homedir, config, mocker, session_maker):
+def test_Controller_authenticated_yes(homedir, config, mocker):
     """
     If the API is authenticated return True.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.api = mocker.MagicMock()
     co.api.token = 'foo'
 
     assert co.authenticated() is True
 
 
-def test_Controller_authenticated_no(homedir, config, mocker, session_maker):
+def test_Controller_authenticated_no(homedir, config, mocker):
     """
     If the API is authenticated return True.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     co.api = mocker.MagicMock()
     co.api.token = None
@@ -399,27 +393,27 @@ def test_Controller_authenticated_no(homedir, config, mocker, session_maker):
     assert co.authenticated() is False
 
 
-def test_Controller_authenticated_no_api(homedir, config, mocker, session_maker):
+def test_Controller_authenticated_no_api(homedir, config, mocker):
     """
     If the API is authenticated return True.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.api = None
 
     assert co.authenticated() is False
 
 
-def test_Controller_sync_api_not_authenticated(homedir, config, mocker, session_maker):
+def test_Controller_sync_api_not_authenticated(homedir, config, mocker):
     """
     If the API isn't authenticated, don't sync.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.authenticated = mocker.MagicMock(return_value=False)
     co.call_api = mocker.MagicMock()
 
@@ -428,14 +422,14 @@ def test_Controller_sync_api_not_authenticated(homedir, config, mocker, session_
     assert co.call_api.call_count == 0
 
 
-def test_Controller_sync_api(homedir, config, mocker, session_maker):
+def test_Controller_sync_api(homedir, config, mocker):
     """
     Sync the API is authenticated.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     co.authenticated = mocker.MagicMock(return_value=True)
     co.call_api = mocker.MagicMock()
@@ -448,7 +442,7 @@ def test_Controller_sync_api(homedir, config, mocker, session_maker):
                                         co.api)
 
 
-def test_Controller_last_sync_with_file(homedir, config, mocker, session_maker):
+def test_Controller_last_sync_with_file(homedir, config, mocker):
     """
     The flag indicating the time of the last sync with the API is stored in a
     dotfile in the user's home directory. If such a file exists, ensure an
@@ -457,7 +451,7 @@ def test_Controller_last_sync_with_file(homedir, config, mocker, session_maker):
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     timestamp = '2018-10-10 18:17:13+01:00'
     mocker.patch("builtins.open", mocker.mock_open(read_data=timestamp))
@@ -468,20 +462,20 @@ def test_Controller_last_sync_with_file(homedir, config, mocker, session_maker):
     assert result.format() == timestamp
 
 
-def test_Controller_last_sync_no_file(homedir, config, mocker, session_maker):
+def test_Controller_last_sync_no_file(homedir, config, mocker):
     """
     If there's no sync file, then just return None.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     mocker.patch("builtins.open", mocker.MagicMock(side_effect=Exception()))
     assert co.last_sync() is None
 
 
-def test_Controller_on_sync_failure(homedir, config, mocker, session_maker):
+def test_Controller_on_sync_failure(homedir, config, mocker):
     """
     If there's no result to syncing, then don't attempt to update local storage
     and perhaps implement some as-yet-undefined UI update.
@@ -489,7 +483,7 @@ def test_Controller_on_sync_failure(homedir, config, mocker, session_maker):
     """
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     co.update_sources = mocker.MagicMock()
     result_data = Exception('Boom')  # Not the expected tuple.
@@ -507,10 +501,8 @@ def test_Controller_on_sync_success(homedir, config, mocker):
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    mock_session = mocker.MagicMock()
-    mock_session_maker = mocker.MagicMock(return_value=mock_session)
 
-    co = Controller('http://localhost', mock_gui, mock_session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.update_sources = mocker.MagicMock()
     co.api_runner = mocker.MagicMock()
     co.gpg = mocker.MagicMock()
@@ -533,10 +525,8 @@ def test_Controller_on_sync_success(homedir, config, mocker):
     co.call_reset = mocker.MagicMock()
     mock_storage = mocker.patch('securedrop_client.logic.storage')
     co.on_sync_success(result_data)
-    mock_storage.update_local_storage. \
-        assert_called_once_with(mock_session, mock_sources, "submissions",
-                                "replies",
-                                os.path.join(homedir, 'data'))
+    mock_storage.update_local_storage.assert_called_once_with(
+        mock_sources, "submissions", "replies", os.path.join(homedir, 'data'))
 
     co.update_sources.assert_called_once_with()
 
@@ -548,10 +538,8 @@ def test_Controller_on_sync_success_with_non_pgp_key(homedir, config, mocker):
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    mock_session = mocker.MagicMock()
-    mock_session_maker = mocker.MagicMock(return_value=mock_session)
 
-    co = Controller('http://localhost', mock_gui, mock_session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.update_sources = mocker.MagicMock()
     co.api_runner = mocker.MagicMock()
 
@@ -566,10 +554,8 @@ def test_Controller_on_sync_success_with_non_pgp_key(homedir, config, mocker):
     co.call_reset = mocker.MagicMock()
     mock_storage = mocker.patch('securedrop_client.logic.storage')
     co.on_sync_success(result_data)
-    mock_storage.update_local_storage. \
-        assert_called_once_with(mock_session, mock_sources, "submissions",
-                                "replies",
-                                os.path.join(homedir, 'data'))
+    mock_storage.update_local_storage.assert_called_once_with(
+        mock_sources, "submissions", "replies", os.path.join(homedir, 'data'))
     co.update_sources.assert_called_once_with()
 
 
@@ -580,10 +566,8 @@ def test_Controller_on_sync_success_with_key_import_fail(homedir, config, mocker
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    mock_session = mocker.MagicMock()
-    mock_session_maker = mocker.MagicMock(return_value=mock_session)
 
-    co = Controller('http://localhost', mock_gui, mock_session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.update_sources = mocker.MagicMock()
     co.api_runner = mocker.MagicMock()
 
@@ -601,55 +585,50 @@ def test_Controller_on_sync_success_with_key_import_fail(homedir, config, mocker
     mock_storage = mocker.patch('securedrop_client.logic.storage')
     mocker.patch.object(co.gpg, 'import_key', side_effect=CryptoError)
     co.on_sync_success(result_data)
-    mock_storage.update_local_storage. \
-        assert_called_once_with(mock_session, mock_sources, "submissions",
-                                "replies",
-                                os.path.join(homedir, 'data'))
+    mock_storage.update_local_storage.assert_called_once_with(
+        mock_sources, "submissions", "replies", os.path.join(homedir, 'data'))
     co.update_sources.assert_called_once_with()
 
 
-def test_Controller_update_sync(homedir, config, mocker, session_maker):
+def test_Controller_update_sync(homedir, config, mocker):
     """
     Cause the UI to update with the result of self.last_sync().
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.last_sync = mocker.MagicMock()
     co.update_sync()
     assert co.last_sync.call_count == 1
     co.gui.show_sync.assert_called_once_with(co.last_sync())
 
 
-def test_Controller_update_sources(homedir, config, mocker):
+def test_Controller_update_sources(homedir, config, mocker, session):
     """
     Ensure the UI displays a list of the available sources from local data
     store.
     Using the `config` fixture to ensure the config is written to disk.
     """
+    mocker.patch('securedrop_client.logic.db.Session', return_value=session)
     mock_gui = mocker.MagicMock()
-    mock_session = mocker.MagicMock()
-    mock_session_maker = mocker.MagicMock(return_value=mock_session)
-
-    co = Controller('http://localhost', mock_gui, mock_session_maker, homedir)
-
+    co = Controller('http://localhost', mock_gui, homedir)
     mock_storage = mocker.patch('securedrop_client.logic.storage')
     source_list = [factory.Source(last_updated=2), factory.Source(last_updated=1)]
     mock_storage.get_local_sources.return_value = source_list
 
     co.update_sources()
 
-    mock_storage.get_local_sources.assert_called_once_with(mock_session)
+    mock_storage.get_local_sources.assert_called_once_with(session)
     mock_gui.show_sources.assert_called_once_with(source_list)
 
 
-def test_Controller_unstars_a_source_if_starred(homedir, config, mocker, session_maker):
+def test_Controller_unstars_a_source_if_starred(homedir, config, mocker):
     """
     Ensure that the client unstars a source if it is starred.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     source_db_object = mocker.MagicMock()
     source_db_object.uuid = mocker.MagicMock()
@@ -675,13 +654,13 @@ def test_Controller_unstars_a_source_if_starred(homedir, config, mocker, session
     mock_gui.clear_error_status.assert_called_once_with()
 
 
-def test_Controller_unstars_a_source_if_unstarred(homedir, config, mocker, session_maker):
+def test_Controller_unstars_a_source_if_unstarred(homedir, config, mocker):
     """
     Ensure that the client stars a source if it is unstarred.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     source_db_object = mocker.MagicMock()
     source_db_object.uuid = mocker.MagicMock()
@@ -707,14 +686,14 @@ def test_Controller_unstars_a_source_if_unstarred(homedir, config, mocker, sessi
     mock_gui.clear_error_status.assert_called_once_with()
 
 
-def test_Controller_update_star_not_logged_in(homedir, config, mocker, session_maker):
+def test_Controller_update_star_not_logged_in(homedir, config, mocker):
     """
     Ensure that starring/unstarring a source when not logged in calls
     the method that displays an error status in the left sidebar.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     source_db_object = mocker.MagicMock()
     co.on_action_requiring_login = mocker.MagicMock()
     co.api = None
@@ -722,14 +701,14 @@ def test_Controller_update_star_not_logged_in(homedir, config, mocker, session_m
     co.on_action_requiring_login.assert_called_with()
 
 
-def test_Controller_on_update_star_success(homedir, config, mocker, session_maker):
+def test_Controller_on_update_star_success(homedir, config, mocker):
     """
     If the starring occurs successfully, then a sync should occur to update
     locally.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     result = True
     co.call_reset = mocker.MagicMock()
     co.sync_api = mocker.MagicMock()
@@ -738,14 +717,14 @@ def test_Controller_on_update_star_success(homedir, config, mocker, session_make
     mock_gui.clear_error_status.assert_called_once_with()
 
 
-def test_Controller_on_update_star_failed(homedir, config, mocker, session_maker):
+def test_Controller_on_update_star_failed(homedir, config, mocker):
     """
     If the starring does not occur properly, then an error should appear
     on the error status sidebar, and a sync will not occur.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     result = Exception('boom')
     co.call_reset = mocker.MagicMock()
     co.sync_api = mocker.MagicMock()
@@ -754,14 +733,14 @@ def test_Controller_on_update_star_failed(homedir, config, mocker, session_maker
     mock_gui.update_error_status.assert_called_once_with('Failed to update star.')
 
 
-def test_Controller_logout(homedir, config, mocker, session_maker):
+def test_Controller_logout(homedir, config, mocker):
     """
     The API is reset to None and the UI is set to logged out state.
     The message and reply threads should also have the
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.api = mocker.MagicMock()
     co.message_sync = mocker.MagicMock()
     co.reply_sync = mocker.MagicMock()
@@ -774,13 +753,13 @@ def test_Controller_logout(homedir, config, mocker, session_maker):
     co.gui.logout.assert_called_once_with()
 
 
-def test_Controller_set_activity_status(homedir, config, mocker, session_maker):
+def test_Controller_set_activity_status(homedir, config, mocker):
     """
     Ensure the GUI set_status API is called.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.set_status("Hello, World!", 1000)
     mock_gui.update_activity_status.assert_called_once_with("Hello, World!", 1000)
 
@@ -805,7 +784,7 @@ PERMISSIONS_CASES = [
 ]
 
 
-def test_create_client_dir_permissions(tmpdir, mocker, session_maker):
+def test_create_client_dir_permissions(tmpdir, mocker):
     '''
     Check that creating an app behaves appropriately with different
     permissions on the various directories needed for it to function.
@@ -826,7 +805,7 @@ def test_create_client_dir_permissions(tmpdir, mocker, session_maker):
             os.mkdir(sdc_home, case['home_perms'])
 
         def func() -> None:
-            Controller('http://localhost', mock_gui, session_maker, sdc_home)
+            Controller('http://localhost', mock_gui, sdc_home)
 
         if case['should_pass']:
             func()
@@ -839,14 +818,14 @@ def test_create_client_dir_permissions(tmpdir, mocker, session_maker):
     assert mock_json.called
 
 
-def test_Controller_on_file_download_Submission(homedir, config, session, mocker, session_maker):
+def test_Controller_on_file_download_Submission(homedir, config, session, mocker):
     """
     If the handler is passed a Submission, check the download_submission
     function is the one called against the API.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     mock_success_signal = mocker.MagicMock()
     mock_failure_signal = mocker.MagicMock()
@@ -857,16 +836,16 @@ def test_Controller_on_file_download_Submission(homedir, config, session, mocker
     mock_queue = mocker.patch.object(co, 'api_job_queue')
 
     source = factory.Source()
-    file_ = factory.File(is_downloaded=None, is_decrypted=None, source=source)
+    file = factory.File(is_downloaded=None, is_decrypted=None, source=source)
     session.add(source)
-    session.add(file_)
+    session.add(file)
     session.commit()
 
-    co.on_submission_download(db.File, file_.uuid)
+    co.on_submission_download(db.File, file.uuid)
 
     mock_job_cls.assert_called_once_with(
         db.File,
-        file_.uuid,
+        file.uuid,
         co.data_dir,
         co.gpg,
     )
@@ -877,13 +856,13 @@ def test_Controller_on_file_download_Submission(homedir, config, session, mocker
         co.on_file_download_failure, type=Qt.QueuedConnection)
 
 
-def test_Controller_on_file_downloaded_success(homedir, config, mocker, session_maker):
+def test_Controller_on_file_downloaded_success(homedir, config, mocker):
     '''
     Using the `config` fixture to ensure the config is written to disk.
     '''
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     # signal when file is downloaded
     mock_file_ready = mocker.patch.object(co, 'file_ready')
@@ -894,12 +873,12 @@ def test_Controller_on_file_downloaded_success(homedir, config, mocker, session_
     mock_file_ready.emit.assert_called_once_with(mock_uuid)
 
 
-def test_Controller_on_file_downloaded_api_failure(homedir, config, mocker, session_maker):
+def test_Controller_on_file_downloaded_api_failure(homedir, config, mocker):
     '''
     Using the `config` fixture to ensure the config is written to disk.
     '''
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     # signal when file is downloaded
     mock_file_ready = mocker.patch.object(co, 'file_ready')
@@ -912,14 +891,14 @@ def test_Controller_on_file_downloaded_api_failure(homedir, config, mocker, sess
     mock_file_ready.emit.assert_not_called()
 
 
-def test_Controller_on_file_open(homedir, config, mocker, session, session_maker, source):
+def test_Controller_on_file_open(homedir, config, mocker, session, source):
     """
     If running on Qubes, a new QProcess with the expected command and args
     should be started.
     Using the `config` fixture to ensure the config is written to disk.
     """
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.proxy = True
 
     submission = factory.File(source=source['source'])
@@ -929,41 +908,41 @@ def test_Controller_on_file_open(homedir, config, mocker, session, session_maker
     mock_subprocess = mocker.MagicMock()
     mock_process = mocker.MagicMock(return_value=mock_subprocess)
     mocker.patch('securedrop_client.logic.QProcess', mock_process)
-    co.on_file_open(submission.uuid)
+    co.on_file_open(submission)
     mock_process.assert_called_once_with(co)
     mock_subprocess.start.call_count == 1
 
 
-def test_Controller_on_delete_source_success(homedir, config, mocker, session_maker):
+def test_Controller_on_delete_source_success(homedir, config, mocker):
     '''
     Using the `config` fixture to ensure the config is written to disk.
     '''
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.sync_api = mocker.MagicMock()
     co.on_delete_source_success(True)
     co.sync_api.assert_called_with()
     co.gui.clear_error_status.assert_called_with()
 
 
-def test_Controller_on_delete_source_failure(homedir, config, mocker, session_maker):
+def test_Controller_on_delete_source_failure(homedir, config, mocker):
     '''
     Using the `config` fixture to ensure the config is written to disk.
     '''
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.sync_api = mocker.MagicMock()
     co.on_delete_source_failure(Exception())
     co.gui.update_error_status.assert_called_with('Failed to delete source at server')
 
 
-def test_Controller_delete_source(homedir, config, mocker, session_maker):
+def test_Controller_delete_source(homedir, config, mocker):
     '''
     Using the `config` fixture to ensure the config is written to disk.
     '''
     mock_gui = mocker.MagicMock()
     mock_source = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.call_api = mocker.MagicMock()
     co.api = mocker.MagicMock()
     co.delete_source(mock_source)
@@ -975,14 +954,14 @@ def test_Controller_delete_source(homedir, config, mocker, session_maker):
     )
 
 
-def test_Controller_send_reply_success(homedir, mocker, session_maker):
+def test_Controller_send_reply_success(homedir, mocker):
     '''
     Check that the "happy path" of encrypting a message and sending it to the sever behaves as
     expected.
     '''
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     co.call_api = mocker.Mock()
     co.api = mocker.Mock()
@@ -1014,13 +993,13 @@ def test_Controller_send_reply_success(homedir, mocker, session_maker):
     assert mock_source_init.called  # to prevent stale mocks
 
 
-def test_Controller_send_reply_gpg_error(homedir, mocker, session_maker):
+def test_Controller_send_reply_gpg_error(homedir, mocker):
     '''
     Check that if gpg fails when sending a message, we alert the UI and do *not* call the API.
     '''
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
 
     co.call_api = mocker.Mock()
     co.api = mocker.Mock()
@@ -1047,7 +1026,7 @@ def test_Controller_send_reply_gpg_error(homedir, mocker, session_maker):
     assert mock_source_init.called  # to prevent stale mocks
 
 
-def test_Controller_on_reply_success(homedir, mocker, session_maker, session):
+def test_Controller_on_reply_success(homedir, mocker, session):
     '''
     Check that when the result is a success, the client emits the correct signal.
     '''
@@ -1061,7 +1040,7 @@ def test_Controller_on_reply_success(homedir, mocker, session_maker, session):
 
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.api = mocker.Mock()
 
     reply = sdclientapi.Reply(uuid='wat', filename='1-lol')
@@ -1071,22 +1050,20 @@ def test_Controller_on_reply_success(homedir, mocker, session_maker, session):
     mock_reply_failed = mocker.patch.object(co, 'reply_failed')
 
     current_object = (source.uuid, msg.uuid)
+    add_reply_fn = mocker.patch('securedrop_client.logic.storage.add_reply')
     co.on_reply_success(reply, current_object)
-    mock_reply_succeeded.emit.assert_called_once_with(msg.uuid)
+    mock_reply_succeeded.emit.assert_called_once_with(source.uuid, msg.uuid)
     assert not mock_reply_failed.emit.called
-
-    # check that this was writtent to the DB
-    replies = session.query(db.Reply).all()
-    assert len(replies) == 1
+    assert add_reply_fn.call_count == 1
 
 
-def test_Controller_on_reply_failure(homedir, mocker, session_maker):
+def test_Controller_on_reply_failure(homedir, mocker):
     '''
     Check that when the result is a failure, the client emits the correct signal.
     '''
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.api = mocker.Mock()
     journalist_uuid = 'abc123'
     co.api.token_journalist_uuid = journalist_uuid
@@ -1097,11 +1074,11 @@ def test_Controller_on_reply_failure(homedir, mocker, session_maker):
     msg_uuid = 'bar222'
     current_object = (source_uuid, msg_uuid)
     co.on_reply_failure(Exception, current_object)
-    mock_reply_failed.emit.assert_called_once_with(msg_uuid)
+    mock_reply_failed.emit.assert_called_once_with(source_uuid, msg_uuid)
     assert not mock_reply_succeeded.emit.called
 
 
-def test_Controller_is_authenticated_property(homedir, mocker, session_maker):
+def test_Controller_is_authenticated_property(homedir, mocker):
     '''
     Check that the @property `is_authenticated`:
       - Cannot be deleted
@@ -1110,7 +1087,7 @@ def test_Controller_is_authenticated_property(homedir, mocker, session_maker):
     '''
     mock_gui = mocker.MagicMock()
 
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     mock_signal = mocker.patch.object(co, 'authentication_state')
 
     # default state is unauthenticated
@@ -1157,12 +1134,12 @@ def test_APICallRunner_api_call_timeout(mocker):
     mock_timeout_signal.emit.assert_called_once_with()
 
 
-def test_Controller_api_call_timeout(homedir, config, mocker, session_maker):
+def test_Controller_api_call_timeout(homedir, config, mocker):
     '''
     Using the `config` fixture to ensure the config is written to disk.
     '''
     mock_gui = mocker.MagicMock()
-    co = Controller('http://localhost', mock_gui, session_maker, homedir)
+    co = Controller('http://localhost', mock_gui, homedir)
     co.on_api_timeout()
     mock_gui.update_error_status.assert_called_once_with(
         'The connection to the SecureDrop server timed out. Please try again.')

--- a/tests/test_message_sync.py
+++ b/tests/test_message_sync.py
@@ -6,7 +6,7 @@ from securedrop_client.message_sync import MessageSync, ReplySync
 from tests import factory
 
 
-def test_MessageSync_init(mocker, session_maker):
+def test_MessageSync_init(mocker):
     """
     Ensure things are set up as expected
     """
@@ -14,14 +14,13 @@ def test_MessageSync_init(mocker, session_maker):
     mock_api = mocker.MagicMock()
     mock_gpg = mocker.MagicMock()
 
-    ms = MessageSync(mock_api, mock_gpg, session_maker)
+    ms = MessageSync(mock_api, mock_gpg)
 
     assert ms.api == mock_api
     assert ms.gpg == mock_gpg
-    assert ms.session_maker == session_maker
 
 
-def test_MessageSync_run_success(mocker, session, source, session_maker, homedir):
+def test_MessageSync_run_success(mocker, session, source, homedir):
     """
     Test when a message successfully downloads and decrypts.
     Using the `homedir` fixture to get a GPG keyring.
@@ -42,7 +41,7 @@ def test_MessageSync_run_success(mocker, session, source, session_maker, homedir
         with open(plaintext_filename, 'w') as f:
             f.write(expected_content)
 
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    gpg = GpgHelper(homedir, is_qubes=False)
     mocker.patch.object(
         gpg,
         'decrypt_submission_or_reply',
@@ -50,7 +49,7 @@ def test_MessageSync_run_success(mocker, session, source, session_maker, homedir
     )
 
     api = mocker.MagicMock(session=session)
-    ms = MessageSync(api, gpg, session_maker)
+    ms = MessageSync(api, gpg)
     ms.api.download_submission = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
 
     mock_message_ready = mocker.patch.object(ms, 'message_ready')
@@ -66,7 +65,7 @@ def test_MessageSync_run_success(mocker, session, source, session_maker, homedir
     assert message.is_decrypted is True
 
 
-def test_MessageSync_run_decrypt_only(mocker, session, source, session_maker, homedir):
+def test_MessageSync_run_decrypt_only(mocker, session, source, homedir):
     """
     Test when a message successfully downloads and decrypts.
     Using the `homedir` fixture to get a GPG keyring.
@@ -87,7 +86,7 @@ def test_MessageSync_run_decrypt_only(mocker, session, source, session_maker, ho
         with open(plaintext_filename, 'w') as f:
             f.write(expected_content)
 
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    gpg = GpgHelper(homedir, is_qubes=False)
     mocker.patch.object(
         gpg,
         'decrypt_submission_or_reply',
@@ -95,7 +94,7 @@ def test_MessageSync_run_decrypt_only(mocker, session, source, session_maker, ho
     )
 
     api = mocker.MagicMock(session=session)
-    ms = MessageSync(api, gpg, session_maker)
+    ms = MessageSync(api, gpg)
     ms.api.download_submission = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
     mock_fetch = mocker.patch.object(ms, 'fetch_the_thing')
 
@@ -113,7 +112,7 @@ def test_MessageSync_run_decrypt_only(mocker, session, source, session_maker, ho
     assert not mock_fetch.called
 
 
-def test_MessageSync_run_decryption_error(mocker, session, source, session_maker, homedir):
+def test_MessageSync_run_decryption_error(mocker, session, source, homedir):
     """
     Test when a message successfully downloads, but does not successfully decrypt.
     Using the `homedir` fixture to get a GPG keyring.
@@ -130,9 +129,9 @@ def test_MessageSync_run_decryption_error(mocker, session, source, session_maker
 
     api = mocker.MagicMock(session=session)
 
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    gpg = GpgHelper(homedir, is_qubes=False)
 
-    ms = MessageSync(api, gpg, session_maker)
+    ms = MessageSync(api, gpg)
     mocker.patch.object(ms.gpg, 'decrypt_submission_or_reply', side_effect=CryptoError)
 
     ms.api.download_submission = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
@@ -148,7 +147,7 @@ def test_MessageSync_run_decryption_error(mocker, session, source, session_maker
     assert message.is_decrypted is False
 
 
-def test_MessageSync_exception(homedir, config, mocker, source, session, session_maker):
+def test_MessageSync_exception(homedir, config, mocker, source, session):
     """
     Makes sure that if an exception is raised in the download thread, the code which catches it is
     actually run.
@@ -165,8 +164,8 @@ def test_MessageSync_exception(homedir, config, mocker, source, session, session
                                 mocker.MagicMock(side_effect=Exception()))
 
     api = mocker.MagicMock()
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
-    ms = MessageSync(api, gpg, session_maker)
+    gpg = GpgHelper(homedir, is_qubes=False)
+    ms = MessageSync(api, gpg)
 
     # check that it runs without raising exceptions
     ms.run(False)
@@ -175,21 +174,21 @@ def test_MessageSync_exception(homedir, config, mocker, source, session, session
     assert mock_message.called
 
 
-def test_MessageSync_run_failure(mocker, source, session, session_maker, homedir):
+def test_MessageSync_run_failure(mocker, source, session, homedir):
     message = factory.Message(source=source['source'])
     session.add(message)
     session.commit()
 
     api = mocker.MagicMock()
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
-    ms = MessageSync(api, gpg, session_maker)
+    gpg = GpgHelper(homedir, is_qubes=False)
+    ms = MessageSync(api, gpg)
     ms.api.download_submission = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
 
     # check that it runs without raising exceptions
     ms.run(False)
 
 
-def test_ReplySync_init(mocker, session_maker):
+def test_ReplySync_init(mocker):
     """
     Ensure things are set up as expected
     """
@@ -197,14 +196,13 @@ def test_ReplySync_init(mocker, session_maker):
     mock_api = mocker.MagicMock()
     mock_gpg = mocker.MagicMock()
 
-    rs = ReplySync(mock_api, mock_gpg, session_maker)
+    rs = ReplySync(mock_api, mock_gpg)
 
     assert rs.api == mock_api
     assert rs.gpg == mock_gpg
-    assert rs.session_maker == session_maker
 
 
-def test_ReplySync_run_success(mocker, session, source, session_maker, homedir):
+def test_ReplySync_run_success(mocker, session, source, homedir):
     """
     Test when a reply successfully downloads and decrypts.
     Using the `homedir` fixture to get a GPG keyring.
@@ -225,7 +223,7 @@ def test_ReplySync_run_success(mocker, session, source, session_maker, homedir):
         with open(plaintext_filename, 'w') as f:
             f.write(expected_content)
 
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    gpg = GpgHelper(homedir, is_qubes=False)
     mocker.patch.object(
         gpg,
         'decrypt_submission_or_reply',
@@ -233,7 +231,7 @@ def test_ReplySync_run_success(mocker, session, source, session_maker, homedir):
     )
 
     api = mocker.MagicMock(session=session)
-    rs = ReplySync(api, gpg, session_maker)
+    rs = ReplySync(api, gpg)
     rs.api.download_reply = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
 
     mock_reply_ready = mocker.patch.object(rs, 'reply_ready')
@@ -249,7 +247,7 @@ def test_ReplySync_run_success(mocker, session, source, session_maker, homedir):
     assert reply.is_decrypted is True
 
 
-def test_ReplySync_run_decrypt_only(mocker, session, source, session_maker, homedir):
+def test_ReplySync_run_decrypt_only(mocker, session, source, homedir):
     """
     Test when a message successfully downloads and decrypts.
     Using the `homedir` fixture to get a GPG keyring.
@@ -270,7 +268,7 @@ def test_ReplySync_run_decrypt_only(mocker, session, source, session_maker, home
         with open(plaintext_filename, 'w') as f:
             f.write(expected_content)
 
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    gpg = GpgHelper(homedir, is_qubes=False)
     mocker.patch.object(
         gpg,
         'decrypt_submission_or_reply',
@@ -278,7 +276,7 @@ def test_ReplySync_run_decrypt_only(mocker, session, source, session_maker, home
     )
 
     api = mocker.MagicMock(session=session)
-    rs = ReplySync(api, gpg, session_maker)
+    rs = ReplySync(api, gpg)
     rs.api.download_submission = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
     mock_fetch = mocker.patch.object(rs, 'fetch_the_thing')
 
@@ -296,7 +294,7 @@ def test_ReplySync_run_decrypt_only(mocker, session, source, session_maker, home
     assert not mock_fetch.called
 
 
-def test_ReplySync_run_decryption_error(mocker, session, source, session_maker, homedir):
+def test_ReplySync_run_decryption_error(mocker, session, source, homedir):
     """
     Test when a reply successfully downloads, but does not successfully decrypt.
     Using the `homedir` fixture to get a GPG keyring.
@@ -313,9 +311,9 @@ def test_ReplySync_run_decryption_error(mocker, session, source, session_maker, 
 
     api = mocker.MagicMock(session=session)
 
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
+    gpg = GpgHelper(homedir, is_qubes=False)
 
-    rs = ReplySync(api, gpg, session_maker)
+    rs = ReplySync(api, gpg)
     mocker.patch.object(rs.gpg, 'decrypt_submission_or_reply', side_effect=CryptoError)
 
     rs.api.download_reply = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
@@ -331,7 +329,7 @@ def test_ReplySync_run_decryption_error(mocker, session, source, session_maker, 
     assert reply.is_decrypted is False
 
 
-def test_ReplySync_exception(homedir, config, mocker, source, session, session_maker):
+def test_ReplySync_exception(homedir, config, mocker, source, session):
     """
     Makes sure that if an exception is raised in the download thread, the code which catches it is
     actually run.
@@ -348,8 +346,8 @@ def test_ReplySync_exception(homedir, config, mocker, source, session, session_m
                               mocker.MagicMock(side_effect=Exception()))
 
     api = mocker.MagicMock()
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
-    rs = ReplySync(api, gpg, session_maker)
+    gpg = GpgHelper(homedir, is_qubes=False)
+    rs = ReplySync(api, gpg)
 
     # check that it runs without raising exceptions
     rs.run(False)
@@ -358,14 +356,14 @@ def test_ReplySync_exception(homedir, config, mocker, source, session, session_m
     assert mock_reply.called
 
 
-def test_ReplySync_run_failure(mocker, source, session, session_maker, homedir):
+def test_ReplySync_run_failure(mocker, source, session, homedir):
     reply = factory.Reply(source=source['source'])
     session.add(reply)
     session.commit()
 
     api = mocker.MagicMock()
-    gpg = GpgHelper(homedir, session_maker, is_qubes=False)
-    rs = ReplySync(api, gpg, session_maker)
+    gpg = GpgHelper(homedir, is_qubes=False)
+    rs = ReplySync(api, gpg)
     rs.api.download_reply = mocker.MagicMock(return_value=(1234, "/home/user/downloads/foo"))
 
     # check that it runs without raising exceptions

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,9 +23,9 @@ def test_string_representation_of_message():
 
 def test_string_representation_of_file():
     source = factory.Source()
-    file_ = File(source=source, uuid="test", size=123, filename="1-test.docx",
-                 download_url='http://test/test')
-    file_.__repr__()
+    file = File(source=source, uuid="test", size=123, filename="1-test.docx",
+                download_url='http://test/test')
+    file.__repr__()
 
 
 def test_string_representation_of_reply():
@@ -39,20 +39,20 @@ def test_string_representation_of_reply():
 def test_source_collection():
     # Create some test submissions and replies
     source = factory.Source()
-    file_ = File(source=source, uuid="test", size=123, filename="2-test.doc.gpg",
-                 download_url='http://test/test')
+    file = File(source=source, uuid="test", size=123, filename="2-test.doc.gpg",
+                download_url='http://test/test')
     message = Message(source=source, uuid="test", size=123, filename="3-test.doc.gpg",
                       download_url='http://test/test')
     user = User(username='hehe')
     reply = Reply(source=source, journalist=user, filename="1-reply.gpg",
                   size=1234, uuid='test')
-    source.files = [file_]
+    source.files = [file]
     source.messages = [message]
     source.replies = [reply]
 
     # Now these items should be in the source collection in the proper order
     assert source.collection[0] == reply
-    assert source.collection[1] == file_
+    assert source.collection[1] == file
     assert source.collection[2] == message
 
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -161,6 +161,18 @@ def test_update_local_storage(homedir, mocker, session):
     msg_fn.assert_called_once_with([remote_message], [local_message], session, homedir)
 
 
+def test_add_reply(mocker, SessionFactory, homedir):
+    # check that reply is to the DB
+    mocker.patch('securedrop_client.db.Session', return_value=SessionFactory)
+    mock_id = str(uuid.uuid4())
+    source = factory.Source()
+
+    add_reply(mock_id, source.uuid, mock_id, '1-spotted-potato-msg.gpg')
+
+    replies = SessionFactory().query(db.Reply).all()
+    assert len(replies) == 1
+
+
 def test_update_sources(homedir, mocker):
     """
     Check that:


### PR DESCRIPTION
# Description

Opening for visibility. Since this is 12 months old, I will need to rebase :P, but you can see the idea is to stop passing around a session maker around and instead to provide a transactional scope around a series of operations like this:

```py
@contextmanager
def session_scope():
    session = SessionFactory()
    try:
        yield session
        session.commit()
    except:
        session.rollback()
        raise
    finally:
        session.close()
```

This moves session management into one place (cleans up code quite a bit) and solves the problem of forgetting to close a session.

# Test Plan


# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/master/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `master` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `master` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed
