### PR TITLE
do not start fullscreen in nonqubes

### DIFF
--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -101,8 +101,11 @@ class Window(QMainWindow):
         """
         Show main application window.
         """
-        self.setWindowState(Qt.WindowFullScreen)
-        self.show()
+        if not self.controller.qubes:
+            self.showMaximized()
+        else:
+            self.setWindowState(Qt.WindowFullScreen)
+            self.show()
 
         if db_user:
             self.set_logged_in_as(db_user)


### PR DESCRIPTION
# Description

Qubick off-sprint PR to no longer start the client in fullscreen.

# Test Plan

- [ ] Start the client in non-qubes and verify that the client shows up max-window instead of fullscreen
- [ ] Start the client in qubes and verify that the client shows up max-window and that https://github.com/freedomofpress/securedrop-client/issues/1109 is not reintroduced

