### PR TITLE
fix fullscreen in qubes

### DIFF
--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -23,14 +23,9 @@ import logging
 from gettext import gettext as _
 from typing import Dict, List, Optional  # noqa: F401
 
-from PyQt5.QtWidgets import (
-    QApplication,
-    QDesktopWidget,
-    QHBoxLayout,
-    QMainWindow,
-    QVBoxLayout,
-    QWidget,
-)
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QGuiApplication
+from PyQt5.QtWidgets import QApplication, QHBoxLayout, QMainWindow, QVBoxLayout, QWidget
 
 from securedrop_client import __version__
 from securedrop_client.db import Source, User
@@ -106,19 +101,11 @@ class Window(QMainWindow):
         """
         Show main application window.
         """
-        self.autosize_window()
+        self.setWindowState(Qt.WindowFullScreen)
         self.show()
 
         if db_user:
             self.set_logged_in_as(db_user)
-
-    def autosize_window(self):
-        """
-        Ensure the application window takes up 100% of the available screen
-        (i.e. the whole of the virtualised desktop in Qubes dom)
-        """
-        screen = QDesktopWidget().screenGeometry()
-        self.resize(screen.width(), screen.height())
 
     def show_login(self, error: str = ""):
         """
@@ -127,7 +114,7 @@ class Window(QMainWindow):
         self.login_dialog = LoginDialog(self)
 
         # Always display the login dialog centered in the screen.
-        screen_size = QDesktopWidget().screenGeometry()
+        screen_size = QGuiApplication.primaryScreen().availableGeometry()
         login_dialog_size = self.login_dialog.geometry()
         x_center = (screen_size.width() - login_dialog_size.width()) / 2
         y_center = (screen_size.height() - login_dialog_size.height()) / 2

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -57,46 +57,25 @@ def test_setup(mocker):
 
 def test_show_main_window(mocker):
     w = Window()
-    w.autosize_window = mocker.MagicMock()
     w.show = mocker.MagicMock()
     w.set_logged_in_as = mocker.MagicMock()
     user = mocker.MagicMock()
 
     w.show_main_window(db_user=user)
 
-    w.autosize_window.assert_called_once_with()
     w.show.assert_called_once_with()
     w.set_logged_in_as.assert_called_once_with(user)
 
 
 def test_show_main_window_without_username(mocker):
     w = Window()
-    w.autosize_window = mocker.MagicMock()
     w.show = mocker.MagicMock()
     w.set_logged_in_as = mocker.MagicMock()
 
     w.show_main_window()
 
-    w.autosize_window.assert_called_once_with()
     w.show.assert_called_once_with()
     w.set_logged_in_as.called is False
-
-
-def test_autosize_window(mocker):
-    """
-    Check the autosizing fits to the full screen size.
-    """
-    w = Window()
-    w.resize = mocker.MagicMock()
-    mock_screen = mocker.MagicMock()
-    mock_screen.width.return_value = 1024
-    mock_screen.height.return_value = 768
-    mock_sg = mocker.MagicMock()
-    mock_sg.screenGeometry.return_value = mock_screen
-    mock_qdw = mocker.MagicMock(return_value=mock_sg)
-    mocker.patch("securedrop_client.gui.main.QDesktopWidget", mock_qdw)
-    w.autosize_window()
-    w.resize.assert_called_once_with(1024, 768)
 
 
 def test_show_login(mocker):


### PR DESCRIPTION
Signed-off-by: Allie Crevier <allie@freedom.press>

# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/1109

# Test Plan

1. Test with one monitor in Qubes
  - [x] log into the client (offline or online mode) and see that the client is full screen
  - [x] click on the resize (square) icon in the upper righthand corner and see the client resizes to a smaller size
  - [x] change the client size and click on the button multiple times and see it switch between the previous state and fullscreen
2. Test with multiple monitors in Qubes
  - [x] log into the client (offline or online mode) and see that the client is full screen
  - [x] click on the resize (square) icon in the upper righthand corner and see the client resizes to a smaller size
  - [x] change the client size and click on the button multiple times and see it switch between the previous state and fullscreen
  - [x] move client window to second monitor and click on the button multiple times and see it switch between the previous state and fullscreen
