### PR TITLE
delete source widgets for current sync update

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -586,7 +586,7 @@ class MainView(QWidget):
             self.empty_conversation_view.show_no_sources_message()
             self.empty_conversation_view.show()
 
-        if self.source_list.source_widgets:
+        if self.source_list.source_items:
             # The source list already contains sources.
             deleted_sources = self.source_list.update(sources)
             for source_uuid in deleted_sources:
@@ -747,8 +747,8 @@ class SourceListWidgetItem(QListWidgetItem):
         me = lw.itemWidget(self)
         them = lw.itemWidget(other)
         if me and them:
-            my_ts = arrow.get(me.source.last_updated)
-            other_ts = arrow.get(them.source.last_updated)
+            my_ts = arrow.get(me.last_updated)
+            other_ts = arrow.get(them.last_updated)
             return my_ts < other_ts
         return True
 
@@ -772,8 +772,8 @@ class SourceList(QListWidget):
         # Enable ordering.
         self.setSortingEnabled(True)
 
-        # To hold references to SourceWidget instances indexed by source UUID.
-        self.source_widgets = {}
+        # To hold references to SourceListWidgetItem instances indexed by source UUID.
+        self.source_items = {}
 
     def setup(self, controller):
         self.controller = controller
@@ -789,52 +789,59 @@ class SourceList(QListWidget):
         """
         Update the list with the passed in list of sources.
         """
-        # Delete widgets that no longer exist in source list
-        source_uuids = [source.uuid for source in sources]
-        deleted_uuids = []
-        for i in range(self.count()):
-            list_item = self.item(i)
-            list_widget = self.itemWidget(list_item)
-
-            if list_widget and list_widget.source_uuid not in source_uuids:
-                if list_item.isSelected():
-                    self.setCurrentItem(None)
-
-                try:
-                    del self.source_widgets[list_widget.source_uuid]
-                except KeyError:
-                    pass
-
-                self.takeItem(i)
-                deleted_uuids.append(list_widget.source_uuid)
-                list_widget.deleteLater()
-
-        # Create new widgets for new sources
-        widget_uuids = [self.itemWidget(self.item(i)).source_uuid for i in range(self.count())]
+        sources_to_update = []
+        sources_to_add = []
         for source in sources:
-            if source.uuid in widget_uuids:
-                try:
-                    self.source_widgets[source.uuid].update()
-                except sqlalchemy.exc.InvalidRequestError as e:
-                    logger.error(
-                        "Could not update SourceWidget for source %s; deleting it. Error was: %s",
-                        source.uuid,
-                        e
-                    )
-                    deleted_uuids.append(source.uuid)
-                    self.source_widgets[source.uuid].deleteLater()
-                    del self.source_widgets[list_widget.source_uuid]
-            else:
-                new_source = SourceWidget(self.controller, source)
-                self.source_widgets[source.uuid] = new_source
+            try:
+                if source.uuid in self.source_items:
+                    sources_to_update.append(source.uuid)
+                else:
+                    sources_to_add.append(source)
+            except sqlalchemy.exc.InvalidRequestError as e:
+                logger.debug(e)
+                continue
 
-                list_item = SourceListWidgetItem()
-                self.insertItem(0, list_item)
-                list_item.setSizeHint(new_source.sizeHint())
-                self.setItemWidget(list_item, new_source)
+        # Delete widgets for sources not in the supplied sourcelist
+        deleted_uuids = []
+        sources_to_delete = [self.source_items[uuid] for uuid in self.source_items
+                             if uuid not in sources_to_update]
+        for source_item in sources_to_delete:
+            if source_item.isSelected():
+                self.setCurrentItem(None)
 
-        # Sort..!
+            source_widget = self.itemWidget(source_item)
+            self.takeItem(self.row(source_item))
+            source_widget.deleteLater()
+            try:
+                del self.source_items[source_widget.source_uuid]
+            except KeyError:
+                pass
+
+            deleted_uuids.append(source_widget.source_uuid)
+
+        # Update the remaining widgets
+        for i in range(self.count()):
+            source_widget = self.itemWidget(self.item(i))
+
+            if not source_widget:
+                continue
+
+            source_widget.update()
+
+        # Create new source widgets for new sources
+        for source in sources_to_add:
+            source_widget = SourceWidget(self.controller, source)
+            source_item = SourceListWidgetItem(self)
+            source_item.setSizeHint(source_widget.sizeHint())
+            self.insertItem(0, source_item)
+            self.setItemWidget(source_item, source_widget)
+            self.source_items[source.uuid] = source_item
+
+        # Re-sort SourceList to make sure the most recently-updated sources appear at the top
         self.sortItems(Qt.DescendingOrder)
+
+        # Return uuids of source widgets that were deleted so we can later delete the corresponding
+        # conversation widgets
         return deleted_uuids
 
     def initial_update(self, sources: List[Source]):
@@ -851,18 +858,21 @@ class SourceList(QListWidget):
 
         def schedule_source_management(slice_size=slice_size):
             if not sources:
-                # Nothing more to do.
                 return
+
             # Process the remaining "slice_size" number of sources.
             sources_slice = sources[:slice_size]
             for source in sources_slice:
-                new_source = SourceWidget(self.controller, source)
-                self.source_widgets[source.uuid] = new_source
-                list_item = SourceListWidgetItem(self)
-                list_item.setSizeHint(new_source.sizeHint())
+                try:
+                    source_widget = SourceWidget(self.controller, source)
+                    source_item = SourceListWidgetItem(self)
+                    source_item.setSizeHint(source_widget.sizeHint())
+                    self.insertItem(0, source_item)
+                    self.setItemWidget(source_item, source_widget)
+                    self.source_items[source.uuid] = source_item
+                except sqlalchemy.exc.InvalidRequestError as e:
+                    logger.debug(e)
 
-                self.insertItem(0, list_item)
-                self.setItemWidget(list_item, new_source)
             # ATTENTION! 32 is an arbitrary number arrived at via
             # experimentation. It adds plenty of sources, but doesn't block
             # for a noticable amount of time.
@@ -888,8 +898,8 @@ class SourceList(QListWidget):
         First try to get the source widget from the cache, then look for it in the SourceList.
         '''
         try:
-            source_widget = self.source_widgets[source_uuid]
-            return source_widget
+            source_item = self.source_items[source_uuid]
+            return self.itemWidget(source_item)
         except KeyError:
             pass
 
@@ -954,6 +964,7 @@ class SourceWidget(QWidget):
 
         # Store source
         self.source_uuid = source.uuid
+        self.last_updated = source.last_updated
         self.source = source
 
         # Set layout
@@ -1039,6 +1050,7 @@ class SourceWidget(QWidget):
         """
         try:
             self.controller.session.refresh(self.source)
+            self.last_updated = self.source.last_updated
             self.timestamp.setText(_(arrow.get(self.source.last_updated).format('DD MMM')))
             self.name.setText(self.source.journalist_designation)
 
@@ -1052,8 +1064,7 @@ class SourceWidget(QWidget):
                 self.paperclip.hide()
             self.star.update(self.source.is_starred)
         except sqlalchemy.exc.InvalidRequestError as e:
-            logger.error(f"Could not update SourceWidget for source {self.source_uuid}: {e}")
-            raise
+            logger.debug(f"Could not update SourceWidget for source {self.source_uuid}: {e}")
 
     def set_snippet(self, source_uuid: str, content: str):
         """

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -812,10 +812,8 @@ class SourceList(QListWidget):
             source_widget = self.itemWidget(source_item)
             self.takeItem(self.row(source_item))
             source_widget.deleteLater()
-            try:
+            if source_widget.source_uuid in self.source_items:
                 del self.source_items[source_widget.source_uuid]
-            except KeyError:
-                pass
 
             deleted_uuids.append(source_widget.source_uuid)
 

--- a/tests/functional/test_delete_source.py
+++ b/tests/functional/test_delete_source.py
@@ -21,13 +21,14 @@ def test_delete_source_and_their_docs(functional_test_logged_in_context, qtbot, 
     qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
-        assert len(list(gui.main_view.source_list.source_widgets.keys()))
+        assert len(list(gui.main_view.source_list.source_items.keys()))
 
     qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
-    source_ids = list(gui.main_view.source_list.source_widgets.keys())
+    source_ids = list(gui.main_view.source_list.source_items.keys())
     assert len(source_ids) == 2
     first_source_id = source_ids[0]
-    first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
+    first_source_item = gui.main_view.source_list.source_items[first_source_id]
+    first_source_widget = gui.main_view.source_list.itemWidget(first_source_item)
     qtbot.mouseClick(first_source_widget, Qt.LeftButton)
     qtbot.wait(TIME_RENDER_CONV_VIEW)
 

--- a/tests/functional/test_download_file.py
+++ b/tests/functional/test_download_file.py
@@ -24,12 +24,13 @@ def test_download_file(functional_test_logged_in_context, qtbot, mocker):
     qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
-        assert len(list(gui.main_view.source_list.source_widgets.keys()))
+        assert len(list(gui.main_view.source_list.source_items.keys()))
 
     qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
-    source_ids = list(gui.main_view.source_list.source_widgets.keys())
+    source_ids = list(gui.main_view.source_list.source_items.keys())
     first_source_id = source_ids[0]
-    first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
+    first_source_item = gui.main_view.source_list.source_items[first_source_id]
+    first_source_widget = gui.main_view.source_list.itemWidget(first_source_item)
     qtbot.mouseClick(first_source_widget, Qt.LeftButton)
 
     qtbot.wait(TIME_SYNC)

--- a/tests/functional/test_export_dialog.py
+++ b/tests/functional/test_export_dialog.py
@@ -24,12 +24,13 @@ def test_export_dialog(functional_test_logged_in_context, qtbot, mocker):
     qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
-        assert len(list(gui.main_view.source_list.source_widgets.keys()))
+        assert len(list(gui.main_view.source_list.source_items.keys()))
 
     qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
-    source_ids = list(gui.main_view.source_list.source_widgets.keys())
+    source_ids = list(gui.main_view.source_list.source_items.keys())
     first_source_id = source_ids[0]
-    first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
+    first_source_item = gui.main_view.source_list.source_items[first_source_id]
+    first_source_widget = gui.main_view.source_list.itemWidget(first_source_item)
     qtbot.mouseClick(first_source_widget, Qt.LeftButton)
 
     qtbot.wait(TIME_SYNC)

--- a/tests/functional/test_offline_delete_source.py
+++ b/tests/functional/test_offline_delete_source.py
@@ -22,13 +22,14 @@ def test_offline_delete_source_and_their_docs(functional_test_logged_in_context,
     qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
-        assert len(list(gui.main_view.source_list.source_widgets.keys()))
+        assert len(list(gui.main_view.source_list.source_items.keys()))
 
     qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
-    source_ids = list(gui.main_view.source_list.source_widgets.keys())
+    source_ids = list(gui.main_view.source_list.source_items.keys())
     assert len(source_ids) == 2
     first_source_id = source_ids[0]
-    first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
+    first_source_item = gui.main_view.source_list.source_items[first_source_id]
+    first_source_widget = gui.main_view.source_list.itemWidget(first_source_item)
     qtbot.mouseClick(first_source_widget, Qt.LeftButton)
     qtbot.wait(TIME_CLICK_ACTION)
 

--- a/tests/functional/test_offline_read_conversations.py
+++ b/tests/functional/test_offline_read_conversations.py
@@ -22,12 +22,13 @@ def test_offline_read_conversations(functional_test_logged_in_context, qtbot, mo
     qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
-        assert len(list(gui.main_view.source_list.source_widgets.keys()))
+        assert len(list(gui.main_view.source_list.source_items.keys()))
 
     qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
-    source_ids = list(gui.main_view.source_list.source_widgets.keys())
+    source_ids = list(gui.main_view.source_list.source_items.keys())
     first_source_id = source_ids[0]
-    first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
+    first_source_item = gui.main_view.source_list.source_items[first_source_id]
+    first_source_widget = gui.main_view.source_list.itemWidget(first_source_item)
     qtbot.mouseClick(first_source_widget, Qt.LeftButton)
 
     # Otherwise our test is running too fast to create all files/directories
@@ -44,7 +45,8 @@ def test_offline_read_conversations(functional_test_logged_in_context, qtbot, mo
     # Ensure that clicking on a source shows a conversation that contains
     # activity.
     second_source_id = source_ids[1]
-    second_source_widget = gui.main_view.source_list.source_widgets[second_source_id]
+    second_source_item = gui.main_view.source_list.source_items[second_source_id]
+    second_source_widget = gui.main_view.source_list.itemWidget(second_source_item)
     qtbot.mouseClick(second_source_widget, Qt.LeftButton)
     conversation = gui.main_view.view_layout.itemAt(0).widget()
     assert len(list(conversation.conversation_view.current_messages.keys())) > 0

--- a/tests/functional/test_offline_send_reply.py
+++ b/tests/functional/test_offline_send_reply.py
@@ -22,12 +22,13 @@ def test_offline_send_reply_to_source(functional_test_logged_in_context, qtbot, 
     qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
-        assert len(list(gui.main_view.source_list.source_widgets.keys()))
+        assert len(list(gui.main_view.source_list.source_items.keys()))
 
     qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
-    source_ids = list(gui.main_view.source_list.source_widgets.keys())
+    source_ids = list(gui.main_view.source_list.source_items.keys())
     first_source_id = source_ids[0]
-    first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
+    first_source_item = gui.main_view.source_list.source_items[first_source_id]
+    first_source_widget = gui.main_view.source_list.itemWidget(first_source_item)
     qtbot.mouseClick(first_source_widget, Qt.LeftButton)
 
     # Now logout.

--- a/tests/functional/test_offline_star_source.py
+++ b/tests/functional/test_offline_star_source.py
@@ -23,12 +23,13 @@ def test_offline_star_source(functional_test_logged_in_context, qtbot):
     qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
-        assert len(list(gui.main_view.source_list.source_widgets.keys()))
+        assert len(list(gui.main_view.source_list.source_items.keys()))
 
     qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
-    source_ids = list(gui.main_view.source_list.source_widgets.keys())
+    source_ids = list(gui.main_view.source_list.source_items.keys())
     first_source_id = source_ids[0]
-    first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
+    first_source_item = gui.main_view.source_list.source_items[first_source_id]
+    first_source_widget = gui.main_view.source_list.itemWidget(first_source_item)
     qtbot.mouseClick(first_source_widget, Qt.LeftButton)
 
     # Now logout.

--- a/tests/functional/test_receive_message.py
+++ b/tests/functional/test_receive_message.py
@@ -24,12 +24,13 @@ def test_receive_message_from_source(functional_test_logged_in_context, qtbot, m
     qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
-        assert len(list(gui.main_view.source_list.source_widgets.keys()))
+        assert len(list(gui.main_view.source_list.source_items.keys()))
 
     qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
-    source_ids = list(gui.main_view.source_list.source_widgets.keys())
+    source_ids = list(gui.main_view.source_list.source_items.keys())
     first_source_id = source_ids[0]
-    first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
+    first_source_item = gui.main_view.source_list.source_items[first_source_id]
+    first_source_widget = gui.main_view.source_list.itemWidget(first_source_item)
     qtbot.mouseClick(first_source_widget, Qt.LeftButton)
 
     qtbot.wait(TIME_SYNC)

--- a/tests/functional/test_send_reply.py
+++ b/tests/functional/test_send_reply.py
@@ -22,12 +22,13 @@ def test_send_reply_to_source(functional_test_logged_in_context, qtbot, mocker):
     qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
-        assert len(list(gui.main_view.source_list.source_widgets.keys()))
+        assert len(list(gui.main_view.source_list.source_items.keys()))
 
     qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
-    source_ids = list(gui.main_view.source_list.source_widgets.keys())
+    source_ids = list(gui.main_view.source_list.source_items.keys())
     first_source_id = source_ids[0]
-    first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
+    first_source_item = gui.main_view.source_list.source_items[first_source_id]
+    first_source_widget = gui.main_view.source_list.itemWidget(first_source_item)
     qtbot.mouseClick(first_source_widget, Qt.LeftButton)
     # Type something into the reply box and click the send button.
     message = "Hello, world!"

--- a/tests/functional/test_star_source.py
+++ b/tests/functional/test_star_source.py
@@ -22,12 +22,13 @@ def test_star_source(functional_test_logged_in_context, qtbot, mocker):
     qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
-        assert len(list(gui.main_view.source_list.source_widgets.keys()))
+        assert len(list(gui.main_view.source_list.source_items.keys()))
 
     qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
-    source_ids = list(gui.main_view.source_list.source_widgets.keys())
+    source_ids = list(gui.main_view.source_list.source_items.keys())
     first_source_id = source_ids[0]
-    first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
+    first_source_item = gui.main_view.source_list.source_items[first_source_id]
+    first_source_widget = gui.main_view.source_list.itemWidget(first_source_item)
     qtbot.mouseClick(first_source_widget, Qt.LeftButton)
 
     # Check the source isn't checked.

--- a/tests/functional/test_unstar_source.py
+++ b/tests/functional/test_unstar_source.py
@@ -22,12 +22,13 @@ def test_unstar_source(functional_test_logged_in_context, qtbot, mocker):
     qtbot.wait(TIME_APP_START)
 
     def check_for_sources():
-        assert len(list(gui.main_view.source_list.source_widgets.keys()))
+        assert len(list(gui.main_view.source_list.source_items.keys()))
 
     qtbot.waitUntil(check_for_sources, timeout=TIME_RENDER_SOURCE_LIST)
-    source_ids = list(gui.main_view.source_list.source_widgets.keys())
+    source_ids = list(gui.main_view.source_list.source_items.keys())
     first_source_id = source_ids[0]
-    first_source_widget = gui.main_view.source_list.source_widgets[first_source_id]
+    first_source_item = gui.main_view.source_list.source_items[first_source_id]
+    first_source_widget = gui.main_view.source_list.itemWidget(first_source_item)
     qtbot.mouseClick(first_source_widget, Qt.LeftButton)
 
     # Check the source IS checked.


### PR DESCRIPTION
# Description

* Fixes https://github.com/freedomofpress/securedrop-client/issues/1113
* Fixes issue 8 documented here: https://github.com/freedomofpress/securedrop-client/issues/906#issuecomment-601410639
    * Fixes https://github.com/freedomofpress/securedrop-client/issues/1116
    * No STR for the second half
* Fixes issue 1 documented here: https://github.com/freedomofpress/securedrop-client/issues/906#issuecomment-601410639
   * Fixes https://github.com/freedomofpress/securedrop-client/issues/1117
   * No STR for the second half
   * While working on this fix, a side effect/refactor I made was to no longer delete widgets on behalf of a different ongoing sync running on a separate thread since the ongoing sync will delete the widgets shortly after.

# Test Plan

* Verify https://github.com/freedomofpress/securedrop-client/issues/1113 is fixed by following the STR there
* Verify https://github.com/freedomofpress/securedrop-client/issues/1117 is fixed by following the STR there
* Verify https://github.com/freedomofpress/securedrop-client/issues/1116 is fixed by following the STR
* Verify that we surround all access of db object properties in try-catch blocks in the `SourceList.update` method to confirm second half of issue 1 and 8 documented here: https://github.com/freedomofpress/securedrop-client/issues/906#issuecomment-601410639
* Verify that test `test_SourceList_update_when_source_deleted` passes and that the rewrite makes sense (because if this makes sense then the refactor I made will make sense)

### Regression test
   1. run `make dev`
   2. run the client
   3. log into the Journalist Interface
   4. get a source ready for deletion by having the deletion popup confirmation in a separate window
   5. have a message ready to that source
   6. (you can do this without adding a sleep in the code if you act fairly fast) delete the source and send the message right after
   7. see that the message fails to send and that the source widget and conversation are deleted next sync (this is also the current behavior)

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/master/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `master` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `master` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed
