### PR TITLE
Only show a preview if its the *last* message/file/reply for a source

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -946,7 +946,7 @@ class SourceList(QListWidget):
         """
         source_widget = self.get_source_widget(source_uuid)
         if source_widget:
-            source_widget.set_snippet(source_uuid, content)
+            source_widget.set_snippet(source_uuid, collection_item_uuid, content)
 
 
 class SourceWidget(QWidget):
@@ -1081,11 +1081,7 @@ class SourceWidget(QWidget):
             self.timestamp.setText(_(arrow.get(self.source.last_updated).format("DD MMM")))
             self.name.setText(self.source.journalist_designation)
 
-            if not self.source.server_collection:
-                self.set_snippet(self.source_uuid, "")
-            else:
-                last_collection_obj = self.source.server_collection[-1]
-                self.set_snippet(self.source_uuid, str(last_collection_obj))
+            self.set_snippet(self.source_uuid)
 
             if self.source.document_count == 0:
                 self.paperclip.hide()
@@ -1093,12 +1089,22 @@ class SourceWidget(QWidget):
         except sqlalchemy.exc.InvalidRequestError as e:
             logger.debug(f"Could not update SourceWidget for source {self.source_uuid}: {e}")
 
-    def set_snippet(self, source_uuid: str, content: str):
+    def set_snippet(self, source_uuid: str, collection_uuid: str = None, content: str = None):
         """
         Update the preview snippet if the source_uuid matches our own.
         """
         if source_uuid != self.source_uuid:
             return
+
+        if not self.source.server_collection:
+            return
+
+        last_activity = self.source.server_collection[-1]
+        if collection_uuid and collection_uuid != last_activity.uuid:
+            return
+
+        if not content:
+            content = str(last_activity)
 
         self.preview.setText(content)
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1133,7 +1133,7 @@ def test_SourceList_set_snippet(mocker):
 
     sl.set_snippet("mock_uuid", "msg_uuid", "msg_content")
 
-    source_widget.set_snippet.assert_called_once_with("mock_uuid", "msg_content")
+    source_widget.set_snippet.assert_called_once_with("mock_uuid", "msg_uuid", "msg_content")
 
 
 def test_SourceList_get_source_widget(mocker):
@@ -1248,8 +1248,8 @@ def test_SourceWidget_set_snippet_draft_only(mocker, session_maker, session, hom
     session.commit()
 
     sw = SourceWidget(controller, source)
-    sw.set_snippet(source.uuid, f.filename)
-    assert sw.preview.text() == f.filename
+    sw.set_snippet(source.uuid, reply.uuid, f.filename)
+    assert sw.preview.text() == "File: " + f.filename
 
 
 def test_SourceWidget_set_snippet(mocker, session_maker, session, homedir):
@@ -1265,19 +1265,19 @@ def test_SourceWidget_set_snippet(mocker, session_maker, session, homedir):
     session.commit()
 
     sw = SourceWidget(controller, source)
-    sw.set_snippet(source.uuid, f.filename)
-    assert sw.preview.text() == f.filename
+    sw.set_snippet(source.uuid, "mock_file_uuid", f.filename)
+    assert sw.preview.text() == "File: " + f.filename
 
     # check when a different source is specified
-    sw.set_snippet("not-the-source-uuid", "something new")
-    assert sw.preview.text() == f.filename
+    sw.set_snippet("not-the-source-uuid", "mock_file_uuid", "something new")
+    assert sw.preview.text() == "File: " + f.filename
 
     source_uuid = source.uuid
     session.delete(source)
     session.commit()
 
     # check when the source has been deleted that it catches sqlalchemy.exc.InvalidRequestError
-    sw.set_snippet(source_uuid, "something new")
+    sw.set_snippet(source_uuid, "mock_file_uuid", "something new")
 
 
 def test_SourceWidget_update_truncate_latest_msg(mocker):


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/1121

# Test Plan

1. Run through STR in issue that this fixes and verify that expected state is what happens now
2. Send a new message from the SI and see that it gets displayed in the preview

# Checklist

 - [x] I have tested these changes in the appropriate Qubes environment
 - [x] No update to the AppArmor profile is required for these changes
 - [x] No database schema changes are needed


---

Once tests are written, I will move this out of a draft PR state