### PR TITLE
update current user info during sync

### DIFF
--- a/securedrop_client/api_jobs/sync.py
+++ b/securedrop_client/api_jobs/sync.py
@@ -5,7 +5,7 @@ from sdclientapi import API
 from sqlalchemy.orm.session import Session
 
 from securedrop_client.api_jobs.base import ApiJob
-from securedrop_client.storage import get_remote_data, update_local_storage
+from securedrop_client.storage import get_remote_data, update_and_get_user, update_local_storage
 
 logger = logging.getLogger(__name__)
 
@@ -37,8 +37,11 @@ class MetadataSyncJob(ApiJob):
         # This timeout is used for 3 different requests: `get_sources`, `get_all_submissions`, and
         # `get_all_replies`
         api_client.default_request_timeout = 60
-        remote_sources, remote_submissions, remote_replies = get_remote_data(api_client)
+        sources, submissions, replies = get_remote_data(api_client)
 
-        update_local_storage(
-            session, remote_sources, remote_submissions, remote_replies, self.data_dir
-        )
+        update_local_storage(session, sources, submissions, replies, self.data_dir)
+        user = api_client.get_current_user()
+        if "uuid" in user and "username" in user and "first_name" in user and "last_name" in user:
+            update_and_get_user(
+                user["uuid"], user["username"], user["first_name"], user["last_name"], session,
+            )

--- a/tests/api_jobs/test_sync.py
+++ b/tests/api_jobs/test_sync.py
@@ -18,9 +18,37 @@ def test_MetadataSyncJob_success(mocker, homedir, session, session_maker):
         "securedrop_client.api_jobs.sync.get_remote_data", return_value=([mock_source], [], [])
     )
 
-    api_client = mocker.MagicMock()
-    api_client.default_request_timeout = mocker.MagicMock()
-    api_client.default_request_timeout = mocker.MagicMock()
+    user = factory.User(uuid="mock1", username="mock1", firstname="mock1", lastname="mock1")
+    session.add(user)
+
+    api_client = mocker.patch("securedrop_client.logic.sdclientapi.API")
+
+    user = {"uuid": "mock1", "username": "mock1", "first_name": "mock1", "last_name": "mock1"}
+    mocker.patch.object(api_client, "get_current_user", return_value=user)
+
+    job.call_api(api_client, session)
+
+    assert mock_get_remote_data.call_count == 1
+
+
+def test_MetadataSyncJob_success_current_user_name_change(mocker, homedir, session, session_maker):
+    job = MetadataSyncJob(homedir)
+
+    mock_source = factory.RemoteSource(
+        key={"type": "PGP", "public": PUB_KEY, "fingerprint": "123456ABC"}
+    )
+
+    mock_get_remote_data = mocker.patch(
+        "securedrop_client.api_jobs.sync.get_remote_data", return_value=([mock_source], [], [])
+    )
+
+    user = factory.User(uuid="mock1", username="mock1", firstname="mock1", lastname="mock1")
+    session.add(user)
+
+    api_client = mocker.patch("securedrop_client.logic.sdclientapi.API")
+
+    user = {"uuid": "mock2", "username": "mock2", "first_name": "mock2", "last_name": "mock2"}
+    mocker.patch.object(api_client, "get_current_user", return_value=user)
 
     job.call_api(api_client, session)
 

--- a/tests/functional/cassettes/test_delete_source.yaml
+++ b/tests/functional/cassettes/test_delete_source.yaml
@@ -17,9 +17,9 @@ interactions:
     uri: http://localhost:8081/api/v1/token
   response:
     body:
-      string: "{\n  \"expiration\": \"2020-08-15T10:29:55.430076Z\", \n  \"journalist_first_name\"\
-        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"b5e001de-19f1-4a93-885b-e0932aa2d441\"\
-        , \n  \"token\": \"eyJleHAiOjE1OTc0ODczOTUsImlhdCI6MTU5NzQ1ODU5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.WYA7zyhgHmnHxKeP8EVhbHQ4UzmXGWtjW6qjl96Xqx0\"\
+      string: "{\n  \"expiration\": \"2020-08-26T01:28:22.380993Z\", \n  \"journalist_first_name\"\
+        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n  \"token\": \"eyJleHAiOjE1OTg0MDUzMDIsImlhdCI6MTU5ODM3NjUwMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.aGwpSXs7EQqqMZOpCj78X6K6A1MhsSU7FqzQPdLkDk8\"\
         \n}\n"
     headers:
       Content-Length:
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:29:55 GMT
+      - Tue, 25 Aug 2020 17:28:22 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -41,7 +41,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczOTUsImlhdCI6MTU5NzQ1ODU5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.WYA7zyhgHmnHxKeP8EVhbHQ4UzmXGWtjW6qjl96Xqx0
+      - Token eyJleHAiOjE1OTg0MDUzMDIsImlhdCI6MTU5ODM3NjUwMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.aGwpSXs7EQqqMZOpCj78X6K6A1MhsSU7FqzQPdLkDk8
       Connection:
       - keep-alive
       Content-Type:
@@ -52,82 +52,48 @@ interactions:
     uri: http://localhost:8081/api/v1/sources
   response:
     body:
-      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/add_star\"\
+      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/add_star\"\
         , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"out-of-town\
-        \ primogeniture\", \n      \"key\": {\n        \"fingerprint\": \"200C271E4E680FFE62E008931554E4BF600B1E3C\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAL4uN551SiYiVLrHoK1QGMDmN1xq42u8o2dmnKFkArW5KfBvBFoX\\\
-        nZX5LnOj9hKKEEmeGX5beS9h+fjsWvx86M2kQj/5xhOmHw0GGESEPQBSUc+Lyohpc\\nUmBoNNBfWIouEQ+IVS0gmrOwiS7wdItMby1lLDlDBoiEm4aRnRw36NIpABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEhPUDNaU05LUFgzNE1MV09QMkVPQkJRVVc2QjZPS0ZFMzZa\\nVktOV0VWNEhXVTVMUlZGQlFENjVKTEtYUENHRE1LVEFTTDM2N0NOT1ZDN0hBRUxF\\\
-        nWVQyWU5LMkJHM0ZWNlZWUUlMMlE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBVU5L9gCx482IED/2w6yFqz19zTBX72qN0MUTq5\\\
-        nCavQIBhhWrbsc1m0p+cxuVJ16TYxiE3S/Lp/rd4r1Q9MQg9BP0+/qjOA541kNq5A\\nmR2Y0teqWonDqeY/660kEFIbio0HbOTjsBhEZxtglJ1wz70tUpd40ZVMsu+Z32Mw\\\
-        n2kSiCclJYHk7uy1eis57\\n=pz11\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:24:42.042205Z\"\
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"pleasant rearguard\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"FF9007318CCAB4DC6149B1B38B7907A15818269D\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAM8jaDDbt3lQQVUEk+MduWYmJHa3eME1Y9C4yj+6n9V9Sksakj3B\\\
+        nWcl9uKzXLtZIP1rdvkW+Bg/P64vTgi+I+pcL5+e5gpF/KdNhrksovmhzc/ASgrn7\\nEcNCwIk+Iyym255IOEsZ8j9SvpzG1VyUdJxlK+P6bmbkFgDDwHjF0QzDABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPEtHQUFQVlNISjJLS0lMV0daTUlBWUFHMlhXU0ZWRlJRQ1pJ\\nNE5QTVBVUEVKNDNIQ1hJVUdPUk9XUEhLUldXRkxRTk5LTko3WEk1Tk9JUkpFTERQ\\\
+        nU0pZN0JMTk9ETk0yTUxNSjRPMkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEIt5B6FYGCadjpUD/1IiTV3TAyduG0UkaxcTT+Bp\\\
+        nKZRsNsK+HhYBCu/VjBcybLkuccDaonnm99OyaWZAZ/F/E/DxRENTxs0OL47GbHG7\\n9hSFWj99MZACMs3aKAmqxZEnQmm0B0xDIlHyd9mQBSieUw6aVMVjxK8p0Z21R7cz\\\
+        nc+DfEuCbShQ6b5+9X308\\n=RU3O\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:26:48.423985Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\
-        , \n      \"uuid\": \"4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"red-rimmed\
-        \ applejack\", \n      \"key\": {\n        \"fingerprint\": \"D449222A7B7B0AC1E134A1FF01203DD2D2636A37\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAOaUXyLQCaUSR4HTaBVGZp1mi3jn3BExTTe2UCBYjsn1zhkOBDf9\\\
-        ncZNBQGjEBIYlOioC4XY1TkQep4L2DdmqO5lBfbyNG6LpGiNo7DvNBxeo5WNDa42C\\n8YcfTaVL9aWm07G12uwwc1WFNb0y86PzuAS1ek0k5B7jUfjNxFN9t0dhABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEtCTEEyQTRDUEtETEVURDM2MllWQUZVRVdRQlJLUzJWRjVG\\nUEs2SElBWFBXQUFNSURMUkZHUEdLU0dFSDJJUUtBUVdZUFdFS0xRWVpaTDZMU1JY\\\
-        nRFRUTUdPUlFFWFA0WE1EUlJJM0E9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEAEgPdLSY2o3LmUD/i+JqgIWc2SzA5OTX9Qo0g/r\\\
-        nqxDmi2NQMXob0fEEcP/GGnbiFE1P77AC6JWxSKPQStlfwvffhYmK2q7JBc71Jj8O\\nRqFRT5WSRpXUCq8tZkIYyoCXKQPlwSb3S1NQ3yM00kbkCM4dArLIFuQ/ZI1xG+l9\\\
-        nIqxWwXYY8SpO8uKDXFd7\\n=FjUe\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:23.753433Z\"\
+        \      \"remove_star_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"uuid\": \"505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\n    }, \n  \
+        \  {\n      \"add_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/add_star\"\
+        , \n      \"interaction_count\": 3, \n      \"is_flagged\": false, \n    \
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"unlawful spectrum\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"CE2A06285C9B1FDB43BFEB853EC2D036DDCA8CD4\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANJ0h2W7p0bViTLpY9w/PDd8sBHR56OVg+EGdXZ51Wuqt8ZUkF8W\\\
+        njSLrjsiOrcQ1lRFEgERFfIBJvlxfB/EMP4wcTY7vg7WQN/rvSJynBW0T6iHI3Rhi\\n/3v35LEuX9tLU/B1e11mRevgHTLRUms38Y5DBSkWACngvH4jWP+kwylJABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPDUyNzdCNDVDNExFUFdJWU9NQlY0VE5FVEI1WjdaVFpERTZK\\nQTJSTlhVNE5HM0g3R0NRVEJYRUdVWkdSRkpSRVZGN01BTzZDUUpWWVpBN0NOSEw3\\\
+        nS0JKVzMyS01XNEJaSVROU0dBVkk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJED7C0DbdyozULzEEALbYIlKPW3wXMi/9V2c/fYJc\\\
+        naX9UE94JwAdfntqAkEF8dL/P6fD5J1BPqQILK4crX6LN6h8g2y1vnrTTg9odsa1L\\nD0JqSpGfIWscGRuzY6b2WngLCgsudMqJgPZUdm/wbxp3Q8Daa8U99mL9jXr9Ia9j\\\
+        n8BFeiB6fb0VoIDgM7UTv\\n=j+JQ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:27:03.031475Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"uuid\": \"70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"potential\
-        \ freshness\", \n      \"key\": {\n        \"fingerprint\": \"06FFA85715E89C0AFBA927A78EA34965AC896EEA\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAMHR1pM94xuFw+GiTQI7RyUN/sKYmupDhwWj1nVricMXRbM7nIXk\\\
-        nsBnqTx0pTkITPxjszoVyFFxG+Uw8TXMZEZdCOhcC2AieHV0mgWsXxLAbD9Sw3VmQ\\ngOQ3S2C/MBrimrK4bkpoKXxKIV5v5Rgku5Pjxzw50HH4e1pYhgW2C+knABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEg3TVJTVUZHWFVKRldQQlM0UjdISk1JNE5HTUREQ0FaRzJL\\nVlIyTTM3RkFTQk9BRjIyUkFYNzdMUVdZNFZJNTJLSlBOQldaRjUyQTdHWFJVN1lQ\\\
-        nN0dQQU5QSFNNUUkzSUFVN1VGNEk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEI6jSWWsiW7qZeYD/ReRVU5y0nssc0+OlRy6M/im\\\
-        nHY9oHex0tSGt1fTuDVqsAKKHMDrZLKkkhJg42wcINwbXTj/vRu7n199IwbSUoDiE\\nJlnO6ZaIG996AUFS64eZBA+kXczqJbsWgdQQpwQJn8LiQUF8iwFhTThltjRSuXqf\\\
-        nMxyFevvxbIvYcs6il7Ip\\n=cZe8\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:36.194245Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"uuid\": \"6db98582-dd69-48ea-879e-5afc5aa388d6\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"inexpressible\
-        \ sepsis\", \n      \"key\": {\n        \"fingerprint\": \"380C70D1C7930985411415B31A1B751385404CC5\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANhgLtWR4jFlhHEPGJjcupkGrNymWv9wFlFM8YppKs6nNXaQdoKf\\\
-        n7+NESFVdkm89/7FWD/It0B49jEBjjs7GOmxhffomt1NVHocYGDBQjMAlKOYQgCnR\\neZDnHCFORSrQcfiNhgKm1/eFOZlNJDZn2Cwpmdk8ZV6B78fGVz+3B+tFABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEo0VFRaVzY2QlBRTFRRVVlNS0hIVzZZTjRGVkJIVFlVQ0ZW\\nNVNWNjNRWlQyT0Y3Wjc2NUxEWk1TVDJNR1JBVFpYSVZJVzVBR1M0N0RFU0hTRUhY\\\
-        nWDZFQVlISkFWTFBZRzc1VFlKQkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBobdROFQEzFd3gD/RUhGdZUriO3QqYTqvH7EZdZ\\\
-        n4r3iFUJVP3xhru9HYBtksepsKzUHYZn4nK29689AdV1A9o/X4YcKWrxFRbMuZs0E\\nTj2Je4jrw3WNf3O3COAWwFa75HOXIhGfFVuJ4Ni2/NVJGDPA6NNIfZfFMIj/NZF3\\\
-        n3RBZhDmxS21yJs9daQfs\\n=NQQJ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:44.877597Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"uuid\": \"f3a61359-1919-4bf0-b6f7-da902a935160\"\n    }\n  ]\n\
+        \      \"remove_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"f9b4da97-a077-412e-8e54-4ef4984a8540\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '6421'
+      - '3214'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:29:55 GMT
+      - Tue, 25 Aug 2020 17:28:22 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -141,7 +107,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczOTUsImlhdCI6MTU5NzQ1ODU5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.WYA7zyhgHmnHxKeP8EVhbHQ4UzmXGWtjW6qjl96Xqx0
+      - Token eyJleHAiOjE1OTg0MDUzMDIsImlhdCI6MTU5ODM3NjUwMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.aGwpSXs7EQqqMZOpCj78X6K6A1MhsSU7FqzQPdLkDk8
       Connection:
       - keep-alive
       Content-Type:
@@ -152,55 +118,34 @@ interactions:
     uri: http://localhost:8081/api/v1/submissions
   response:
     body:
-      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96/download\"\
-        , \n      \"filename\": \"1-out-of-town_primogeniture-msg.gpg\", \n      \"\
-        is_read\": true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\
-        , \n      \"submission_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96\"\
-        , \n      \"uuid\": \"f836676a-c1aa-49a8-90c2-bb171f60cd96\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/99509e6d-62dd-48f3-8208-623f9290bc03/download\"\
-        , \n      \"filename\": \"2-out-of-town_primogeniture-doc.gz.gpg\", \n   \
-        \   \"is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"\
-        /api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\", \n      \"submission_url\"\
-        : \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/99509e6d-62dd-48f3-8208-623f9290bc03\"\
-        , \n      \"uuid\": \"99509e6d-62dd-48f3-8208-623f9290bc03\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download\"\
-        , \n      \"filename\": \"1-red-rimmed_applejack-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170\"\
-        , \n      \"uuid\": \"ceb44744-68cd-4b29-ada9-4c6ed4127170\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015/download\"\
-        , \n      \"filename\": \"2-red-rimmed_applejack-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015\"\
-        , \n      \"uuid\": \"1deb4f4f-1094-49ec-b0da-5d714b60c015\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download\"\
-        , \n      \"filename\": \"1-potential_freshness-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e\"\
-        , \n      \"uuid\": \"da095cb7-5a81-4b57-912c-14b0501dc00e\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d/download\"\
-        , \n      \"filename\": \"2-potential_freshness-doc.gz.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d\"\
-        , \n      \"uuid\": \"ed460264-f0e9-415f-8247-738eb482c75d\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download\"\
-        , \n      \"filename\": \"1-inexpressible_sepsis-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a\"\
-        , \n      \"uuid\": \"a3bb0937-6240-4200-99d5-b514c465e56a\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01/download\"\
-        , \n      \"filename\": \"2-inexpressible_sepsis-doc.gz.gpg\", \n      \"\
-        is_read\": true, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\
-        , \n      \"uuid\": \"1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\n    }\n  ]\n\
+      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442/download\"\
+        , \n      \"filename\": \"1-pleasant_rearguard-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"submission_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442\"\
+        , \n      \"uuid\": \"bbc25300-917a-4b73-b0f4-10f3d6957442\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/a8699ca4-55a5-4737-b8f1-c9e170ec8250/download\"\
+        , \n      \"filename\": \"2-pleasant_rearguard-doc.gz.gpg\", \n      \"is_read\"\
+        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"submission_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/a8699ca4-55a5-4737-b8f1-c9e170ec8250\"\
+        , \n      \"uuid\": \"a8699ca4-55a5-4737-b8f1-c9e170ec8250\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download\"\
+        , \n      \"filename\": \"1-unlawful_spectrum-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\
+        , \n      \"uuid\": \"d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a/download\"\
+        , \n      \"filename\": \"2-unlawful_spectrum-doc.gz.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a\"\
+        , \n      \"uuid\": \"55e459bd-cf4e-45f9-adce-95d79998254a\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '4112'
+      - '2054'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:29:55 GMT
+      - Tue, 25 Aug 2020 17:28:22 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -214,7 +159,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczOTUsImlhdCI6MTU5NzQ1ODU5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.WYA7zyhgHmnHxKeP8EVhbHQ4UzmXGWtjW6qjl96Xqx0
+      - Token eyJleHAiOjE1OTg0MDUzMDIsImlhdCI6MTU5ODM3NjUwMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.aGwpSXs7EQqqMZOpCj78X6K6A1MhsSU7FqzQPdLkDk8
       Connection:
       - keep-alive
       Content-Type:
@@ -225,14 +170,21 @@ interactions:
     uri: http://localhost:8081/api/v1/replies
   response:
     body:
-      string: "{\n  \"replies\": []\n}\n"
+      string: "{\n  \"replies\": [\n    {\n      \"filename\": \"3-unlawful_spectrum-reply.gpg\"\
+        , \n      \"is_deleted_by_source\": false, \n      \"journalist_first_name\"\
+        : \"\", \n      \"journalist_last_name\": \"\", \n      \"journalist_username\"\
+        : \"journalist\", \n      \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n      \"reply_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies/b8bfb5d1-7a5a-4413-9df2-52205fffa5b5\"\
+        , \n      \"size\": 1085, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"b8bfb5d1-7a5a-4413-9df2-52205fffa5b5\"\n    }\n  ]\n\
+        }\n"
     headers:
       Content-Length:
-      - '20'
+      - '578'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:29:55 GMT
+      - Tue, 25 Aug 2020 17:28:22 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -246,7 +198,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczOTUsImlhdCI6MTU5NzQ1ODU5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.WYA7zyhgHmnHxKeP8EVhbHQ4UzmXGWtjW6qjl96Xqx0
+      - Token eyJleHAiOjE1OTg0MDUzMDIsImlhdCI6MTU5ODM3NjUwMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.aGwpSXs7EQqqMZOpCj78X6K6A1MhsSU7FqzQPdLkDk8
       Connection:
       - keep-alive
       Content-Type:
@@ -254,38 +206,20 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download
+    uri: http://localhost:8081/api/v1/user
   response:
     body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqAQ//Z/S89kAgGiAOh+UVD2ePgDvU/l/JnvR2DkCEnnqTivaWTKetbcTOxv8D
-        iHQFUvQKPTADA4g5u56foRmzC0Yb2mP36vRMUqLq87hb/XfZFfr3Ak7E169EyaCN6ht5he28mLV0
-        j9brHPGxQWt2vrE4FFdwnUVQWNfAp13rFMm0IDFsHN3o3lNSjywJ62jlr1rce3mdkC+rXkwDh3zs
-        0ZDvxqFGx4X8YPbQiAStvUsK1n3u9NBnKE3cyeHe70xnMdQxq1N4NuACJZkNovKet6C3s8LTvj58
-        XiK6+/AgtbO9Pk6c89s1WW0x3hUGFtWVI+GqSUSQda5CDlWaq6Fq7mBURfuW7yD/rOJ0EypOOJED
-        b1GoyTiK6V1gC/mktb6u/Ei16SmPOjcsAzW7BFn5tsvl3lZULN+b4Bs+E7/Pxl4ymVaPDgbcsAh9
-        Ipp0thhF1a2A3MobRsTtNidryxvfzUTj5ou70vguzn7zthzog2sijyM9hBI0FPr6YRVWXvrS7BEQ
-        Ly9BA1AuzGy0kS1B6MUYdcWAaxQZHWNne02zDHZqe2sBFLM04tJU4myKrXlBOok4YILQ7OWDSoa8
-        Whkyohid0Eympcv+6YMaKI+9yBzHFWgcpu27rlrAuRGRXi9ibBxovyCRg5SSYc1Guo0jalDJWdDy
-        lRdLGsmqJAcWq2PUvNLSTAGpSiJRM+Iwxr77j/lapCOSRGfVJaivW59X5+ZQa6BN57DKWvcgPtCb
-        xDfXOBD4hOG9w/Qv5iKwgOcj/ckygOpvtrcQosdK9ZzrrdY=
+      string: "{\n  \"first_name\": \"\", \n  \"is_admin\": true, \n  \"last_login\"\
+        : \"2020-08-25T17:28:22.381333Z\", \n  \"last_name\": \"\", \n  \"username\"\
+        : \"journalist\", \n  \"uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\n\
+        }\n"
     headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-inexpressible_sepsis-msg.gpg
       Content-Length:
-      - '605'
+      - '192'
       Content-Type:
-      - application/pgp-encrypted
+      - application/json
       Date:
-      - Sat, 15 Aug 2020 02:29:55 GMT
-      Etag:
-      - sha256:20db26d5f8240c2efbc83f40184bd03e74f0b927394627fe24bc2954cb4a6c2a
-      Expires:
-      - Sat, 15 Aug 2020 14:29:55 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:25:44 GMT
+      - Tue, 25 Aug 2020 17:28:22 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -299,7 +233,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczOTUsImlhdCI6MTU5NzQ1ODU5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.WYA7zyhgHmnHxKeP8EVhbHQ4UzmXGWtjW6qjl96Xqx0
+      - Token eyJleHAiOjE1OTg0MDUzMDIsImlhdCI6MTU5ODM3NjUwMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.aGwpSXs7EQqqMZOpCj78X6K6A1MhsSU7FqzQPdLkDk8
       Connection:
       - keep-alive
       Content-Type:
@@ -307,38 +241,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAs+tSZVdjh2H5sgW3rQYsinaTUd1To3XLy/EC0UcNed15/OLbU142ic10
-        6l41iWmBW44aOmjYFIY46VfqPxQSM0G7fl2g5A0SZdmckTqzu141v/+BoTmvbzzZ8sXmpxKjbP/A
-        1F6aBPQ2qX7HcUVyGOadyMRjuKB+IO1pROBeFB5R0hE+FD+y4/yq2y4J9SVeYcdcwcsWJytFUm73
-        emXQ6vcBspvlgSjE1gywgfPFkmOLIKxv9INHFTT/FrfPvJ/yeFZ7jKtG0wxBQYPL4DG5QiVi1Gyz
-        Ln039tgWjFVnM5FhJ+XNhLbLHuISii/0CrKq9TeRea85xFHR6UGKgTm3/fOeWtEhC6FKa0XstXhU
-        T0E9dmh80Rd3myvN0HU3eyNFvmjyZ1weVguXjg4Ao1yWZ8a8AmqlA6m4conr4bbscqQKXCJSF1D+
-        g/i5ng78t0+4wnWMiKtN9rNTJkVBzXpaoYzOn+14EJbkYa+zkCyQS8TbjMBpLaP0aTFO4VXk7OAU
-        ygtKj6P8KmkfqivWrQ047DjqwVot+wBpKT+3t8ASscApC7KaSF0+d/fBvb05ZLzLtfSXM+Ts6pQ8
-        sn60uh2dnW/12nbqAdzFnrEPtDdtz5PFWn8brJpvhhMids/A7dkmbbLK6oirkLSRMF7Wdp8Stz2m
-        aI8Xz6brh2GQeKZafWnSTAHRguSmKDs+h+zUuP/hFFyLlLy2TWX3VLR2rLCEHhm82jP4UcMTpBkU
-        sgsFKxLyPddNYl+9D7kh9NLhzaLsXc2RihQWRvXYM9f3E0Y=
+        hQIMA8PnxMCiIBsqAQ//Rw1NPH3mwdBg9NnblanYiQgqmPuHTY9ha8sR24r6Cbv4UunDrGcjIMeT
+        qUZfK1zok/ZjbbLMo+yVWG2my899P8meyJS9C9MzmPC/x8hpoSUVdxyRorBDja9qNtZUyhOrm5Dz
+        rsiuEaqB1T5iYPinyCzeOcGKxTlrDJE78s5aHQVGQeBjXN+7BqZXsGCWrUueXTF10QrC8u0T/Fnw
+        T+BLvR8FmCIEilEDQESn653nL2wbkTz/7OMxUJJUDkG9xO6VHsTcH4KAzVsonMaan2RVXarJ1393
+        esjkZJ3vMiKXSMNIdsdDQ8WbP/2JGL8rhdg3WZqRbX7ePEJ5C7moUGiJsXmYwNMDarImp/be0O+1
+        YGk1Bfig2smMD280G8vYNykGvLkiGWJU0tGQQBbc5NeM3WZ8chZsyKofidoc9CIY7NLVHGg5u6zf
+        AEe1bjVuWveL5NaUJUpzWxDQzkIBuvX/E9stjEvqb0fZCRkGqPQLOix/YVUjUzj2i1zGAgL/w3xw
+        jhadu4aN05dbf5cBeKRIUS43HnrDXluA0vq0HbX30xuFpoo/noZUiZ8uNfR2UKLQfIK0gNVH1ydw
+        MhHIDKyiUWm/0YQgzcozy14n9OCGtLCucWfxXy7nozJ7JnVJpSYPgAmozMOoqEiz3C0Dnsax/PRV
+        AvwhOEGda6nAIosZZ6nSTAGpDbf6bksYyI2J4JEtY4b7jBvCz6Qmg+n4ZIIH7IEeIBCkhnUtU8xz
+        JHiwor7B/FnoP6RymaVAKyAPqoKGfrJ/XGbwPXJRvQl2PeM=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-potential_freshness-msg.gpg
+      - attachment; filename=1-unlawful_spectrum-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:29:55 GMT
+      - Tue, 25 Aug 2020 17:28:22 GMT
       Etag:
-      - sha256:624b8cc271f0bc4a153ff893f14d4b63464577579c0baa49ca2e6f5b2fb715a8
+      - sha256:dd82012b8656a3f7175b619f2875895a11071daf681b996cdc2704ddf5388664
       Expires:
-      - Sat, 15 Aug 2020 14:29:55 GMT
+      - Wed, 26 Aug 2020 05:28:22 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:35 GMT
+      - Tue, 25 Aug 2020 17:27:02 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -352,7 +286,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczOTUsImlhdCI6MTU5NzQ1ODU5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.WYA7zyhgHmnHxKeP8EVhbHQ4UzmXGWtjW6qjl96Xqx0
+      - Token eyJleHAiOjE1OTg0MDUzMDIsImlhdCI6MTU5ODM3NjUwMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.aGwpSXs7EQqqMZOpCj78X6K6A1MhsSU7FqzQPdLkDk8
       Connection:
       - keep-alive
       Content-Type:
@@ -360,38 +294,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download
+    uri: http://localhost:8081/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAp+9fU8qzd8lBJJJeTGUfrTvtC7bBj77m96ioEWln23lreSXOi7W1E++i
-        X3mCeNg6hLC0PSAtuO0QTw+LE6TGqLJtQh5y14fIxzgIX5G02eaoOlsayjQbVfXHTJ6HBSFx1VkS
-        ImILNuS170DhYiOyW91R3OJ2zg4DeTlPkyegMGScWCued6EcBBL+/EOrvZLDoXtpFAHFkGGcoQSD
-        p/6L5/pp8AuB5N43NRCtslfsD8D4gpZT7L9gkvNIJbMrBQ4FVUzjB/XI5mkOhXAubjKzgGcpqiM+
-        N2k5nqSPFzotGHmKDy77Bq4D3Sk4fcLzvWMe9hY+Prp6QqW5/F3uvFhJdpdOR9JZ4WqY6pWk0VsA
-        jeIuaxGH3rRqFegi59AiZV+EvpORA7tx8qmkVHch5UifaJCsHthaxOrBk1D/rgutgmoQvVaCN+UA
-        6So9D0H/w6RIE0vE3SAsCpXV3XQJWwsya8O5R5jCuETvi1s5NnMXrtxRuBqkFZUcRSNZyzrUWLGA
-        8djkwjYcO5lP7qt40ztUosMmb2y+4z8ad3zhWP71SKA+chx8lUvY7ziiSmFOpRJOr0OEgKMU59lR
-        ovyT6mu5yB1d5d8G9ns8s5H8/ymV5WE/MdG+o472wWPKoKHnIu0zlj1Qqso8l/khM5wIjs8XvICl
-        pm7uojnWqaFcIaJg4EvSTAEw45cGmA90NotlV9qwHi0fJ0qlbFKf6FAyeDaRL0TPoLKx9JbGf+9M
-        +wwWhoyWoWili+hOxuju3sNSeN1iYkv3fEIyKyEy5rXvf/0=
+        hQIMA8PnxMCiIBsqAQ//RtWsdfVE8eGi8sFqp1/cmLdkiut2OkXfs7DdjD0CBr6qfYUG8woosTjZ
+        +bdA5IIg1ewECF+eOZbfgW3EGzq/xN9rKaE+yTEbrR2swkoHNv1tUTrBoRGwUfHOYl3LOWlftNHt
+        8HbCVEZ/TAs1NQolRpSXj9o+mR6wjPvXtArQkW0io6D8ah9YO+YkEEkl4B2CwK1BwUQHj4B1TXw+
+        QGubNNIfGeXM9OkSCQMZapmumEt4m+8KImF1ncNMINXO/WV3tbTKDrCO63R/K6ibSuq//vd72Q2z
+        DFalhfcmnu7ksX0/4TFsrsvfuQoppTqepI6YklIKhTRkoRuY5fQeoK2w93qrZh0dmsVvlhx13/xl
+        19wcO1vASiZzfSHT/XDaXoS+3XmgW/xKr+Y0IJq+PZSs/EZ/2mr6zXePR8HtdFuvCnGiNjPFsRsE
+        sRIB1iq6FEV3zKxLU7FI46MTNrBpTYj3xAn2MqGM0UgCvwC1v73s6mMe6njwvYak8V0J/ny3sd/J
+        NHnbftRaGOmlrQbiXhoRIDEV5Kric9qBJG5R12kxDHHqce/viMEnZ1543+2snmsGrmWvX3Kxsbq4
+        cm1rmE/1dwYYtUaTpj1j4HDr7OY0PUN4F2BXK1gOSOONWiKd8hRAbY4Emwv60g+36ZtwY6kQu4v3
+        pQhKYVCTt8xL1gZkYYfSTAFnY4M6ViJKpbRI6FGnAQsYaB74rBUx6FatdEvztAN5VHarQPHN9uDF
+        TLPp+suitZOgA4wsgUWL+sUze53pOc/MCAUfBwrk2YD7hO8=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-red-rimmed_applejack-msg.gpg
+      - attachment; filename=1-pleasant_rearguard-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:29:55 GMT
+      - Tue, 25 Aug 2020 17:28:22 GMT
       Etag:
-      - sha256:2e1bdbd452ce54d49602552182cb0146b2334c58a7c5aec0c0565645e2ab4286
+      - sha256:cecd2591b0a9a0315f320e9878f68fdaec03c70b286da162c4416fab137ec00e
       Expires:
-      - Sat, 15 Aug 2020 14:29:55 GMT
+      - Wed, 26 Aug 2020 05:28:22 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:23 GMT
+      - Tue, 25 Aug 2020 17:26:47 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -405,7 +339,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczOTUsImlhdCI6MTU5NzQ1ODU5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.WYA7zyhgHmnHxKeP8EVhbHQ4UzmXGWtjW6qjl96Xqx0
+      - Token eyJleHAiOjE1OTg0MDUzMDIsImlhdCI6MTU5ODM3NjUwMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.aGwpSXs7EQqqMZOpCj78X6K6A1MhsSU7FqzQPdLkDk8
       Connection:
       - keep-alive
       Content-Type:
@@ -413,38 +347,66 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96/download
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies/b8bfb5d1-7a5a-4413-9df2-52205fffa5b5/download
   response:
     body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqARAAqBkguUOJVhB1E0rEBd3bIvbOJe9umLBp5QVPye5M4nsh0yl0IWnltszf
-        edV/FKB+H0YdtACRB57Zur0vTrOWAA4o1cC9tyUi18aWslfgDvVwJXLjELZYOQiDv//vmcWEG4Mw
-        ckXqK+/zvkgGLST9xjubdcQozWQNW8mXNzqLzLPLYd57oejEzr73iwn2UwQbQjXb31YI5ZsvCB0y
-        sltvyQevn92quua31WmlxjwzTndQ9u9mGQ5zZSxwK39HaZ3oEmPZlWelrnUfbodPJw5wQqGBN++n
-        lwGMVphNGN+EssKtSUb5Hmutd6jTajcfPWPf0yU6AYtJ3v/1wiOyXCaN3tnPStKUzP6w/htB2nFz
-        irbFi2VQ5v1Lg/nAYl0n3cVU4A8O8P8nhIX5KOsxNhYqNyuyjZsJgFAiKtCzEcXxlpyCQiPwpHbo
-        PM7nDr1JtS7w+IY4xlOkwdOmTIjq+WYjfwbOMd8GlwMQmpp2s6n4S7whSIcYI5acs14DERizF7lG
-        vY8XG7/ExbA0zt9B8j0MKTDsAxgkEEMALTPtINMmuc3xaDoTP7HA8e/X6tyPvrVarY8zFuPVxKuY
-        VXdPQuf6in/3uzja0QlWwq+Ibm+I/gBtQPRM1cDpW5n7XdYkzRcTIluElj8U8VnbECvkFNLt8NUk
-        IF792WIIe570TmeeRXfSTAE9fPtTykzrDiTy5LSwqQ91J/Og4d484LO+VkYSPGe37sfcFRSAOSL6
-        KHNlQb9u2IoOgkORHi/6PABz5ty5K45/OvEOhlB4/xbxkbA=
+      string: '-----BEGIN PGP MESSAGE-----
+
+
+        hIwDPsLQNt3KjNQBA/9ojtfC9t1XqWV3wWgAlu95dTxfMqqYczw6sQSmgcEkg9+P
+
+        vCeb05aaW5jMMlYXkUm62SVqdw/KJW1Dg8trcMvRFIeCKNZQhA01Rsqb7jzDLzD/
+
+        kqJ0JGGZk01wDAdRZwWHtA96PY6Qp7mpEJcQTfliBzdWhe03KWfPEJxzZCfT84UC
+
+        DAPD58TAoiAbKgEP/RRt/jqDFFWYxpc4SrqshMubiyh/GImTEOePHfhgQujDvKLu
+
+        kRQovxq1xujHfCuVaBHUgCpm3jWcKCQPrpNT8xLNngu8Uem1degoqstCk+0MVVpC
+
+        +YkmUCajX9X7J98xxuJ/evZMWgWzbk3kD2AuTlYolXqNB6nY50RWQwt1Si/k9p7Y
+
+        RO1ERKa9M99a+lReuF2E2dEYW0Ru3YdTbz/sYuX65Hl/UM6lEhdq9A2EDBElDoiH
+
+        0wkY+YybjFMJlfKnK97nxJ2rwfPQqIiRFEWRbHci+pbtjcPxPjEM37aM/9urM6WR
+
+        CJ3leluB9ZYHzKAFA5VGHH1W1/xPe8STvySggG/cjb4jIxqyu9rV+dkrwK0xjfhN
+
+        15G7B5gvJmXWAp5IDvQD3Pux128hpJYzLUBMURAK1oVf0SCjqWFwQeAIEOE67eJ6
+
+        Nu046qIKcTz6jSH6JrxSneHyDySZaM8DwV9u24voInDGGjEwAbuLfvOGYu6yawAX
+
+        JkD7tAHHpEnsqfOYcH/dMFDLjaE1ybzrD1W2JmJUitMjL449QrTQS8ABpZvZvNl7
+
+        egjy2PgtxHkGvLZ52xv4gGq0Q+5eXquL8uE/zFEi8cUuCj1Q0owvkfqia1j+ZU5p
+
+        JnCZY4UkEivnwu9pbRXu1nuUlPo+/HQSpO9a7SEpIWo4WbnQPxZ9f5LgCiIl0lMB
+
+        /uKyfBrojiN6UOwbopz3CqwC+C3QKzbnKpV6LfyweT8hBt8nYZCp+vDcQ+iucyxb
+
+        1C7h2wAzePF2VFz/1plVSNOGVwqzf8Qf7wCBfJpAt+z7UQ==
+
+        =EqXV
+
+        -----END PGP MESSAGE-----
+
+        '
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-out-of-town_primogeniture-msg.gpg
+      - attachment; filename=3-unlawful_spectrum-reply.gpg
       Content-Length:
-      - '605'
+      - '1085'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:29:55 GMT
+      - Tue, 25 Aug 2020 17:28:22 GMT
       Etag:
-      - sha256:64f0c214fab76a0aa8a1407daf0c0478f7851bd7b5c0aaca5b5c8de53aae9336
+      - sha256:8055a4fea7b7e8e4bf0e3ea6d3e4ee5959899e7f4732b0585b5b4ae5b58231e0
       Expires:
-      - Sat, 15 Aug 2020 14:29:55 GMT
+      - Wed, 26 Aug 2020 05:28:22 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:24:41 GMT
+      - Tue, 25 Aug 2020 17:28:16 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -458,7 +420,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczOTUsImlhdCI6MTU5NzQ1ODU5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.WYA7zyhgHmnHxKeP8EVhbHQ4UzmXGWtjW6qjl96Xqx0
+      - Token eyJleHAiOjE1OTg0MDUzMDIsImlhdCI6MTU5ODM3NjUwMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.aGwpSXs7EQqqMZOpCj78X6K6A1MhsSU7FqzQPdLkDk8
       Connection:
       - keep-alive
       Content-Length:
@@ -468,7 +430,7 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: DELETE
-    uri: http://localhost:8081/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a
+    uri: http://localhost:8081/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f
   response:
     body:
       string: "{\n  \"message\": \"Source and submissions deleted\"\n}\n"
@@ -478,7 +440,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:29:57 GMT
+      - Tue, 25 Aug 2020 17:28:24 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -492,7 +454,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczOTUsImlhdCI6MTU5NzQ1ODU5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.WYA7zyhgHmnHxKeP8EVhbHQ4UzmXGWtjW6qjl96Xqx0
+      - Token eyJleHAiOjE1OTg0MDUzMDIsImlhdCI6MTU5ODM3NjUwMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.aGwpSXs7EQqqMZOpCj78X6K6A1MhsSU7FqzQPdLkDk8
       Connection:
       - keep-alive
       Content-Type:
@@ -503,65 +465,31 @@ interactions:
     uri: http://localhost:8081/api/v1/sources
   response:
     body:
-      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"red-rimmed\
-        \ applejack\", \n      \"key\": {\n        \"fingerprint\": \"D449222A7B7B0AC1E134A1FF01203DD2D2636A37\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAOaUXyLQCaUSR4HTaBVGZp1mi3jn3BExTTe2UCBYjsn1zhkOBDf9\\\
-        ncZNBQGjEBIYlOioC4XY1TkQep4L2DdmqO5lBfbyNG6LpGiNo7DvNBxeo5WNDa42C\\n8YcfTaVL9aWm07G12uwwc1WFNb0y86PzuAS1ek0k5B7jUfjNxFN9t0dhABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEtCTEEyQTRDUEtETEVURDM2MllWQUZVRVdRQlJLUzJWRjVG\\nUEs2SElBWFBXQUFNSURMUkZHUEdLU0dFSDJJUUtBUVdZUFdFS0xRWVpaTDZMU1JY\\\
-        nRFRUTUdPUlFFWFA0WE1EUlJJM0E9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEAEgPdLSY2o3LmUD/i+JqgIWc2SzA5OTX9Qo0g/r\\\
-        nqxDmi2NQMXob0fEEcP/GGnbiFE1P77AC6JWxSKPQStlfwvffhYmK2q7JBc71Jj8O\\nRqFRT5WSRpXUCq8tZkIYyoCXKQPlwSb3S1NQ3yM00kbkCM4dArLIFuQ/ZI1xG+l9\\\
-        nIqxWwXYY8SpO8uKDXFd7\\n=FjUe\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:23.753433Z\"\
+      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/add_star\"\
+        , \n      \"interaction_count\": 3, \n      \"is_flagged\": false, \n    \
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"unlawful spectrum\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"CE2A06285C9B1FDB43BFEB853EC2D036DDCA8CD4\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANJ0h2W7p0bViTLpY9w/PDd8sBHR56OVg+EGdXZ51Wuqt8ZUkF8W\\\
+        njSLrjsiOrcQ1lRFEgERFfIBJvlxfB/EMP4wcTY7vg7WQN/rvSJynBW0T6iHI3Rhi\\n/3v35LEuX9tLU/B1e11mRevgHTLRUms38Y5DBSkWACngvH4jWP+kwylJABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPDUyNzdCNDVDNExFUFdJWU9NQlY0VE5FVEI1WjdaVFpERTZK\\nQTJSTlhVNE5HM0g3R0NRVEJYRUdVWkdSRkpSRVZGN01BTzZDUUpWWVpBN0NOSEw3\\\
+        nS0JKVzMyS01XNEJaSVROU0dBVkk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJED7C0DbdyozULzEEALbYIlKPW3wXMi/9V2c/fYJc\\\
+        naX9UE94JwAdfntqAkEF8dL/P6fD5J1BPqQILK4crX6LN6h8g2y1vnrTTg9odsa1L\\nD0JqSpGfIWscGRuzY6b2WngLCgsudMqJgPZUdm/wbxp3Q8Daa8U99mL9jXr9Ia9j\\\
+        n8BFeiB6fb0VoIDgM7UTv\\n=j+JQ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:27:03.031475Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"uuid\": \"70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"potential\
-        \ freshness\", \n      \"key\": {\n        \"fingerprint\": \"06FFA85715E89C0AFBA927A78EA34965AC896EEA\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAMHR1pM94xuFw+GiTQI7RyUN/sKYmupDhwWj1nVricMXRbM7nIXk\\\
-        nsBnqTx0pTkITPxjszoVyFFxG+Uw8TXMZEZdCOhcC2AieHV0mgWsXxLAbD9Sw3VmQ\\ngOQ3S2C/MBrimrK4bkpoKXxKIV5v5Rgku5Pjxzw50HH4e1pYhgW2C+knABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEg3TVJTVUZHWFVKRldQQlM0UjdISk1JNE5HTUREQ0FaRzJL\\nVlIyTTM3RkFTQk9BRjIyUkFYNzdMUVdZNFZJNTJLSlBOQldaRjUyQTdHWFJVN1lQ\\\
-        nN0dQQU5QSFNNUUkzSUFVN1VGNEk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEI6jSWWsiW7qZeYD/ReRVU5y0nssc0+OlRy6M/im\\\
-        nHY9oHex0tSGt1fTuDVqsAKKHMDrZLKkkhJg42wcINwbXTj/vRu7n199IwbSUoDiE\\nJlnO6ZaIG996AUFS64eZBA+kXczqJbsWgdQQpwQJn8LiQUF8iwFhTThltjRSuXqf\\\
-        nMxyFevvxbIvYcs6il7Ip\\n=cZe8\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:36.194245Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"uuid\": \"6db98582-dd69-48ea-879e-5afc5aa388d6\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"inexpressible\
-        \ sepsis\", \n      \"key\": {\n        \"fingerprint\": \"380C70D1C7930985411415B31A1B751385404CC5\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANhgLtWR4jFlhHEPGJjcupkGrNymWv9wFlFM8YppKs6nNXaQdoKf\\\
-        n7+NESFVdkm89/7FWD/It0B49jEBjjs7GOmxhffomt1NVHocYGDBQjMAlKOYQgCnR\\neZDnHCFORSrQcfiNhgKm1/eFOZlNJDZn2Cwpmdk8ZV6B78fGVz+3B+tFABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEo0VFRaVzY2QlBRTFRRVVlNS0hIVzZZTjRGVkJIVFlVQ0ZW\\nNVNWNjNRWlQyT0Y3Wjc2NUxEWk1TVDJNR1JBVFpYSVZJVzVBR1M0N0RFU0hTRUhY\\\
-        nWDZFQVlISkFWTFBZRzc1VFlKQkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBobdROFQEzFd3gD/RUhGdZUriO3QqYTqvH7EZdZ\\\
-        n4r3iFUJVP3xhru9HYBtksepsKzUHYZn4nK29689AdV1A9o/X4YcKWrxFRbMuZs0E\\nTj2Je4jrw3WNf3O3COAWwFa75HOXIhGfFVuJ4Ni2/NVJGDPA6NNIfZfFMIj/NZF3\\\
-        n3RBZhDmxS21yJs9daQfs\\n=NQQJ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:44.877597Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"uuid\": \"f3a61359-1919-4bf0-b6f7-da902a935160\"\n    }\n  ]\n\
+        \      \"remove_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"f9b4da97-a077-412e-8e54-4ef4984a8540\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '4817'
+      - '1617'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:10 GMT
+      - Tue, 25 Aug 2020 17:28:37 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -575,7 +503,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczOTUsImlhdCI6MTU5NzQ1ODU5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.WYA7zyhgHmnHxKeP8EVhbHQ4UzmXGWtjW6qjl96Xqx0
+      - Token eyJleHAiOjE1OTg0MDUzMDIsImlhdCI6MTU5ODM3NjUwMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.aGwpSXs7EQqqMZOpCj78X6K6A1MhsSU7FqzQPdLkDk8
       Connection:
       - keep-alive
       Content-Type:
@@ -586,44 +514,24 @@ interactions:
     uri: http://localhost:8081/api/v1/submissions
   response:
     body:
-      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download\"\
-        , \n      \"filename\": \"1-red-rimmed_applejack-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170\"\
-        , \n      \"uuid\": \"ceb44744-68cd-4b29-ada9-4c6ed4127170\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015/download\"\
-        , \n      \"filename\": \"2-red-rimmed_applejack-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015\"\
-        , \n      \"uuid\": \"1deb4f4f-1094-49ec-b0da-5d714b60c015\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download\"\
-        , \n      \"filename\": \"1-potential_freshness-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e\"\
-        , \n      \"uuid\": \"da095cb7-5a81-4b57-912c-14b0501dc00e\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d/download\"\
-        , \n      \"filename\": \"2-potential_freshness-doc.gz.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d\"\
-        , \n      \"uuid\": \"ed460264-f0e9-415f-8247-738eb482c75d\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download\"\
-        , \n      \"filename\": \"1-inexpressible_sepsis-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a\"\
-        , \n      \"uuid\": \"a3bb0937-6240-4200-99d5-b514c465e56a\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01/download\"\
-        , \n      \"filename\": \"2-inexpressible_sepsis-doc.gz.gpg\", \n      \"\
-        is_read\": true, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\
-        , \n      \"uuid\": \"1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\n    }\n  ]\n\
+      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download\"\
+        , \n      \"filename\": \"1-unlawful_spectrum-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\
+        , \n      \"uuid\": \"d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a/download\"\
+        , \n      \"filename\": \"2-unlawful_spectrum-doc.gz.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a\"\
+        , \n      \"uuid\": \"55e459bd-cf4e-45f9-adce-95d79998254a\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '3082'
+      - '1038'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:10 GMT
+      - Tue, 25 Aug 2020 17:28:37 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -637,7 +545,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczOTUsImlhdCI6MTU5NzQ1ODU5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.WYA7zyhgHmnHxKeP8EVhbHQ4UzmXGWtjW6qjl96Xqx0
+      - Token eyJleHAiOjE1OTg0MDUzMDIsImlhdCI6MTU5ODM3NjUwMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.aGwpSXs7EQqqMZOpCj78X6K6A1MhsSU7FqzQPdLkDk8
       Connection:
       - keep-alive
       Content-Type:
@@ -648,14 +556,56 @@ interactions:
     uri: http://localhost:8081/api/v1/replies
   response:
     body:
-      string: "{\n  \"replies\": []\n}\n"
+      string: "{\n  \"replies\": [\n    {\n      \"filename\": \"3-unlawful_spectrum-reply.gpg\"\
+        , \n      \"is_deleted_by_source\": false, \n      \"journalist_first_name\"\
+        : \"\", \n      \"journalist_last_name\": \"\", \n      \"journalist_username\"\
+        : \"journalist\", \n      \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n      \"reply_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies/b8bfb5d1-7a5a-4413-9df2-52205fffa5b5\"\
+        , \n      \"size\": 1085, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"b8bfb5d1-7a5a-4413-9df2-52205fffa5b5\"\n    }\n  ]\n\
+        }\n"
     headers:
       Content-Length:
-      - '20'
+      - '578'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:10 GMT
+      - Tue, 25 Aug 2020 17:28:37 GMT
+      Server:
+      - Werkzeug/0.16.0 Python/3.5.2
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Token eyJleHAiOjE1OTg0MDUzMDIsImlhdCI6MTU5ODM3NjUwMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.aGwpSXs7EQqqMZOpCj78X6K6A1MhsSU7FqzQPdLkDk8
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.20.0
+    method: GET
+    uri: http://localhost:8081/api/v1/user
+  response:
+    body:
+      string: "{\n  \"first_name\": \"\", \n  \"is_admin\": true, \n  \"last_login\"\
+        : \"2020-08-25T17:28:22.381333Z\", \n  \"last_name\": \"\", \n  \"username\"\
+        : \"journalist\", \n  \"uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\n\
+        }\n"
+    headers:
+      Content-Length:
+      - '192'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 25 Aug 2020 17:28:37 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:

--- a/tests/functional/cassettes/test_download_file.yaml
+++ b/tests/functional/cassettes/test_download_file.yaml
@@ -17,9 +17,9 @@ interactions:
     uri: http://localhost:8081/api/v1/token
   response:
     body:
-      string: "{\n  \"expiration\": \"2020-08-15T10:30:15.486646Z\", \n  \"journalist_first_name\"\
-        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"b5e001de-19f1-4a93-885b-e0932aa2d441\"\
-        , \n  \"token\": \"eyJleHAiOjE1OTc0ODc0MTUsImlhdCI6MTU5NzQ1ODYxNSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.wgecKBWREKmPBQ7MomwpAG4SpMZIX1UnGKOZHK9N8Tg\"\
+      string: "{\n  \"expiration\": \"2020-08-26T01:28:03.387499Z\", \n  \"journalist_first_name\"\
+        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n  \"token\": \"eyJleHAiOjE1OTg0MDUyODMsImlhdCI6MTU5ODM3NjQ4MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.PWyfpWWP5QM2yA-K_2f-cqhkCrxLQimf9TUiXnYN2_U\"\
         \n}\n"
     headers:
       Content-Length:
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:15 GMT
+      - Tue, 25 Aug 2020 17:28:03 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -41,7 +41,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MTUsImlhdCI6MTU5NzQ1ODYxNSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.wgecKBWREKmPBQ7MomwpAG4SpMZIX1UnGKOZHK9N8Tg
+      - Token eyJleHAiOjE1OTg0MDUyODMsImlhdCI6MTU5ODM3NjQ4MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.PWyfpWWP5QM2yA-K_2f-cqhkCrxLQimf9TUiXnYN2_U
       Connection:
       - keep-alive
       Content-Type:
@@ -52,65 +52,48 @@ interactions:
     uri: http://localhost:8081/api/v1/sources
   response:
     body:
-      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/add_star\"\
+      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/add_star\"\
         , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"red-rimmed\
-        \ applejack\", \n      \"key\": {\n        \"fingerprint\": \"D449222A7B7B0AC1E134A1FF01203DD2D2636A37\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAOaUXyLQCaUSR4HTaBVGZp1mi3jn3BExTTe2UCBYjsn1zhkOBDf9\\\
-        ncZNBQGjEBIYlOioC4XY1TkQep4L2DdmqO5lBfbyNG6LpGiNo7DvNBxeo5WNDa42C\\n8YcfTaVL9aWm07G12uwwc1WFNb0y86PzuAS1ek0k5B7jUfjNxFN9t0dhABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEtCTEEyQTRDUEtETEVURDM2MllWQUZVRVdRQlJLUzJWRjVG\\nUEs2SElBWFBXQUFNSURMUkZHUEdLU0dFSDJJUUtBUVdZUFdFS0xRWVpaTDZMU1JY\\\
-        nRFRUTUdPUlFFWFA0WE1EUlJJM0E9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEAEgPdLSY2o3LmUD/i+JqgIWc2SzA5OTX9Qo0g/r\\\
-        nqxDmi2NQMXob0fEEcP/GGnbiFE1P77AC6JWxSKPQStlfwvffhYmK2q7JBc71Jj8O\\nRqFRT5WSRpXUCq8tZkIYyoCXKQPlwSb3S1NQ3yM00kbkCM4dArLIFuQ/ZI1xG+l9\\\
-        nIqxWwXYY8SpO8uKDXFd7\\n=FjUe\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:23.753433Z\"\
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"pleasant rearguard\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"FF9007318CCAB4DC6149B1B38B7907A15818269D\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAM8jaDDbt3lQQVUEk+MduWYmJHa3eME1Y9C4yj+6n9V9Sksakj3B\\\
+        nWcl9uKzXLtZIP1rdvkW+Bg/P64vTgi+I+pcL5+e5gpF/KdNhrksovmhzc/ASgrn7\\nEcNCwIk+Iyym255IOEsZ8j9SvpzG1VyUdJxlK+P6bmbkFgDDwHjF0QzDABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPEtHQUFQVlNISjJLS0lMV0daTUlBWUFHMlhXU0ZWRlJRQ1pJ\\nNE5QTVBVUEVKNDNIQ1hJVUdPUk9XUEhLUldXRkxRTk5LTko3WEk1Tk9JUkpFTERQ\\\
+        nU0pZN0JMTk9ETk0yTUxNSjRPMkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEIt5B6FYGCadjpUD/1IiTV3TAyduG0UkaxcTT+Bp\\\
+        nKZRsNsK+HhYBCu/VjBcybLkuccDaonnm99OyaWZAZ/F/E/DxRENTxs0OL47GbHG7\\n9hSFWj99MZACMs3aKAmqxZEnQmm0B0xDIlHyd9mQBSieUw6aVMVjxK8p0Z21R7cz\\\
+        nc+DfEuCbShQ6b5+9X308\\n=RU3O\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:26:48.423985Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"uuid\": \"70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/add_star\"\
+        \      \"remove_star_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"uuid\": \"505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\n    }, \n  \
+        \  {\n      \"add_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/add_star\"\
         , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"potential\
-        \ freshness\", \n      \"key\": {\n        \"fingerprint\": \"06FFA85715E89C0AFBA927A78EA34965AC896EEA\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAMHR1pM94xuFw+GiTQI7RyUN/sKYmupDhwWj1nVricMXRbM7nIXk\\\
-        nsBnqTx0pTkITPxjszoVyFFxG+Uw8TXMZEZdCOhcC2AieHV0mgWsXxLAbD9Sw3VmQ\\ngOQ3S2C/MBrimrK4bkpoKXxKIV5v5Rgku5Pjxzw50HH4e1pYhgW2C+knABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEg3TVJTVUZHWFVKRldQQlM0UjdISk1JNE5HTUREQ0FaRzJL\\nVlIyTTM3RkFTQk9BRjIyUkFYNzdMUVdZNFZJNTJLSlBOQldaRjUyQTdHWFJVN1lQ\\\
-        nN0dQQU5QSFNNUUkzSUFVN1VGNEk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEI6jSWWsiW7qZeYD/ReRVU5y0nssc0+OlRy6M/im\\\
-        nHY9oHex0tSGt1fTuDVqsAKKHMDrZLKkkhJg42wcINwbXTj/vRu7n199IwbSUoDiE\\nJlnO6ZaIG996AUFS64eZBA+kXczqJbsWgdQQpwQJn8LiQUF8iwFhTThltjRSuXqf\\\
-        nMxyFevvxbIvYcs6il7Ip\\n=cZe8\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:36.194245Z\"\
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"unlawful spectrum\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"CE2A06285C9B1FDB43BFEB853EC2D036DDCA8CD4\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANJ0h2W7p0bViTLpY9w/PDd8sBHR56OVg+EGdXZ51Wuqt8ZUkF8W\\\
+        njSLrjsiOrcQ1lRFEgERFfIBJvlxfB/EMP4wcTY7vg7WQN/rvSJynBW0T6iHI3Rhi\\n/3v35LEuX9tLU/B1e11mRevgHTLRUms38Y5DBSkWACngvH4jWP+kwylJABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPDUyNzdCNDVDNExFUFdJWU9NQlY0VE5FVEI1WjdaVFpERTZK\\nQTJSTlhVNE5HM0g3R0NRVEJYRUdVWkdSRkpSRVZGN01BTzZDUUpWWVpBN0NOSEw3\\\
+        nS0JKVzMyS01XNEJaSVROU0dBVkk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJED7C0DbdyozULzEEALbYIlKPW3wXMi/9V2c/fYJc\\\
+        naX9UE94JwAdfntqAkEF8dL/P6fD5J1BPqQILK4crX6LN6h8g2y1vnrTTg9odsa1L\\nD0JqSpGfIWscGRuzY6b2WngLCgsudMqJgPZUdm/wbxp3Q8Daa8U99mL9jXr9Ia9j\\\
+        n8BFeiB6fb0VoIDgM7UTv\\n=j+JQ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:27:03.031475Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"uuid\": \"6db98582-dd69-48ea-879e-5afc5aa388d6\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"inexpressible\
-        \ sepsis\", \n      \"key\": {\n        \"fingerprint\": \"380C70D1C7930985411415B31A1B751385404CC5\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANhgLtWR4jFlhHEPGJjcupkGrNymWv9wFlFM8YppKs6nNXaQdoKf\\\
-        n7+NESFVdkm89/7FWD/It0B49jEBjjs7GOmxhffomt1NVHocYGDBQjMAlKOYQgCnR\\neZDnHCFORSrQcfiNhgKm1/eFOZlNJDZn2Cwpmdk8ZV6B78fGVz+3B+tFABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEo0VFRaVzY2QlBRTFRRVVlNS0hIVzZZTjRGVkJIVFlVQ0ZW\\nNVNWNjNRWlQyT0Y3Wjc2NUxEWk1TVDJNR1JBVFpYSVZJVzVBR1M0N0RFU0hTRUhY\\\
-        nWDZFQVlISkFWTFBZRzc1VFlKQkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBobdROFQEzFd3gD/RUhGdZUriO3QqYTqvH7EZdZ\\\
-        n4r3iFUJVP3xhru9HYBtksepsKzUHYZn4nK29689AdV1A9o/X4YcKWrxFRbMuZs0E\\nTj2Je4jrw3WNf3O3COAWwFa75HOXIhGfFVuJ4Ni2/NVJGDPA6NNIfZfFMIj/NZF3\\\
-        n3RBZhDmxS21yJs9daQfs\\n=NQQJ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:44.877597Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"uuid\": \"f3a61359-1919-4bf0-b6f7-da902a935160\"\n    }\n  ]\n\
+        \      \"remove_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"f9b4da97-a077-412e-8e54-4ef4984a8540\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '4817'
+      - '3214'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:15 GMT
+      - Tue, 25 Aug 2020 17:28:03 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -124,7 +107,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MTUsImlhdCI6MTU5NzQ1ODYxNSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.wgecKBWREKmPBQ7MomwpAG4SpMZIX1UnGKOZHK9N8Tg
+      - Token eyJleHAiOjE1OTg0MDUyODMsImlhdCI6MTU5ODM3NjQ4MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.PWyfpWWP5QM2yA-K_2f-cqhkCrxLQimf9TUiXnYN2_U
       Connection:
       - keep-alive
       Content-Type:
@@ -135,44 +118,34 @@ interactions:
     uri: http://localhost:8081/api/v1/submissions
   response:
     body:
-      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download\"\
-        , \n      \"filename\": \"1-red-rimmed_applejack-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170\"\
-        , \n      \"uuid\": \"ceb44744-68cd-4b29-ada9-4c6ed4127170\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015/download\"\
-        , \n      \"filename\": \"2-red-rimmed_applejack-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015\"\
-        , \n      \"uuid\": \"1deb4f4f-1094-49ec-b0da-5d714b60c015\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download\"\
-        , \n      \"filename\": \"1-potential_freshness-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e\"\
-        , \n      \"uuid\": \"da095cb7-5a81-4b57-912c-14b0501dc00e\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d/download\"\
-        , \n      \"filename\": \"2-potential_freshness-doc.gz.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d\"\
-        , \n      \"uuid\": \"ed460264-f0e9-415f-8247-738eb482c75d\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download\"\
-        , \n      \"filename\": \"1-inexpressible_sepsis-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a\"\
-        , \n      \"uuid\": \"a3bb0937-6240-4200-99d5-b514c465e56a\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01/download\"\
-        , \n      \"filename\": \"2-inexpressible_sepsis-doc.gz.gpg\", \n      \"\
-        is_read\": true, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\
-        , \n      \"uuid\": \"1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\n    }\n  ]\n\
+      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442/download\"\
+        , \n      \"filename\": \"1-pleasant_rearguard-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"submission_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442\"\
+        , \n      \"uuid\": \"bbc25300-917a-4b73-b0f4-10f3d6957442\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/a8699ca4-55a5-4737-b8f1-c9e170ec8250/download\"\
+        , \n      \"filename\": \"2-pleasant_rearguard-doc.gz.gpg\", \n      \"is_read\"\
+        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"submission_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/a8699ca4-55a5-4737-b8f1-c9e170ec8250\"\
+        , \n      \"uuid\": \"a8699ca4-55a5-4737-b8f1-c9e170ec8250\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download\"\
+        , \n      \"filename\": \"1-unlawful_spectrum-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\
+        , \n      \"uuid\": \"d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a/download\"\
+        , \n      \"filename\": \"2-unlawful_spectrum-doc.gz.gpg\", \n      \"is_read\"\
+        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a\"\
+        , \n      \"uuid\": \"55e459bd-cf4e-45f9-adce-95d79998254a\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '3082'
+      - '2055'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:15 GMT
+      - Tue, 25 Aug 2020 17:28:03 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -186,7 +159,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MTUsImlhdCI6MTU5NzQ1ODYxNSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.wgecKBWREKmPBQ7MomwpAG4SpMZIX1UnGKOZHK9N8Tg
+      - Token eyJleHAiOjE1OTg0MDUyODMsImlhdCI6MTU5ODM3NjQ4MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.PWyfpWWP5QM2yA-K_2f-cqhkCrxLQimf9TUiXnYN2_U
       Connection:
       - keep-alive
       Content-Type:
@@ -204,7 +177,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:15 GMT
+      - Tue, 25 Aug 2020 17:28:03 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -218,7 +191,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MTUsImlhdCI6MTU5NzQ1ODYxNSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.wgecKBWREKmPBQ7MomwpAG4SpMZIX1UnGKOZHK9N8Tg
+      - Token eyJleHAiOjE1OTg0MDUyODMsImlhdCI6MTU5ODM3NjQ4MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.PWyfpWWP5QM2yA-K_2f-cqhkCrxLQimf9TUiXnYN2_U
       Connection:
       - keep-alive
       Content-Type:
@@ -226,38 +199,73 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download
+    uri: http://localhost:8081/api/v1/user
+  response:
+    body:
+      string: "{\n  \"first_name\": \"\", \n  \"is_admin\": true, \n  \"last_login\"\
+        : \"2020-08-25T17:28:03.387879Z\", \n  \"last_name\": \"\", \n  \"username\"\
+        : \"journalist\", \n  \"uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\n\
+        }\n"
+    headers:
+      Content-Length:
+      - '192'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 25 Aug 2020 17:28:03 GMT
+      Server:
+      - Werkzeug/0.16.0 Python/3.5.2
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Token eyJleHAiOjE1OTg0MDUyODMsImlhdCI6MTU5ODM3NjQ4MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.PWyfpWWP5QM2yA-K_2f-cqhkCrxLQimf9TUiXnYN2_U
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.20.0
+    method: GET
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqAQ//Z/S89kAgGiAOh+UVD2ePgDvU/l/JnvR2DkCEnnqTivaWTKetbcTOxv8D
-        iHQFUvQKPTADA4g5u56foRmzC0Yb2mP36vRMUqLq87hb/XfZFfr3Ak7E169EyaCN6ht5he28mLV0
-        j9brHPGxQWt2vrE4FFdwnUVQWNfAp13rFMm0IDFsHN3o3lNSjywJ62jlr1rce3mdkC+rXkwDh3zs
-        0ZDvxqFGx4X8YPbQiAStvUsK1n3u9NBnKE3cyeHe70xnMdQxq1N4NuACJZkNovKet6C3s8LTvj58
-        XiK6+/AgtbO9Pk6c89s1WW0x3hUGFtWVI+GqSUSQda5CDlWaq6Fq7mBURfuW7yD/rOJ0EypOOJED
-        b1GoyTiK6V1gC/mktb6u/Ei16SmPOjcsAzW7BFn5tsvl3lZULN+b4Bs+E7/Pxl4ymVaPDgbcsAh9
-        Ipp0thhF1a2A3MobRsTtNidryxvfzUTj5ou70vguzn7zthzog2sijyM9hBI0FPr6YRVWXvrS7BEQ
-        Ly9BA1AuzGy0kS1B6MUYdcWAaxQZHWNne02zDHZqe2sBFLM04tJU4myKrXlBOok4YILQ7OWDSoa8
-        Whkyohid0Eympcv+6YMaKI+9yBzHFWgcpu27rlrAuRGRXi9ibBxovyCRg5SSYc1Guo0jalDJWdDy
-        lRdLGsmqJAcWq2PUvNLSTAGpSiJRM+Iwxr77j/lapCOSRGfVJaivW59X5+ZQa6BN57DKWvcgPtCb
-        xDfXOBD4hOG9w/Qv5iKwgOcj/ckygOpvtrcQosdK9ZzrrdY=
+        hQIMA8PnxMCiIBsqAQ//Rw1NPH3mwdBg9NnblanYiQgqmPuHTY9ha8sR24r6Cbv4UunDrGcjIMeT
+        qUZfK1zok/ZjbbLMo+yVWG2my899P8meyJS9C9MzmPC/x8hpoSUVdxyRorBDja9qNtZUyhOrm5Dz
+        rsiuEaqB1T5iYPinyCzeOcGKxTlrDJE78s5aHQVGQeBjXN+7BqZXsGCWrUueXTF10QrC8u0T/Fnw
+        T+BLvR8FmCIEilEDQESn653nL2wbkTz/7OMxUJJUDkG9xO6VHsTcH4KAzVsonMaan2RVXarJ1393
+        esjkZJ3vMiKXSMNIdsdDQ8WbP/2JGL8rhdg3WZqRbX7ePEJ5C7moUGiJsXmYwNMDarImp/be0O+1
+        YGk1Bfig2smMD280G8vYNykGvLkiGWJU0tGQQBbc5NeM3WZ8chZsyKofidoc9CIY7NLVHGg5u6zf
+        AEe1bjVuWveL5NaUJUpzWxDQzkIBuvX/E9stjEvqb0fZCRkGqPQLOix/YVUjUzj2i1zGAgL/w3xw
+        jhadu4aN05dbf5cBeKRIUS43HnrDXluA0vq0HbX30xuFpoo/noZUiZ8uNfR2UKLQfIK0gNVH1ydw
+        MhHIDKyiUWm/0YQgzcozy14n9OCGtLCucWfxXy7nozJ7JnVJpSYPgAmozMOoqEiz3C0Dnsax/PRV
+        AvwhOEGda6nAIosZZ6nSTAGpDbf6bksYyI2J4JEtY4b7jBvCz6Qmg+n4ZIIH7IEeIBCkhnUtU8xz
+        JHiwor7B/FnoP6RymaVAKyAPqoKGfrJ/XGbwPXJRvQl2PeM=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-inexpressible_sepsis-msg.gpg
+      - attachment; filename=1-unlawful_spectrum-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:30:15 GMT
+      - Tue, 25 Aug 2020 17:28:03 GMT
       Etag:
-      - sha256:20db26d5f8240c2efbc83f40184bd03e74f0b927394627fe24bc2954cb4a6c2a
+      - sha256:dd82012b8656a3f7175b619f2875895a11071daf681b996cdc2704ddf5388664
       Expires:
-      - Sat, 15 Aug 2020 14:30:15 GMT
+      - Wed, 26 Aug 2020 05:28:03 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:44 GMT
+      - Tue, 25 Aug 2020 17:27:02 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -271,7 +279,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MTUsImlhdCI6MTU5NzQ1ODYxNSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.wgecKBWREKmPBQ7MomwpAG4SpMZIX1UnGKOZHK9N8Tg
+      - Token eyJleHAiOjE1OTg0MDUyODMsImlhdCI6MTU5ODM3NjQ4MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.PWyfpWWP5QM2yA-K_2f-cqhkCrxLQimf9TUiXnYN2_U
       Connection:
       - keep-alive
       Content-Type:
@@ -279,38 +287,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download
+    uri: http://localhost:8081/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAs+tSZVdjh2H5sgW3rQYsinaTUd1To3XLy/EC0UcNed15/OLbU142ic10
-        6l41iWmBW44aOmjYFIY46VfqPxQSM0G7fl2g5A0SZdmckTqzu141v/+BoTmvbzzZ8sXmpxKjbP/A
-        1F6aBPQ2qX7HcUVyGOadyMRjuKB+IO1pROBeFB5R0hE+FD+y4/yq2y4J9SVeYcdcwcsWJytFUm73
-        emXQ6vcBspvlgSjE1gywgfPFkmOLIKxv9INHFTT/FrfPvJ/yeFZ7jKtG0wxBQYPL4DG5QiVi1Gyz
-        Ln039tgWjFVnM5FhJ+XNhLbLHuISii/0CrKq9TeRea85xFHR6UGKgTm3/fOeWtEhC6FKa0XstXhU
-        T0E9dmh80Rd3myvN0HU3eyNFvmjyZ1weVguXjg4Ao1yWZ8a8AmqlA6m4conr4bbscqQKXCJSF1D+
-        g/i5ng78t0+4wnWMiKtN9rNTJkVBzXpaoYzOn+14EJbkYa+zkCyQS8TbjMBpLaP0aTFO4VXk7OAU
-        ygtKj6P8KmkfqivWrQ047DjqwVot+wBpKT+3t8ASscApC7KaSF0+d/fBvb05ZLzLtfSXM+Ts6pQ8
-        sn60uh2dnW/12nbqAdzFnrEPtDdtz5PFWn8brJpvhhMids/A7dkmbbLK6oirkLSRMF7Wdp8Stz2m
-        aI8Xz6brh2GQeKZafWnSTAHRguSmKDs+h+zUuP/hFFyLlLy2TWX3VLR2rLCEHhm82jP4UcMTpBkU
-        sgsFKxLyPddNYl+9D7kh9NLhzaLsXc2RihQWRvXYM9f3E0Y=
+        hQIMA8PnxMCiIBsqAQ//RtWsdfVE8eGi8sFqp1/cmLdkiut2OkXfs7DdjD0CBr6qfYUG8woosTjZ
+        +bdA5IIg1ewECF+eOZbfgW3EGzq/xN9rKaE+yTEbrR2swkoHNv1tUTrBoRGwUfHOYl3LOWlftNHt
+        8HbCVEZ/TAs1NQolRpSXj9o+mR6wjPvXtArQkW0io6D8ah9YO+YkEEkl4B2CwK1BwUQHj4B1TXw+
+        QGubNNIfGeXM9OkSCQMZapmumEt4m+8KImF1ncNMINXO/WV3tbTKDrCO63R/K6ibSuq//vd72Q2z
+        DFalhfcmnu7ksX0/4TFsrsvfuQoppTqepI6YklIKhTRkoRuY5fQeoK2w93qrZh0dmsVvlhx13/xl
+        19wcO1vASiZzfSHT/XDaXoS+3XmgW/xKr+Y0IJq+PZSs/EZ/2mr6zXePR8HtdFuvCnGiNjPFsRsE
+        sRIB1iq6FEV3zKxLU7FI46MTNrBpTYj3xAn2MqGM0UgCvwC1v73s6mMe6njwvYak8V0J/ny3sd/J
+        NHnbftRaGOmlrQbiXhoRIDEV5Kric9qBJG5R12kxDHHqce/viMEnZ1543+2snmsGrmWvX3Kxsbq4
+        cm1rmE/1dwYYtUaTpj1j4HDr7OY0PUN4F2BXK1gOSOONWiKd8hRAbY4Emwv60g+36ZtwY6kQu4v3
+        pQhKYVCTt8xL1gZkYYfSTAFnY4M6ViJKpbRI6FGnAQsYaB74rBUx6FatdEvztAN5VHarQPHN9uDF
+        TLPp+suitZOgA4wsgUWL+sUze53pOc/MCAUfBwrk2YD7hO8=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-potential_freshness-msg.gpg
+      - attachment; filename=1-pleasant_rearguard-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:30:15 GMT
+      - Tue, 25 Aug 2020 17:28:03 GMT
       Etag:
-      - sha256:624b8cc271f0bc4a153ff893f14d4b63464577579c0baa49ca2e6f5b2fb715a8
+      - sha256:cecd2591b0a9a0315f320e9878f68fdaec03c70b286da162c4416fab137ec00e
       Expires:
-      - Sat, 15 Aug 2020 14:30:15 GMT
+      - Wed, 26 Aug 2020 05:28:03 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:35 GMT
+      - Tue, 25 Aug 2020 17:26:47 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -324,7 +332,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MTUsImlhdCI6MTU5NzQ1ODYxNSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.wgecKBWREKmPBQ7MomwpAG4SpMZIX1UnGKOZHK9N8Tg
+      - Token eyJleHAiOjE1OTg0MDUyODMsImlhdCI6MTU5ODM3NjQ4MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.PWyfpWWP5QM2yA-K_2f-cqhkCrxLQimf9TUiXnYN2_U
       Connection:
       - keep-alive
       Content-Type:
@@ -332,91 +340,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAp+9fU8qzd8lBJJJeTGUfrTvtC7bBj77m96ioEWln23lreSXOi7W1E++i
-        X3mCeNg6hLC0PSAtuO0QTw+LE6TGqLJtQh5y14fIxzgIX5G02eaoOlsayjQbVfXHTJ6HBSFx1VkS
-        ImILNuS170DhYiOyW91R3OJ2zg4DeTlPkyegMGScWCued6EcBBL+/EOrvZLDoXtpFAHFkGGcoQSD
-        p/6L5/pp8AuB5N43NRCtslfsD8D4gpZT7L9gkvNIJbMrBQ4FVUzjB/XI5mkOhXAubjKzgGcpqiM+
-        N2k5nqSPFzotGHmKDy77Bq4D3Sk4fcLzvWMe9hY+Prp6QqW5/F3uvFhJdpdOR9JZ4WqY6pWk0VsA
-        jeIuaxGH3rRqFegi59AiZV+EvpORA7tx8qmkVHch5UifaJCsHthaxOrBk1D/rgutgmoQvVaCN+UA
-        6So9D0H/w6RIE0vE3SAsCpXV3XQJWwsya8O5R5jCuETvi1s5NnMXrtxRuBqkFZUcRSNZyzrUWLGA
-        8djkwjYcO5lP7qt40ztUosMmb2y+4z8ad3zhWP71SKA+chx8lUvY7ziiSmFOpRJOr0OEgKMU59lR
-        ovyT6mu5yB1d5d8G9ns8s5H8/ymV5WE/MdG+o472wWPKoKHnIu0zlj1Qqso8l/khM5wIjs8XvICl
-        pm7uojnWqaFcIaJg4EvSTAEw45cGmA90NotlV9qwHi0fJ0qlbFKf6FAyeDaRL0TPoLKx9JbGf+9M
-        +wwWhoyWoWili+hOxuju3sNSeN1iYkv3fEIyKyEy5rXvf/0=
+        hQIMA8PnxMCiIBsqAQ/+PYP0nHBDyO7t31SHbMoS/JaxM9zZq5Y6ZlAxTXAit9tYJQj1LOb7J+QK
+        kWHSSLDHTqGvp22A+uQaNqiJnZ8piznrD3ZWW/tJ2+s8Mx1Jn+TjWNjH8SPBc0mUE4ohmnhUzwYe
+        e6ztSMmiFPsOU1er2HfKRs9h76w+EZ36SZP1gnmtSy0FfDbSUaNXODsLZTuWflwVnj6aI+AxxDaJ
+        k1J+qBF9/S5ST2MW9KJ91IQ5PRtnCT7HqCT4anuaeUgb6krL0uyDEJ2Qye1XOu/6p++dPZBbRa+m
+        C3b/AVYDtgeFDJTtC/dlOWjPVLEmeUq+hSkwcR8td8CZ2pE1xj6u/ZG9NcbAGMyM4URnmEtz4Qrq
+        yu1mWHgQKuab1SqlZN5b6j+3PPZGy4u7jxCq0RsNaayOgXB9uLpY9idW91zqvQolW81QEpmksagS
+        u//cImwcStP0EkMJN9oAjqI2vYvngkVXtnjbfS3RPYfTtfFt21WMlEZb+krmRPE29S4Mi/S7JkaY
+        sdSwdRqIQ/TeT/QpfG14PBBUsG65z7MhyE8qH/qxnokPXm0mdKW1Jf3fmETFsCJORCk7TtT8iX5X
+        A4mOZ5Yhe8TLMMPKheqhd+J1m63jJtXV/jks5j0T5KZyi5Fwj4cO+zEEbyWS17VHKEqHTUbjIUwB
+        EhWrI2xIPGKeh4dc6r3SXQENUMM0bBT2S+4ibmKU4MV5d814J6Ti3FF3Xv1goQ0T58xEeAczpAF6
+        dvNl/5SYXqOcpTtY+WyE3pBjRCe2yfL5xGr2Edoim+8qBf9TA8gpi9FO40xKOO0CW17AYQ==
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-red-rimmed_applejack-msg.gpg
-      Content-Length:
-      - '605'
-      Content-Type:
-      - application/pgp-encrypted
-      Date:
-      - Sat, 15 Aug 2020 02:30:15 GMT
-      Etag:
-      - sha256:2e1bdbd452ce54d49602552182cb0146b2334c58a7c5aec0c0565645e2ab4286
-      Expires:
-      - Sat, 15 Aug 2020 14:30:15 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:25:23 GMT
-      Server:
-      - Werkzeug/0.16.0 Python/3.5.2
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MTUsImlhdCI6MTU5NzQ1ODYxNSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.wgecKBWREKmPBQ7MomwpAG4SpMZIX1UnGKOZHK9N8Tg
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.20.0
-    method: GET
-    uri: http://localhost:8081/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01/download
-  response:
-    body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqAQ//ZJ/7rmmfPSKIICTS8ibETOju7Sl4Y0v26XY+8udWXlP3+d7rHDEFPJ9P
-        6OUTMwkhPOAp6Zo8t/81zTz7p+slNbF9hdGZdi25SS9ts5UQdeaS0MEr8SS+P94gi1KKvoX8AvTz
-        B0MX9e2dq1iHa0yWtXlkBzCu9dTynfqdf3J9T5lofYEpUdHzvBt1rdo45S4k8840rrklV2EIT5oI
-        88s77ZwKoxdEMKr5tjldyuwdaCiNub3pzqleh8EiVlbJXusUk+HvtqF5OAn8syAbGXKs2vndSKt5
-        HNCMiguMmKuMSEGk40BXMiZ5iYp+81/rjltTyLu3V5qRabZKjQtrHSoqUcIjaEfpivUkS2elOeA0
-        nUgf+qN/FABn4CWTA3qGZjJAlCtaF9XXlzFjfaZS3DFlBlprpO1NC3y1L7ISlY8l+8ZI31S6HDl9
-        P5X/ucfBayberL78U/sHPrbZXWlbzMq7JQ+4FYFOTNsZKIa8CDuO6EyxHhxW8FGzEXst/ImNCJ3/
-        p26OUrmAzyZM58bl6BQ8FYeGeABofrKz4U7m3a36T/J/ZCvJ+OezCsn+kftgTkaVn7JaL2vUA1RS
-        JFATZJQdFDBP4KMdyj36JHVjREesfToBFyKb6+K75147U8p6tWmfyj7DsynSUzGs2F/zgZxldGlV
-        Fbo0F++URXEKpuXCz07SXQGf6dsX0CwJdQAfhC8riRcHzxe9KZOc/t47aOQOAvxz79sdnPJwTu3z
-        M4WKXWKzxJl2CpjSnvZM2CpN+fwbyNoXCn0MvSBJk3QnAEo58eAZskVHZ3N0d6FaZIcJJQ==
-    headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=2-inexpressible_sepsis-doc.gz.gpg
+      - attachment; filename=2-unlawful_spectrum-doc.gz.gpg
       Content-Length:
       - '622'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:30:17 GMT
+      - Tue, 25 Aug 2020 17:28:05 GMT
       Etag:
-      - sha256:01eec14f9dc4f7d3f0bd7e510b10125b50b522fddfbed532ee1415dc0836020c
+      - sha256:ca8bb328480e3eb00a9eb245d0b25a3253e03673d61a677cabcb0db621fb8973
       Expires:
-      - Sat, 15 Aug 2020 14:30:17 GMT
+      - Wed, 26 Aug 2020 05:28:05 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:44 GMT
+      - Tue, 25 Aug 2020 17:27:02 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:

--- a/tests/functional/cassettes/test_export_dialog.yaml
+++ b/tests/functional/cassettes/test_export_dialog.yaml
@@ -17,9 +17,9 @@ interactions:
     uri: http://localhost:8081/api/v1/token
   response:
     body:
-      string: "{\n  \"expiration\": \"2020-08-15T10:29:01.413617Z\", \n  \"journalist_first_name\"\
-        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"b5e001de-19f1-4a93-885b-e0932aa2d441\"\
-        , \n  \"token\": \"eyJleHAiOjE1OTc0ODczNDEsImlhdCI6MTU5NzQ1ODU0MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.8b_K7QBEjNjRUMEvi3czgiRVlr0ADxwxPLAJD9XeEg4\"\
+      string: "{\n  \"expiration\": \"2020-08-26T01:28:52.385085Z\", \n  \"journalist_first_name\"\
+        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n  \"token\": \"eyJleHAiOjE1OTg0MDUzMzIsImlhdCI6MTU5ODM3NjUzMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.4Y5dtHnUe_8TSZd_tipmzEJL7hpBdmx_BshNXVGQlsw\"\
         \n}\n"
     headers:
       Content-Length:
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:29:01 GMT
+      - Tue, 25 Aug 2020 17:28:52 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -41,7 +41,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczNDEsImlhdCI6MTU5NzQ1ODU0MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.8b_K7QBEjNjRUMEvi3czgiRVlr0ADxwxPLAJD9XeEg4
+      - Token eyJleHAiOjE1OTg0MDUzMzIsImlhdCI6MTU5ODM3NjUzMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.4Y5dtHnUe_8TSZd_tipmzEJL7hpBdmx_BshNXVGQlsw
       Connection:
       - keep-alive
       Content-Type:
@@ -52,82 +52,31 @@ interactions:
     uri: http://localhost:8081/api/v1/sources
   response:
     body:
-      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"out-of-town\
-        \ primogeniture\", \n      \"key\": {\n        \"fingerprint\": \"200C271E4E680FFE62E008931554E4BF600B1E3C\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAL4uN551SiYiVLrHoK1QGMDmN1xq42u8o2dmnKFkArW5KfBvBFoX\\\
-        nZX5LnOj9hKKEEmeGX5beS9h+fjsWvx86M2kQj/5xhOmHw0GGESEPQBSUc+Lyohpc\\nUmBoNNBfWIouEQ+IVS0gmrOwiS7wdItMby1lLDlDBoiEm4aRnRw36NIpABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEhPUDNaU05LUFgzNE1MV09QMkVPQkJRVVc2QjZPS0ZFMzZa\\nVktOV0VWNEhXVTVMUlZGQlFENjVKTEtYUENHRE1LVEFTTDM2N0NOT1ZDN0hBRUxF\\\
-        nWVQyWU5LMkJHM0ZWNlZWUUlMMlE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBVU5L9gCx482IED/2w6yFqz19zTBX72qN0MUTq5\\\
-        nCavQIBhhWrbsc1m0p+cxuVJ16TYxiE3S/Lp/rd4r1Q9MQg9BP0+/qjOA541kNq5A\\nmR2Y0teqWonDqeY/660kEFIbio0HbOTjsBhEZxtglJ1wz70tUpd40ZVMsu+Z32Mw\\\
-        n2kSiCclJYHk7uy1eis57\\n=pz11\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:24:42.042205Z\"\
+      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/add_star\"\
+        , \n      \"interaction_count\": 3, \n      \"is_flagged\": false, \n    \
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"unlawful spectrum\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"CE2A06285C9B1FDB43BFEB853EC2D036DDCA8CD4\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANJ0h2W7p0bViTLpY9w/PDd8sBHR56OVg+EGdXZ51Wuqt8ZUkF8W\\\
+        njSLrjsiOrcQ1lRFEgERFfIBJvlxfB/EMP4wcTY7vg7WQN/rvSJynBW0T6iHI3Rhi\\n/3v35LEuX9tLU/B1e11mRevgHTLRUms38Y5DBSkWACngvH4jWP+kwylJABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPDUyNzdCNDVDNExFUFdJWU9NQlY0VE5FVEI1WjdaVFpERTZK\\nQTJSTlhVNE5HM0g3R0NRVEJYRUdVWkdSRkpSRVZGN01BTzZDUUpWWVpBN0NOSEw3\\\
+        nS0JKVzMyS01XNEJaSVROU0dBVkk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJED7C0DbdyozULzEEALbYIlKPW3wXMi/9V2c/fYJc\\\
+        naX9UE94JwAdfntqAkEF8dL/P6fD5J1BPqQILK4crX6LN6h8g2y1vnrTTg9odsa1L\\nD0JqSpGfIWscGRuzY6b2WngLCgsudMqJgPZUdm/wbxp3Q8Daa8U99mL9jXr9Ia9j\\\
+        n8BFeiB6fb0VoIDgM7UTv\\n=j+JQ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:27:03.031475Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\
-        , \n      \"uuid\": \"4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"red-rimmed\
-        \ applejack\", \n      \"key\": {\n        \"fingerprint\": \"D449222A7B7B0AC1E134A1FF01203DD2D2636A37\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAOaUXyLQCaUSR4HTaBVGZp1mi3jn3BExTTe2UCBYjsn1zhkOBDf9\\\
-        ncZNBQGjEBIYlOioC4XY1TkQep4L2DdmqO5lBfbyNG6LpGiNo7DvNBxeo5WNDa42C\\n8YcfTaVL9aWm07G12uwwc1WFNb0y86PzuAS1ek0k5B7jUfjNxFN9t0dhABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEtCTEEyQTRDUEtETEVURDM2MllWQUZVRVdRQlJLUzJWRjVG\\nUEs2SElBWFBXQUFNSURMUkZHUEdLU0dFSDJJUUtBUVdZUFdFS0xRWVpaTDZMU1JY\\\
-        nRFRUTUdPUlFFWFA0WE1EUlJJM0E9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEAEgPdLSY2o3LmUD/i+JqgIWc2SzA5OTX9Qo0g/r\\\
-        nqxDmi2NQMXob0fEEcP/GGnbiFE1P77AC6JWxSKPQStlfwvffhYmK2q7JBc71Jj8O\\nRqFRT5WSRpXUCq8tZkIYyoCXKQPlwSb3S1NQ3yM00kbkCM4dArLIFuQ/ZI1xG+l9\\\
-        nIqxWwXYY8SpO8uKDXFd7\\n=FjUe\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:23.753433Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"uuid\": \"70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"potential\
-        \ freshness\", \n      \"key\": {\n        \"fingerprint\": \"06FFA85715E89C0AFBA927A78EA34965AC896EEA\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAMHR1pM94xuFw+GiTQI7RyUN/sKYmupDhwWj1nVricMXRbM7nIXk\\\
-        nsBnqTx0pTkITPxjszoVyFFxG+Uw8TXMZEZdCOhcC2AieHV0mgWsXxLAbD9Sw3VmQ\\ngOQ3S2C/MBrimrK4bkpoKXxKIV5v5Rgku5Pjxzw50HH4e1pYhgW2C+knABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEg3TVJTVUZHWFVKRldQQlM0UjdISk1JNE5HTUREQ0FaRzJL\\nVlIyTTM3RkFTQk9BRjIyUkFYNzdMUVdZNFZJNTJLSlBOQldaRjUyQTdHWFJVN1lQ\\\
-        nN0dQQU5QSFNNUUkzSUFVN1VGNEk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEI6jSWWsiW7qZeYD/ReRVU5y0nssc0+OlRy6M/im\\\
-        nHY9oHex0tSGt1fTuDVqsAKKHMDrZLKkkhJg42wcINwbXTj/vRu7n199IwbSUoDiE\\nJlnO6ZaIG996AUFS64eZBA+kXczqJbsWgdQQpwQJn8LiQUF8iwFhTThltjRSuXqf\\\
-        nMxyFevvxbIvYcs6il7Ip\\n=cZe8\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:36.194245Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"uuid\": \"6db98582-dd69-48ea-879e-5afc5aa388d6\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"inexpressible\
-        \ sepsis\", \n      \"key\": {\n        \"fingerprint\": \"380C70D1C7930985411415B31A1B751385404CC5\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANhgLtWR4jFlhHEPGJjcupkGrNymWv9wFlFM8YppKs6nNXaQdoKf\\\
-        n7+NESFVdkm89/7FWD/It0B49jEBjjs7GOmxhffomt1NVHocYGDBQjMAlKOYQgCnR\\neZDnHCFORSrQcfiNhgKm1/eFOZlNJDZn2Cwpmdk8ZV6B78fGVz+3B+tFABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEo0VFRaVzY2QlBRTFRRVVlNS0hIVzZZTjRGVkJIVFlVQ0ZW\\nNVNWNjNRWlQyT0Y3Wjc2NUxEWk1TVDJNR1JBVFpYSVZJVzVBR1M0N0RFU0hTRUhY\\\
-        nWDZFQVlISkFWTFBZRzc1VFlKQkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBobdROFQEzFd3gD/RUhGdZUriO3QqYTqvH7EZdZ\\\
-        n4r3iFUJVP3xhru9HYBtksepsKzUHYZn4nK29689AdV1A9o/X4YcKWrxFRbMuZs0E\\nTj2Je4jrw3WNf3O3COAWwFa75HOXIhGfFVuJ4Ni2/NVJGDPA6NNIfZfFMIj/NZF3\\\
-        n3RBZhDmxS21yJs9daQfs\\n=NQQJ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:44.877597Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"uuid\": \"f3a61359-1919-4bf0-b6f7-da902a935160\"\n    }\n  ]\n\
+        \      \"remove_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"f9b4da97-a077-412e-8e54-4ef4984a8540\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '6421'
+      - '1617'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:29:01 GMT
+      - Tue, 25 Aug 2020 17:28:52 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -141,7 +90,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczNDEsImlhdCI6MTU5NzQ1ODU0MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.8b_K7QBEjNjRUMEvi3czgiRVlr0ADxwxPLAJD9XeEg4
+      - Token eyJleHAiOjE1OTg0MDUzMzIsImlhdCI6MTU5ODM3NjUzMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.4Y5dtHnUe_8TSZd_tipmzEJL7hpBdmx_BshNXVGQlsw
       Connection:
       - keep-alive
       Content-Type:
@@ -152,55 +101,24 @@ interactions:
     uri: http://localhost:8081/api/v1/submissions
   response:
     body:
-      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96/download\"\
-        , \n      \"filename\": \"1-out-of-town_primogeniture-msg.gpg\", \n      \"\
-        is_read\": true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\
-        , \n      \"submission_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96\"\
-        , \n      \"uuid\": \"f836676a-c1aa-49a8-90c2-bb171f60cd96\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/99509e6d-62dd-48f3-8208-623f9290bc03/download\"\
-        , \n      \"filename\": \"2-out-of-town_primogeniture-doc.gz.gpg\", \n   \
-        \   \"is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"\
-        /api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\", \n      \"submission_url\"\
-        : \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/99509e6d-62dd-48f3-8208-623f9290bc03\"\
-        , \n      \"uuid\": \"99509e6d-62dd-48f3-8208-623f9290bc03\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download\"\
-        , \n      \"filename\": \"1-red-rimmed_applejack-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170\"\
-        , \n      \"uuid\": \"ceb44744-68cd-4b29-ada9-4c6ed4127170\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015/download\"\
-        , \n      \"filename\": \"2-red-rimmed_applejack-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015\"\
-        , \n      \"uuid\": \"1deb4f4f-1094-49ec-b0da-5d714b60c015\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download\"\
-        , \n      \"filename\": \"1-potential_freshness-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e\"\
-        , \n      \"uuid\": \"da095cb7-5a81-4b57-912c-14b0501dc00e\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d/download\"\
-        , \n      \"filename\": \"2-potential_freshness-doc.gz.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d\"\
-        , \n      \"uuid\": \"ed460264-f0e9-415f-8247-738eb482c75d\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download\"\
-        , \n      \"filename\": \"1-inexpressible_sepsis-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a\"\
-        , \n      \"uuid\": \"a3bb0937-6240-4200-99d5-b514c465e56a\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01/download\"\
-        , \n      \"filename\": \"2-inexpressible_sepsis-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\
-        , \n      \"uuid\": \"1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\n    }\n  ]\n\
+      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download\"\
+        , \n      \"filename\": \"1-unlawful_spectrum-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\
+        , \n      \"uuid\": \"d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a/download\"\
+        , \n      \"filename\": \"2-unlawful_spectrum-doc.gz.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a\"\
+        , \n      \"uuid\": \"55e459bd-cf4e-45f9-adce-95d79998254a\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '4113'
+      - '1038'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:29:01 GMT
+      - Tue, 25 Aug 2020 17:28:52 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -214,7 +132,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczNDEsImlhdCI6MTU5NzQ1ODU0MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.8b_K7QBEjNjRUMEvi3czgiRVlr0ADxwxPLAJD9XeEg4
+      - Token eyJleHAiOjE1OTg0MDUzMzIsImlhdCI6MTU5ODM3NjUzMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.4Y5dtHnUe_8TSZd_tipmzEJL7hpBdmx_BshNXVGQlsw
       Connection:
       - keep-alive
       Content-Type:
@@ -225,14 +143,21 @@ interactions:
     uri: http://localhost:8081/api/v1/replies
   response:
     body:
-      string: "{\n  \"replies\": []\n}\n"
+      string: "{\n  \"replies\": [\n    {\n      \"filename\": \"3-unlawful_spectrum-reply.gpg\"\
+        , \n      \"is_deleted_by_source\": false, \n      \"journalist_first_name\"\
+        : \"\", \n      \"journalist_last_name\": \"\", \n      \"journalist_username\"\
+        : \"journalist\", \n      \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n      \"reply_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies/b8bfb5d1-7a5a-4413-9df2-52205fffa5b5\"\
+        , \n      \"size\": 1085, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"b8bfb5d1-7a5a-4413-9df2-52205fffa5b5\"\n    }\n  ]\n\
+        }\n"
     headers:
       Content-Length:
-      - '20'
+      - '578'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:29:01 GMT
+      - Tue, 25 Aug 2020 17:28:52 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -246,7 +171,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczNDEsImlhdCI6MTU5NzQ1ODU0MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.8b_K7QBEjNjRUMEvi3czgiRVlr0ADxwxPLAJD9XeEg4
+      - Token eyJleHAiOjE1OTg0MDUzMzIsImlhdCI6MTU5ODM3NjUzMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.4Y5dtHnUe_8TSZd_tipmzEJL7hpBdmx_BshNXVGQlsw
       Connection:
       - keep-alive
       Content-Type:
@@ -254,38 +179,20 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download
+    uri: http://localhost:8081/api/v1/user
   response:
     body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqAQ//Z/S89kAgGiAOh+UVD2ePgDvU/l/JnvR2DkCEnnqTivaWTKetbcTOxv8D
-        iHQFUvQKPTADA4g5u56foRmzC0Yb2mP36vRMUqLq87hb/XfZFfr3Ak7E169EyaCN6ht5he28mLV0
-        j9brHPGxQWt2vrE4FFdwnUVQWNfAp13rFMm0IDFsHN3o3lNSjywJ62jlr1rce3mdkC+rXkwDh3zs
-        0ZDvxqFGx4X8YPbQiAStvUsK1n3u9NBnKE3cyeHe70xnMdQxq1N4NuACJZkNovKet6C3s8LTvj58
-        XiK6+/AgtbO9Pk6c89s1WW0x3hUGFtWVI+GqSUSQda5CDlWaq6Fq7mBURfuW7yD/rOJ0EypOOJED
-        b1GoyTiK6V1gC/mktb6u/Ei16SmPOjcsAzW7BFn5tsvl3lZULN+b4Bs+E7/Pxl4ymVaPDgbcsAh9
-        Ipp0thhF1a2A3MobRsTtNidryxvfzUTj5ou70vguzn7zthzog2sijyM9hBI0FPr6YRVWXvrS7BEQ
-        Ly9BA1AuzGy0kS1B6MUYdcWAaxQZHWNne02zDHZqe2sBFLM04tJU4myKrXlBOok4YILQ7OWDSoa8
-        Whkyohid0Eympcv+6YMaKI+9yBzHFWgcpu27rlrAuRGRXi9ibBxovyCRg5SSYc1Guo0jalDJWdDy
-        lRdLGsmqJAcWq2PUvNLSTAGpSiJRM+Iwxr77j/lapCOSRGfVJaivW59X5+ZQa6BN57DKWvcgPtCb
-        xDfXOBD4hOG9w/Qv5iKwgOcj/ckygOpvtrcQosdK9ZzrrdY=
+      string: "{\n  \"first_name\": \"\", \n  \"is_admin\": true, \n  \"last_login\"\
+        : \"2020-08-25T17:28:52.385417Z\", \n  \"last_name\": \"\", \n  \"username\"\
+        : \"journalist\", \n  \"uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\n\
+        }\n"
     headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-inexpressible_sepsis-msg.gpg
       Content-Length:
-      - '605'
+      - '192'
       Content-Type:
-      - application/pgp-encrypted
+      - application/json
       Date:
-      - Sat, 15 Aug 2020 02:29:01 GMT
-      Etag:
-      - sha256:20db26d5f8240c2efbc83f40184bd03e74f0b927394627fe24bc2954cb4a6c2a
-      Expires:
-      - Sat, 15 Aug 2020 14:29:01 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:25:44 GMT
+      - Tue, 25 Aug 2020 17:28:52 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -299,7 +206,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczNDEsImlhdCI6MTU5NzQ1ODU0MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.8b_K7QBEjNjRUMEvi3czgiRVlr0ADxwxPLAJD9XeEg4
+      - Token eyJleHAiOjE1OTg0MDUzMzIsImlhdCI6MTU5ODM3NjUzMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.4Y5dtHnUe_8TSZd_tipmzEJL7hpBdmx_BshNXVGQlsw
       Connection:
       - keep-alive
       Content-Type:
@@ -307,38 +214,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAs+tSZVdjh2H5sgW3rQYsinaTUd1To3XLy/EC0UcNed15/OLbU142ic10
-        6l41iWmBW44aOmjYFIY46VfqPxQSM0G7fl2g5A0SZdmckTqzu141v/+BoTmvbzzZ8sXmpxKjbP/A
-        1F6aBPQ2qX7HcUVyGOadyMRjuKB+IO1pROBeFB5R0hE+FD+y4/yq2y4J9SVeYcdcwcsWJytFUm73
-        emXQ6vcBspvlgSjE1gywgfPFkmOLIKxv9INHFTT/FrfPvJ/yeFZ7jKtG0wxBQYPL4DG5QiVi1Gyz
-        Ln039tgWjFVnM5FhJ+XNhLbLHuISii/0CrKq9TeRea85xFHR6UGKgTm3/fOeWtEhC6FKa0XstXhU
-        T0E9dmh80Rd3myvN0HU3eyNFvmjyZ1weVguXjg4Ao1yWZ8a8AmqlA6m4conr4bbscqQKXCJSF1D+
-        g/i5ng78t0+4wnWMiKtN9rNTJkVBzXpaoYzOn+14EJbkYa+zkCyQS8TbjMBpLaP0aTFO4VXk7OAU
-        ygtKj6P8KmkfqivWrQ047DjqwVot+wBpKT+3t8ASscApC7KaSF0+d/fBvb05ZLzLtfSXM+Ts6pQ8
-        sn60uh2dnW/12nbqAdzFnrEPtDdtz5PFWn8brJpvhhMids/A7dkmbbLK6oirkLSRMF7Wdp8Stz2m
-        aI8Xz6brh2GQeKZafWnSTAHRguSmKDs+h+zUuP/hFFyLlLy2TWX3VLR2rLCEHhm82jP4UcMTpBkU
-        sgsFKxLyPddNYl+9D7kh9NLhzaLsXc2RihQWRvXYM9f3E0Y=
+        hQIMA8PnxMCiIBsqAQ//Rw1NPH3mwdBg9NnblanYiQgqmPuHTY9ha8sR24r6Cbv4UunDrGcjIMeT
+        qUZfK1zok/ZjbbLMo+yVWG2my899P8meyJS9C9MzmPC/x8hpoSUVdxyRorBDja9qNtZUyhOrm5Dz
+        rsiuEaqB1T5iYPinyCzeOcGKxTlrDJE78s5aHQVGQeBjXN+7BqZXsGCWrUueXTF10QrC8u0T/Fnw
+        T+BLvR8FmCIEilEDQESn653nL2wbkTz/7OMxUJJUDkG9xO6VHsTcH4KAzVsonMaan2RVXarJ1393
+        esjkZJ3vMiKXSMNIdsdDQ8WbP/2JGL8rhdg3WZqRbX7ePEJ5C7moUGiJsXmYwNMDarImp/be0O+1
+        YGk1Bfig2smMD280G8vYNykGvLkiGWJU0tGQQBbc5NeM3WZ8chZsyKofidoc9CIY7NLVHGg5u6zf
+        AEe1bjVuWveL5NaUJUpzWxDQzkIBuvX/E9stjEvqb0fZCRkGqPQLOix/YVUjUzj2i1zGAgL/w3xw
+        jhadu4aN05dbf5cBeKRIUS43HnrDXluA0vq0HbX30xuFpoo/noZUiZ8uNfR2UKLQfIK0gNVH1ydw
+        MhHIDKyiUWm/0YQgzcozy14n9OCGtLCucWfxXy7nozJ7JnVJpSYPgAmozMOoqEiz3C0Dnsax/PRV
+        AvwhOEGda6nAIosZZ6nSTAGpDbf6bksYyI2J4JEtY4b7jBvCz6Qmg+n4ZIIH7IEeIBCkhnUtU8xz
+        JHiwor7B/FnoP6RymaVAKyAPqoKGfrJ/XGbwPXJRvQl2PeM=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-potential_freshness-msg.gpg
+      - attachment; filename=1-unlawful_spectrum-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:29:01 GMT
+      - Tue, 25 Aug 2020 17:28:52 GMT
       Etag:
-      - sha256:624b8cc271f0bc4a153ff893f14d4b63464577579c0baa49ca2e6f5b2fb715a8
+      - sha256:dd82012b8656a3f7175b619f2875895a11071daf681b996cdc2704ddf5388664
       Expires:
-      - Sat, 15 Aug 2020 14:29:01 GMT
+      - Wed, 26 Aug 2020 05:28:52 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:35 GMT
+      - Tue, 25 Aug 2020 17:27:02 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -352,7 +259,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczNDEsImlhdCI6MTU5NzQ1ODU0MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.8b_K7QBEjNjRUMEvi3czgiRVlr0ADxwxPLAJD9XeEg4
+      - Token eyJleHAiOjE1OTg0MDUzMzIsImlhdCI6MTU5ODM3NjUzMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.4Y5dtHnUe_8TSZd_tipmzEJL7hpBdmx_BshNXVGQlsw
       Connection:
       - keep-alive
       Content-Type:
@@ -360,38 +267,66 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies/b8bfb5d1-7a5a-4413-9df2-52205fffa5b5/download
   response:
     body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqARAAp+9fU8qzd8lBJJJeTGUfrTvtC7bBj77m96ioEWln23lreSXOi7W1E++i
-        X3mCeNg6hLC0PSAtuO0QTw+LE6TGqLJtQh5y14fIxzgIX5G02eaoOlsayjQbVfXHTJ6HBSFx1VkS
-        ImILNuS170DhYiOyW91R3OJ2zg4DeTlPkyegMGScWCued6EcBBL+/EOrvZLDoXtpFAHFkGGcoQSD
-        p/6L5/pp8AuB5N43NRCtslfsD8D4gpZT7L9gkvNIJbMrBQ4FVUzjB/XI5mkOhXAubjKzgGcpqiM+
-        N2k5nqSPFzotGHmKDy77Bq4D3Sk4fcLzvWMe9hY+Prp6QqW5/F3uvFhJdpdOR9JZ4WqY6pWk0VsA
-        jeIuaxGH3rRqFegi59AiZV+EvpORA7tx8qmkVHch5UifaJCsHthaxOrBk1D/rgutgmoQvVaCN+UA
-        6So9D0H/w6RIE0vE3SAsCpXV3XQJWwsya8O5R5jCuETvi1s5NnMXrtxRuBqkFZUcRSNZyzrUWLGA
-        8djkwjYcO5lP7qt40ztUosMmb2y+4z8ad3zhWP71SKA+chx8lUvY7ziiSmFOpRJOr0OEgKMU59lR
-        ovyT6mu5yB1d5d8G9ns8s5H8/ymV5WE/MdG+o472wWPKoKHnIu0zlj1Qqso8l/khM5wIjs8XvICl
-        pm7uojnWqaFcIaJg4EvSTAEw45cGmA90NotlV9qwHi0fJ0qlbFKf6FAyeDaRL0TPoLKx9JbGf+9M
-        +wwWhoyWoWili+hOxuju3sNSeN1iYkv3fEIyKyEy5rXvf/0=
+      string: '-----BEGIN PGP MESSAGE-----
+
+
+        hIwDPsLQNt3KjNQBA/9ojtfC9t1XqWV3wWgAlu95dTxfMqqYczw6sQSmgcEkg9+P
+
+        vCeb05aaW5jMMlYXkUm62SVqdw/KJW1Dg8trcMvRFIeCKNZQhA01Rsqb7jzDLzD/
+
+        kqJ0JGGZk01wDAdRZwWHtA96PY6Qp7mpEJcQTfliBzdWhe03KWfPEJxzZCfT84UC
+
+        DAPD58TAoiAbKgEP/RRt/jqDFFWYxpc4SrqshMubiyh/GImTEOePHfhgQujDvKLu
+
+        kRQovxq1xujHfCuVaBHUgCpm3jWcKCQPrpNT8xLNngu8Uem1degoqstCk+0MVVpC
+
+        +YkmUCajX9X7J98xxuJ/evZMWgWzbk3kD2AuTlYolXqNB6nY50RWQwt1Si/k9p7Y
+
+        RO1ERKa9M99a+lReuF2E2dEYW0Ru3YdTbz/sYuX65Hl/UM6lEhdq9A2EDBElDoiH
+
+        0wkY+YybjFMJlfKnK97nxJ2rwfPQqIiRFEWRbHci+pbtjcPxPjEM37aM/9urM6WR
+
+        CJ3leluB9ZYHzKAFA5VGHH1W1/xPe8STvySggG/cjb4jIxqyu9rV+dkrwK0xjfhN
+
+        15G7B5gvJmXWAp5IDvQD3Pux128hpJYzLUBMURAK1oVf0SCjqWFwQeAIEOE67eJ6
+
+        Nu046qIKcTz6jSH6JrxSneHyDySZaM8DwV9u24voInDGGjEwAbuLfvOGYu6yawAX
+
+        JkD7tAHHpEnsqfOYcH/dMFDLjaE1ybzrD1W2JmJUitMjL449QrTQS8ABpZvZvNl7
+
+        egjy2PgtxHkGvLZ52xv4gGq0Q+5eXquL8uE/zFEi8cUuCj1Q0owvkfqia1j+ZU5p
+
+        JnCZY4UkEivnwu9pbRXu1nuUlPo+/HQSpO9a7SEpIWo4WbnQPxZ9f5LgCiIl0lMB
+
+        /uKyfBrojiN6UOwbopz3CqwC+C3QKzbnKpV6LfyweT8hBt8nYZCp+vDcQ+iucyxb
+
+        1C7h2wAzePF2VFz/1plVSNOGVwqzf8Qf7wCBfJpAt+z7UQ==
+
+        =EqXV
+
+        -----END PGP MESSAGE-----
+
+        '
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-red-rimmed_applejack-msg.gpg
+      - attachment; filename=3-unlawful_spectrum-reply.gpg
       Content-Length:
-      - '605'
+      - '1085'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:29:01 GMT
+      - Tue, 25 Aug 2020 17:28:52 GMT
       Etag:
-      - sha256:2e1bdbd452ce54d49602552182cb0146b2334c58a7c5aec0c0565645e2ab4286
+      - sha256:8055a4fea7b7e8e4bf0e3ea6d3e4ee5959899e7f4732b0585b5b4ae5b58231e0
       Expires:
-      - Sat, 15 Aug 2020 14:29:01 GMT
+      - Wed, 26 Aug 2020 05:28:52 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:23 GMT
+      - Tue, 25 Aug 2020 17:28:16 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -405,7 +340,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczNDEsImlhdCI6MTU5NzQ1ODU0MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.8b_K7QBEjNjRUMEvi3czgiRVlr0ADxwxPLAJD9XeEg4
+      - Token eyJleHAiOjE1OTg0MDUzMzIsImlhdCI6MTU5ODM3NjUzMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.4Y5dtHnUe_8TSZd_tipmzEJL7hpBdmx_BshNXVGQlsw
       Connection:
       - keep-alive
       Content-Type:
@@ -413,91 +348,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96/download
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAqBkguUOJVhB1E0rEBd3bIvbOJe9umLBp5QVPye5M4nsh0yl0IWnltszf
-        edV/FKB+H0YdtACRB57Zur0vTrOWAA4o1cC9tyUi18aWslfgDvVwJXLjELZYOQiDv//vmcWEG4Mw
-        ckXqK+/zvkgGLST9xjubdcQozWQNW8mXNzqLzLPLYd57oejEzr73iwn2UwQbQjXb31YI5ZsvCB0y
-        sltvyQevn92quua31WmlxjwzTndQ9u9mGQ5zZSxwK39HaZ3oEmPZlWelrnUfbodPJw5wQqGBN++n
-        lwGMVphNGN+EssKtSUb5Hmutd6jTajcfPWPf0yU6AYtJ3v/1wiOyXCaN3tnPStKUzP6w/htB2nFz
-        irbFi2VQ5v1Lg/nAYl0n3cVU4A8O8P8nhIX5KOsxNhYqNyuyjZsJgFAiKtCzEcXxlpyCQiPwpHbo
-        PM7nDr1JtS7w+IY4xlOkwdOmTIjq+WYjfwbOMd8GlwMQmpp2s6n4S7whSIcYI5acs14DERizF7lG
-        vY8XG7/ExbA0zt9B8j0MKTDsAxgkEEMALTPtINMmuc3xaDoTP7HA8e/X6tyPvrVarY8zFuPVxKuY
-        VXdPQuf6in/3uzja0QlWwq+Ibm+I/gBtQPRM1cDpW5n7XdYkzRcTIluElj8U8VnbECvkFNLt8NUk
-        IF792WIIe570TmeeRXfSTAE9fPtTykzrDiTy5LSwqQ91J/Og4d484LO+VkYSPGe37sfcFRSAOSL6
-        KHNlQb9u2IoOgkORHi/6PABz5ty5K45/OvEOhlB4/xbxkbA=
+        hQIMA8PnxMCiIBsqAQ/+PYP0nHBDyO7t31SHbMoS/JaxM9zZq5Y6ZlAxTXAit9tYJQj1LOb7J+QK
+        kWHSSLDHTqGvp22A+uQaNqiJnZ8piznrD3ZWW/tJ2+s8Mx1Jn+TjWNjH8SPBc0mUE4ohmnhUzwYe
+        e6ztSMmiFPsOU1er2HfKRs9h76w+EZ36SZP1gnmtSy0FfDbSUaNXODsLZTuWflwVnj6aI+AxxDaJ
+        k1J+qBF9/S5ST2MW9KJ91IQ5PRtnCT7HqCT4anuaeUgb6krL0uyDEJ2Qye1XOu/6p++dPZBbRa+m
+        C3b/AVYDtgeFDJTtC/dlOWjPVLEmeUq+hSkwcR8td8CZ2pE1xj6u/ZG9NcbAGMyM4URnmEtz4Qrq
+        yu1mWHgQKuab1SqlZN5b6j+3PPZGy4u7jxCq0RsNaayOgXB9uLpY9idW91zqvQolW81QEpmksagS
+        u//cImwcStP0EkMJN9oAjqI2vYvngkVXtnjbfS3RPYfTtfFt21WMlEZb+krmRPE29S4Mi/S7JkaY
+        sdSwdRqIQ/TeT/QpfG14PBBUsG65z7MhyE8qH/qxnokPXm0mdKW1Jf3fmETFsCJORCk7TtT8iX5X
+        A4mOZ5Yhe8TLMMPKheqhd+J1m63jJtXV/jks5j0T5KZyi5Fwj4cO+zEEbyWS17VHKEqHTUbjIUwB
+        EhWrI2xIPGKeh4dc6r3SXQENUMM0bBT2S+4ibmKU4MV5d814J6Ti3FF3Xv1goQ0T58xEeAczpAF6
+        dvNl/5SYXqOcpTtY+WyE3pBjRCe2yfL5xGr2Edoim+8qBf9TA8gpi9FO40xKOO0CW17AYQ==
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-out-of-town_primogeniture-msg.gpg
-      Content-Length:
-      - '605'
-      Content-Type:
-      - application/pgp-encrypted
-      Date:
-      - Sat, 15 Aug 2020 02:29:01 GMT
-      Etag:
-      - sha256:64f0c214fab76a0aa8a1407daf0c0478f7851bd7b5c0aaca5b5c8de53aae9336
-      Expires:
-      - Sat, 15 Aug 2020 14:29:01 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:24:41 GMT
-      Server:
-      - Werkzeug/0.16.0 Python/3.5.2
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Token eyJleHAiOjE1OTc0ODczNDEsImlhdCI6MTU5NzQ1ODU0MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.8b_K7QBEjNjRUMEvi3czgiRVlr0ADxwxPLAJD9XeEg4
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.20.0
-    method: GET
-    uri: http://localhost:8081/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01/download
-  response:
-    body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqAQ//ZJ/7rmmfPSKIICTS8ibETOju7Sl4Y0v26XY+8udWXlP3+d7rHDEFPJ9P
-        6OUTMwkhPOAp6Zo8t/81zTz7p+slNbF9hdGZdi25SS9ts5UQdeaS0MEr8SS+P94gi1KKvoX8AvTz
-        B0MX9e2dq1iHa0yWtXlkBzCu9dTynfqdf3J9T5lofYEpUdHzvBt1rdo45S4k8840rrklV2EIT5oI
-        88s77ZwKoxdEMKr5tjldyuwdaCiNub3pzqleh8EiVlbJXusUk+HvtqF5OAn8syAbGXKs2vndSKt5
-        HNCMiguMmKuMSEGk40BXMiZ5iYp+81/rjltTyLu3V5qRabZKjQtrHSoqUcIjaEfpivUkS2elOeA0
-        nUgf+qN/FABn4CWTA3qGZjJAlCtaF9XXlzFjfaZS3DFlBlprpO1NC3y1L7ISlY8l+8ZI31S6HDl9
-        P5X/ucfBayberL78U/sHPrbZXWlbzMq7JQ+4FYFOTNsZKIa8CDuO6EyxHhxW8FGzEXst/ImNCJ3/
-        p26OUrmAzyZM58bl6BQ8FYeGeABofrKz4U7m3a36T/J/ZCvJ+OezCsn+kftgTkaVn7JaL2vUA1RS
-        JFATZJQdFDBP4KMdyj36JHVjREesfToBFyKb6+K75147U8p6tWmfyj7DsynSUzGs2F/zgZxldGlV
-        Fbo0F++URXEKpuXCz07SXQGf6dsX0CwJdQAfhC8riRcHzxe9KZOc/t47aOQOAvxz79sdnPJwTu3z
-        M4WKXWKzxJl2CpjSnvZM2CpN+fwbyNoXCn0MvSBJk3QnAEo58eAZskVHZ3N0d6FaZIcJJQ==
-    headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=2-inexpressible_sepsis-doc.gz.gpg
+      - attachment; filename=2-unlawful_spectrum-doc.gz.gpg
       Content-Length:
       - '622'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:29:03 GMT
+      - Tue, 25 Aug 2020 17:28:54 GMT
       Etag:
-      - sha256:01eec14f9dc4f7d3f0bd7e510b10125b50b522fddfbed532ee1415dc0836020c
+      - sha256:ca8bb328480e3eb00a9eb245d0b25a3253e03673d61a677cabcb0db621fb8973
       Expires:
-      - Sat, 15 Aug 2020 14:29:03 GMT
+      - Wed, 26 Aug 2020 05:28:54 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:44 GMT
+      - Tue, 25 Aug 2020 17:27:02 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:

--- a/tests/functional/cassettes/test_login_as_journalist.yaml
+++ b/tests/functional/cassettes/test_login_as_journalist.yaml
@@ -17,9 +17,9 @@ interactions:
     uri: http://localhost:8081/api/v1/token
   response:
     body:
-      string: "{\n  \"expiration\": \"2020-08-15T10:30:11.554376Z\", \n  \"journalist_first_name\"\
-        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"b5e001de-19f1-4a93-885b-e0932aa2d441\"\
-        , \n  \"token\": \"eyJleHAiOjE1OTc0ODc0MTEsImlhdCI6MTU5NzQ1ODYxMSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Y7sAJxeXOfAdSlTrC1wnhL0z2uw8Yi3HQvhLvk34iGI\"\
+      string: "{\n  \"expiration\": \"2020-08-26T01:28:18.284367Z\", \n  \"journalist_first_name\"\
+        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n  \"token\": \"eyJleHAiOjE1OTg0MDUyOTgsImlhdCI6MTU5ODM3NjQ5OCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.YS2zdWxUb1ZOypyR4YRSdsofsToYuYQWSzSvuP-V1vk\"\
         \n}\n"
     headers:
       Content-Length:
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:11 GMT
+      - Tue, 25 Aug 2020 17:28:18 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -41,7 +41,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MTEsImlhdCI6MTU5NzQ1ODYxMSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Y7sAJxeXOfAdSlTrC1wnhL0z2uw8Yi3HQvhLvk34iGI
+      - Token eyJleHAiOjE1OTg0MDUyOTgsImlhdCI6MTU5ODM3NjQ5OCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.YS2zdWxUb1ZOypyR4YRSdsofsToYuYQWSzSvuP-V1vk
       Connection:
       - keep-alive
       Content-Type:
@@ -52,65 +52,48 @@ interactions:
     uri: http://localhost:8081/api/v1/sources
   response:
     body:
-      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/add_star\"\
+      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/add_star\"\
         , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"red-rimmed\
-        \ applejack\", \n      \"key\": {\n        \"fingerprint\": \"D449222A7B7B0AC1E134A1FF01203DD2D2636A37\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAOaUXyLQCaUSR4HTaBVGZp1mi3jn3BExTTe2UCBYjsn1zhkOBDf9\\\
-        ncZNBQGjEBIYlOioC4XY1TkQep4L2DdmqO5lBfbyNG6LpGiNo7DvNBxeo5WNDa42C\\n8YcfTaVL9aWm07G12uwwc1WFNb0y86PzuAS1ek0k5B7jUfjNxFN9t0dhABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEtCTEEyQTRDUEtETEVURDM2MllWQUZVRVdRQlJLUzJWRjVG\\nUEs2SElBWFBXQUFNSURMUkZHUEdLU0dFSDJJUUtBUVdZUFdFS0xRWVpaTDZMU1JY\\\
-        nRFRUTUdPUlFFWFA0WE1EUlJJM0E9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEAEgPdLSY2o3LmUD/i+JqgIWc2SzA5OTX9Qo0g/r\\\
-        nqxDmi2NQMXob0fEEcP/GGnbiFE1P77AC6JWxSKPQStlfwvffhYmK2q7JBc71Jj8O\\nRqFRT5WSRpXUCq8tZkIYyoCXKQPlwSb3S1NQ3yM00kbkCM4dArLIFuQ/ZI1xG+l9\\\
-        nIqxWwXYY8SpO8uKDXFd7\\n=FjUe\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:23.753433Z\"\
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"pleasant rearguard\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"FF9007318CCAB4DC6149B1B38B7907A15818269D\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAM8jaDDbt3lQQVUEk+MduWYmJHa3eME1Y9C4yj+6n9V9Sksakj3B\\\
+        nWcl9uKzXLtZIP1rdvkW+Bg/P64vTgi+I+pcL5+e5gpF/KdNhrksovmhzc/ASgrn7\\nEcNCwIk+Iyym255IOEsZ8j9SvpzG1VyUdJxlK+P6bmbkFgDDwHjF0QzDABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPEtHQUFQVlNISjJLS0lMV0daTUlBWUFHMlhXU0ZWRlJRQ1pJ\\nNE5QTVBVUEVKNDNIQ1hJVUdPUk9XUEhLUldXRkxRTk5LTko3WEk1Tk9JUkpFTERQ\\\
+        nU0pZN0JMTk9ETk0yTUxNSjRPMkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEIt5B6FYGCadjpUD/1IiTV3TAyduG0UkaxcTT+Bp\\\
+        nKZRsNsK+HhYBCu/VjBcybLkuccDaonnm99OyaWZAZ/F/E/DxRENTxs0OL47GbHG7\\n9hSFWj99MZACMs3aKAmqxZEnQmm0B0xDIlHyd9mQBSieUw6aVMVjxK8p0Z21R7cz\\\
+        nc+DfEuCbShQ6b5+9X308\\n=RU3O\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:26:48.423985Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"uuid\": \"70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"potential\
-        \ freshness\", \n      \"key\": {\n        \"fingerprint\": \"06FFA85715E89C0AFBA927A78EA34965AC896EEA\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAMHR1pM94xuFw+GiTQI7RyUN/sKYmupDhwWj1nVricMXRbM7nIXk\\\
-        nsBnqTx0pTkITPxjszoVyFFxG+Uw8TXMZEZdCOhcC2AieHV0mgWsXxLAbD9Sw3VmQ\\ngOQ3S2C/MBrimrK4bkpoKXxKIV5v5Rgku5Pjxzw50HH4e1pYhgW2C+knABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEg3TVJTVUZHWFVKRldQQlM0UjdISk1JNE5HTUREQ0FaRzJL\\nVlIyTTM3RkFTQk9BRjIyUkFYNzdMUVdZNFZJNTJLSlBOQldaRjUyQTdHWFJVN1lQ\\\
-        nN0dQQU5QSFNNUUkzSUFVN1VGNEk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEI6jSWWsiW7qZeYD/ReRVU5y0nssc0+OlRy6M/im\\\
-        nHY9oHex0tSGt1fTuDVqsAKKHMDrZLKkkhJg42wcINwbXTj/vRu7n199IwbSUoDiE\\nJlnO6ZaIG996AUFS64eZBA+kXczqJbsWgdQQpwQJn8LiQUF8iwFhTThltjRSuXqf\\\
-        nMxyFevvxbIvYcs6il7Ip\\n=cZe8\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:36.194245Z\"\
+        \      \"remove_star_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"uuid\": \"505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\n    }, \n  \
+        \  {\n      \"add_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/add_star\"\
+        , \n      \"interaction_count\": 3, \n      \"is_flagged\": false, \n    \
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"unlawful spectrum\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"CE2A06285C9B1FDB43BFEB853EC2D036DDCA8CD4\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANJ0h2W7p0bViTLpY9w/PDd8sBHR56OVg+EGdXZ51Wuqt8ZUkF8W\\\
+        njSLrjsiOrcQ1lRFEgERFfIBJvlxfB/EMP4wcTY7vg7WQN/rvSJynBW0T6iHI3Rhi\\n/3v35LEuX9tLU/B1e11mRevgHTLRUms38Y5DBSkWACngvH4jWP+kwylJABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPDUyNzdCNDVDNExFUFdJWU9NQlY0VE5FVEI1WjdaVFpERTZK\\nQTJSTlhVNE5HM0g3R0NRVEJYRUdVWkdSRkpSRVZGN01BTzZDUUpWWVpBN0NOSEw3\\\
+        nS0JKVzMyS01XNEJaSVROU0dBVkk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJED7C0DbdyozULzEEALbYIlKPW3wXMi/9V2c/fYJc\\\
+        naX9UE94JwAdfntqAkEF8dL/P6fD5J1BPqQILK4crX6LN6h8g2y1vnrTTg9odsa1L\\nD0JqSpGfIWscGRuzY6b2WngLCgsudMqJgPZUdm/wbxp3Q8Daa8U99mL9jXr9Ia9j\\\
+        n8BFeiB6fb0VoIDgM7UTv\\n=j+JQ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:27:03.031475Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"uuid\": \"6db98582-dd69-48ea-879e-5afc5aa388d6\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"inexpressible\
-        \ sepsis\", \n      \"key\": {\n        \"fingerprint\": \"380C70D1C7930985411415B31A1B751385404CC5\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANhgLtWR4jFlhHEPGJjcupkGrNymWv9wFlFM8YppKs6nNXaQdoKf\\\
-        n7+NESFVdkm89/7FWD/It0B49jEBjjs7GOmxhffomt1NVHocYGDBQjMAlKOYQgCnR\\neZDnHCFORSrQcfiNhgKm1/eFOZlNJDZn2Cwpmdk8ZV6B78fGVz+3B+tFABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEo0VFRaVzY2QlBRTFRRVVlNS0hIVzZZTjRGVkJIVFlVQ0ZW\\nNVNWNjNRWlQyT0Y3Wjc2NUxEWk1TVDJNR1JBVFpYSVZJVzVBR1M0N0RFU0hTRUhY\\\
-        nWDZFQVlISkFWTFBZRzc1VFlKQkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBobdROFQEzFd3gD/RUhGdZUriO3QqYTqvH7EZdZ\\\
-        n4r3iFUJVP3xhru9HYBtksepsKzUHYZn4nK29689AdV1A9o/X4YcKWrxFRbMuZs0E\\nTj2Je4jrw3WNf3O3COAWwFa75HOXIhGfFVuJ4Ni2/NVJGDPA6NNIfZfFMIj/NZF3\\\
-        n3RBZhDmxS21yJs9daQfs\\n=NQQJ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:44.877597Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"uuid\": \"f3a61359-1919-4bf0-b6f7-da902a935160\"\n    }\n  ]\n\
+        \      \"remove_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"f9b4da97-a077-412e-8e54-4ef4984a8540\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '4817'
+      - '3214'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:11 GMT
+      - Tue, 25 Aug 2020 17:28:18 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -124,7 +107,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MTEsImlhdCI6MTU5NzQ1ODYxMSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Y7sAJxeXOfAdSlTrC1wnhL0z2uw8Yi3HQvhLvk34iGI
+      - Token eyJleHAiOjE1OTg0MDUyOTgsImlhdCI6MTU5ODM3NjQ5OCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.YS2zdWxUb1ZOypyR4YRSdsofsToYuYQWSzSvuP-V1vk
       Connection:
       - keep-alive
       Content-Type:
@@ -135,44 +118,34 @@ interactions:
     uri: http://localhost:8081/api/v1/submissions
   response:
     body:
-      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download\"\
-        , \n      \"filename\": \"1-red-rimmed_applejack-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170\"\
-        , \n      \"uuid\": \"ceb44744-68cd-4b29-ada9-4c6ed4127170\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015/download\"\
-        , \n      \"filename\": \"2-red-rimmed_applejack-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015\"\
-        , \n      \"uuid\": \"1deb4f4f-1094-49ec-b0da-5d714b60c015\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download\"\
-        , \n      \"filename\": \"1-potential_freshness-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e\"\
-        , \n      \"uuid\": \"da095cb7-5a81-4b57-912c-14b0501dc00e\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d/download\"\
-        , \n      \"filename\": \"2-potential_freshness-doc.gz.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d\"\
-        , \n      \"uuid\": \"ed460264-f0e9-415f-8247-738eb482c75d\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download\"\
-        , \n      \"filename\": \"1-inexpressible_sepsis-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a\"\
-        , \n      \"uuid\": \"a3bb0937-6240-4200-99d5-b514c465e56a\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01/download\"\
-        , \n      \"filename\": \"2-inexpressible_sepsis-doc.gz.gpg\", \n      \"\
-        is_read\": true, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\
-        , \n      \"uuid\": \"1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\n    }\n  ]\n\
+      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442/download\"\
+        , \n      \"filename\": \"1-pleasant_rearguard-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"submission_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442\"\
+        , \n      \"uuid\": \"bbc25300-917a-4b73-b0f4-10f3d6957442\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/a8699ca4-55a5-4737-b8f1-c9e170ec8250/download\"\
+        , \n      \"filename\": \"2-pleasant_rearguard-doc.gz.gpg\", \n      \"is_read\"\
+        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"submission_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/a8699ca4-55a5-4737-b8f1-c9e170ec8250\"\
+        , \n      \"uuid\": \"a8699ca4-55a5-4737-b8f1-c9e170ec8250\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download\"\
+        , \n      \"filename\": \"1-unlawful_spectrum-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\
+        , \n      \"uuid\": \"d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a/download\"\
+        , \n      \"filename\": \"2-unlawful_spectrum-doc.gz.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a\"\
+        , \n      \"uuid\": \"55e459bd-cf4e-45f9-adce-95d79998254a\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '3082'
+      - '2054'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:11 GMT
+      - Tue, 25 Aug 2020 17:28:18 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -186,7 +159,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MTEsImlhdCI6MTU5NzQ1ODYxMSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Y7sAJxeXOfAdSlTrC1wnhL0z2uw8Yi3HQvhLvk34iGI
+      - Token eyJleHAiOjE1OTg0MDUyOTgsImlhdCI6MTU5ODM3NjQ5OCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.YS2zdWxUb1ZOypyR4YRSdsofsToYuYQWSzSvuP-V1vk
       Connection:
       - keep-alive
       Content-Type:
@@ -197,14 +170,21 @@ interactions:
     uri: http://localhost:8081/api/v1/replies
   response:
     body:
-      string: "{\n  \"replies\": []\n}\n"
+      string: "{\n  \"replies\": [\n    {\n      \"filename\": \"3-unlawful_spectrum-reply.gpg\"\
+        , \n      \"is_deleted_by_source\": false, \n      \"journalist_first_name\"\
+        : \"\", \n      \"journalist_last_name\": \"\", \n      \"journalist_username\"\
+        : \"journalist\", \n      \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n      \"reply_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies/b8bfb5d1-7a5a-4413-9df2-52205fffa5b5\"\
+        , \n      \"size\": 1085, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"b8bfb5d1-7a5a-4413-9df2-52205fffa5b5\"\n    }\n  ]\n\
+        }\n"
     headers:
       Content-Length:
-      - '20'
+      - '578'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:11 GMT
+      - Tue, 25 Aug 2020 17:28:18 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -218,7 +198,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MTEsImlhdCI6MTU5NzQ1ODYxMSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Y7sAJxeXOfAdSlTrC1wnhL0z2uw8Yi3HQvhLvk34iGI
+      - Token eyJleHAiOjE1OTg0MDUyOTgsImlhdCI6MTU5ODM3NjQ5OCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.YS2zdWxUb1ZOypyR4YRSdsofsToYuYQWSzSvuP-V1vk
       Connection:
       - keep-alive
       Content-Type:
@@ -226,38 +206,20 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download
+    uri: http://localhost:8081/api/v1/user
   response:
     body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqAQ//Z/S89kAgGiAOh+UVD2ePgDvU/l/JnvR2DkCEnnqTivaWTKetbcTOxv8D
-        iHQFUvQKPTADA4g5u56foRmzC0Yb2mP36vRMUqLq87hb/XfZFfr3Ak7E169EyaCN6ht5he28mLV0
-        j9brHPGxQWt2vrE4FFdwnUVQWNfAp13rFMm0IDFsHN3o3lNSjywJ62jlr1rce3mdkC+rXkwDh3zs
-        0ZDvxqFGx4X8YPbQiAStvUsK1n3u9NBnKE3cyeHe70xnMdQxq1N4NuACJZkNovKet6C3s8LTvj58
-        XiK6+/AgtbO9Pk6c89s1WW0x3hUGFtWVI+GqSUSQda5CDlWaq6Fq7mBURfuW7yD/rOJ0EypOOJED
-        b1GoyTiK6V1gC/mktb6u/Ei16SmPOjcsAzW7BFn5tsvl3lZULN+b4Bs+E7/Pxl4ymVaPDgbcsAh9
-        Ipp0thhF1a2A3MobRsTtNidryxvfzUTj5ou70vguzn7zthzog2sijyM9hBI0FPr6YRVWXvrS7BEQ
-        Ly9BA1AuzGy0kS1B6MUYdcWAaxQZHWNne02zDHZqe2sBFLM04tJU4myKrXlBOok4YILQ7OWDSoa8
-        Whkyohid0Eympcv+6YMaKI+9yBzHFWgcpu27rlrAuRGRXi9ibBxovyCRg5SSYc1Guo0jalDJWdDy
-        lRdLGsmqJAcWq2PUvNLSTAGpSiJRM+Iwxr77j/lapCOSRGfVJaivW59X5+ZQa6BN57DKWvcgPtCb
-        xDfXOBD4hOG9w/Qv5iKwgOcj/ckygOpvtrcQosdK9ZzrrdY=
+      string: "{\n  \"first_name\": \"\", \n  \"is_admin\": true, \n  \"last_login\"\
+        : \"2020-08-25T17:28:18.284628Z\", \n  \"last_name\": \"\", \n  \"username\"\
+        : \"journalist\", \n  \"uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\n\
+        }\n"
     headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-inexpressible_sepsis-msg.gpg
       Content-Length:
-      - '605'
+      - '192'
       Content-Type:
-      - application/pgp-encrypted
+      - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:11 GMT
-      Etag:
-      - sha256:20db26d5f8240c2efbc83f40184bd03e74f0b927394627fe24bc2954cb4a6c2a
-      Expires:
-      - Sat, 15 Aug 2020 14:30:11 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:25:44 GMT
+      - Tue, 25 Aug 2020 17:28:18 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -271,7 +233,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MTEsImlhdCI6MTU5NzQ1ODYxMSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Y7sAJxeXOfAdSlTrC1wnhL0z2uw8Yi3HQvhLvk34iGI
+      - Token eyJleHAiOjE1OTg0MDUyOTgsImlhdCI6MTU5ODM3NjQ5OCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.YS2zdWxUb1ZOypyR4YRSdsofsToYuYQWSzSvuP-V1vk
       Connection:
       - keep-alive
       Content-Type:
@@ -279,38 +241,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAs+tSZVdjh2H5sgW3rQYsinaTUd1To3XLy/EC0UcNed15/OLbU142ic10
-        6l41iWmBW44aOmjYFIY46VfqPxQSM0G7fl2g5A0SZdmckTqzu141v/+BoTmvbzzZ8sXmpxKjbP/A
-        1F6aBPQ2qX7HcUVyGOadyMRjuKB+IO1pROBeFB5R0hE+FD+y4/yq2y4J9SVeYcdcwcsWJytFUm73
-        emXQ6vcBspvlgSjE1gywgfPFkmOLIKxv9INHFTT/FrfPvJ/yeFZ7jKtG0wxBQYPL4DG5QiVi1Gyz
-        Ln039tgWjFVnM5FhJ+XNhLbLHuISii/0CrKq9TeRea85xFHR6UGKgTm3/fOeWtEhC6FKa0XstXhU
-        T0E9dmh80Rd3myvN0HU3eyNFvmjyZ1weVguXjg4Ao1yWZ8a8AmqlA6m4conr4bbscqQKXCJSF1D+
-        g/i5ng78t0+4wnWMiKtN9rNTJkVBzXpaoYzOn+14EJbkYa+zkCyQS8TbjMBpLaP0aTFO4VXk7OAU
-        ygtKj6P8KmkfqivWrQ047DjqwVot+wBpKT+3t8ASscApC7KaSF0+d/fBvb05ZLzLtfSXM+Ts6pQ8
-        sn60uh2dnW/12nbqAdzFnrEPtDdtz5PFWn8brJpvhhMids/A7dkmbbLK6oirkLSRMF7Wdp8Stz2m
-        aI8Xz6brh2GQeKZafWnSTAHRguSmKDs+h+zUuP/hFFyLlLy2TWX3VLR2rLCEHhm82jP4UcMTpBkU
-        sgsFKxLyPddNYl+9D7kh9NLhzaLsXc2RihQWRvXYM9f3E0Y=
+        hQIMA8PnxMCiIBsqAQ//Rw1NPH3mwdBg9NnblanYiQgqmPuHTY9ha8sR24r6Cbv4UunDrGcjIMeT
+        qUZfK1zok/ZjbbLMo+yVWG2my899P8meyJS9C9MzmPC/x8hpoSUVdxyRorBDja9qNtZUyhOrm5Dz
+        rsiuEaqB1T5iYPinyCzeOcGKxTlrDJE78s5aHQVGQeBjXN+7BqZXsGCWrUueXTF10QrC8u0T/Fnw
+        T+BLvR8FmCIEilEDQESn653nL2wbkTz/7OMxUJJUDkG9xO6VHsTcH4KAzVsonMaan2RVXarJ1393
+        esjkZJ3vMiKXSMNIdsdDQ8WbP/2JGL8rhdg3WZqRbX7ePEJ5C7moUGiJsXmYwNMDarImp/be0O+1
+        YGk1Bfig2smMD280G8vYNykGvLkiGWJU0tGQQBbc5NeM3WZ8chZsyKofidoc9CIY7NLVHGg5u6zf
+        AEe1bjVuWveL5NaUJUpzWxDQzkIBuvX/E9stjEvqb0fZCRkGqPQLOix/YVUjUzj2i1zGAgL/w3xw
+        jhadu4aN05dbf5cBeKRIUS43HnrDXluA0vq0HbX30xuFpoo/noZUiZ8uNfR2UKLQfIK0gNVH1ydw
+        MhHIDKyiUWm/0YQgzcozy14n9OCGtLCucWfxXy7nozJ7JnVJpSYPgAmozMOoqEiz3C0Dnsax/PRV
+        AvwhOEGda6nAIosZZ6nSTAGpDbf6bksYyI2J4JEtY4b7jBvCz6Qmg+n4ZIIH7IEeIBCkhnUtU8xz
+        JHiwor7B/FnoP6RymaVAKyAPqoKGfrJ/XGbwPXJRvQl2PeM=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-potential_freshness-msg.gpg
+      - attachment; filename=1-unlawful_spectrum-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:30:11 GMT
+      - Tue, 25 Aug 2020 17:28:18 GMT
       Etag:
-      - sha256:624b8cc271f0bc4a153ff893f14d4b63464577579c0baa49ca2e6f5b2fb715a8
+      - sha256:dd82012b8656a3f7175b619f2875895a11071daf681b996cdc2704ddf5388664
       Expires:
-      - Sat, 15 Aug 2020 14:30:11 GMT
+      - Wed, 26 Aug 2020 05:28:18 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:35 GMT
+      - Tue, 25 Aug 2020 17:27:02 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -324,7 +286,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MTEsImlhdCI6MTU5NzQ1ODYxMSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Y7sAJxeXOfAdSlTrC1wnhL0z2uw8Yi3HQvhLvk34iGI
+      - Token eyJleHAiOjE1OTg0MDUyOTgsImlhdCI6MTU5ODM3NjQ5OCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.YS2zdWxUb1ZOypyR4YRSdsofsToYuYQWSzSvuP-V1vk
       Connection:
       - keep-alive
       Content-Type:
@@ -332,38 +294,119 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download
+    uri: http://localhost:8081/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAp+9fU8qzd8lBJJJeTGUfrTvtC7bBj77m96ioEWln23lreSXOi7W1E++i
-        X3mCeNg6hLC0PSAtuO0QTw+LE6TGqLJtQh5y14fIxzgIX5G02eaoOlsayjQbVfXHTJ6HBSFx1VkS
-        ImILNuS170DhYiOyW91R3OJ2zg4DeTlPkyegMGScWCued6EcBBL+/EOrvZLDoXtpFAHFkGGcoQSD
-        p/6L5/pp8AuB5N43NRCtslfsD8D4gpZT7L9gkvNIJbMrBQ4FVUzjB/XI5mkOhXAubjKzgGcpqiM+
-        N2k5nqSPFzotGHmKDy77Bq4D3Sk4fcLzvWMe9hY+Prp6QqW5/F3uvFhJdpdOR9JZ4WqY6pWk0VsA
-        jeIuaxGH3rRqFegi59AiZV+EvpORA7tx8qmkVHch5UifaJCsHthaxOrBk1D/rgutgmoQvVaCN+UA
-        6So9D0H/w6RIE0vE3SAsCpXV3XQJWwsya8O5R5jCuETvi1s5NnMXrtxRuBqkFZUcRSNZyzrUWLGA
-        8djkwjYcO5lP7qt40ztUosMmb2y+4z8ad3zhWP71SKA+chx8lUvY7ziiSmFOpRJOr0OEgKMU59lR
-        ovyT6mu5yB1d5d8G9ns8s5H8/ymV5WE/MdG+o472wWPKoKHnIu0zlj1Qqso8l/khM5wIjs8XvICl
-        pm7uojnWqaFcIaJg4EvSTAEw45cGmA90NotlV9qwHi0fJ0qlbFKf6FAyeDaRL0TPoLKx9JbGf+9M
-        +wwWhoyWoWili+hOxuju3sNSeN1iYkv3fEIyKyEy5rXvf/0=
+        hQIMA8PnxMCiIBsqAQ//RtWsdfVE8eGi8sFqp1/cmLdkiut2OkXfs7DdjD0CBr6qfYUG8woosTjZ
+        +bdA5IIg1ewECF+eOZbfgW3EGzq/xN9rKaE+yTEbrR2swkoHNv1tUTrBoRGwUfHOYl3LOWlftNHt
+        8HbCVEZ/TAs1NQolRpSXj9o+mR6wjPvXtArQkW0io6D8ah9YO+YkEEkl4B2CwK1BwUQHj4B1TXw+
+        QGubNNIfGeXM9OkSCQMZapmumEt4m+8KImF1ncNMINXO/WV3tbTKDrCO63R/K6ibSuq//vd72Q2z
+        DFalhfcmnu7ksX0/4TFsrsvfuQoppTqepI6YklIKhTRkoRuY5fQeoK2w93qrZh0dmsVvlhx13/xl
+        19wcO1vASiZzfSHT/XDaXoS+3XmgW/xKr+Y0IJq+PZSs/EZ/2mr6zXePR8HtdFuvCnGiNjPFsRsE
+        sRIB1iq6FEV3zKxLU7FI46MTNrBpTYj3xAn2MqGM0UgCvwC1v73s6mMe6njwvYak8V0J/ny3sd/J
+        NHnbftRaGOmlrQbiXhoRIDEV5Kric9qBJG5R12kxDHHqce/viMEnZ1543+2snmsGrmWvX3Kxsbq4
+        cm1rmE/1dwYYtUaTpj1j4HDr7OY0PUN4F2BXK1gOSOONWiKd8hRAbY4Emwv60g+36ZtwY6kQu4v3
+        pQhKYVCTt8xL1gZkYYfSTAFnY4M6ViJKpbRI6FGnAQsYaB74rBUx6FatdEvztAN5VHarQPHN9uDF
+        TLPp+suitZOgA4wsgUWL+sUze53pOc/MCAUfBwrk2YD7hO8=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-red-rimmed_applejack-msg.gpg
+      - attachment; filename=1-pleasant_rearguard-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:30:11 GMT
+      - Tue, 25 Aug 2020 17:28:18 GMT
       Etag:
-      - sha256:2e1bdbd452ce54d49602552182cb0146b2334c58a7c5aec0c0565645e2ab4286
+      - sha256:cecd2591b0a9a0315f320e9878f68fdaec03c70b286da162c4416fab137ec00e
       Expires:
-      - Sat, 15 Aug 2020 14:30:11 GMT
+      - Wed, 26 Aug 2020 05:28:18 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:23 GMT
+      - Tue, 25 Aug 2020 17:26:47 GMT
+      Server:
+      - Werkzeug/0.16.0 Python/3.5.2
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Token eyJleHAiOjE1OTg0MDUyOTgsImlhdCI6MTU5ODM3NjQ5OCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.YS2zdWxUb1ZOypyR4YRSdsofsToYuYQWSzSvuP-V1vk
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.20.0
+    method: GET
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies/b8bfb5d1-7a5a-4413-9df2-52205fffa5b5/download
+  response:
+    body:
+      string: '-----BEGIN PGP MESSAGE-----
+
+
+        hIwDPsLQNt3KjNQBA/9ojtfC9t1XqWV3wWgAlu95dTxfMqqYczw6sQSmgcEkg9+P
+
+        vCeb05aaW5jMMlYXkUm62SVqdw/KJW1Dg8trcMvRFIeCKNZQhA01Rsqb7jzDLzD/
+
+        kqJ0JGGZk01wDAdRZwWHtA96PY6Qp7mpEJcQTfliBzdWhe03KWfPEJxzZCfT84UC
+
+        DAPD58TAoiAbKgEP/RRt/jqDFFWYxpc4SrqshMubiyh/GImTEOePHfhgQujDvKLu
+
+        kRQovxq1xujHfCuVaBHUgCpm3jWcKCQPrpNT8xLNngu8Uem1degoqstCk+0MVVpC
+
+        +YkmUCajX9X7J98xxuJ/evZMWgWzbk3kD2AuTlYolXqNB6nY50RWQwt1Si/k9p7Y
+
+        RO1ERKa9M99a+lReuF2E2dEYW0Ru3YdTbz/sYuX65Hl/UM6lEhdq9A2EDBElDoiH
+
+        0wkY+YybjFMJlfKnK97nxJ2rwfPQqIiRFEWRbHci+pbtjcPxPjEM37aM/9urM6WR
+
+        CJ3leluB9ZYHzKAFA5VGHH1W1/xPe8STvySggG/cjb4jIxqyu9rV+dkrwK0xjfhN
+
+        15G7B5gvJmXWAp5IDvQD3Pux128hpJYzLUBMURAK1oVf0SCjqWFwQeAIEOE67eJ6
+
+        Nu046qIKcTz6jSH6JrxSneHyDySZaM8DwV9u24voInDGGjEwAbuLfvOGYu6yawAX
+
+        JkD7tAHHpEnsqfOYcH/dMFDLjaE1ybzrD1W2JmJUitMjL449QrTQS8ABpZvZvNl7
+
+        egjy2PgtxHkGvLZ52xv4gGq0Q+5eXquL8uE/zFEi8cUuCj1Q0owvkfqia1j+ZU5p
+
+        JnCZY4UkEivnwu9pbRXu1nuUlPo+/HQSpO9a7SEpIWo4WbnQPxZ9f5LgCiIl0lMB
+
+        /uKyfBrojiN6UOwbopz3CqwC+C3QKzbnKpV6LfyweT8hBt8nYZCp+vDcQ+iucyxb
+
+        1C7h2wAzePF2VFz/1plVSNOGVwqzf8Qf7wCBfJpAt+z7UQ==
+
+        =EqXV
+
+        -----END PGP MESSAGE-----
+
+        '
+    headers:
+      Cache-Control:
+      - max-age=43200, public
+      Content-Disposition:
+      - attachment; filename=3-unlawful_spectrum-reply.gpg
+      Content-Length:
+      - '1085'
+      Content-Type:
+      - application/pgp-encrypted
+      Date:
+      - Tue, 25 Aug 2020 17:28:18 GMT
+      Etag:
+      - sha256:8055a4fea7b7e8e4bf0e3ea6d3e4ee5959899e7f4732b0585b5b4ae5b58231e0
+      Expires:
+      - Wed, 26 Aug 2020 05:28:18 GMT
+      Last-Modified:
+      - Tue, 25 Aug 2020 17:28:16 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:

--- a/tests/functional/cassettes/test_login_from_offline.yaml
+++ b/tests/functional/cassettes/test_login_from_offline.yaml
@@ -17,9 +17,9 @@ interactions:
     uri: http://localhost:8081/api/v1/token
   response:
     body:
-      string: "{\n  \"expiration\": \"2020-08-15T10:30:32.434352Z\", \n  \"journalist_first_name\"\
-        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"b5e001de-19f1-4a93-885b-e0932aa2d441\"\
-        , \n  \"token\": \"eyJleHAiOjE1OTc0ODc0MzIsImlhdCI6MTU5NzQ1ODYzMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.8oeTXKFQyLEf9ork0HpTrbQdOGImJQSTsQULlFdn41Y\"\
+      string: "{\n  \"expiration\": \"2020-08-26T01:28:39.469206Z\", \n  \"journalist_first_name\"\
+        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n  \"token\": \"eyJleHAiOjE1OTg0MDUzMTksImlhdCI6MTU5ODM3NjUxOSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.hWRS4zlZGgFRWuh2sRWWLlkzFW4kQ60GCMyBcaAfbNU\"\
         \n}\n"
     headers:
       Content-Length:
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:32 GMT
+      - Tue, 25 Aug 2020 17:28:39 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -41,7 +41,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MzIsImlhdCI6MTU5NzQ1ODYzMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.8oeTXKFQyLEf9ork0HpTrbQdOGImJQSTsQULlFdn41Y
+      - Token eyJleHAiOjE1OTg0MDUzMTksImlhdCI6MTU5ODM3NjUxOSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.hWRS4zlZGgFRWuh2sRWWLlkzFW4kQ60GCMyBcaAfbNU
       Connection:
       - keep-alive
       Content-Type:
@@ -52,65 +52,31 @@ interactions:
     uri: http://localhost:8081/api/v1/sources
   response:
     body:
-      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"red-rimmed\
-        \ applejack\", \n      \"key\": {\n        \"fingerprint\": \"D449222A7B7B0AC1E134A1FF01203DD2D2636A37\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAOaUXyLQCaUSR4HTaBVGZp1mi3jn3BExTTe2UCBYjsn1zhkOBDf9\\\
-        ncZNBQGjEBIYlOioC4XY1TkQep4L2DdmqO5lBfbyNG6LpGiNo7DvNBxeo5WNDa42C\\n8YcfTaVL9aWm07G12uwwc1WFNb0y86PzuAS1ek0k5B7jUfjNxFN9t0dhABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEtCTEEyQTRDUEtETEVURDM2MllWQUZVRVdRQlJLUzJWRjVG\\nUEs2SElBWFBXQUFNSURMUkZHUEdLU0dFSDJJUUtBUVdZUFdFS0xRWVpaTDZMU1JY\\\
-        nRFRUTUdPUlFFWFA0WE1EUlJJM0E9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEAEgPdLSY2o3LmUD/i+JqgIWc2SzA5OTX9Qo0g/r\\\
-        nqxDmi2NQMXob0fEEcP/GGnbiFE1P77AC6JWxSKPQStlfwvffhYmK2q7JBc71Jj8O\\nRqFRT5WSRpXUCq8tZkIYyoCXKQPlwSb3S1NQ3yM00kbkCM4dArLIFuQ/ZI1xG+l9\\\
-        nIqxWwXYY8SpO8uKDXFd7\\n=FjUe\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:23.753433Z\"\
+      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/add_star\"\
+        , \n      \"interaction_count\": 3, \n      \"is_flagged\": false, \n    \
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"unlawful spectrum\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"CE2A06285C9B1FDB43BFEB853EC2D036DDCA8CD4\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANJ0h2W7p0bViTLpY9w/PDd8sBHR56OVg+EGdXZ51Wuqt8ZUkF8W\\\
+        njSLrjsiOrcQ1lRFEgERFfIBJvlxfB/EMP4wcTY7vg7WQN/rvSJynBW0T6iHI3Rhi\\n/3v35LEuX9tLU/B1e11mRevgHTLRUms38Y5DBSkWACngvH4jWP+kwylJABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPDUyNzdCNDVDNExFUFdJWU9NQlY0VE5FVEI1WjdaVFpERTZK\\nQTJSTlhVNE5HM0g3R0NRVEJYRUdVWkdSRkpSRVZGN01BTzZDUUpWWVpBN0NOSEw3\\\
+        nS0JKVzMyS01XNEJaSVROU0dBVkk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJED7C0DbdyozULzEEALbYIlKPW3wXMi/9V2c/fYJc\\\
+        naX9UE94JwAdfntqAkEF8dL/P6fD5J1BPqQILK4crX6LN6h8g2y1vnrTTg9odsa1L\\nD0JqSpGfIWscGRuzY6b2WngLCgsudMqJgPZUdm/wbxp3Q8Daa8U99mL9jXr9Ia9j\\\
+        n8BFeiB6fb0VoIDgM7UTv\\n=j+JQ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:27:03.031475Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"uuid\": \"70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"potential\
-        \ freshness\", \n      \"key\": {\n        \"fingerprint\": \"06FFA85715E89C0AFBA927A78EA34965AC896EEA\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAMHR1pM94xuFw+GiTQI7RyUN/sKYmupDhwWj1nVricMXRbM7nIXk\\\
-        nsBnqTx0pTkITPxjszoVyFFxG+Uw8TXMZEZdCOhcC2AieHV0mgWsXxLAbD9Sw3VmQ\\ngOQ3S2C/MBrimrK4bkpoKXxKIV5v5Rgku5Pjxzw50HH4e1pYhgW2C+knABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEg3TVJTVUZHWFVKRldQQlM0UjdISk1JNE5HTUREQ0FaRzJL\\nVlIyTTM3RkFTQk9BRjIyUkFYNzdMUVdZNFZJNTJLSlBOQldaRjUyQTdHWFJVN1lQ\\\
-        nN0dQQU5QSFNNUUkzSUFVN1VGNEk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEI6jSWWsiW7qZeYD/ReRVU5y0nssc0+OlRy6M/im\\\
-        nHY9oHex0tSGt1fTuDVqsAKKHMDrZLKkkhJg42wcINwbXTj/vRu7n199IwbSUoDiE\\nJlnO6ZaIG996AUFS64eZBA+kXczqJbsWgdQQpwQJn8LiQUF8iwFhTThltjRSuXqf\\\
-        nMxyFevvxbIvYcs6il7Ip\\n=cZe8\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:36.194245Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"uuid\": \"6db98582-dd69-48ea-879e-5afc5aa388d6\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"inexpressible\
-        \ sepsis\", \n      \"key\": {\n        \"fingerprint\": \"380C70D1C7930985411415B31A1B751385404CC5\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANhgLtWR4jFlhHEPGJjcupkGrNymWv9wFlFM8YppKs6nNXaQdoKf\\\
-        n7+NESFVdkm89/7FWD/It0B49jEBjjs7GOmxhffomt1NVHocYGDBQjMAlKOYQgCnR\\neZDnHCFORSrQcfiNhgKm1/eFOZlNJDZn2Cwpmdk8ZV6B78fGVz+3B+tFABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEo0VFRaVzY2QlBRTFRRVVlNS0hIVzZZTjRGVkJIVFlVQ0ZW\\nNVNWNjNRWlQyT0Y3Wjc2NUxEWk1TVDJNR1JBVFpYSVZJVzVBR1M0N0RFU0hTRUhY\\\
-        nWDZFQVlISkFWTFBZRzc1VFlKQkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBobdROFQEzFd3gD/RUhGdZUriO3QqYTqvH7EZdZ\\\
-        n4r3iFUJVP3xhru9HYBtksepsKzUHYZn4nK29689AdV1A9o/X4YcKWrxFRbMuZs0E\\nTj2Je4jrw3WNf3O3COAWwFa75HOXIhGfFVuJ4Ni2/NVJGDPA6NNIfZfFMIj/NZF3\\\
-        n3RBZhDmxS21yJs9daQfs\\n=NQQJ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:44.877597Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"uuid\": \"f3a61359-1919-4bf0-b6f7-da902a935160\"\n    }\n  ]\n\
+        \      \"remove_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"f9b4da97-a077-412e-8e54-4ef4984a8540\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '4817'
+      - '1617'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:32 GMT
+      - Tue, 25 Aug 2020 17:28:39 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -124,7 +90,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MzIsImlhdCI6MTU5NzQ1ODYzMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.8oeTXKFQyLEf9ork0HpTrbQdOGImJQSTsQULlFdn41Y
+      - Token eyJleHAiOjE1OTg0MDUzMTksImlhdCI6MTU5ODM3NjUxOSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.hWRS4zlZGgFRWuh2sRWWLlkzFW4kQ60GCMyBcaAfbNU
       Connection:
       - keep-alive
       Content-Type:
@@ -135,44 +101,24 @@ interactions:
     uri: http://localhost:8081/api/v1/submissions
   response:
     body:
-      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download\"\
-        , \n      \"filename\": \"1-red-rimmed_applejack-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170\"\
-        , \n      \"uuid\": \"ceb44744-68cd-4b29-ada9-4c6ed4127170\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015/download\"\
-        , \n      \"filename\": \"2-red-rimmed_applejack-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015\"\
-        , \n      \"uuid\": \"1deb4f4f-1094-49ec-b0da-5d714b60c015\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download\"\
-        , \n      \"filename\": \"1-potential_freshness-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e\"\
-        , \n      \"uuid\": \"da095cb7-5a81-4b57-912c-14b0501dc00e\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d/download\"\
-        , \n      \"filename\": \"2-potential_freshness-doc.gz.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d\"\
-        , \n      \"uuid\": \"ed460264-f0e9-415f-8247-738eb482c75d\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download\"\
-        , \n      \"filename\": \"1-inexpressible_sepsis-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a\"\
-        , \n      \"uuid\": \"a3bb0937-6240-4200-99d5-b514c465e56a\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01/download\"\
-        , \n      \"filename\": \"2-inexpressible_sepsis-doc.gz.gpg\", \n      \"\
-        is_read\": true, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\
-        , \n      \"uuid\": \"1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\n    }\n  ]\n\
+      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download\"\
+        , \n      \"filename\": \"1-unlawful_spectrum-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\
+        , \n      \"uuid\": \"d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a/download\"\
+        , \n      \"filename\": \"2-unlawful_spectrum-doc.gz.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a\"\
+        , \n      \"uuid\": \"55e459bd-cf4e-45f9-adce-95d79998254a\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '3082'
+      - '1038'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:32 GMT
+      - Tue, 25 Aug 2020 17:28:39 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -186,7 +132,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MzIsImlhdCI6MTU5NzQ1ODYzMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.8oeTXKFQyLEf9ork0HpTrbQdOGImJQSTsQULlFdn41Y
+      - Token eyJleHAiOjE1OTg0MDUzMTksImlhdCI6MTU5ODM3NjUxOSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.hWRS4zlZGgFRWuh2sRWWLlkzFW4kQ60GCMyBcaAfbNU
       Connection:
       - keep-alive
       Content-Type:
@@ -197,14 +143,21 @@ interactions:
     uri: http://localhost:8081/api/v1/replies
   response:
     body:
-      string: "{\n  \"replies\": []\n}\n"
+      string: "{\n  \"replies\": [\n    {\n      \"filename\": \"3-unlawful_spectrum-reply.gpg\"\
+        , \n      \"is_deleted_by_source\": false, \n      \"journalist_first_name\"\
+        : \"\", \n      \"journalist_last_name\": \"\", \n      \"journalist_username\"\
+        : \"journalist\", \n      \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n      \"reply_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies/b8bfb5d1-7a5a-4413-9df2-52205fffa5b5\"\
+        , \n      \"size\": 1085, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"b8bfb5d1-7a5a-4413-9df2-52205fffa5b5\"\n    }\n  ]\n\
+        }\n"
     headers:
       Content-Length:
-      - '20'
+      - '578'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:32 GMT
+      - Tue, 25 Aug 2020 17:28:39 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -218,7 +171,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MzIsImlhdCI6MTU5NzQ1ODYzMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.8oeTXKFQyLEf9ork0HpTrbQdOGImJQSTsQULlFdn41Y
+      - Token eyJleHAiOjE1OTg0MDUzMTksImlhdCI6MTU5ODM3NjUxOSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.hWRS4zlZGgFRWuh2sRWWLlkzFW4kQ60GCMyBcaAfbNU
       Connection:
       - keep-alive
       Content-Type:
@@ -226,38 +179,20 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download
+    uri: http://localhost:8081/api/v1/user
   response:
     body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqAQ//Z/S89kAgGiAOh+UVD2ePgDvU/l/JnvR2DkCEnnqTivaWTKetbcTOxv8D
-        iHQFUvQKPTADA4g5u56foRmzC0Yb2mP36vRMUqLq87hb/XfZFfr3Ak7E169EyaCN6ht5he28mLV0
-        j9brHPGxQWt2vrE4FFdwnUVQWNfAp13rFMm0IDFsHN3o3lNSjywJ62jlr1rce3mdkC+rXkwDh3zs
-        0ZDvxqFGx4X8YPbQiAStvUsK1n3u9NBnKE3cyeHe70xnMdQxq1N4NuACJZkNovKet6C3s8LTvj58
-        XiK6+/AgtbO9Pk6c89s1WW0x3hUGFtWVI+GqSUSQda5CDlWaq6Fq7mBURfuW7yD/rOJ0EypOOJED
-        b1GoyTiK6V1gC/mktb6u/Ei16SmPOjcsAzW7BFn5tsvl3lZULN+b4Bs+E7/Pxl4ymVaPDgbcsAh9
-        Ipp0thhF1a2A3MobRsTtNidryxvfzUTj5ou70vguzn7zthzog2sijyM9hBI0FPr6YRVWXvrS7BEQ
-        Ly9BA1AuzGy0kS1B6MUYdcWAaxQZHWNne02zDHZqe2sBFLM04tJU4myKrXlBOok4YILQ7OWDSoa8
-        Whkyohid0Eympcv+6YMaKI+9yBzHFWgcpu27rlrAuRGRXi9ibBxovyCRg5SSYc1Guo0jalDJWdDy
-        lRdLGsmqJAcWq2PUvNLSTAGpSiJRM+Iwxr77j/lapCOSRGfVJaivW59X5+ZQa6BN57DKWvcgPtCb
-        xDfXOBD4hOG9w/Qv5iKwgOcj/ckygOpvtrcQosdK9ZzrrdY=
+      string: "{\n  \"first_name\": \"\", \n  \"is_admin\": true, \n  \"last_login\"\
+        : \"2020-08-25T17:28:39.469600Z\", \n  \"last_name\": \"\", \n  \"username\"\
+        : \"journalist\", \n  \"uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\n\
+        }\n"
     headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-inexpressible_sepsis-msg.gpg
       Content-Length:
-      - '605'
+      - '192'
       Content-Type:
-      - application/pgp-encrypted
+      - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:32 GMT
-      Etag:
-      - sha256:20db26d5f8240c2efbc83f40184bd03e74f0b927394627fe24bc2954cb4a6c2a
-      Expires:
-      - Sat, 15 Aug 2020 14:30:32 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:25:44 GMT
+      - Tue, 25 Aug 2020 17:28:39 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -271,7 +206,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MzIsImlhdCI6MTU5NzQ1ODYzMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.8oeTXKFQyLEf9ork0HpTrbQdOGImJQSTsQULlFdn41Y
+      - Token eyJleHAiOjE1OTg0MDUzMTksImlhdCI6MTU5ODM3NjUxOSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.hWRS4zlZGgFRWuh2sRWWLlkzFW4kQ60GCMyBcaAfbNU
       Connection:
       - keep-alive
       Content-Type:
@@ -279,38 +214,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAs+tSZVdjh2H5sgW3rQYsinaTUd1To3XLy/EC0UcNed15/OLbU142ic10
-        6l41iWmBW44aOmjYFIY46VfqPxQSM0G7fl2g5A0SZdmckTqzu141v/+BoTmvbzzZ8sXmpxKjbP/A
-        1F6aBPQ2qX7HcUVyGOadyMRjuKB+IO1pROBeFB5R0hE+FD+y4/yq2y4J9SVeYcdcwcsWJytFUm73
-        emXQ6vcBspvlgSjE1gywgfPFkmOLIKxv9INHFTT/FrfPvJ/yeFZ7jKtG0wxBQYPL4DG5QiVi1Gyz
-        Ln039tgWjFVnM5FhJ+XNhLbLHuISii/0CrKq9TeRea85xFHR6UGKgTm3/fOeWtEhC6FKa0XstXhU
-        T0E9dmh80Rd3myvN0HU3eyNFvmjyZ1weVguXjg4Ao1yWZ8a8AmqlA6m4conr4bbscqQKXCJSF1D+
-        g/i5ng78t0+4wnWMiKtN9rNTJkVBzXpaoYzOn+14EJbkYa+zkCyQS8TbjMBpLaP0aTFO4VXk7OAU
-        ygtKj6P8KmkfqivWrQ047DjqwVot+wBpKT+3t8ASscApC7KaSF0+d/fBvb05ZLzLtfSXM+Ts6pQ8
-        sn60uh2dnW/12nbqAdzFnrEPtDdtz5PFWn8brJpvhhMids/A7dkmbbLK6oirkLSRMF7Wdp8Stz2m
-        aI8Xz6brh2GQeKZafWnSTAHRguSmKDs+h+zUuP/hFFyLlLy2TWX3VLR2rLCEHhm82jP4UcMTpBkU
-        sgsFKxLyPddNYl+9D7kh9NLhzaLsXc2RihQWRvXYM9f3E0Y=
+        hQIMA8PnxMCiIBsqAQ//Rw1NPH3mwdBg9NnblanYiQgqmPuHTY9ha8sR24r6Cbv4UunDrGcjIMeT
+        qUZfK1zok/ZjbbLMo+yVWG2my899P8meyJS9C9MzmPC/x8hpoSUVdxyRorBDja9qNtZUyhOrm5Dz
+        rsiuEaqB1T5iYPinyCzeOcGKxTlrDJE78s5aHQVGQeBjXN+7BqZXsGCWrUueXTF10QrC8u0T/Fnw
+        T+BLvR8FmCIEilEDQESn653nL2wbkTz/7OMxUJJUDkG9xO6VHsTcH4KAzVsonMaan2RVXarJ1393
+        esjkZJ3vMiKXSMNIdsdDQ8WbP/2JGL8rhdg3WZqRbX7ePEJ5C7moUGiJsXmYwNMDarImp/be0O+1
+        YGk1Bfig2smMD280G8vYNykGvLkiGWJU0tGQQBbc5NeM3WZ8chZsyKofidoc9CIY7NLVHGg5u6zf
+        AEe1bjVuWveL5NaUJUpzWxDQzkIBuvX/E9stjEvqb0fZCRkGqPQLOix/YVUjUzj2i1zGAgL/w3xw
+        jhadu4aN05dbf5cBeKRIUS43HnrDXluA0vq0HbX30xuFpoo/noZUiZ8uNfR2UKLQfIK0gNVH1ydw
+        MhHIDKyiUWm/0YQgzcozy14n9OCGtLCucWfxXy7nozJ7JnVJpSYPgAmozMOoqEiz3C0Dnsax/PRV
+        AvwhOEGda6nAIosZZ6nSTAGpDbf6bksYyI2J4JEtY4b7jBvCz6Qmg+n4ZIIH7IEeIBCkhnUtU8xz
+        JHiwor7B/FnoP6RymaVAKyAPqoKGfrJ/XGbwPXJRvQl2PeM=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-potential_freshness-msg.gpg
+      - attachment; filename=1-unlawful_spectrum-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:30:32 GMT
+      - Tue, 25 Aug 2020 17:28:39 GMT
       Etag:
-      - sha256:624b8cc271f0bc4a153ff893f14d4b63464577579c0baa49ca2e6f5b2fb715a8
+      - sha256:dd82012b8656a3f7175b619f2875895a11071daf681b996cdc2704ddf5388664
       Expires:
-      - Sat, 15 Aug 2020 14:30:32 GMT
+      - Wed, 26 Aug 2020 05:28:39 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:35 GMT
+      - Tue, 25 Aug 2020 17:27:02 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -324,7 +259,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MzIsImlhdCI6MTU5NzQ1ODYzMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.8oeTXKFQyLEf9ork0HpTrbQdOGImJQSTsQULlFdn41Y
+      - Token eyJleHAiOjE1OTg0MDUzMTksImlhdCI6MTU5ODM3NjUxOSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.hWRS4zlZGgFRWuh2sRWWLlkzFW4kQ60GCMyBcaAfbNU
       Connection:
       - keep-alive
       Content-Type:
@@ -332,38 +267,66 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies/b8bfb5d1-7a5a-4413-9df2-52205fffa5b5/download
   response:
     body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqARAAp+9fU8qzd8lBJJJeTGUfrTvtC7bBj77m96ioEWln23lreSXOi7W1E++i
-        X3mCeNg6hLC0PSAtuO0QTw+LE6TGqLJtQh5y14fIxzgIX5G02eaoOlsayjQbVfXHTJ6HBSFx1VkS
-        ImILNuS170DhYiOyW91R3OJ2zg4DeTlPkyegMGScWCued6EcBBL+/EOrvZLDoXtpFAHFkGGcoQSD
-        p/6L5/pp8AuB5N43NRCtslfsD8D4gpZT7L9gkvNIJbMrBQ4FVUzjB/XI5mkOhXAubjKzgGcpqiM+
-        N2k5nqSPFzotGHmKDy77Bq4D3Sk4fcLzvWMe9hY+Prp6QqW5/F3uvFhJdpdOR9JZ4WqY6pWk0VsA
-        jeIuaxGH3rRqFegi59AiZV+EvpORA7tx8qmkVHch5UifaJCsHthaxOrBk1D/rgutgmoQvVaCN+UA
-        6So9D0H/w6RIE0vE3SAsCpXV3XQJWwsya8O5R5jCuETvi1s5NnMXrtxRuBqkFZUcRSNZyzrUWLGA
-        8djkwjYcO5lP7qt40ztUosMmb2y+4z8ad3zhWP71SKA+chx8lUvY7ziiSmFOpRJOr0OEgKMU59lR
-        ovyT6mu5yB1d5d8G9ns8s5H8/ymV5WE/MdG+o472wWPKoKHnIu0zlj1Qqso8l/khM5wIjs8XvICl
-        pm7uojnWqaFcIaJg4EvSTAEw45cGmA90NotlV9qwHi0fJ0qlbFKf6FAyeDaRL0TPoLKx9JbGf+9M
-        +wwWhoyWoWili+hOxuju3sNSeN1iYkv3fEIyKyEy5rXvf/0=
+      string: '-----BEGIN PGP MESSAGE-----
+
+
+        hIwDPsLQNt3KjNQBA/9ojtfC9t1XqWV3wWgAlu95dTxfMqqYczw6sQSmgcEkg9+P
+
+        vCeb05aaW5jMMlYXkUm62SVqdw/KJW1Dg8trcMvRFIeCKNZQhA01Rsqb7jzDLzD/
+
+        kqJ0JGGZk01wDAdRZwWHtA96PY6Qp7mpEJcQTfliBzdWhe03KWfPEJxzZCfT84UC
+
+        DAPD58TAoiAbKgEP/RRt/jqDFFWYxpc4SrqshMubiyh/GImTEOePHfhgQujDvKLu
+
+        kRQovxq1xujHfCuVaBHUgCpm3jWcKCQPrpNT8xLNngu8Uem1degoqstCk+0MVVpC
+
+        +YkmUCajX9X7J98xxuJ/evZMWgWzbk3kD2AuTlYolXqNB6nY50RWQwt1Si/k9p7Y
+
+        RO1ERKa9M99a+lReuF2E2dEYW0Ru3YdTbz/sYuX65Hl/UM6lEhdq9A2EDBElDoiH
+
+        0wkY+YybjFMJlfKnK97nxJ2rwfPQqIiRFEWRbHci+pbtjcPxPjEM37aM/9urM6WR
+
+        CJ3leluB9ZYHzKAFA5VGHH1W1/xPe8STvySggG/cjb4jIxqyu9rV+dkrwK0xjfhN
+
+        15G7B5gvJmXWAp5IDvQD3Pux128hpJYzLUBMURAK1oVf0SCjqWFwQeAIEOE67eJ6
+
+        Nu046qIKcTz6jSH6JrxSneHyDySZaM8DwV9u24voInDGGjEwAbuLfvOGYu6yawAX
+
+        JkD7tAHHpEnsqfOYcH/dMFDLjaE1ybzrD1W2JmJUitMjL449QrTQS8ABpZvZvNl7
+
+        egjy2PgtxHkGvLZ52xv4gGq0Q+5eXquL8uE/zFEi8cUuCj1Q0owvkfqia1j+ZU5p
+
+        JnCZY4UkEivnwu9pbRXu1nuUlPo+/HQSpO9a7SEpIWo4WbnQPxZ9f5LgCiIl0lMB
+
+        /uKyfBrojiN6UOwbopz3CqwC+C3QKzbnKpV6LfyweT8hBt8nYZCp+vDcQ+iucyxb
+
+        1C7h2wAzePF2VFz/1plVSNOGVwqzf8Qf7wCBfJpAt+z7UQ==
+
+        =EqXV
+
+        -----END PGP MESSAGE-----
+
+        '
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-red-rimmed_applejack-msg.gpg
+      - attachment; filename=3-unlawful_spectrum-reply.gpg
       Content-Length:
-      - '605'
+      - '1085'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:30:32 GMT
+      - Tue, 25 Aug 2020 17:28:39 GMT
       Etag:
-      - sha256:2e1bdbd452ce54d49602552182cb0146b2334c58a7c5aec0c0565645e2ab4286
+      - sha256:8055a4fea7b7e8e4bf0e3ea6d3e4ee5959899e7f4732b0585b5b4ae5b58231e0
       Expires:
-      - Sat, 15 Aug 2020 14:30:32 GMT
+      - Wed, 26 Aug 2020 05:28:39 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:23 GMT
+      - Tue, 25 Aug 2020 17:28:16 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -377,7 +340,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MzIsImlhdCI6MTU5NzQ1ODYzMiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.8oeTXKFQyLEf9ork0HpTrbQdOGImJQSTsQULlFdn41Y
+      - Token eyJleHAiOjE1OTg0MDUzMTksImlhdCI6MTU5ODM3NjUxOSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.hWRS4zlZGgFRWuh2sRWWLlkzFW4kQ60GCMyBcaAfbNU
       Connection:
       - keep-alive
       Content-Length:
@@ -397,7 +360,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:43 GMT
+      - Tue, 25 Aug 2020 17:28:50 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -421,9 +384,9 @@ interactions:
     uri: http://localhost:8081/api/v1/token
   response:
     body:
-      string: "{\n  \"expiration\": \"2020-08-15T10:30:43.447888Z\", \n  \"journalist_first_name\"\
-        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"b5e001de-19f1-4a93-885b-e0932aa2d441\"\
-        , \n  \"token\": \"eyJleHAiOjE1OTc0ODc0NDMsImlhdCI6MTU5NzQ1ODY0MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.gdau1Z15fLgO52iarPnif77_Ln5wdo2dXP9AxhCzN3o\"\
+      string: "{\n  \"expiration\": \"2020-08-26T01:28:50.430358Z\", \n  \"journalist_first_name\"\
+        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n  \"token\": \"eyJleHAiOjE1OTg0MDUzMzAsImlhdCI6MTU5ODM3NjUzMCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.VHnrSeXIDfd2ls49-hLBv-DiSnSiaq-HMiWx7Gnr0bU\"\
         \n}\n"
     headers:
       Content-Length:
@@ -431,7 +394,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:43 GMT
+      - Tue, 25 Aug 2020 17:28:50 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:

--- a/tests/functional/cassettes/test_logout_as_journalist.yaml
+++ b/tests/functional/cassettes/test_logout_as_journalist.yaml
@@ -17,9 +17,9 @@ interactions:
     uri: http://localhost:8081/api/v1/token
   response:
     body:
-      string: "{\n  \"expiration\": \"2020-08-15T10:30:25.429788Z\", \n  \"journalist_first_name\"\
-        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"b5e001de-19f1-4a93-885b-e0932aa2d441\"\
-        , \n  \"token\": \"eyJleHAiOjE1OTc0ODc0MjUsImlhdCI6MTU5NzQ1ODYyNSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.tABXDsCX14KTnL4ItmJZ2AsI2vEx6SoUWC7V3k6FSJw\"\
+      string: "{\n  \"expiration\": \"2020-08-26T01:27:40.383842Z\", \n  \"journalist_first_name\"\
+        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n  \"token\": \"eyJleHAiOjE1OTg0MDUyNjAsImlhdCI6MTU5ODM3NjQ2MCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.6cB39kCdPXxFpsaA1JUM0HQTxfviyJ8vJYT31iG7Ln0\"\
         \n}\n"
     headers:
       Content-Length:
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:25 GMT
+      - Tue, 25 Aug 2020 17:27:40 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -41,7 +41,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MjUsImlhdCI6MTU5NzQ1ODYyNSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.tABXDsCX14KTnL4ItmJZ2AsI2vEx6SoUWC7V3k6FSJw
+      - Token eyJleHAiOjE1OTg0MDUyNjAsImlhdCI6MTU5ODM3NjQ2MCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.6cB39kCdPXxFpsaA1JUM0HQTxfviyJ8vJYT31iG7Ln0
       Connection:
       - keep-alive
       Content-Type:
@@ -52,65 +52,48 @@ interactions:
     uri: http://localhost:8081/api/v1/sources
   response:
     body:
-      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/add_star\"\
+      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/add_star\"\
         , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"red-rimmed\
-        \ applejack\", \n      \"key\": {\n        \"fingerprint\": \"D449222A7B7B0AC1E134A1FF01203DD2D2636A37\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAOaUXyLQCaUSR4HTaBVGZp1mi3jn3BExTTe2UCBYjsn1zhkOBDf9\\\
-        ncZNBQGjEBIYlOioC4XY1TkQep4L2DdmqO5lBfbyNG6LpGiNo7DvNBxeo5WNDa42C\\n8YcfTaVL9aWm07G12uwwc1WFNb0y86PzuAS1ek0k5B7jUfjNxFN9t0dhABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEtCTEEyQTRDUEtETEVURDM2MllWQUZVRVdRQlJLUzJWRjVG\\nUEs2SElBWFBXQUFNSURMUkZHUEdLU0dFSDJJUUtBUVdZUFdFS0xRWVpaTDZMU1JY\\\
-        nRFRUTUdPUlFFWFA0WE1EUlJJM0E9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEAEgPdLSY2o3LmUD/i+JqgIWc2SzA5OTX9Qo0g/r\\\
-        nqxDmi2NQMXob0fEEcP/GGnbiFE1P77AC6JWxSKPQStlfwvffhYmK2q7JBc71Jj8O\\nRqFRT5WSRpXUCq8tZkIYyoCXKQPlwSb3S1NQ3yM00kbkCM4dArLIFuQ/ZI1xG+l9\\\
-        nIqxWwXYY8SpO8uKDXFd7\\n=FjUe\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:23.753433Z\"\
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"pleasant rearguard\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"FF9007318CCAB4DC6149B1B38B7907A15818269D\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAM8jaDDbt3lQQVUEk+MduWYmJHa3eME1Y9C4yj+6n9V9Sksakj3B\\\
+        nWcl9uKzXLtZIP1rdvkW+Bg/P64vTgi+I+pcL5+e5gpF/KdNhrksovmhzc/ASgrn7\\nEcNCwIk+Iyym255IOEsZ8j9SvpzG1VyUdJxlK+P6bmbkFgDDwHjF0QzDABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPEtHQUFQVlNISjJLS0lMV0daTUlBWUFHMlhXU0ZWRlJRQ1pJ\\nNE5QTVBVUEVKNDNIQ1hJVUdPUk9XUEhLUldXRkxRTk5LTko3WEk1Tk9JUkpFTERQ\\\
+        nU0pZN0JMTk9ETk0yTUxNSjRPMkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEIt5B6FYGCadjpUD/1IiTV3TAyduG0UkaxcTT+Bp\\\
+        nKZRsNsK+HhYBCu/VjBcybLkuccDaonnm99OyaWZAZ/F/E/DxRENTxs0OL47GbHG7\\n9hSFWj99MZACMs3aKAmqxZEnQmm0B0xDIlHyd9mQBSieUw6aVMVjxK8p0Z21R7cz\\\
+        nc+DfEuCbShQ6b5+9X308\\n=RU3O\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:26:48.423985Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"uuid\": \"70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/add_star\"\
+        \      \"remove_star_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"uuid\": \"505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\n    }, \n  \
+        \  {\n      \"add_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/add_star\"\
         , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"potential\
-        \ freshness\", \n      \"key\": {\n        \"fingerprint\": \"06FFA85715E89C0AFBA927A78EA34965AC896EEA\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAMHR1pM94xuFw+GiTQI7RyUN/sKYmupDhwWj1nVricMXRbM7nIXk\\\
-        nsBnqTx0pTkITPxjszoVyFFxG+Uw8TXMZEZdCOhcC2AieHV0mgWsXxLAbD9Sw3VmQ\\ngOQ3S2C/MBrimrK4bkpoKXxKIV5v5Rgku5Pjxzw50HH4e1pYhgW2C+knABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEg3TVJTVUZHWFVKRldQQlM0UjdISk1JNE5HTUREQ0FaRzJL\\nVlIyTTM3RkFTQk9BRjIyUkFYNzdMUVdZNFZJNTJLSlBOQldaRjUyQTdHWFJVN1lQ\\\
-        nN0dQQU5QSFNNUUkzSUFVN1VGNEk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEI6jSWWsiW7qZeYD/ReRVU5y0nssc0+OlRy6M/im\\\
-        nHY9oHex0tSGt1fTuDVqsAKKHMDrZLKkkhJg42wcINwbXTj/vRu7n199IwbSUoDiE\\nJlnO6ZaIG996AUFS64eZBA+kXczqJbsWgdQQpwQJn8LiQUF8iwFhTThltjRSuXqf\\\
-        nMxyFevvxbIvYcs6il7Ip\\n=cZe8\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:36.194245Z\"\
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"unlawful spectrum\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"CE2A06285C9B1FDB43BFEB853EC2D036DDCA8CD4\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANJ0h2W7p0bViTLpY9w/PDd8sBHR56OVg+EGdXZ51Wuqt8ZUkF8W\\\
+        njSLrjsiOrcQ1lRFEgERFfIBJvlxfB/EMP4wcTY7vg7WQN/rvSJynBW0T6iHI3Rhi\\n/3v35LEuX9tLU/B1e11mRevgHTLRUms38Y5DBSkWACngvH4jWP+kwylJABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPDUyNzdCNDVDNExFUFdJWU9NQlY0VE5FVEI1WjdaVFpERTZK\\nQTJSTlhVNE5HM0g3R0NRVEJYRUdVWkdSRkpSRVZGN01BTzZDUUpWWVpBN0NOSEw3\\\
+        nS0JKVzMyS01XNEJaSVROU0dBVkk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJED7C0DbdyozULzEEALbYIlKPW3wXMi/9V2c/fYJc\\\
+        naX9UE94JwAdfntqAkEF8dL/P6fD5J1BPqQILK4crX6LN6h8g2y1vnrTTg9odsa1L\\nD0JqSpGfIWscGRuzY6b2WngLCgsudMqJgPZUdm/wbxp3Q8Daa8U99mL9jXr9Ia9j\\\
+        n8BFeiB6fb0VoIDgM7UTv\\n=j+JQ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:27:03.031475Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"uuid\": \"6db98582-dd69-48ea-879e-5afc5aa388d6\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"inexpressible\
-        \ sepsis\", \n      \"key\": {\n        \"fingerprint\": \"380C70D1C7930985411415B31A1B751385404CC5\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANhgLtWR4jFlhHEPGJjcupkGrNymWv9wFlFM8YppKs6nNXaQdoKf\\\
-        n7+NESFVdkm89/7FWD/It0B49jEBjjs7GOmxhffomt1NVHocYGDBQjMAlKOYQgCnR\\neZDnHCFORSrQcfiNhgKm1/eFOZlNJDZn2Cwpmdk8ZV6B78fGVz+3B+tFABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEo0VFRaVzY2QlBRTFRRVVlNS0hIVzZZTjRGVkJIVFlVQ0ZW\\nNVNWNjNRWlQyT0Y3Wjc2NUxEWk1TVDJNR1JBVFpYSVZJVzVBR1M0N0RFU0hTRUhY\\\
-        nWDZFQVlISkFWTFBZRzc1VFlKQkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBobdROFQEzFd3gD/RUhGdZUriO3QqYTqvH7EZdZ\\\
-        n4r3iFUJVP3xhru9HYBtksepsKzUHYZn4nK29689AdV1A9o/X4YcKWrxFRbMuZs0E\\nTj2Je4jrw3WNf3O3COAWwFa75HOXIhGfFVuJ4Ni2/NVJGDPA6NNIfZfFMIj/NZF3\\\
-        n3RBZhDmxS21yJs9daQfs\\n=NQQJ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:44.877597Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"uuid\": \"f3a61359-1919-4bf0-b6f7-da902a935160\"\n    }\n  ]\n\
+        \      \"remove_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"f9b4da97-a077-412e-8e54-4ef4984a8540\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '4817'
+      - '3214'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:25 GMT
+      - Tue, 25 Aug 2020 17:27:40 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -124,7 +107,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MjUsImlhdCI6MTU5NzQ1ODYyNSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.tABXDsCX14KTnL4ItmJZ2AsI2vEx6SoUWC7V3k6FSJw
+      - Token eyJleHAiOjE1OTg0MDUyNjAsImlhdCI6MTU5ODM3NjQ2MCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.6cB39kCdPXxFpsaA1JUM0HQTxfviyJ8vJYT31iG7Ln0
       Connection:
       - keep-alive
       Content-Type:
@@ -135,44 +118,34 @@ interactions:
     uri: http://localhost:8081/api/v1/submissions
   response:
     body:
-      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download\"\
-        , \n      \"filename\": \"1-red-rimmed_applejack-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170\"\
-        , \n      \"uuid\": \"ceb44744-68cd-4b29-ada9-4c6ed4127170\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015/download\"\
-        , \n      \"filename\": \"2-red-rimmed_applejack-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015\"\
-        , \n      \"uuid\": \"1deb4f4f-1094-49ec-b0da-5d714b60c015\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download\"\
-        , \n      \"filename\": \"1-potential_freshness-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e\"\
-        , \n      \"uuid\": \"da095cb7-5a81-4b57-912c-14b0501dc00e\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d/download\"\
-        , \n      \"filename\": \"2-potential_freshness-doc.gz.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d\"\
-        , \n      \"uuid\": \"ed460264-f0e9-415f-8247-738eb482c75d\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download\"\
-        , \n      \"filename\": \"1-inexpressible_sepsis-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a\"\
-        , \n      \"uuid\": \"a3bb0937-6240-4200-99d5-b514c465e56a\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01/download\"\
-        , \n      \"filename\": \"2-inexpressible_sepsis-doc.gz.gpg\", \n      \"\
-        is_read\": true, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\
-        , \n      \"uuid\": \"1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\n    }\n  ]\n\
+      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442/download\"\
+        , \n      \"filename\": \"1-pleasant_rearguard-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"submission_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442\"\
+        , \n      \"uuid\": \"bbc25300-917a-4b73-b0f4-10f3d6957442\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/a8699ca4-55a5-4737-b8f1-c9e170ec8250/download\"\
+        , \n      \"filename\": \"2-pleasant_rearguard-doc.gz.gpg\", \n      \"is_read\"\
+        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"submission_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/a8699ca4-55a5-4737-b8f1-c9e170ec8250\"\
+        , \n      \"uuid\": \"a8699ca4-55a5-4737-b8f1-c9e170ec8250\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download\"\
+        , \n      \"filename\": \"1-unlawful_spectrum-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\
+        , \n      \"uuid\": \"d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a/download\"\
+        , \n      \"filename\": \"2-unlawful_spectrum-doc.gz.gpg\", \n      \"is_read\"\
+        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a\"\
+        , \n      \"uuid\": \"55e459bd-cf4e-45f9-adce-95d79998254a\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '3082'
+      - '2055'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:25 GMT
+      - Tue, 25 Aug 2020 17:27:40 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -186,7 +159,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MjUsImlhdCI6MTU5NzQ1ODYyNSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.tABXDsCX14KTnL4ItmJZ2AsI2vEx6SoUWC7V3k6FSJw
+      - Token eyJleHAiOjE1OTg0MDUyNjAsImlhdCI6MTU5ODM3NjQ2MCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.6cB39kCdPXxFpsaA1JUM0HQTxfviyJ8vJYT31iG7Ln0
       Connection:
       - keep-alive
       Content-Type:
@@ -204,7 +177,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:25 GMT
+      - Tue, 25 Aug 2020 17:27:40 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -218,7 +191,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MjUsImlhdCI6MTU5NzQ1ODYyNSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.tABXDsCX14KTnL4ItmJZ2AsI2vEx6SoUWC7V3k6FSJw
+      - Token eyJleHAiOjE1OTg0MDUyNjAsImlhdCI6MTU5ODM3NjQ2MCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.6cB39kCdPXxFpsaA1JUM0HQTxfviyJ8vJYT31iG7Ln0
       Connection:
       - keep-alive
       Content-Type:
@@ -226,38 +199,20 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download
+    uri: http://localhost:8081/api/v1/user
   response:
     body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqAQ//Z/S89kAgGiAOh+UVD2ePgDvU/l/JnvR2DkCEnnqTivaWTKetbcTOxv8D
-        iHQFUvQKPTADA4g5u56foRmzC0Yb2mP36vRMUqLq87hb/XfZFfr3Ak7E169EyaCN6ht5he28mLV0
-        j9brHPGxQWt2vrE4FFdwnUVQWNfAp13rFMm0IDFsHN3o3lNSjywJ62jlr1rce3mdkC+rXkwDh3zs
-        0ZDvxqFGx4X8YPbQiAStvUsK1n3u9NBnKE3cyeHe70xnMdQxq1N4NuACJZkNovKet6C3s8LTvj58
-        XiK6+/AgtbO9Pk6c89s1WW0x3hUGFtWVI+GqSUSQda5CDlWaq6Fq7mBURfuW7yD/rOJ0EypOOJED
-        b1GoyTiK6V1gC/mktb6u/Ei16SmPOjcsAzW7BFn5tsvl3lZULN+b4Bs+E7/Pxl4ymVaPDgbcsAh9
-        Ipp0thhF1a2A3MobRsTtNidryxvfzUTj5ou70vguzn7zthzog2sijyM9hBI0FPr6YRVWXvrS7BEQ
-        Ly9BA1AuzGy0kS1B6MUYdcWAaxQZHWNne02zDHZqe2sBFLM04tJU4myKrXlBOok4YILQ7OWDSoa8
-        Whkyohid0Eympcv+6YMaKI+9yBzHFWgcpu27rlrAuRGRXi9ibBxovyCRg5SSYc1Guo0jalDJWdDy
-        lRdLGsmqJAcWq2PUvNLSTAGpSiJRM+Iwxr77j/lapCOSRGfVJaivW59X5+ZQa6BN57DKWvcgPtCb
-        xDfXOBD4hOG9w/Qv5iKwgOcj/ckygOpvtrcQosdK9ZzrrdY=
+      string: "{\n  \"first_name\": \"\", \n  \"is_admin\": true, \n  \"last_login\"\
+        : \"2020-08-25T17:27:40.384234Z\", \n  \"last_name\": \"\", \n  \"username\"\
+        : \"journalist\", \n  \"uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\n\
+        }\n"
     headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-inexpressible_sepsis-msg.gpg
       Content-Length:
-      - '605'
+      - '192'
       Content-Type:
-      - application/pgp-encrypted
+      - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:25 GMT
-      Etag:
-      - sha256:20db26d5f8240c2efbc83f40184bd03e74f0b927394627fe24bc2954cb4a6c2a
-      Expires:
-      - Sat, 15 Aug 2020 14:30:25 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:25:44 GMT
+      - Tue, 25 Aug 2020 17:27:40 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -271,7 +226,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MjUsImlhdCI6MTU5NzQ1ODYyNSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.tABXDsCX14KTnL4ItmJZ2AsI2vEx6SoUWC7V3k6FSJw
+      - Token eyJleHAiOjE1OTg0MDUyNjAsImlhdCI6MTU5ODM3NjQ2MCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.6cB39kCdPXxFpsaA1JUM0HQTxfviyJ8vJYT31iG7Ln0
       Connection:
       - keep-alive
       Content-Type:
@@ -279,38 +234,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAs+tSZVdjh2H5sgW3rQYsinaTUd1To3XLy/EC0UcNed15/OLbU142ic10
-        6l41iWmBW44aOmjYFIY46VfqPxQSM0G7fl2g5A0SZdmckTqzu141v/+BoTmvbzzZ8sXmpxKjbP/A
-        1F6aBPQ2qX7HcUVyGOadyMRjuKB+IO1pROBeFB5R0hE+FD+y4/yq2y4J9SVeYcdcwcsWJytFUm73
-        emXQ6vcBspvlgSjE1gywgfPFkmOLIKxv9INHFTT/FrfPvJ/yeFZ7jKtG0wxBQYPL4DG5QiVi1Gyz
-        Ln039tgWjFVnM5FhJ+XNhLbLHuISii/0CrKq9TeRea85xFHR6UGKgTm3/fOeWtEhC6FKa0XstXhU
-        T0E9dmh80Rd3myvN0HU3eyNFvmjyZ1weVguXjg4Ao1yWZ8a8AmqlA6m4conr4bbscqQKXCJSF1D+
-        g/i5ng78t0+4wnWMiKtN9rNTJkVBzXpaoYzOn+14EJbkYa+zkCyQS8TbjMBpLaP0aTFO4VXk7OAU
-        ygtKj6P8KmkfqivWrQ047DjqwVot+wBpKT+3t8ASscApC7KaSF0+d/fBvb05ZLzLtfSXM+Ts6pQ8
-        sn60uh2dnW/12nbqAdzFnrEPtDdtz5PFWn8brJpvhhMids/A7dkmbbLK6oirkLSRMF7Wdp8Stz2m
-        aI8Xz6brh2GQeKZafWnSTAHRguSmKDs+h+zUuP/hFFyLlLy2TWX3VLR2rLCEHhm82jP4UcMTpBkU
-        sgsFKxLyPddNYl+9D7kh9NLhzaLsXc2RihQWRvXYM9f3E0Y=
+        hQIMA8PnxMCiIBsqAQ//Rw1NPH3mwdBg9NnblanYiQgqmPuHTY9ha8sR24r6Cbv4UunDrGcjIMeT
+        qUZfK1zok/ZjbbLMo+yVWG2my899P8meyJS9C9MzmPC/x8hpoSUVdxyRorBDja9qNtZUyhOrm5Dz
+        rsiuEaqB1T5iYPinyCzeOcGKxTlrDJE78s5aHQVGQeBjXN+7BqZXsGCWrUueXTF10QrC8u0T/Fnw
+        T+BLvR8FmCIEilEDQESn653nL2wbkTz/7OMxUJJUDkG9xO6VHsTcH4KAzVsonMaan2RVXarJ1393
+        esjkZJ3vMiKXSMNIdsdDQ8WbP/2JGL8rhdg3WZqRbX7ePEJ5C7moUGiJsXmYwNMDarImp/be0O+1
+        YGk1Bfig2smMD280G8vYNykGvLkiGWJU0tGQQBbc5NeM3WZ8chZsyKofidoc9CIY7NLVHGg5u6zf
+        AEe1bjVuWveL5NaUJUpzWxDQzkIBuvX/E9stjEvqb0fZCRkGqPQLOix/YVUjUzj2i1zGAgL/w3xw
+        jhadu4aN05dbf5cBeKRIUS43HnrDXluA0vq0HbX30xuFpoo/noZUiZ8uNfR2UKLQfIK0gNVH1ydw
+        MhHIDKyiUWm/0YQgzcozy14n9OCGtLCucWfxXy7nozJ7JnVJpSYPgAmozMOoqEiz3C0Dnsax/PRV
+        AvwhOEGda6nAIosZZ6nSTAGpDbf6bksYyI2J4JEtY4b7jBvCz6Qmg+n4ZIIH7IEeIBCkhnUtU8xz
+        JHiwor7B/FnoP6RymaVAKyAPqoKGfrJ/XGbwPXJRvQl2PeM=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-potential_freshness-msg.gpg
+      - attachment; filename=1-unlawful_spectrum-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:30:25 GMT
+      - Tue, 25 Aug 2020 17:27:40 GMT
       Etag:
-      - sha256:624b8cc271f0bc4a153ff893f14d4b63464577579c0baa49ca2e6f5b2fb715a8
+      - sha256:dd82012b8656a3f7175b619f2875895a11071daf681b996cdc2704ddf5388664
       Expires:
-      - Sat, 15 Aug 2020 14:30:25 GMT
+      - Wed, 26 Aug 2020 05:27:40 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:35 GMT
+      - Tue, 25 Aug 2020 17:27:02 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -324,7 +279,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MjUsImlhdCI6MTU5NzQ1ODYyNSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.tABXDsCX14KTnL4ItmJZ2AsI2vEx6SoUWC7V3k6FSJw
+      - Token eyJleHAiOjE1OTg0MDUyNjAsImlhdCI6MTU5ODM3NjQ2MCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.6cB39kCdPXxFpsaA1JUM0HQTxfviyJ8vJYT31iG7Ln0
       Connection:
       - keep-alive
       Content-Type:
@@ -332,38 +287,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download
+    uri: http://localhost:8081/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAp+9fU8qzd8lBJJJeTGUfrTvtC7bBj77m96ioEWln23lreSXOi7W1E++i
-        X3mCeNg6hLC0PSAtuO0QTw+LE6TGqLJtQh5y14fIxzgIX5G02eaoOlsayjQbVfXHTJ6HBSFx1VkS
-        ImILNuS170DhYiOyW91R3OJ2zg4DeTlPkyegMGScWCued6EcBBL+/EOrvZLDoXtpFAHFkGGcoQSD
-        p/6L5/pp8AuB5N43NRCtslfsD8D4gpZT7L9gkvNIJbMrBQ4FVUzjB/XI5mkOhXAubjKzgGcpqiM+
-        N2k5nqSPFzotGHmKDy77Bq4D3Sk4fcLzvWMe9hY+Prp6QqW5/F3uvFhJdpdOR9JZ4WqY6pWk0VsA
-        jeIuaxGH3rRqFegi59AiZV+EvpORA7tx8qmkVHch5UifaJCsHthaxOrBk1D/rgutgmoQvVaCN+UA
-        6So9D0H/w6RIE0vE3SAsCpXV3XQJWwsya8O5R5jCuETvi1s5NnMXrtxRuBqkFZUcRSNZyzrUWLGA
-        8djkwjYcO5lP7qt40ztUosMmb2y+4z8ad3zhWP71SKA+chx8lUvY7ziiSmFOpRJOr0OEgKMU59lR
-        ovyT6mu5yB1d5d8G9ns8s5H8/ymV5WE/MdG+o472wWPKoKHnIu0zlj1Qqso8l/khM5wIjs8XvICl
-        pm7uojnWqaFcIaJg4EvSTAEw45cGmA90NotlV9qwHi0fJ0qlbFKf6FAyeDaRL0TPoLKx9JbGf+9M
-        +wwWhoyWoWili+hOxuju3sNSeN1iYkv3fEIyKyEy5rXvf/0=
+        hQIMA8PnxMCiIBsqAQ//RtWsdfVE8eGi8sFqp1/cmLdkiut2OkXfs7DdjD0CBr6qfYUG8woosTjZ
+        +bdA5IIg1ewECF+eOZbfgW3EGzq/xN9rKaE+yTEbrR2swkoHNv1tUTrBoRGwUfHOYl3LOWlftNHt
+        8HbCVEZ/TAs1NQolRpSXj9o+mR6wjPvXtArQkW0io6D8ah9YO+YkEEkl4B2CwK1BwUQHj4B1TXw+
+        QGubNNIfGeXM9OkSCQMZapmumEt4m+8KImF1ncNMINXO/WV3tbTKDrCO63R/K6ibSuq//vd72Q2z
+        DFalhfcmnu7ksX0/4TFsrsvfuQoppTqepI6YklIKhTRkoRuY5fQeoK2w93qrZh0dmsVvlhx13/xl
+        19wcO1vASiZzfSHT/XDaXoS+3XmgW/xKr+Y0IJq+PZSs/EZ/2mr6zXePR8HtdFuvCnGiNjPFsRsE
+        sRIB1iq6FEV3zKxLU7FI46MTNrBpTYj3xAn2MqGM0UgCvwC1v73s6mMe6njwvYak8V0J/ny3sd/J
+        NHnbftRaGOmlrQbiXhoRIDEV5Kric9qBJG5R12kxDHHqce/viMEnZ1543+2snmsGrmWvX3Kxsbq4
+        cm1rmE/1dwYYtUaTpj1j4HDr7OY0PUN4F2BXK1gOSOONWiKd8hRAbY4Emwv60g+36ZtwY6kQu4v3
+        pQhKYVCTt8xL1gZkYYfSTAFnY4M6ViJKpbRI6FGnAQsYaB74rBUx6FatdEvztAN5VHarQPHN9uDF
+        TLPp+suitZOgA4wsgUWL+sUze53pOc/MCAUfBwrk2YD7hO8=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-red-rimmed_applejack-msg.gpg
+      - attachment; filename=1-pleasant_rearguard-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:30:25 GMT
+      - Tue, 25 Aug 2020 17:27:40 GMT
       Etag:
-      - sha256:2e1bdbd452ce54d49602552182cb0146b2334c58a7c5aec0c0565645e2ab4286
+      - sha256:cecd2591b0a9a0315f320e9878f68fdaec03c70b286da162c4416fab137ec00e
       Expires:
-      - Sat, 15 Aug 2020 14:30:25 GMT
+      - Wed, 26 Aug 2020 05:27:40 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:23 GMT
+      - Tue, 25 Aug 2020 17:26:47 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:

--- a/tests/functional/cassettes/test_offline_delete_source_attempt.yaml
+++ b/tests/functional/cassettes/test_offline_delete_source_attempt.yaml
@@ -17,9 +17,9 @@ interactions:
     uri: http://localhost:8081/api/v1/token
   response:
     body:
-      string: "{\n  \"expiration\": \"2020-08-15T10:26:21.428727Z\", \n  \"journalist_first_name\"\
-        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"b5e001de-19f1-4a93-885b-e0932aa2d441\"\
-        , \n  \"token\": \"eyJleHAiOjE1OTc0ODcxODEsImlhdCI6MTU5NzQ1ODM4MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.ZQDu5CcwcG9EZnzOU2pWeBddNoqm96aoegeB3xHReaM\"\
+      string: "{\n  \"expiration\": \"2020-08-26T01:27:08.528467Z\", \n  \"journalist_first_name\"\
+        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n  \"token\": \"eyJleHAiOjE1OTg0MDUyMjgsImlhdCI6MTU5ODM3NjQyOCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Mw_MUbprtST5Cr13DIRmQnddnfeOLvOSqZmEKaWUvv0\"\
         \n}\n"
     headers:
       Content-Length:
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:21 GMT
+      - Tue, 25 Aug 2020 17:27:08 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -41,7 +41,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxODEsImlhdCI6MTU5NzQ1ODM4MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.ZQDu5CcwcG9EZnzOU2pWeBddNoqm96aoegeB3xHReaM
+      - Token eyJleHAiOjE1OTg0MDUyMjgsImlhdCI6MTU5ODM3NjQyOCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Mw_MUbprtST5Cr13DIRmQnddnfeOLvOSqZmEKaWUvv0
       Connection:
       - keep-alive
       Content-Type:
@@ -52,99 +52,48 @@ interactions:
     uri: http://localhost:8081/api/v1/sources
   response:
     body:
-      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/add_star\"\
+      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/add_star\"\
         , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"out-of-town\
-        \ primogeniture\", \n      \"key\": {\n        \"fingerprint\": \"200C271E4E680FFE62E008931554E4BF600B1E3C\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAL4uN551SiYiVLrHoK1QGMDmN1xq42u8o2dmnKFkArW5KfBvBFoX\\\
-        nZX5LnOj9hKKEEmeGX5beS9h+fjsWvx86M2kQj/5xhOmHw0GGESEPQBSUc+Lyohpc\\nUmBoNNBfWIouEQ+IVS0gmrOwiS7wdItMby1lLDlDBoiEm4aRnRw36NIpABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEhPUDNaU05LUFgzNE1MV09QMkVPQkJRVVc2QjZPS0ZFMzZa\\nVktOV0VWNEhXVTVMUlZGQlFENjVKTEtYUENHRE1LVEFTTDM2N0NOT1ZDN0hBRUxF\\\
-        nWVQyWU5LMkJHM0ZWNlZWUUlMMlE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBVU5L9gCx482IED/2w6yFqz19zTBX72qN0MUTq5\\\
-        nCavQIBhhWrbsc1m0p+cxuVJ16TYxiE3S/Lp/rd4r1Q9MQg9BP0+/qjOA541kNq5A\\nmR2Y0teqWonDqeY/660kEFIbio0HbOTjsBhEZxtglJ1wz70tUpd40ZVMsu+Z32Mw\\\
-        n2kSiCclJYHk7uy1eis57\\n=pz11\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:24:42.042205Z\"\
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"pleasant rearguard\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"FF9007318CCAB4DC6149B1B38B7907A15818269D\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAM8jaDDbt3lQQVUEk+MduWYmJHa3eME1Y9C4yj+6n9V9Sksakj3B\\\
+        nWcl9uKzXLtZIP1rdvkW+Bg/P64vTgi+I+pcL5+e5gpF/KdNhrksovmhzc/ASgrn7\\nEcNCwIk+Iyym255IOEsZ8j9SvpzG1VyUdJxlK+P6bmbkFgDDwHjF0QzDABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPEtHQUFQVlNISjJLS0lMV0daTUlBWUFHMlhXU0ZWRlJRQ1pJ\\nNE5QTVBVUEVKNDNIQ1hJVUdPUk9XUEhLUldXRkxRTk5LTko3WEk1Tk9JUkpFTERQ\\\
+        nU0pZN0JMTk9ETk0yTUxNSjRPMkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEIt5B6FYGCadjpUD/1IiTV3TAyduG0UkaxcTT+Bp\\\
+        nKZRsNsK+HhYBCu/VjBcybLkuccDaonnm99OyaWZAZ/F/E/DxRENTxs0OL47GbHG7\\n9hSFWj99MZACMs3aKAmqxZEnQmm0B0xDIlHyd9mQBSieUw6aVMVjxK8p0Z21R7cz\\\
+        nc+DfEuCbShQ6b5+9X308\\n=RU3O\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:26:48.423985Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\
-        , \n      \"uuid\": \"4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/add_star\"\
+        \      \"remove_star_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"uuid\": \"505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\n    }, \n  \
+        \  {\n      \"add_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/add_star\"\
         , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"red-rimmed\
-        \ applejack\", \n      \"key\": {\n        \"fingerprint\": \"D449222A7B7B0AC1E134A1FF01203DD2D2636A37\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAOaUXyLQCaUSR4HTaBVGZp1mi3jn3BExTTe2UCBYjsn1zhkOBDf9\\\
-        ncZNBQGjEBIYlOioC4XY1TkQep4L2DdmqO5lBfbyNG6LpGiNo7DvNBxeo5WNDa42C\\n8YcfTaVL9aWm07G12uwwc1WFNb0y86PzuAS1ek0k5B7jUfjNxFN9t0dhABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEtCTEEyQTRDUEtETEVURDM2MllWQUZVRVdRQlJLUzJWRjVG\\nUEs2SElBWFBXQUFNSURMUkZHUEdLU0dFSDJJUUtBUVdZUFdFS0xRWVpaTDZMU1JY\\\
-        nRFRUTUdPUlFFWFA0WE1EUlJJM0E9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEAEgPdLSY2o3LmUD/i+JqgIWc2SzA5OTX9Qo0g/r\\\
-        nqxDmi2NQMXob0fEEcP/GGnbiFE1P77AC6JWxSKPQStlfwvffhYmK2q7JBc71Jj8O\\nRqFRT5WSRpXUCq8tZkIYyoCXKQPlwSb3S1NQ3yM00kbkCM4dArLIFuQ/ZI1xG+l9\\\
-        nIqxWwXYY8SpO8uKDXFd7\\n=FjUe\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:23.753433Z\"\
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"unlawful spectrum\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"CE2A06285C9B1FDB43BFEB853EC2D036DDCA8CD4\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANJ0h2W7p0bViTLpY9w/PDd8sBHR56OVg+EGdXZ51Wuqt8ZUkF8W\\\
+        njSLrjsiOrcQ1lRFEgERFfIBJvlxfB/EMP4wcTY7vg7WQN/rvSJynBW0T6iHI3Rhi\\n/3v35LEuX9tLU/B1e11mRevgHTLRUms38Y5DBSkWACngvH4jWP+kwylJABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPDUyNzdCNDVDNExFUFdJWU9NQlY0VE5FVEI1WjdaVFpERTZK\\nQTJSTlhVNE5HM0g3R0NRVEJYRUdVWkdSRkpSRVZGN01BTzZDUUpWWVpBN0NOSEw3\\\
+        nS0JKVzMyS01XNEJaSVROU0dBVkk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJED7C0DbdyozULzEEALbYIlKPW3wXMi/9V2c/fYJc\\\
+        naX9UE94JwAdfntqAkEF8dL/P6fD5J1BPqQILK4crX6LN6h8g2y1vnrTTg9odsa1L\\nD0JqSpGfIWscGRuzY6b2WngLCgsudMqJgPZUdm/wbxp3Q8Daa8U99mL9jXr9Ia9j\\\
+        n8BFeiB6fb0VoIDgM7UTv\\n=j+JQ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:27:03.031475Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"uuid\": \"70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"potential\
-        \ freshness\", \n      \"key\": {\n        \"fingerprint\": \"06FFA85715E89C0AFBA927A78EA34965AC896EEA\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAMHR1pM94xuFw+GiTQI7RyUN/sKYmupDhwWj1nVricMXRbM7nIXk\\\
-        nsBnqTx0pTkITPxjszoVyFFxG+Uw8TXMZEZdCOhcC2AieHV0mgWsXxLAbD9Sw3VmQ\\ngOQ3S2C/MBrimrK4bkpoKXxKIV5v5Rgku5Pjxzw50HH4e1pYhgW2C+knABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEg3TVJTVUZHWFVKRldQQlM0UjdISk1JNE5HTUREQ0FaRzJL\\nVlIyTTM3RkFTQk9BRjIyUkFYNzdMUVdZNFZJNTJLSlBOQldaRjUyQTdHWFJVN1lQ\\\
-        nN0dQQU5QSFNNUUkzSUFVN1VGNEk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEI6jSWWsiW7qZeYD/ReRVU5y0nssc0+OlRy6M/im\\\
-        nHY9oHex0tSGt1fTuDVqsAKKHMDrZLKkkhJg42wcINwbXTj/vRu7n199IwbSUoDiE\\nJlnO6ZaIG996AUFS64eZBA+kXczqJbsWgdQQpwQJn8LiQUF8iwFhTThltjRSuXqf\\\
-        nMxyFevvxbIvYcs6il7Ip\\n=cZe8\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:36.194245Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"uuid\": \"6db98582-dd69-48ea-879e-5afc5aa388d6\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"inexpressible\
-        \ sepsis\", \n      \"key\": {\n        \"fingerprint\": \"380C70D1C7930985411415B31A1B751385404CC5\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANhgLtWR4jFlhHEPGJjcupkGrNymWv9wFlFM8YppKs6nNXaQdoKf\\\
-        n7+NESFVdkm89/7FWD/It0B49jEBjjs7GOmxhffomt1NVHocYGDBQjMAlKOYQgCnR\\neZDnHCFORSrQcfiNhgKm1/eFOZlNJDZn2Cwpmdk8ZV6B78fGVz+3B+tFABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEo0VFRaVzY2QlBRTFRRVVlNS0hIVzZZTjRGVkJIVFlVQ0ZW\\nNVNWNjNRWlQyT0Y3Wjc2NUxEWk1TVDJNR1JBVFpYSVZJVzVBR1M0N0RFU0hTRUhY\\\
-        nWDZFQVlISkFWTFBZRzc1VFlKQkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBobdROFQEzFd3gD/RUhGdZUriO3QqYTqvH7EZdZ\\\
-        n4r3iFUJVP3xhru9HYBtksepsKzUHYZn4nK29689AdV1A9o/X4YcKWrxFRbMuZs0E\\nTj2Je4jrw3WNf3O3COAWwFa75HOXIhGfFVuJ4Ni2/NVJGDPA6NNIfZfFMIj/NZF3\\\
-        n3RBZhDmxS21yJs9daQfs\\n=NQQJ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:44.877597Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"uuid\": \"f3a61359-1919-4bf0-b6f7-da902a935160\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"newfound necessity\"\
-        , \n      \"key\": {\n        \"fingerprint\": \"7FBC4515353AE647D938C764EEE9B96CF5D1BE8E\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAL5F4eU1lEB3y0oi3X6T8FU3jjZjLrsuh7pO8UcwNtQX4SccJ++B\\\
-        nHChPo4OarAIfmIENAL3aP2/IVGM0w6BvHFOJvztQpEagiwf1g5voHC8mlr0m9maq\\n/pFAIbFSsTKh+nCwEvXjwxGfUt8l5w0P59kpRp/1j2DzIrwjvFomK1DZABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEtZWEZDUldUM1hSSU1MRzdDU0NJN1paVVFaRkxMSldLMlhP\\nWEFCNVdHVkRPNEVOSEY3NTJZSzJBU0lFWktYUVBHRUJXRk02NlVRSFpBVUhBMjQy\\\
-        nUkQ2NjVZQzRHQlk2UEZFVFRLWVk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEO7puWz10b6O+F0EAKBLCQEcRuGffqEjWHS+B2QO\\\
-        nXWvovvU1mWTDvGPFLzyq92iQUVe+fAjgfEcEyX6btD0ivZDctfhImVqqXQj23zP7\\n8j1lvDXFBbU41AfZbBljEk69MIPicdviWnZaWZ2hk7ScO9Lc6D+CcU+3/l3hlh6X\\\
-        ngQPZEQ30NO7w2/7ADAvs\\n=P6eJ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:53.136494Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1\"\
-        , \n      \"uuid\": \"5fb61bc7-8819-4f66-99b0-538a389f8fa1\"\n    }\n  ]\n\
+        \      \"remove_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"f9b4da97-a077-412e-8e54-4ef4984a8540\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '8018'
+      - '3214'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:21 GMT
+      - Tue, 25 Aug 2020 17:27:08 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -158,7 +107,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxODEsImlhdCI6MTU5NzQ1ODM4MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.ZQDu5CcwcG9EZnzOU2pWeBddNoqm96aoegeB3xHReaM
+      - Token eyJleHAiOjE1OTg0MDUyMjgsImlhdCI6MTU5ODM3NjQyOCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Mw_MUbprtST5Cr13DIRmQnddnfeOLvOSqZmEKaWUvv0
       Connection:
       - keep-alive
       Content-Type:
@@ -169,65 +118,34 @@ interactions:
     uri: http://localhost:8081/api/v1/submissions
   response:
     body:
-      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96/download\"\
-        , \n      \"filename\": \"1-out-of-town_primogeniture-msg.gpg\", \n      \"\
-        is_read\": true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\
-        , \n      \"submission_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96\"\
-        , \n      \"uuid\": \"f836676a-c1aa-49a8-90c2-bb171f60cd96\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/99509e6d-62dd-48f3-8208-623f9290bc03/download\"\
-        , \n      \"filename\": \"2-out-of-town_primogeniture-doc.gz.gpg\", \n   \
-        \   \"is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"\
-        /api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\", \n      \"submission_url\"\
-        : \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/99509e6d-62dd-48f3-8208-623f9290bc03\"\
-        , \n      \"uuid\": \"99509e6d-62dd-48f3-8208-623f9290bc03\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download\"\
-        , \n      \"filename\": \"1-red-rimmed_applejack-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170\"\
-        , \n      \"uuid\": \"ceb44744-68cd-4b29-ada9-4c6ed4127170\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015/download\"\
-        , \n      \"filename\": \"2-red-rimmed_applejack-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015\"\
-        , \n      \"uuid\": \"1deb4f4f-1094-49ec-b0da-5d714b60c015\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download\"\
-        , \n      \"filename\": \"1-potential_freshness-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e\"\
-        , \n      \"uuid\": \"da095cb7-5a81-4b57-912c-14b0501dc00e\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d/download\"\
-        , \n      \"filename\": \"2-potential_freshness-doc.gz.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d\"\
-        , \n      \"uuid\": \"ed460264-f0e9-415f-8247-738eb482c75d\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download\"\
-        , \n      \"filename\": \"1-inexpressible_sepsis-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a\"\
-        , \n      \"uuid\": \"a3bb0937-6240-4200-99d5-b514c465e56a\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01/download\"\
-        , \n      \"filename\": \"2-inexpressible_sepsis-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\
-        , \n      \"uuid\": \"1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions/2b1dce9e-852d-40a5-8148-d4e54cf3c322/download\"\
-        , \n      \"filename\": \"1-newfound_necessity-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1\"\
-        , \n      \"submission_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions/2b1dce9e-852d-40a5-8148-d4e54cf3c322\"\
-        , \n      \"uuid\": \"2b1dce9e-852d-40a5-8148-d4e54cf3c322\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions/9cc1760b-3d1e-4cd2-8f0e-5af35661509a/download\"\
-        , \n      \"filename\": \"2-newfound_necessity-doc.gz.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1\"\
-        , \n      \"submission_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions/9cc1760b-3d1e-4cd2-8f0e-5af35661509a\"\
-        , \n      \"uuid\": \"9cc1760b-3d1e-4cd2-8f0e-5af35661509a\"\n    }\n  ]\n\
+      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442/download\"\
+        , \n      \"filename\": \"1-pleasant_rearguard-msg.gpg\", \n      \"is_read\"\
+        : false, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"submission_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442\"\
+        , \n      \"uuid\": \"bbc25300-917a-4b73-b0f4-10f3d6957442\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/a8699ca4-55a5-4737-b8f1-c9e170ec8250/download\"\
+        , \n      \"filename\": \"2-pleasant_rearguard-doc.gz.gpg\", \n      \"is_read\"\
+        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"submission_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/a8699ca4-55a5-4737-b8f1-c9e170ec8250\"\
+        , \n      \"uuid\": \"a8699ca4-55a5-4737-b8f1-c9e170ec8250\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download\"\
+        , \n      \"filename\": \"1-unlawful_spectrum-msg.gpg\", \n      \"is_read\"\
+        : false, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\
+        , \n      \"uuid\": \"d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a/download\"\
+        , \n      \"filename\": \"2-unlawful_spectrum-doc.gz.gpg\", \n      \"is_read\"\
+        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a\"\
+        , \n      \"uuid\": \"55e459bd-cf4e-45f9-adce-95d79998254a\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '5129'
+      - '2057'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:21 GMT
+      - Tue, 25 Aug 2020 17:27:08 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -241,7 +159,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxODEsImlhdCI6MTU5NzQ1ODM4MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.ZQDu5CcwcG9EZnzOU2pWeBddNoqm96aoegeB3xHReaM
+      - Token eyJleHAiOjE1OTg0MDUyMjgsImlhdCI6MTU5ODM3NjQyOCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Mw_MUbprtST5Cr13DIRmQnddnfeOLvOSqZmEKaWUvv0
       Connection:
       - keep-alive
       Content-Type:
@@ -259,7 +177,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:21 GMT
+      - Tue, 25 Aug 2020 17:27:08 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -273,7 +191,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxODEsImlhdCI6MTU5NzQ1ODM4MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.ZQDu5CcwcG9EZnzOU2pWeBddNoqm96aoegeB3xHReaM
+      - Token eyJleHAiOjE1OTg0MDUyMjgsImlhdCI6MTU5ODM3NjQyOCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Mw_MUbprtST5Cr13DIRmQnddnfeOLvOSqZmEKaWUvv0
       Connection:
       - keep-alive
       Content-Type:
@@ -281,38 +199,20 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions/2b1dce9e-852d-40a5-8148-d4e54cf3c322/download
+    uri: http://localhost:8081/api/v1/user
   response:
     body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqARAArL7MGys+bU7mIl18TJs5rSTC9NvcRhYXjmB/UMdxG2z6sYPXOrpcIJgO
-        fJwQMwe0Osu5iYDmaGVZ+5oYmVdaCTt2inZKxn1Li8iCV4RnbXWItYlt03WeLO8Mfa/k8LMqwGb2
-        RWoW3yOPZm4NsTc30c60z7PBnjsgXuCbCjLCZs1uXQnOXqr4f6C4hq3S+CCvxqOfytPY4vBtVkvN
-        pcbaBm4jCgMAuyg/f3cXLt4w0b2TZ5LHejmppv1cOkpq/ia8cmyv0kW+hTh5uKnRiZtu+PlEWCEI
-        QhkNF7uVT1xoNDQZJE/wze0ni7u5V8Afze7oEEqbOJg/nLjUrAKdPM/08yB3CIiHU66LF5lsQMcc
-        eg/lpcMRja9YgkPYfOjWYxyZqYH9gHKykMlbjr5c2mGSswpkANw3wmuS9DIB96EYpPc2ebqDLKkt
-        8+yC5vDu81VBlxC0xPlRzb7bK81jFvzwavb86T4HEEl/n69QwiuPeiFNpw48tNSK6l2oDVyq6TjU
-        uRjyC/ICo8D4V1LYFp4fy8WdNG96AGADwMFNTTmxOuY1Gi8Qn8XXpeOzxPPiwPv/P+W7SAGM08dt
-        LuEdA9U+0GoHEGqIrzSy4B/EUaVby947Lz15FQzjS2AfNIx32PDcCnw80l5i/rV2v1G+qF7Iv1Kc
-        e5sYaAZ1FJ91j6S+VXvSTAEY9XnwSOWdtr//CvagOwodz5TtI/TXCt7yEiGJBGwz3dnAxWwlziOs
-        5yBjLzVsDX+GHrPL3cc/VbXd7be3fi/7omVkmeHmLma8vmI=
+      string: "{\n  \"first_name\": \"\", \n  \"is_admin\": true, \n  \"last_login\"\
+        : \"2020-08-25T17:27:08.528792Z\", \n  \"last_name\": \"\", \n  \"username\"\
+        : \"journalist\", \n  \"uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\n\
+        }\n"
     headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-newfound_necessity-msg.gpg
       Content-Length:
-      - '605'
+      - '192'
       Content-Type:
-      - application/pgp-encrypted
+      - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:21 GMT
-      Etag:
-      - sha256:cd8ca8320d46a9d2654a353aec5bec455d4afed05744d0ca95e47c7ccf358c1b
-      Expires:
-      - Sat, 15 Aug 2020 14:26:21 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:25:52 GMT
+      - Tue, 25 Aug 2020 17:27:08 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -326,7 +226,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxODEsImlhdCI6MTU5NzQ1ODM4MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.ZQDu5CcwcG9EZnzOU2pWeBddNoqm96aoegeB3xHReaM
+      - Token eyJleHAiOjE1OTg0MDUyMjgsImlhdCI6MTU5ODM3NjQyOCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Mw_MUbprtST5Cr13DIRmQnddnfeOLvOSqZmEKaWUvv0
       Connection:
       - keep-alive
       Content-Type:
@@ -334,38 +234,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqAQ//Z/S89kAgGiAOh+UVD2ePgDvU/l/JnvR2DkCEnnqTivaWTKetbcTOxv8D
-        iHQFUvQKPTADA4g5u56foRmzC0Yb2mP36vRMUqLq87hb/XfZFfr3Ak7E169EyaCN6ht5he28mLV0
-        j9brHPGxQWt2vrE4FFdwnUVQWNfAp13rFMm0IDFsHN3o3lNSjywJ62jlr1rce3mdkC+rXkwDh3zs
-        0ZDvxqFGx4X8YPbQiAStvUsK1n3u9NBnKE3cyeHe70xnMdQxq1N4NuACJZkNovKet6C3s8LTvj58
-        XiK6+/AgtbO9Pk6c89s1WW0x3hUGFtWVI+GqSUSQda5CDlWaq6Fq7mBURfuW7yD/rOJ0EypOOJED
-        b1GoyTiK6V1gC/mktb6u/Ei16SmPOjcsAzW7BFn5tsvl3lZULN+b4Bs+E7/Pxl4ymVaPDgbcsAh9
-        Ipp0thhF1a2A3MobRsTtNidryxvfzUTj5ou70vguzn7zthzog2sijyM9hBI0FPr6YRVWXvrS7BEQ
-        Ly9BA1AuzGy0kS1B6MUYdcWAaxQZHWNne02zDHZqe2sBFLM04tJU4myKrXlBOok4YILQ7OWDSoa8
-        Whkyohid0Eympcv+6YMaKI+9yBzHFWgcpu27rlrAuRGRXi9ibBxovyCRg5SSYc1Guo0jalDJWdDy
-        lRdLGsmqJAcWq2PUvNLSTAGpSiJRM+Iwxr77j/lapCOSRGfVJaivW59X5+ZQa6BN57DKWvcgPtCb
-        xDfXOBD4hOG9w/Qv5iKwgOcj/ckygOpvtrcQosdK9ZzrrdY=
+        hQIMA8PnxMCiIBsqAQ//Rw1NPH3mwdBg9NnblanYiQgqmPuHTY9ha8sR24r6Cbv4UunDrGcjIMeT
+        qUZfK1zok/ZjbbLMo+yVWG2my899P8meyJS9C9MzmPC/x8hpoSUVdxyRorBDja9qNtZUyhOrm5Dz
+        rsiuEaqB1T5iYPinyCzeOcGKxTlrDJE78s5aHQVGQeBjXN+7BqZXsGCWrUueXTF10QrC8u0T/Fnw
+        T+BLvR8FmCIEilEDQESn653nL2wbkTz/7OMxUJJUDkG9xO6VHsTcH4KAzVsonMaan2RVXarJ1393
+        esjkZJ3vMiKXSMNIdsdDQ8WbP/2JGL8rhdg3WZqRbX7ePEJ5C7moUGiJsXmYwNMDarImp/be0O+1
+        YGk1Bfig2smMD280G8vYNykGvLkiGWJU0tGQQBbc5NeM3WZ8chZsyKofidoc9CIY7NLVHGg5u6zf
+        AEe1bjVuWveL5NaUJUpzWxDQzkIBuvX/E9stjEvqb0fZCRkGqPQLOix/YVUjUzj2i1zGAgL/w3xw
+        jhadu4aN05dbf5cBeKRIUS43HnrDXluA0vq0HbX30xuFpoo/noZUiZ8uNfR2UKLQfIK0gNVH1ydw
+        MhHIDKyiUWm/0YQgzcozy14n9OCGtLCucWfxXy7nozJ7JnVJpSYPgAmozMOoqEiz3C0Dnsax/PRV
+        AvwhOEGda6nAIosZZ6nSTAGpDbf6bksYyI2J4JEtY4b7jBvCz6Qmg+n4ZIIH7IEeIBCkhnUtU8xz
+        JHiwor7B/FnoP6RymaVAKyAPqoKGfrJ/XGbwPXJRvQl2PeM=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-inexpressible_sepsis-msg.gpg
+      - attachment; filename=1-unlawful_spectrum-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:26:21 GMT
+      - Tue, 25 Aug 2020 17:27:08 GMT
       Etag:
-      - sha256:20db26d5f8240c2efbc83f40184bd03e74f0b927394627fe24bc2954cb4a6c2a
+      - sha256:dd82012b8656a3f7175b619f2875895a11071daf681b996cdc2704ddf5388664
       Expires:
-      - Sat, 15 Aug 2020 14:26:21 GMT
+      - Wed, 26 Aug 2020 05:27:08 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:44 GMT
+      - Tue, 25 Aug 2020 17:27:02 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -379,7 +279,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxODEsImlhdCI6MTU5NzQ1ODM4MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.ZQDu5CcwcG9EZnzOU2pWeBddNoqm96aoegeB3xHReaM
+      - Token eyJleHAiOjE1OTg0MDUyMjgsImlhdCI6MTU5ODM3NjQyOCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Mw_MUbprtST5Cr13DIRmQnddnfeOLvOSqZmEKaWUvv0
       Connection:
       - keep-alive
       Content-Type:
@@ -387,38 +287,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download
+    uri: http://localhost:8081/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAs+tSZVdjh2H5sgW3rQYsinaTUd1To3XLy/EC0UcNed15/OLbU142ic10
-        6l41iWmBW44aOmjYFIY46VfqPxQSM0G7fl2g5A0SZdmckTqzu141v/+BoTmvbzzZ8sXmpxKjbP/A
-        1F6aBPQ2qX7HcUVyGOadyMRjuKB+IO1pROBeFB5R0hE+FD+y4/yq2y4J9SVeYcdcwcsWJytFUm73
-        emXQ6vcBspvlgSjE1gywgfPFkmOLIKxv9INHFTT/FrfPvJ/yeFZ7jKtG0wxBQYPL4DG5QiVi1Gyz
-        Ln039tgWjFVnM5FhJ+XNhLbLHuISii/0CrKq9TeRea85xFHR6UGKgTm3/fOeWtEhC6FKa0XstXhU
-        T0E9dmh80Rd3myvN0HU3eyNFvmjyZ1weVguXjg4Ao1yWZ8a8AmqlA6m4conr4bbscqQKXCJSF1D+
-        g/i5ng78t0+4wnWMiKtN9rNTJkVBzXpaoYzOn+14EJbkYa+zkCyQS8TbjMBpLaP0aTFO4VXk7OAU
-        ygtKj6P8KmkfqivWrQ047DjqwVot+wBpKT+3t8ASscApC7KaSF0+d/fBvb05ZLzLtfSXM+Ts6pQ8
-        sn60uh2dnW/12nbqAdzFnrEPtDdtz5PFWn8brJpvhhMids/A7dkmbbLK6oirkLSRMF7Wdp8Stz2m
-        aI8Xz6brh2GQeKZafWnSTAHRguSmKDs+h+zUuP/hFFyLlLy2TWX3VLR2rLCEHhm82jP4UcMTpBkU
-        sgsFKxLyPddNYl+9D7kh9NLhzaLsXc2RihQWRvXYM9f3E0Y=
+        hQIMA8PnxMCiIBsqAQ//RtWsdfVE8eGi8sFqp1/cmLdkiut2OkXfs7DdjD0CBr6qfYUG8woosTjZ
+        +bdA5IIg1ewECF+eOZbfgW3EGzq/xN9rKaE+yTEbrR2swkoHNv1tUTrBoRGwUfHOYl3LOWlftNHt
+        8HbCVEZ/TAs1NQolRpSXj9o+mR6wjPvXtArQkW0io6D8ah9YO+YkEEkl4B2CwK1BwUQHj4B1TXw+
+        QGubNNIfGeXM9OkSCQMZapmumEt4m+8KImF1ncNMINXO/WV3tbTKDrCO63R/K6ibSuq//vd72Q2z
+        DFalhfcmnu7ksX0/4TFsrsvfuQoppTqepI6YklIKhTRkoRuY5fQeoK2w93qrZh0dmsVvlhx13/xl
+        19wcO1vASiZzfSHT/XDaXoS+3XmgW/xKr+Y0IJq+PZSs/EZ/2mr6zXePR8HtdFuvCnGiNjPFsRsE
+        sRIB1iq6FEV3zKxLU7FI46MTNrBpTYj3xAn2MqGM0UgCvwC1v73s6mMe6njwvYak8V0J/ny3sd/J
+        NHnbftRaGOmlrQbiXhoRIDEV5Kric9qBJG5R12kxDHHqce/viMEnZ1543+2snmsGrmWvX3Kxsbq4
+        cm1rmE/1dwYYtUaTpj1j4HDr7OY0PUN4F2BXK1gOSOONWiKd8hRAbY4Emwv60g+36ZtwY6kQu4v3
+        pQhKYVCTt8xL1gZkYYfSTAFnY4M6ViJKpbRI6FGnAQsYaB74rBUx6FatdEvztAN5VHarQPHN9uDF
+        TLPp+suitZOgA4wsgUWL+sUze53pOc/MCAUfBwrk2YD7hO8=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-potential_freshness-msg.gpg
+      - attachment; filename=1-pleasant_rearguard-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:26:21 GMT
+      - Tue, 25 Aug 2020 17:27:08 GMT
       Etag:
-      - sha256:624b8cc271f0bc4a153ff893f14d4b63464577579c0baa49ca2e6f5b2fb715a8
+      - sha256:cecd2591b0a9a0315f320e9878f68fdaec03c70b286da162c4416fab137ec00e
       Expires:
-      - Sat, 15 Aug 2020 14:26:21 GMT
+      - Wed, 26 Aug 2020 05:27:08 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:35 GMT
+      - Tue, 25 Aug 2020 17:26:47 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -432,113 +332,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxODEsImlhdCI6MTU5NzQ1ODM4MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.ZQDu5CcwcG9EZnzOU2pWeBddNoqm96aoegeB3xHReaM
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.20.0
-    method: GET
-    uri: http://localhost:8081/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download
-  response:
-    body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqARAAp+9fU8qzd8lBJJJeTGUfrTvtC7bBj77m96ioEWln23lreSXOi7W1E++i
-        X3mCeNg6hLC0PSAtuO0QTw+LE6TGqLJtQh5y14fIxzgIX5G02eaoOlsayjQbVfXHTJ6HBSFx1VkS
-        ImILNuS170DhYiOyW91R3OJ2zg4DeTlPkyegMGScWCued6EcBBL+/EOrvZLDoXtpFAHFkGGcoQSD
-        p/6L5/pp8AuB5N43NRCtslfsD8D4gpZT7L9gkvNIJbMrBQ4FVUzjB/XI5mkOhXAubjKzgGcpqiM+
-        N2k5nqSPFzotGHmKDy77Bq4D3Sk4fcLzvWMe9hY+Prp6QqW5/F3uvFhJdpdOR9JZ4WqY6pWk0VsA
-        jeIuaxGH3rRqFegi59AiZV+EvpORA7tx8qmkVHch5UifaJCsHthaxOrBk1D/rgutgmoQvVaCN+UA
-        6So9D0H/w6RIE0vE3SAsCpXV3XQJWwsya8O5R5jCuETvi1s5NnMXrtxRuBqkFZUcRSNZyzrUWLGA
-        8djkwjYcO5lP7qt40ztUosMmb2y+4z8ad3zhWP71SKA+chx8lUvY7ziiSmFOpRJOr0OEgKMU59lR
-        ovyT6mu5yB1d5d8G9ns8s5H8/ymV5WE/MdG+o472wWPKoKHnIu0zlj1Qqso8l/khM5wIjs8XvICl
-        pm7uojnWqaFcIaJg4EvSTAEw45cGmA90NotlV9qwHi0fJ0qlbFKf6FAyeDaRL0TPoLKx9JbGf+9M
-        +wwWhoyWoWili+hOxuju3sNSeN1iYkv3fEIyKyEy5rXvf/0=
-    headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-red-rimmed_applejack-msg.gpg
-      Content-Length:
-      - '605'
-      Content-Type:
-      - application/pgp-encrypted
-      Date:
-      - Sat, 15 Aug 2020 02:26:21 GMT
-      Etag:
-      - sha256:2e1bdbd452ce54d49602552182cb0146b2334c58a7c5aec0c0565645e2ab4286
-      Expires:
-      - Sat, 15 Aug 2020 14:26:21 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:25:23 GMT
-      Server:
-      - Werkzeug/0.16.0 Python/3.5.2
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxODEsImlhdCI6MTU5NzQ1ODM4MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.ZQDu5CcwcG9EZnzOU2pWeBddNoqm96aoegeB3xHReaM
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.20.0
-    method: GET
-    uri: http://localhost:8081/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96/download
-  response:
-    body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqARAAqBkguUOJVhB1E0rEBd3bIvbOJe9umLBp5QVPye5M4nsh0yl0IWnltszf
-        edV/FKB+H0YdtACRB57Zur0vTrOWAA4o1cC9tyUi18aWslfgDvVwJXLjELZYOQiDv//vmcWEG4Mw
-        ckXqK+/zvkgGLST9xjubdcQozWQNW8mXNzqLzLPLYd57oejEzr73iwn2UwQbQjXb31YI5ZsvCB0y
-        sltvyQevn92quua31WmlxjwzTndQ9u9mGQ5zZSxwK39HaZ3oEmPZlWelrnUfbodPJw5wQqGBN++n
-        lwGMVphNGN+EssKtSUb5Hmutd6jTajcfPWPf0yU6AYtJ3v/1wiOyXCaN3tnPStKUzP6w/htB2nFz
-        irbFi2VQ5v1Lg/nAYl0n3cVU4A8O8P8nhIX5KOsxNhYqNyuyjZsJgFAiKtCzEcXxlpyCQiPwpHbo
-        PM7nDr1JtS7w+IY4xlOkwdOmTIjq+WYjfwbOMd8GlwMQmpp2s6n4S7whSIcYI5acs14DERizF7lG
-        vY8XG7/ExbA0zt9B8j0MKTDsAxgkEEMALTPtINMmuc3xaDoTP7HA8e/X6tyPvrVarY8zFuPVxKuY
-        VXdPQuf6in/3uzja0QlWwq+Ibm+I/gBtQPRM1cDpW5n7XdYkzRcTIluElj8U8VnbECvkFNLt8NUk
-        IF792WIIe570TmeeRXfSTAE9fPtTykzrDiTy5LSwqQ91J/Og4d484LO+VkYSPGe37sfcFRSAOSL6
-        KHNlQb9u2IoOgkORHi/6PABz5ty5K45/OvEOhlB4/xbxkbA=
-    headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-out-of-town_primogeniture-msg.gpg
-      Content-Length:
-      - '605'
-      Content-Type:
-      - application/pgp-encrypted
-      Date:
-      - Sat, 15 Aug 2020 02:26:21 GMT
-      Etag:
-      - sha256:64f0c214fab76a0aa8a1407daf0c0478f7851bd7b5c0aaca5b5c8de53aae9336
-      Expires:
-      - Sat, 15 Aug 2020 14:26:21 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:24:41 GMT
-      Server:
-      - Werkzeug/0.16.0 Python/3.5.2
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxODEsImlhdCI6MTU5NzQ1ODM4MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.ZQDu5CcwcG9EZnzOU2pWeBddNoqm96aoegeB3xHReaM
+      - Token eyJleHAiOjE1OTg0MDUyMjgsImlhdCI6MTU5ODM3NjQyOCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Mw_MUbprtST5Cr13DIRmQnddnfeOLvOSqZmEKaWUvv0
       Connection:
       - keep-alive
       Content-Length:
@@ -558,7 +352,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:32 GMT
+      - Tue, 25 Aug 2020 17:27:19 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:

--- a/tests/functional/cassettes/test_offline_read_conversation.yaml
+++ b/tests/functional/cassettes/test_offline_read_conversation.yaml
@@ -17,9 +17,9 @@ interactions:
     uri: http://localhost:8081/api/v1/token
   response:
     body:
-      string: "{\n  \"expiration\": \"2020-08-15T10:26:07.433109Z\", \n  \"journalist_first_name\"\
-        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"b5e001de-19f1-4a93-885b-e0932aa2d441\"\
-        , \n  \"token\": \"eyJleHAiOjE1OTc0ODcxNjcsImlhdCI6MTU5NzQ1ODM2NywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ge78iqZG4gFXFnwfrtRxNMPlIzrGGXqOY7aiV3F32n8\"\
+      string: "{\n  \"expiration\": \"2020-08-26T01:27:49.452999Z\", \n  \"journalist_first_name\"\
+        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n  \"token\": \"eyJleHAiOjE1OTg0MDUyNjksImlhdCI6MTU5ODM3NjQ2OSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.mqGDCsm-4SC09ASMMch_SHbLhNG9d-zxzQ-msol6vFo\"\
         \n}\n"
     headers:
       Content-Length:
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:07 GMT
+      - Tue, 25 Aug 2020 17:27:49 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -41,7 +41,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxNjcsImlhdCI6MTU5NzQ1ODM2NywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ge78iqZG4gFXFnwfrtRxNMPlIzrGGXqOY7aiV3F32n8
+      - Token eyJleHAiOjE1OTg0MDUyNjksImlhdCI6MTU5ODM3NjQ2OSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.mqGDCsm-4SC09ASMMch_SHbLhNG9d-zxzQ-msol6vFo
       Connection:
       - keep-alive
       Content-Type:
@@ -52,99 +52,48 @@ interactions:
     uri: http://localhost:8081/api/v1/sources
   response:
     body:
-      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/add_star\"\
+      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/add_star\"\
         , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"out-of-town\
-        \ primogeniture\", \n      \"key\": {\n        \"fingerprint\": \"200C271E4E680FFE62E008931554E4BF600B1E3C\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAL4uN551SiYiVLrHoK1QGMDmN1xq42u8o2dmnKFkArW5KfBvBFoX\\\
-        nZX5LnOj9hKKEEmeGX5beS9h+fjsWvx86M2kQj/5xhOmHw0GGESEPQBSUc+Lyohpc\\nUmBoNNBfWIouEQ+IVS0gmrOwiS7wdItMby1lLDlDBoiEm4aRnRw36NIpABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEhPUDNaU05LUFgzNE1MV09QMkVPQkJRVVc2QjZPS0ZFMzZa\\nVktOV0VWNEhXVTVMUlZGQlFENjVKTEtYUENHRE1LVEFTTDM2N0NOT1ZDN0hBRUxF\\\
-        nWVQyWU5LMkJHM0ZWNlZWUUlMMlE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBVU5L9gCx482IED/2w6yFqz19zTBX72qN0MUTq5\\\
-        nCavQIBhhWrbsc1m0p+cxuVJ16TYxiE3S/Lp/rd4r1Q9MQg9BP0+/qjOA541kNq5A\\nmR2Y0teqWonDqeY/660kEFIbio0HbOTjsBhEZxtglJ1wz70tUpd40ZVMsu+Z32Mw\\\
-        n2kSiCclJYHk7uy1eis57\\n=pz11\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:24:42.042205Z\"\
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"pleasant rearguard\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"FF9007318CCAB4DC6149B1B38B7907A15818269D\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAM8jaDDbt3lQQVUEk+MduWYmJHa3eME1Y9C4yj+6n9V9Sksakj3B\\\
+        nWcl9uKzXLtZIP1rdvkW+Bg/P64vTgi+I+pcL5+e5gpF/KdNhrksovmhzc/ASgrn7\\nEcNCwIk+Iyym255IOEsZ8j9SvpzG1VyUdJxlK+P6bmbkFgDDwHjF0QzDABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPEtHQUFQVlNISjJLS0lMV0daTUlBWUFHMlhXU0ZWRlJRQ1pJ\\nNE5QTVBVUEVKNDNIQ1hJVUdPUk9XUEhLUldXRkxRTk5LTko3WEk1Tk9JUkpFTERQ\\\
+        nU0pZN0JMTk9ETk0yTUxNSjRPMkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEIt5B6FYGCadjpUD/1IiTV3TAyduG0UkaxcTT+Bp\\\
+        nKZRsNsK+HhYBCu/VjBcybLkuccDaonnm99OyaWZAZ/F/E/DxRENTxs0OL47GbHG7\\n9hSFWj99MZACMs3aKAmqxZEnQmm0B0xDIlHyd9mQBSieUw6aVMVjxK8p0Z21R7cz\\\
+        nc+DfEuCbShQ6b5+9X308\\n=RU3O\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:26:48.423985Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\
-        , \n      \"uuid\": \"4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/add_star\"\
+        \      \"remove_star_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"uuid\": \"505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\n    }, \n  \
+        \  {\n      \"add_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/add_star\"\
         , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"red-rimmed\
-        \ applejack\", \n      \"key\": {\n        \"fingerprint\": \"D449222A7B7B0AC1E134A1FF01203DD2D2636A37\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAOaUXyLQCaUSR4HTaBVGZp1mi3jn3BExTTe2UCBYjsn1zhkOBDf9\\\
-        ncZNBQGjEBIYlOioC4XY1TkQep4L2DdmqO5lBfbyNG6LpGiNo7DvNBxeo5WNDa42C\\n8YcfTaVL9aWm07G12uwwc1WFNb0y86PzuAS1ek0k5B7jUfjNxFN9t0dhABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEtCTEEyQTRDUEtETEVURDM2MllWQUZVRVdRQlJLUzJWRjVG\\nUEs2SElBWFBXQUFNSURMUkZHUEdLU0dFSDJJUUtBUVdZUFdFS0xRWVpaTDZMU1JY\\\
-        nRFRUTUdPUlFFWFA0WE1EUlJJM0E9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEAEgPdLSY2o3LmUD/i+JqgIWc2SzA5OTX9Qo0g/r\\\
-        nqxDmi2NQMXob0fEEcP/GGnbiFE1P77AC6JWxSKPQStlfwvffhYmK2q7JBc71Jj8O\\nRqFRT5WSRpXUCq8tZkIYyoCXKQPlwSb3S1NQ3yM00kbkCM4dArLIFuQ/ZI1xG+l9\\\
-        nIqxWwXYY8SpO8uKDXFd7\\n=FjUe\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:23.753433Z\"\
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"unlawful spectrum\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"CE2A06285C9B1FDB43BFEB853EC2D036DDCA8CD4\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANJ0h2W7p0bViTLpY9w/PDd8sBHR56OVg+EGdXZ51Wuqt8ZUkF8W\\\
+        njSLrjsiOrcQ1lRFEgERFfIBJvlxfB/EMP4wcTY7vg7WQN/rvSJynBW0T6iHI3Rhi\\n/3v35LEuX9tLU/B1e11mRevgHTLRUms38Y5DBSkWACngvH4jWP+kwylJABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPDUyNzdCNDVDNExFUFdJWU9NQlY0VE5FVEI1WjdaVFpERTZK\\nQTJSTlhVNE5HM0g3R0NRVEJYRUdVWkdSRkpSRVZGN01BTzZDUUpWWVpBN0NOSEw3\\\
+        nS0JKVzMyS01XNEJaSVROU0dBVkk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJED7C0DbdyozULzEEALbYIlKPW3wXMi/9V2c/fYJc\\\
+        naX9UE94JwAdfntqAkEF8dL/P6fD5J1BPqQILK4crX6LN6h8g2y1vnrTTg9odsa1L\\nD0JqSpGfIWscGRuzY6b2WngLCgsudMqJgPZUdm/wbxp3Q8Daa8U99mL9jXr9Ia9j\\\
+        n8BFeiB6fb0VoIDgM7UTv\\n=j+JQ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:27:03.031475Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"uuid\": \"70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"potential\
-        \ freshness\", \n      \"key\": {\n        \"fingerprint\": \"06FFA85715E89C0AFBA927A78EA34965AC896EEA\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAMHR1pM94xuFw+GiTQI7RyUN/sKYmupDhwWj1nVricMXRbM7nIXk\\\
-        nsBnqTx0pTkITPxjszoVyFFxG+Uw8TXMZEZdCOhcC2AieHV0mgWsXxLAbD9Sw3VmQ\\ngOQ3S2C/MBrimrK4bkpoKXxKIV5v5Rgku5Pjxzw50HH4e1pYhgW2C+knABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEg3TVJTVUZHWFVKRldQQlM0UjdISk1JNE5HTUREQ0FaRzJL\\nVlIyTTM3RkFTQk9BRjIyUkFYNzdMUVdZNFZJNTJLSlBOQldaRjUyQTdHWFJVN1lQ\\\
-        nN0dQQU5QSFNNUUkzSUFVN1VGNEk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEI6jSWWsiW7qZeYD/ReRVU5y0nssc0+OlRy6M/im\\\
-        nHY9oHex0tSGt1fTuDVqsAKKHMDrZLKkkhJg42wcINwbXTj/vRu7n199IwbSUoDiE\\nJlnO6ZaIG996AUFS64eZBA+kXczqJbsWgdQQpwQJn8LiQUF8iwFhTThltjRSuXqf\\\
-        nMxyFevvxbIvYcs6il7Ip\\n=cZe8\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:36.194245Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"uuid\": \"6db98582-dd69-48ea-879e-5afc5aa388d6\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"inexpressible\
-        \ sepsis\", \n      \"key\": {\n        \"fingerprint\": \"380C70D1C7930985411415B31A1B751385404CC5\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANhgLtWR4jFlhHEPGJjcupkGrNymWv9wFlFM8YppKs6nNXaQdoKf\\\
-        n7+NESFVdkm89/7FWD/It0B49jEBjjs7GOmxhffomt1NVHocYGDBQjMAlKOYQgCnR\\neZDnHCFORSrQcfiNhgKm1/eFOZlNJDZn2Cwpmdk8ZV6B78fGVz+3B+tFABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEo0VFRaVzY2QlBRTFRRVVlNS0hIVzZZTjRGVkJIVFlVQ0ZW\\nNVNWNjNRWlQyT0Y3Wjc2NUxEWk1TVDJNR1JBVFpYSVZJVzVBR1M0N0RFU0hTRUhY\\\
-        nWDZFQVlISkFWTFBZRzc1VFlKQkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBobdROFQEzFd3gD/RUhGdZUriO3QqYTqvH7EZdZ\\\
-        n4r3iFUJVP3xhru9HYBtksepsKzUHYZn4nK29689AdV1A9o/X4YcKWrxFRbMuZs0E\\nTj2Je4jrw3WNf3O3COAWwFa75HOXIhGfFVuJ4Ni2/NVJGDPA6NNIfZfFMIj/NZF3\\\
-        n3RBZhDmxS21yJs9daQfs\\n=NQQJ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:44.877597Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"uuid\": \"f3a61359-1919-4bf0-b6f7-da902a935160\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"newfound necessity\"\
-        , \n      \"key\": {\n        \"fingerprint\": \"7FBC4515353AE647D938C764EEE9B96CF5D1BE8E\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAL5F4eU1lEB3y0oi3X6T8FU3jjZjLrsuh7pO8UcwNtQX4SccJ++B\\\
-        nHChPo4OarAIfmIENAL3aP2/IVGM0w6BvHFOJvztQpEagiwf1g5voHC8mlr0m9maq\\n/pFAIbFSsTKh+nCwEvXjwxGfUt8l5w0P59kpRp/1j2DzIrwjvFomK1DZABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEtZWEZDUldUM1hSSU1MRzdDU0NJN1paVVFaRkxMSldLMlhP\\nWEFCNVdHVkRPNEVOSEY3NTJZSzJBU0lFWktYUVBHRUJXRk02NlVRSFpBVUhBMjQy\\\
-        nUkQ2NjVZQzRHQlk2UEZFVFRLWVk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEO7puWz10b6O+F0EAKBLCQEcRuGffqEjWHS+B2QO\\\
-        nXWvovvU1mWTDvGPFLzyq92iQUVe+fAjgfEcEyX6btD0ivZDctfhImVqqXQj23zP7\\n8j1lvDXFBbU41AfZbBljEk69MIPicdviWnZaWZ2hk7ScO9Lc6D+CcU+3/l3hlh6X\\\
-        ngQPZEQ30NO7w2/7ADAvs\\n=P6eJ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:53.136494Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1\"\
-        , \n      \"uuid\": \"5fb61bc7-8819-4f66-99b0-538a389f8fa1\"\n    }\n  ]\n\
+        \      \"remove_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"f9b4da97-a077-412e-8e54-4ef4984a8540\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '8018'
+      - '3214'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:07 GMT
+      - Tue, 25 Aug 2020 17:27:49 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -158,7 +107,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxNjcsImlhdCI6MTU5NzQ1ODM2NywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ge78iqZG4gFXFnwfrtRxNMPlIzrGGXqOY7aiV3F32n8
+      - Token eyJleHAiOjE1OTg0MDUyNjksImlhdCI6MTU5ODM3NjQ2OSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.mqGDCsm-4SC09ASMMch_SHbLhNG9d-zxzQ-msol6vFo
       Connection:
       - keep-alive
       Content-Type:
@@ -169,65 +118,34 @@ interactions:
     uri: http://localhost:8081/api/v1/submissions
   response:
     body:
-      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96/download\"\
-        , \n      \"filename\": \"1-out-of-town_primogeniture-msg.gpg\", \n      \"\
-        is_read\": true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\
-        , \n      \"submission_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96\"\
-        , \n      \"uuid\": \"f836676a-c1aa-49a8-90c2-bb171f60cd96\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/99509e6d-62dd-48f3-8208-623f9290bc03/download\"\
-        , \n      \"filename\": \"2-out-of-town_primogeniture-doc.gz.gpg\", \n   \
-        \   \"is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"\
-        /api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\", \n      \"submission_url\"\
-        : \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/99509e6d-62dd-48f3-8208-623f9290bc03\"\
-        , \n      \"uuid\": \"99509e6d-62dd-48f3-8208-623f9290bc03\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download\"\
-        , \n      \"filename\": \"1-red-rimmed_applejack-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170\"\
-        , \n      \"uuid\": \"ceb44744-68cd-4b29-ada9-4c6ed4127170\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015/download\"\
-        , \n      \"filename\": \"2-red-rimmed_applejack-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015\"\
-        , \n      \"uuid\": \"1deb4f4f-1094-49ec-b0da-5d714b60c015\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download\"\
-        , \n      \"filename\": \"1-potential_freshness-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e\"\
-        , \n      \"uuid\": \"da095cb7-5a81-4b57-912c-14b0501dc00e\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d/download\"\
-        , \n      \"filename\": \"2-potential_freshness-doc.gz.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d\"\
-        , \n      \"uuid\": \"ed460264-f0e9-415f-8247-738eb482c75d\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download\"\
-        , \n      \"filename\": \"1-inexpressible_sepsis-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a\"\
-        , \n      \"uuid\": \"a3bb0937-6240-4200-99d5-b514c465e56a\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01/download\"\
-        , \n      \"filename\": \"2-inexpressible_sepsis-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\
-        , \n      \"uuid\": \"1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions/2b1dce9e-852d-40a5-8148-d4e54cf3c322/download\"\
-        , \n      \"filename\": \"1-newfound_necessity-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1\"\
-        , \n      \"submission_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions/2b1dce9e-852d-40a5-8148-d4e54cf3c322\"\
-        , \n      \"uuid\": \"2b1dce9e-852d-40a5-8148-d4e54cf3c322\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions/9cc1760b-3d1e-4cd2-8f0e-5af35661509a/download\"\
-        , \n      \"filename\": \"2-newfound_necessity-doc.gz.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1\"\
-        , \n      \"submission_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions/9cc1760b-3d1e-4cd2-8f0e-5af35661509a\"\
-        , \n      \"uuid\": \"9cc1760b-3d1e-4cd2-8f0e-5af35661509a\"\n    }\n  ]\n\
+      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442/download\"\
+        , \n      \"filename\": \"1-pleasant_rearguard-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"submission_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442\"\
+        , \n      \"uuid\": \"bbc25300-917a-4b73-b0f4-10f3d6957442\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/a8699ca4-55a5-4737-b8f1-c9e170ec8250/download\"\
+        , \n      \"filename\": \"2-pleasant_rearguard-doc.gz.gpg\", \n      \"is_read\"\
+        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"submission_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/a8699ca4-55a5-4737-b8f1-c9e170ec8250\"\
+        , \n      \"uuid\": \"a8699ca4-55a5-4737-b8f1-c9e170ec8250\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download\"\
+        , \n      \"filename\": \"1-unlawful_spectrum-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\
+        , \n      \"uuid\": \"d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a/download\"\
+        , \n      \"filename\": \"2-unlawful_spectrum-doc.gz.gpg\", \n      \"is_read\"\
+        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a\"\
+        , \n      \"uuid\": \"55e459bd-cf4e-45f9-adce-95d79998254a\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '5129'
+      - '2055'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:07 GMT
+      - Tue, 25 Aug 2020 17:27:49 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -241,7 +159,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxNjcsImlhdCI6MTU5NzQ1ODM2NywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ge78iqZG4gFXFnwfrtRxNMPlIzrGGXqOY7aiV3F32n8
+      - Token eyJleHAiOjE1OTg0MDUyNjksImlhdCI6MTU5ODM3NjQ2OSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.mqGDCsm-4SC09ASMMch_SHbLhNG9d-zxzQ-msol6vFo
       Connection:
       - keep-alive
       Content-Type:
@@ -259,7 +177,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:07 GMT
+      - Tue, 25 Aug 2020 17:27:49 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -273,7 +191,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxNjcsImlhdCI6MTU5NzQ1ODM2NywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ge78iqZG4gFXFnwfrtRxNMPlIzrGGXqOY7aiV3F32n8
+      - Token eyJleHAiOjE1OTg0MDUyNjksImlhdCI6MTU5ODM3NjQ2OSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.mqGDCsm-4SC09ASMMch_SHbLhNG9d-zxzQ-msol6vFo
       Connection:
       - keep-alive
       Content-Type:
@@ -281,38 +199,20 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions/2b1dce9e-852d-40a5-8148-d4e54cf3c322/download
+    uri: http://localhost:8081/api/v1/user
   response:
     body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqARAArL7MGys+bU7mIl18TJs5rSTC9NvcRhYXjmB/UMdxG2z6sYPXOrpcIJgO
-        fJwQMwe0Osu5iYDmaGVZ+5oYmVdaCTt2inZKxn1Li8iCV4RnbXWItYlt03WeLO8Mfa/k8LMqwGb2
-        RWoW3yOPZm4NsTc30c60z7PBnjsgXuCbCjLCZs1uXQnOXqr4f6C4hq3S+CCvxqOfytPY4vBtVkvN
-        pcbaBm4jCgMAuyg/f3cXLt4w0b2TZ5LHejmppv1cOkpq/ia8cmyv0kW+hTh5uKnRiZtu+PlEWCEI
-        QhkNF7uVT1xoNDQZJE/wze0ni7u5V8Afze7oEEqbOJg/nLjUrAKdPM/08yB3CIiHU66LF5lsQMcc
-        eg/lpcMRja9YgkPYfOjWYxyZqYH9gHKykMlbjr5c2mGSswpkANw3wmuS9DIB96EYpPc2ebqDLKkt
-        8+yC5vDu81VBlxC0xPlRzb7bK81jFvzwavb86T4HEEl/n69QwiuPeiFNpw48tNSK6l2oDVyq6TjU
-        uRjyC/ICo8D4V1LYFp4fy8WdNG96AGADwMFNTTmxOuY1Gi8Qn8XXpeOzxPPiwPv/P+W7SAGM08dt
-        LuEdA9U+0GoHEGqIrzSy4B/EUaVby947Lz15FQzjS2AfNIx32PDcCnw80l5i/rV2v1G+qF7Iv1Kc
-        e5sYaAZ1FJ91j6S+VXvSTAEY9XnwSOWdtr//CvagOwodz5TtI/TXCt7yEiGJBGwz3dnAxWwlziOs
-        5yBjLzVsDX+GHrPL3cc/VbXd7be3fi/7omVkmeHmLma8vmI=
+      string: "{\n  \"first_name\": \"\", \n  \"is_admin\": true, \n  \"last_login\"\
+        : \"2020-08-25T17:27:49.453334Z\", \n  \"last_name\": \"\", \n  \"username\"\
+        : \"journalist\", \n  \"uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\n\
+        }\n"
     headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-newfound_necessity-msg.gpg
       Content-Length:
-      - '605'
+      - '192'
       Content-Type:
-      - application/pgp-encrypted
+      - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:07 GMT
-      Etag:
-      - sha256:cd8ca8320d46a9d2654a353aec5bec455d4afed05744d0ca95e47c7ccf358c1b
-      Expires:
-      - Sat, 15 Aug 2020 14:26:07 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:25:52 GMT
+      - Tue, 25 Aug 2020 17:27:49 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -326,7 +226,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxNjcsImlhdCI6MTU5NzQ1ODM2NywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ge78iqZG4gFXFnwfrtRxNMPlIzrGGXqOY7aiV3F32n8
+      - Token eyJleHAiOjE1OTg0MDUyNjksImlhdCI6MTU5ODM3NjQ2OSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.mqGDCsm-4SC09ASMMch_SHbLhNG9d-zxzQ-msol6vFo
       Connection:
       - keep-alive
       Content-Type:
@@ -334,38 +234,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqAQ//Z/S89kAgGiAOh+UVD2ePgDvU/l/JnvR2DkCEnnqTivaWTKetbcTOxv8D
-        iHQFUvQKPTADA4g5u56foRmzC0Yb2mP36vRMUqLq87hb/XfZFfr3Ak7E169EyaCN6ht5he28mLV0
-        j9brHPGxQWt2vrE4FFdwnUVQWNfAp13rFMm0IDFsHN3o3lNSjywJ62jlr1rce3mdkC+rXkwDh3zs
-        0ZDvxqFGx4X8YPbQiAStvUsK1n3u9NBnKE3cyeHe70xnMdQxq1N4NuACJZkNovKet6C3s8LTvj58
-        XiK6+/AgtbO9Pk6c89s1WW0x3hUGFtWVI+GqSUSQda5CDlWaq6Fq7mBURfuW7yD/rOJ0EypOOJED
-        b1GoyTiK6V1gC/mktb6u/Ei16SmPOjcsAzW7BFn5tsvl3lZULN+b4Bs+E7/Pxl4ymVaPDgbcsAh9
-        Ipp0thhF1a2A3MobRsTtNidryxvfzUTj5ou70vguzn7zthzog2sijyM9hBI0FPr6YRVWXvrS7BEQ
-        Ly9BA1AuzGy0kS1B6MUYdcWAaxQZHWNne02zDHZqe2sBFLM04tJU4myKrXlBOok4YILQ7OWDSoa8
-        Whkyohid0Eympcv+6YMaKI+9yBzHFWgcpu27rlrAuRGRXi9ibBxovyCRg5SSYc1Guo0jalDJWdDy
-        lRdLGsmqJAcWq2PUvNLSTAGpSiJRM+Iwxr77j/lapCOSRGfVJaivW59X5+ZQa6BN57DKWvcgPtCb
-        xDfXOBD4hOG9w/Qv5iKwgOcj/ckygOpvtrcQosdK9ZzrrdY=
+        hQIMA8PnxMCiIBsqAQ//Rw1NPH3mwdBg9NnblanYiQgqmPuHTY9ha8sR24r6Cbv4UunDrGcjIMeT
+        qUZfK1zok/ZjbbLMo+yVWG2my899P8meyJS9C9MzmPC/x8hpoSUVdxyRorBDja9qNtZUyhOrm5Dz
+        rsiuEaqB1T5iYPinyCzeOcGKxTlrDJE78s5aHQVGQeBjXN+7BqZXsGCWrUueXTF10QrC8u0T/Fnw
+        T+BLvR8FmCIEilEDQESn653nL2wbkTz/7OMxUJJUDkG9xO6VHsTcH4KAzVsonMaan2RVXarJ1393
+        esjkZJ3vMiKXSMNIdsdDQ8WbP/2JGL8rhdg3WZqRbX7ePEJ5C7moUGiJsXmYwNMDarImp/be0O+1
+        YGk1Bfig2smMD280G8vYNykGvLkiGWJU0tGQQBbc5NeM3WZ8chZsyKofidoc9CIY7NLVHGg5u6zf
+        AEe1bjVuWveL5NaUJUpzWxDQzkIBuvX/E9stjEvqb0fZCRkGqPQLOix/YVUjUzj2i1zGAgL/w3xw
+        jhadu4aN05dbf5cBeKRIUS43HnrDXluA0vq0HbX30xuFpoo/noZUiZ8uNfR2UKLQfIK0gNVH1ydw
+        MhHIDKyiUWm/0YQgzcozy14n9OCGtLCucWfxXy7nozJ7JnVJpSYPgAmozMOoqEiz3C0Dnsax/PRV
+        AvwhOEGda6nAIosZZ6nSTAGpDbf6bksYyI2J4JEtY4b7jBvCz6Qmg+n4ZIIH7IEeIBCkhnUtU8xz
+        JHiwor7B/FnoP6RymaVAKyAPqoKGfrJ/XGbwPXJRvQl2PeM=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-inexpressible_sepsis-msg.gpg
+      - attachment; filename=1-unlawful_spectrum-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:26:07 GMT
+      - Tue, 25 Aug 2020 17:27:49 GMT
       Etag:
-      - sha256:20db26d5f8240c2efbc83f40184bd03e74f0b927394627fe24bc2954cb4a6c2a
+      - sha256:dd82012b8656a3f7175b619f2875895a11071daf681b996cdc2704ddf5388664
       Expires:
-      - Sat, 15 Aug 2020 14:26:07 GMT
+      - Wed, 26 Aug 2020 05:27:49 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:44 GMT
+      - Tue, 25 Aug 2020 17:27:02 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -379,7 +279,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxNjcsImlhdCI6MTU5NzQ1ODM2NywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ge78iqZG4gFXFnwfrtRxNMPlIzrGGXqOY7aiV3F32n8
+      - Token eyJleHAiOjE1OTg0MDUyNjksImlhdCI6MTU5ODM3NjQ2OSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.mqGDCsm-4SC09ASMMch_SHbLhNG9d-zxzQ-msol6vFo
       Connection:
       - keep-alive
       Content-Type:
@@ -387,38 +287,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download
+    uri: http://localhost:8081/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAs+tSZVdjh2H5sgW3rQYsinaTUd1To3XLy/EC0UcNed15/OLbU142ic10
-        6l41iWmBW44aOmjYFIY46VfqPxQSM0G7fl2g5A0SZdmckTqzu141v/+BoTmvbzzZ8sXmpxKjbP/A
-        1F6aBPQ2qX7HcUVyGOadyMRjuKB+IO1pROBeFB5R0hE+FD+y4/yq2y4J9SVeYcdcwcsWJytFUm73
-        emXQ6vcBspvlgSjE1gywgfPFkmOLIKxv9INHFTT/FrfPvJ/yeFZ7jKtG0wxBQYPL4DG5QiVi1Gyz
-        Ln039tgWjFVnM5FhJ+XNhLbLHuISii/0CrKq9TeRea85xFHR6UGKgTm3/fOeWtEhC6FKa0XstXhU
-        T0E9dmh80Rd3myvN0HU3eyNFvmjyZ1weVguXjg4Ao1yWZ8a8AmqlA6m4conr4bbscqQKXCJSF1D+
-        g/i5ng78t0+4wnWMiKtN9rNTJkVBzXpaoYzOn+14EJbkYa+zkCyQS8TbjMBpLaP0aTFO4VXk7OAU
-        ygtKj6P8KmkfqivWrQ047DjqwVot+wBpKT+3t8ASscApC7KaSF0+d/fBvb05ZLzLtfSXM+Ts6pQ8
-        sn60uh2dnW/12nbqAdzFnrEPtDdtz5PFWn8brJpvhhMids/A7dkmbbLK6oirkLSRMF7Wdp8Stz2m
-        aI8Xz6brh2GQeKZafWnSTAHRguSmKDs+h+zUuP/hFFyLlLy2TWX3VLR2rLCEHhm82jP4UcMTpBkU
-        sgsFKxLyPddNYl+9D7kh9NLhzaLsXc2RihQWRvXYM9f3E0Y=
+        hQIMA8PnxMCiIBsqAQ//RtWsdfVE8eGi8sFqp1/cmLdkiut2OkXfs7DdjD0CBr6qfYUG8woosTjZ
+        +bdA5IIg1ewECF+eOZbfgW3EGzq/xN9rKaE+yTEbrR2swkoHNv1tUTrBoRGwUfHOYl3LOWlftNHt
+        8HbCVEZ/TAs1NQolRpSXj9o+mR6wjPvXtArQkW0io6D8ah9YO+YkEEkl4B2CwK1BwUQHj4B1TXw+
+        QGubNNIfGeXM9OkSCQMZapmumEt4m+8KImF1ncNMINXO/WV3tbTKDrCO63R/K6ibSuq//vd72Q2z
+        DFalhfcmnu7ksX0/4TFsrsvfuQoppTqepI6YklIKhTRkoRuY5fQeoK2w93qrZh0dmsVvlhx13/xl
+        19wcO1vASiZzfSHT/XDaXoS+3XmgW/xKr+Y0IJq+PZSs/EZ/2mr6zXePR8HtdFuvCnGiNjPFsRsE
+        sRIB1iq6FEV3zKxLU7FI46MTNrBpTYj3xAn2MqGM0UgCvwC1v73s6mMe6njwvYak8V0J/ny3sd/J
+        NHnbftRaGOmlrQbiXhoRIDEV5Kric9qBJG5R12kxDHHqce/viMEnZ1543+2snmsGrmWvX3Kxsbq4
+        cm1rmE/1dwYYtUaTpj1j4HDr7OY0PUN4F2BXK1gOSOONWiKd8hRAbY4Emwv60g+36ZtwY6kQu4v3
+        pQhKYVCTt8xL1gZkYYfSTAFnY4M6ViJKpbRI6FGnAQsYaB74rBUx6FatdEvztAN5VHarQPHN9uDF
+        TLPp+suitZOgA4wsgUWL+sUze53pOc/MCAUfBwrk2YD7hO8=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-potential_freshness-msg.gpg
+      - attachment; filename=1-pleasant_rearguard-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:26:07 GMT
+      - Tue, 25 Aug 2020 17:27:49 GMT
       Etag:
-      - sha256:624b8cc271f0bc4a153ff893f14d4b63464577579c0baa49ca2e6f5b2fb715a8
+      - sha256:cecd2591b0a9a0315f320e9878f68fdaec03c70b286da162c4416fab137ec00e
       Expires:
-      - Sat, 15 Aug 2020 14:26:07 GMT
+      - Wed, 26 Aug 2020 05:27:49 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:35 GMT
+      - Tue, 25 Aug 2020 17:26:47 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -432,113 +332,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxNjcsImlhdCI6MTU5NzQ1ODM2NywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ge78iqZG4gFXFnwfrtRxNMPlIzrGGXqOY7aiV3F32n8
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.20.0
-    method: GET
-    uri: http://localhost:8081/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download
-  response:
-    body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqARAAp+9fU8qzd8lBJJJeTGUfrTvtC7bBj77m96ioEWln23lreSXOi7W1E++i
-        X3mCeNg6hLC0PSAtuO0QTw+LE6TGqLJtQh5y14fIxzgIX5G02eaoOlsayjQbVfXHTJ6HBSFx1VkS
-        ImILNuS170DhYiOyW91R3OJ2zg4DeTlPkyegMGScWCued6EcBBL+/EOrvZLDoXtpFAHFkGGcoQSD
-        p/6L5/pp8AuB5N43NRCtslfsD8D4gpZT7L9gkvNIJbMrBQ4FVUzjB/XI5mkOhXAubjKzgGcpqiM+
-        N2k5nqSPFzotGHmKDy77Bq4D3Sk4fcLzvWMe9hY+Prp6QqW5/F3uvFhJdpdOR9JZ4WqY6pWk0VsA
-        jeIuaxGH3rRqFegi59AiZV+EvpORA7tx8qmkVHch5UifaJCsHthaxOrBk1D/rgutgmoQvVaCN+UA
-        6So9D0H/w6RIE0vE3SAsCpXV3XQJWwsya8O5R5jCuETvi1s5NnMXrtxRuBqkFZUcRSNZyzrUWLGA
-        8djkwjYcO5lP7qt40ztUosMmb2y+4z8ad3zhWP71SKA+chx8lUvY7ziiSmFOpRJOr0OEgKMU59lR
-        ovyT6mu5yB1d5d8G9ns8s5H8/ymV5WE/MdG+o472wWPKoKHnIu0zlj1Qqso8l/khM5wIjs8XvICl
-        pm7uojnWqaFcIaJg4EvSTAEw45cGmA90NotlV9qwHi0fJ0qlbFKf6FAyeDaRL0TPoLKx9JbGf+9M
-        +wwWhoyWoWili+hOxuju3sNSeN1iYkv3fEIyKyEy5rXvf/0=
-    headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-red-rimmed_applejack-msg.gpg
-      Content-Length:
-      - '605'
-      Content-Type:
-      - application/pgp-encrypted
-      Date:
-      - Sat, 15 Aug 2020 02:26:07 GMT
-      Etag:
-      - sha256:2e1bdbd452ce54d49602552182cb0146b2334c58a7c5aec0c0565645e2ab4286
-      Expires:
-      - Sat, 15 Aug 2020 14:26:07 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:25:23 GMT
-      Server:
-      - Werkzeug/0.16.0 Python/3.5.2
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxNjcsImlhdCI6MTU5NzQ1ODM2NywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ge78iqZG4gFXFnwfrtRxNMPlIzrGGXqOY7aiV3F32n8
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.20.0
-    method: GET
-    uri: http://localhost:8081/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96/download
-  response:
-    body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqARAAqBkguUOJVhB1E0rEBd3bIvbOJe9umLBp5QVPye5M4nsh0yl0IWnltszf
-        edV/FKB+H0YdtACRB57Zur0vTrOWAA4o1cC9tyUi18aWslfgDvVwJXLjELZYOQiDv//vmcWEG4Mw
-        ckXqK+/zvkgGLST9xjubdcQozWQNW8mXNzqLzLPLYd57oejEzr73iwn2UwQbQjXb31YI5ZsvCB0y
-        sltvyQevn92quua31WmlxjwzTndQ9u9mGQ5zZSxwK39HaZ3oEmPZlWelrnUfbodPJw5wQqGBN++n
-        lwGMVphNGN+EssKtSUb5Hmutd6jTajcfPWPf0yU6AYtJ3v/1wiOyXCaN3tnPStKUzP6w/htB2nFz
-        irbFi2VQ5v1Lg/nAYl0n3cVU4A8O8P8nhIX5KOsxNhYqNyuyjZsJgFAiKtCzEcXxlpyCQiPwpHbo
-        PM7nDr1JtS7w+IY4xlOkwdOmTIjq+WYjfwbOMd8GlwMQmpp2s6n4S7whSIcYI5acs14DERizF7lG
-        vY8XG7/ExbA0zt9B8j0MKTDsAxgkEEMALTPtINMmuc3xaDoTP7HA8e/X6tyPvrVarY8zFuPVxKuY
-        VXdPQuf6in/3uzja0QlWwq+Ibm+I/gBtQPRM1cDpW5n7XdYkzRcTIluElj8U8VnbECvkFNLt8NUk
-        IF792WIIe570TmeeRXfSTAE9fPtTykzrDiTy5LSwqQ91J/Og4d484LO+VkYSPGe37sfcFRSAOSL6
-        KHNlQb9u2IoOgkORHi/6PABz5ty5K45/OvEOhlB4/xbxkbA=
-    headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-out-of-town_primogeniture-msg.gpg
-      Content-Length:
-      - '605'
-      Content-Type:
-      - application/pgp-encrypted
-      Date:
-      - Sat, 15 Aug 2020 02:26:07 GMT
-      Etag:
-      - sha256:64f0c214fab76a0aa8a1407daf0c0478f7851bd7b5c0aaca5b5c8de53aae9336
-      Expires:
-      - Sat, 15 Aug 2020 14:26:07 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:24:41 GMT
-      Server:
-      - Werkzeug/0.16.0 Python/3.5.2
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxNjcsImlhdCI6MTU5NzQ1ODM2NywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ge78iqZG4gFXFnwfrtRxNMPlIzrGGXqOY7aiV3F32n8
+      - Token eyJleHAiOjE1OTg0MDUyNjksImlhdCI6MTU5ODM3NjQ2OSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.mqGDCsm-4SC09ASMMch_SHbLhNG9d-zxzQ-msol6vFo
       Connection:
       - keep-alive
       Content-Length:
@@ -558,7 +352,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:18 GMT
+      - Tue, 25 Aug 2020 17:28:00 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:

--- a/tests/functional/cassettes/test_offline_send_reply_to_source.yaml
+++ b/tests/functional/cassettes/test_offline_send_reply_to_source.yaml
@@ -17,9 +17,9 @@ interactions:
     uri: http://localhost:8081/api/v1/token
   response:
     body:
-      string: "{\n  \"expiration\": \"2020-08-15T10:30:45.440156Z\", \n  \"journalist_first_name\"\
-        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"b5e001de-19f1-4a93-885b-e0932aa2d441\"\
-        , \n  \"token\": \"eyJleHAiOjE1OTc0ODc0NDUsImlhdCI6MTU5NzQ1ODY0NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Kj-X-Xd-GieDvko5nb7rsmLfvWgKXBP4FlADocerQFI\"\
+      string: "{\n  \"expiration\": \"2020-08-26T01:29:09.554607Z\", \n  \"journalist_first_name\"\
+        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n  \"token\": \"eyJleHAiOjE1OTg0MDUzNDksImlhdCI6MTU5ODM3NjU0OSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.LILU3EVoOanUPNVNpq6ybWF54HvDxgeBkQWTrHP2OeE\"\
         \n}\n"
     headers:
       Content-Length:
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:45 GMT
+      - Tue, 25 Aug 2020 17:29:09 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -41,7 +41,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0NDUsImlhdCI6MTU5NzQ1ODY0NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Kj-X-Xd-GieDvko5nb7rsmLfvWgKXBP4FlADocerQFI
+      - Token eyJleHAiOjE1OTg0MDUzNDksImlhdCI6MTU5ODM3NjU0OSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.LILU3EVoOanUPNVNpq6ybWF54HvDxgeBkQWTrHP2OeE
       Connection:
       - keep-alive
       Content-Type:
@@ -52,65 +52,31 @@ interactions:
     uri: http://localhost:8081/api/v1/sources
   response:
     body:
-      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"red-rimmed\
-        \ applejack\", \n      \"key\": {\n        \"fingerprint\": \"D449222A7B7B0AC1E134A1FF01203DD2D2636A37\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAOaUXyLQCaUSR4HTaBVGZp1mi3jn3BExTTe2UCBYjsn1zhkOBDf9\\\
-        ncZNBQGjEBIYlOioC4XY1TkQep4L2DdmqO5lBfbyNG6LpGiNo7DvNBxeo5WNDa42C\\n8YcfTaVL9aWm07G12uwwc1WFNb0y86PzuAS1ek0k5B7jUfjNxFN9t0dhABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEtCTEEyQTRDUEtETEVURDM2MllWQUZVRVdRQlJLUzJWRjVG\\nUEs2SElBWFBXQUFNSURMUkZHUEdLU0dFSDJJUUtBUVdZUFdFS0xRWVpaTDZMU1JY\\\
-        nRFRUTUdPUlFFWFA0WE1EUlJJM0E9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEAEgPdLSY2o3LmUD/i+JqgIWc2SzA5OTX9Qo0g/r\\\
-        nqxDmi2NQMXob0fEEcP/GGnbiFE1P77AC6JWxSKPQStlfwvffhYmK2q7JBc71Jj8O\\nRqFRT5WSRpXUCq8tZkIYyoCXKQPlwSb3S1NQ3yM00kbkCM4dArLIFuQ/ZI1xG+l9\\\
-        nIqxWwXYY8SpO8uKDXFd7\\n=FjUe\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:23.753433Z\"\
+      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/add_star\"\
+        , \n      \"interaction_count\": 3, \n      \"is_flagged\": false, \n    \
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"unlawful spectrum\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"CE2A06285C9B1FDB43BFEB853EC2D036DDCA8CD4\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANJ0h2W7p0bViTLpY9w/PDd8sBHR56OVg+EGdXZ51Wuqt8ZUkF8W\\\
+        njSLrjsiOrcQ1lRFEgERFfIBJvlxfB/EMP4wcTY7vg7WQN/rvSJynBW0T6iHI3Rhi\\n/3v35LEuX9tLU/B1e11mRevgHTLRUms38Y5DBSkWACngvH4jWP+kwylJABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPDUyNzdCNDVDNExFUFdJWU9NQlY0VE5FVEI1WjdaVFpERTZK\\nQTJSTlhVNE5HM0g3R0NRVEJYRUdVWkdSRkpSRVZGN01BTzZDUUpWWVpBN0NOSEw3\\\
+        nS0JKVzMyS01XNEJaSVROU0dBVkk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJED7C0DbdyozULzEEALbYIlKPW3wXMi/9V2c/fYJc\\\
+        naX9UE94JwAdfntqAkEF8dL/P6fD5J1BPqQILK4crX6LN6h8g2y1vnrTTg9odsa1L\\nD0JqSpGfIWscGRuzY6b2WngLCgsudMqJgPZUdm/wbxp3Q8Daa8U99mL9jXr9Ia9j\\\
+        n8BFeiB6fb0VoIDgM7UTv\\n=j+JQ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:27:03.031475Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"uuid\": \"70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"potential\
-        \ freshness\", \n      \"key\": {\n        \"fingerprint\": \"06FFA85715E89C0AFBA927A78EA34965AC896EEA\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAMHR1pM94xuFw+GiTQI7RyUN/sKYmupDhwWj1nVricMXRbM7nIXk\\\
-        nsBnqTx0pTkITPxjszoVyFFxG+Uw8TXMZEZdCOhcC2AieHV0mgWsXxLAbD9Sw3VmQ\\ngOQ3S2C/MBrimrK4bkpoKXxKIV5v5Rgku5Pjxzw50HH4e1pYhgW2C+knABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEg3TVJTVUZHWFVKRldQQlM0UjdISk1JNE5HTUREQ0FaRzJL\\nVlIyTTM3RkFTQk9BRjIyUkFYNzdMUVdZNFZJNTJLSlBOQldaRjUyQTdHWFJVN1lQ\\\
-        nN0dQQU5QSFNNUUkzSUFVN1VGNEk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEI6jSWWsiW7qZeYD/ReRVU5y0nssc0+OlRy6M/im\\\
-        nHY9oHex0tSGt1fTuDVqsAKKHMDrZLKkkhJg42wcINwbXTj/vRu7n199IwbSUoDiE\\nJlnO6ZaIG996AUFS64eZBA+kXczqJbsWgdQQpwQJn8LiQUF8iwFhTThltjRSuXqf\\\
-        nMxyFevvxbIvYcs6il7Ip\\n=cZe8\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:36.194245Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"uuid\": \"6db98582-dd69-48ea-879e-5afc5aa388d6\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"inexpressible\
-        \ sepsis\", \n      \"key\": {\n        \"fingerprint\": \"380C70D1C7930985411415B31A1B751385404CC5\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANhgLtWR4jFlhHEPGJjcupkGrNymWv9wFlFM8YppKs6nNXaQdoKf\\\
-        n7+NESFVdkm89/7FWD/It0B49jEBjjs7GOmxhffomt1NVHocYGDBQjMAlKOYQgCnR\\neZDnHCFORSrQcfiNhgKm1/eFOZlNJDZn2Cwpmdk8ZV6B78fGVz+3B+tFABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEo0VFRaVzY2QlBRTFRRVVlNS0hIVzZZTjRGVkJIVFlVQ0ZW\\nNVNWNjNRWlQyT0Y3Wjc2NUxEWk1TVDJNR1JBVFpYSVZJVzVBR1M0N0RFU0hTRUhY\\\
-        nWDZFQVlISkFWTFBZRzc1VFlKQkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBobdROFQEzFd3gD/RUhGdZUriO3QqYTqvH7EZdZ\\\
-        n4r3iFUJVP3xhru9HYBtksepsKzUHYZn4nK29689AdV1A9o/X4YcKWrxFRbMuZs0E\\nTj2Je4jrw3WNf3O3COAWwFa75HOXIhGfFVuJ4Ni2/NVJGDPA6NNIfZfFMIj/NZF3\\\
-        n3RBZhDmxS21yJs9daQfs\\n=NQQJ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:44.877597Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"uuid\": \"f3a61359-1919-4bf0-b6f7-da902a935160\"\n    }\n  ]\n\
+        \      \"remove_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"f9b4da97-a077-412e-8e54-4ef4984a8540\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '4817'
+      - '1617'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:45 GMT
+      - Tue, 25 Aug 2020 17:29:09 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -124,7 +90,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0NDUsImlhdCI6MTU5NzQ1ODY0NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Kj-X-Xd-GieDvko5nb7rsmLfvWgKXBP4FlADocerQFI
+      - Token eyJleHAiOjE1OTg0MDUzNDksImlhdCI6MTU5ODM3NjU0OSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.LILU3EVoOanUPNVNpq6ybWF54HvDxgeBkQWTrHP2OeE
       Connection:
       - keep-alive
       Content-Type:
@@ -135,44 +101,24 @@ interactions:
     uri: http://localhost:8081/api/v1/submissions
   response:
     body:
-      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download\"\
-        , \n      \"filename\": \"1-red-rimmed_applejack-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170\"\
-        , \n      \"uuid\": \"ceb44744-68cd-4b29-ada9-4c6ed4127170\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015/download\"\
-        , \n      \"filename\": \"2-red-rimmed_applejack-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015\"\
-        , \n      \"uuid\": \"1deb4f4f-1094-49ec-b0da-5d714b60c015\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download\"\
-        , \n      \"filename\": \"1-potential_freshness-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e\"\
-        , \n      \"uuid\": \"da095cb7-5a81-4b57-912c-14b0501dc00e\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d/download\"\
-        , \n      \"filename\": \"2-potential_freshness-doc.gz.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d\"\
-        , \n      \"uuid\": \"ed460264-f0e9-415f-8247-738eb482c75d\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download\"\
-        , \n      \"filename\": \"1-inexpressible_sepsis-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a\"\
-        , \n      \"uuid\": \"a3bb0937-6240-4200-99d5-b514c465e56a\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01/download\"\
-        , \n      \"filename\": \"2-inexpressible_sepsis-doc.gz.gpg\", \n      \"\
-        is_read\": true, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\
-        , \n      \"uuid\": \"1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\n    }\n  ]\n\
+      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download\"\
+        , \n      \"filename\": \"1-unlawful_spectrum-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\
+        , \n      \"uuid\": \"d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a/download\"\
+        , \n      \"filename\": \"2-unlawful_spectrum-doc.gz.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a\"\
+        , \n      \"uuid\": \"55e459bd-cf4e-45f9-adce-95d79998254a\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '3082'
+      - '1038'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:45 GMT
+      - Tue, 25 Aug 2020 17:29:09 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -186,7 +132,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0NDUsImlhdCI6MTU5NzQ1ODY0NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Kj-X-Xd-GieDvko5nb7rsmLfvWgKXBP4FlADocerQFI
+      - Token eyJleHAiOjE1OTg0MDUzNDksImlhdCI6MTU5ODM3NjU0OSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.LILU3EVoOanUPNVNpq6ybWF54HvDxgeBkQWTrHP2OeE
       Connection:
       - keep-alive
       Content-Type:
@@ -197,14 +143,21 @@ interactions:
     uri: http://localhost:8081/api/v1/replies
   response:
     body:
-      string: "{\n  \"replies\": []\n}\n"
+      string: "{\n  \"replies\": [\n    {\n      \"filename\": \"3-unlawful_spectrum-reply.gpg\"\
+        , \n      \"is_deleted_by_source\": false, \n      \"journalist_first_name\"\
+        : \"\", \n      \"journalist_last_name\": \"\", \n      \"journalist_username\"\
+        : \"journalist\", \n      \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n      \"reply_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies/b8bfb5d1-7a5a-4413-9df2-52205fffa5b5\"\
+        , \n      \"size\": 1085, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"b8bfb5d1-7a5a-4413-9df2-52205fffa5b5\"\n    }\n  ]\n\
+        }\n"
     headers:
       Content-Length:
-      - '20'
+      - '578'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:45 GMT
+      - Tue, 25 Aug 2020 17:29:09 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -218,7 +171,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0NDUsImlhdCI6MTU5NzQ1ODY0NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Kj-X-Xd-GieDvko5nb7rsmLfvWgKXBP4FlADocerQFI
+      - Token eyJleHAiOjE1OTg0MDUzNDksImlhdCI6MTU5ODM3NjU0OSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.LILU3EVoOanUPNVNpq6ybWF54HvDxgeBkQWTrHP2OeE
       Connection:
       - keep-alive
       Content-Type:
@@ -226,38 +179,20 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download
+    uri: http://localhost:8081/api/v1/user
   response:
     body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqAQ//Z/S89kAgGiAOh+UVD2ePgDvU/l/JnvR2DkCEnnqTivaWTKetbcTOxv8D
-        iHQFUvQKPTADA4g5u56foRmzC0Yb2mP36vRMUqLq87hb/XfZFfr3Ak7E169EyaCN6ht5he28mLV0
-        j9brHPGxQWt2vrE4FFdwnUVQWNfAp13rFMm0IDFsHN3o3lNSjywJ62jlr1rce3mdkC+rXkwDh3zs
-        0ZDvxqFGx4X8YPbQiAStvUsK1n3u9NBnKE3cyeHe70xnMdQxq1N4NuACJZkNovKet6C3s8LTvj58
-        XiK6+/AgtbO9Pk6c89s1WW0x3hUGFtWVI+GqSUSQda5CDlWaq6Fq7mBURfuW7yD/rOJ0EypOOJED
-        b1GoyTiK6V1gC/mktb6u/Ei16SmPOjcsAzW7BFn5tsvl3lZULN+b4Bs+E7/Pxl4ymVaPDgbcsAh9
-        Ipp0thhF1a2A3MobRsTtNidryxvfzUTj5ou70vguzn7zthzog2sijyM9hBI0FPr6YRVWXvrS7BEQ
-        Ly9BA1AuzGy0kS1B6MUYdcWAaxQZHWNne02zDHZqe2sBFLM04tJU4myKrXlBOok4YILQ7OWDSoa8
-        Whkyohid0Eympcv+6YMaKI+9yBzHFWgcpu27rlrAuRGRXi9ibBxovyCRg5SSYc1Guo0jalDJWdDy
-        lRdLGsmqJAcWq2PUvNLSTAGpSiJRM+Iwxr77j/lapCOSRGfVJaivW59X5+ZQa6BN57DKWvcgPtCb
-        xDfXOBD4hOG9w/Qv5iKwgOcj/ckygOpvtrcQosdK9ZzrrdY=
+      string: "{\n  \"first_name\": \"\", \n  \"is_admin\": true, \n  \"last_login\"\
+        : \"2020-08-25T17:29:09.554989Z\", \n  \"last_name\": \"\", \n  \"username\"\
+        : \"journalist\", \n  \"uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\n\
+        }\n"
     headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-inexpressible_sepsis-msg.gpg
       Content-Length:
-      - '605'
+      - '192'
       Content-Type:
-      - application/pgp-encrypted
+      - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:45 GMT
-      Etag:
-      - sha256:20db26d5f8240c2efbc83f40184bd03e74f0b927394627fe24bc2954cb4a6c2a
-      Expires:
-      - Sat, 15 Aug 2020 14:30:45 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:25:44 GMT
+      - Tue, 25 Aug 2020 17:29:09 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -271,7 +206,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0NDUsImlhdCI6MTU5NzQ1ODY0NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Kj-X-Xd-GieDvko5nb7rsmLfvWgKXBP4FlADocerQFI
+      - Token eyJleHAiOjE1OTg0MDUzNDksImlhdCI6MTU5ODM3NjU0OSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.LILU3EVoOanUPNVNpq6ybWF54HvDxgeBkQWTrHP2OeE
       Connection:
       - keep-alive
       Content-Type:
@@ -279,38 +214,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAs+tSZVdjh2H5sgW3rQYsinaTUd1To3XLy/EC0UcNed15/OLbU142ic10
-        6l41iWmBW44aOmjYFIY46VfqPxQSM0G7fl2g5A0SZdmckTqzu141v/+BoTmvbzzZ8sXmpxKjbP/A
-        1F6aBPQ2qX7HcUVyGOadyMRjuKB+IO1pROBeFB5R0hE+FD+y4/yq2y4J9SVeYcdcwcsWJytFUm73
-        emXQ6vcBspvlgSjE1gywgfPFkmOLIKxv9INHFTT/FrfPvJ/yeFZ7jKtG0wxBQYPL4DG5QiVi1Gyz
-        Ln039tgWjFVnM5FhJ+XNhLbLHuISii/0CrKq9TeRea85xFHR6UGKgTm3/fOeWtEhC6FKa0XstXhU
-        T0E9dmh80Rd3myvN0HU3eyNFvmjyZ1weVguXjg4Ao1yWZ8a8AmqlA6m4conr4bbscqQKXCJSF1D+
-        g/i5ng78t0+4wnWMiKtN9rNTJkVBzXpaoYzOn+14EJbkYa+zkCyQS8TbjMBpLaP0aTFO4VXk7OAU
-        ygtKj6P8KmkfqivWrQ047DjqwVot+wBpKT+3t8ASscApC7KaSF0+d/fBvb05ZLzLtfSXM+Ts6pQ8
-        sn60uh2dnW/12nbqAdzFnrEPtDdtz5PFWn8brJpvhhMids/A7dkmbbLK6oirkLSRMF7Wdp8Stz2m
-        aI8Xz6brh2GQeKZafWnSTAHRguSmKDs+h+zUuP/hFFyLlLy2TWX3VLR2rLCEHhm82jP4UcMTpBkU
-        sgsFKxLyPddNYl+9D7kh9NLhzaLsXc2RihQWRvXYM9f3E0Y=
+        hQIMA8PnxMCiIBsqAQ//Rw1NPH3mwdBg9NnblanYiQgqmPuHTY9ha8sR24r6Cbv4UunDrGcjIMeT
+        qUZfK1zok/ZjbbLMo+yVWG2my899P8meyJS9C9MzmPC/x8hpoSUVdxyRorBDja9qNtZUyhOrm5Dz
+        rsiuEaqB1T5iYPinyCzeOcGKxTlrDJE78s5aHQVGQeBjXN+7BqZXsGCWrUueXTF10QrC8u0T/Fnw
+        T+BLvR8FmCIEilEDQESn653nL2wbkTz/7OMxUJJUDkG9xO6VHsTcH4KAzVsonMaan2RVXarJ1393
+        esjkZJ3vMiKXSMNIdsdDQ8WbP/2JGL8rhdg3WZqRbX7ePEJ5C7moUGiJsXmYwNMDarImp/be0O+1
+        YGk1Bfig2smMD280G8vYNykGvLkiGWJU0tGQQBbc5NeM3WZ8chZsyKofidoc9CIY7NLVHGg5u6zf
+        AEe1bjVuWveL5NaUJUpzWxDQzkIBuvX/E9stjEvqb0fZCRkGqPQLOix/YVUjUzj2i1zGAgL/w3xw
+        jhadu4aN05dbf5cBeKRIUS43HnrDXluA0vq0HbX30xuFpoo/noZUiZ8uNfR2UKLQfIK0gNVH1ydw
+        MhHIDKyiUWm/0YQgzcozy14n9OCGtLCucWfxXy7nozJ7JnVJpSYPgAmozMOoqEiz3C0Dnsax/PRV
+        AvwhOEGda6nAIosZZ6nSTAGpDbf6bksYyI2J4JEtY4b7jBvCz6Qmg+n4ZIIH7IEeIBCkhnUtU8xz
+        JHiwor7B/FnoP6RymaVAKyAPqoKGfrJ/XGbwPXJRvQl2PeM=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-potential_freshness-msg.gpg
+      - attachment; filename=1-unlawful_spectrum-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:30:45 GMT
+      - Tue, 25 Aug 2020 17:29:09 GMT
       Etag:
-      - sha256:624b8cc271f0bc4a153ff893f14d4b63464577579c0baa49ca2e6f5b2fb715a8
+      - sha256:dd82012b8656a3f7175b619f2875895a11071daf681b996cdc2704ddf5388664
       Expires:
-      - Sat, 15 Aug 2020 14:30:45 GMT
+      - Wed, 26 Aug 2020 05:29:09 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:35 GMT
+      - Tue, 25 Aug 2020 17:27:02 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -324,7 +259,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0NDUsImlhdCI6MTU5NzQ1ODY0NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Kj-X-Xd-GieDvko5nb7rsmLfvWgKXBP4FlADocerQFI
+      - Token eyJleHAiOjE1OTg0MDUzNDksImlhdCI6MTU5ODM3NjU0OSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.LILU3EVoOanUPNVNpq6ybWF54HvDxgeBkQWTrHP2OeE
       Connection:
       - keep-alive
       Content-Type:
@@ -332,38 +267,66 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies/b8bfb5d1-7a5a-4413-9df2-52205fffa5b5/download
   response:
     body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqARAAp+9fU8qzd8lBJJJeTGUfrTvtC7bBj77m96ioEWln23lreSXOi7W1E++i
-        X3mCeNg6hLC0PSAtuO0QTw+LE6TGqLJtQh5y14fIxzgIX5G02eaoOlsayjQbVfXHTJ6HBSFx1VkS
-        ImILNuS170DhYiOyW91R3OJ2zg4DeTlPkyegMGScWCued6EcBBL+/EOrvZLDoXtpFAHFkGGcoQSD
-        p/6L5/pp8AuB5N43NRCtslfsD8D4gpZT7L9gkvNIJbMrBQ4FVUzjB/XI5mkOhXAubjKzgGcpqiM+
-        N2k5nqSPFzotGHmKDy77Bq4D3Sk4fcLzvWMe9hY+Prp6QqW5/F3uvFhJdpdOR9JZ4WqY6pWk0VsA
-        jeIuaxGH3rRqFegi59AiZV+EvpORA7tx8qmkVHch5UifaJCsHthaxOrBk1D/rgutgmoQvVaCN+UA
-        6So9D0H/w6RIE0vE3SAsCpXV3XQJWwsya8O5R5jCuETvi1s5NnMXrtxRuBqkFZUcRSNZyzrUWLGA
-        8djkwjYcO5lP7qt40ztUosMmb2y+4z8ad3zhWP71SKA+chx8lUvY7ziiSmFOpRJOr0OEgKMU59lR
-        ovyT6mu5yB1d5d8G9ns8s5H8/ymV5WE/MdG+o472wWPKoKHnIu0zlj1Qqso8l/khM5wIjs8XvICl
-        pm7uojnWqaFcIaJg4EvSTAEw45cGmA90NotlV9qwHi0fJ0qlbFKf6FAyeDaRL0TPoLKx9JbGf+9M
-        +wwWhoyWoWili+hOxuju3sNSeN1iYkv3fEIyKyEy5rXvf/0=
+      string: '-----BEGIN PGP MESSAGE-----
+
+
+        hIwDPsLQNt3KjNQBA/9ojtfC9t1XqWV3wWgAlu95dTxfMqqYczw6sQSmgcEkg9+P
+
+        vCeb05aaW5jMMlYXkUm62SVqdw/KJW1Dg8trcMvRFIeCKNZQhA01Rsqb7jzDLzD/
+
+        kqJ0JGGZk01wDAdRZwWHtA96PY6Qp7mpEJcQTfliBzdWhe03KWfPEJxzZCfT84UC
+
+        DAPD58TAoiAbKgEP/RRt/jqDFFWYxpc4SrqshMubiyh/GImTEOePHfhgQujDvKLu
+
+        kRQovxq1xujHfCuVaBHUgCpm3jWcKCQPrpNT8xLNngu8Uem1degoqstCk+0MVVpC
+
+        +YkmUCajX9X7J98xxuJ/evZMWgWzbk3kD2AuTlYolXqNB6nY50RWQwt1Si/k9p7Y
+
+        RO1ERKa9M99a+lReuF2E2dEYW0Ru3YdTbz/sYuX65Hl/UM6lEhdq9A2EDBElDoiH
+
+        0wkY+YybjFMJlfKnK97nxJ2rwfPQqIiRFEWRbHci+pbtjcPxPjEM37aM/9urM6WR
+
+        CJ3leluB9ZYHzKAFA5VGHH1W1/xPe8STvySggG/cjb4jIxqyu9rV+dkrwK0xjfhN
+
+        15G7B5gvJmXWAp5IDvQD3Pux128hpJYzLUBMURAK1oVf0SCjqWFwQeAIEOE67eJ6
+
+        Nu046qIKcTz6jSH6JrxSneHyDySZaM8DwV9u24voInDGGjEwAbuLfvOGYu6yawAX
+
+        JkD7tAHHpEnsqfOYcH/dMFDLjaE1ybzrD1W2JmJUitMjL449QrTQS8ABpZvZvNl7
+
+        egjy2PgtxHkGvLZ52xv4gGq0Q+5eXquL8uE/zFEi8cUuCj1Q0owvkfqia1j+ZU5p
+
+        JnCZY4UkEivnwu9pbRXu1nuUlPo+/HQSpO9a7SEpIWo4WbnQPxZ9f5LgCiIl0lMB
+
+        /uKyfBrojiN6UOwbopz3CqwC+C3QKzbnKpV6LfyweT8hBt8nYZCp+vDcQ+iucyxb
+
+        1C7h2wAzePF2VFz/1plVSNOGVwqzf8Qf7wCBfJpAt+z7UQ==
+
+        =EqXV
+
+        -----END PGP MESSAGE-----
+
+        '
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-red-rimmed_applejack-msg.gpg
+      - attachment; filename=3-unlawful_spectrum-reply.gpg
       Content-Length:
-      - '605'
+      - '1085'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:30:45 GMT
+      - Tue, 25 Aug 2020 17:29:09 GMT
       Etag:
-      - sha256:2e1bdbd452ce54d49602552182cb0146b2334c58a7c5aec0c0565645e2ab4286
+      - sha256:8055a4fea7b7e8e4bf0e3ea6d3e4ee5959899e7f4732b0585b5b4ae5b58231e0
       Expires:
-      - Sat, 15 Aug 2020 14:30:45 GMT
+      - Wed, 26 Aug 2020 05:29:09 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:23 GMT
+      - Tue, 25 Aug 2020 17:28:16 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -377,7 +340,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0NDUsImlhdCI6MTU5NzQ1ODY0NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Kj-X-Xd-GieDvko5nb7rsmLfvWgKXBP4FlADocerQFI
+      - Token eyJleHAiOjE1OTg0MDUzNDksImlhdCI6MTU5ODM3NjU0OSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.LILU3EVoOanUPNVNpq6ybWF54HvDxgeBkQWTrHP2OeE
       Connection:
       - keep-alive
       Content-Length:
@@ -397,7 +360,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:56 GMT
+      - Tue, 25 Aug 2020 17:29:20 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:

--- a/tests/functional/cassettes/test_offline_star_source.yaml
+++ b/tests/functional/cassettes/test_offline_star_source.yaml
@@ -17,9 +17,9 @@ interactions:
     uri: http://localhost:8081/api/v1/token
   response:
     body:
-      string: "{\n  \"expiration\": \"2020-08-15T10:28:33.961582Z\", \n  \"journalist_first_name\"\
-        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"b5e001de-19f1-4a93-885b-e0932aa2d441\"\
-        , \n  \"token\": \"eyJleHAiOjE1OTc0ODczMTMsImlhdCI6MTU5NzQ1ODUxMywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.RozZEVV3hF4sYBBuWEXsMxBVVdBNvVsemLtm33rWJLw\"\
+      string: "{\n  \"expiration\": \"2020-08-26T01:27:26.387706Z\", \n  \"journalist_first_name\"\
+        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n  \"token\": \"eyJleHAiOjE1OTg0MDUyNDYsImlhdCI6MTU5ODM3NjQ0NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.RJOIk4zqY-bce24Z_YKNrp0z5-Obi9fFFamNWxBSYZA\"\
         \n}\n"
     headers:
       Content-Length:
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:28:33 GMT
+      - Tue, 25 Aug 2020 17:27:26 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -41,7 +41,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczMTMsImlhdCI6MTU5NzQ1ODUxMywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.RozZEVV3hF4sYBBuWEXsMxBVVdBNvVsemLtm33rWJLw
+      - Token eyJleHAiOjE1OTg0MDUyNDYsImlhdCI6MTU5ODM3NjQ0NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.RJOIk4zqY-bce24Z_YKNrp0z5-Obi9fFFamNWxBSYZA
       Connection:
       - keep-alive
       Content-Type:
@@ -52,82 +52,48 @@ interactions:
     uri: http://localhost:8081/api/v1/sources
   response:
     body:
-      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/add_star\"\
+      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/add_star\"\
         , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"out-of-town\
-        \ primogeniture\", \n      \"key\": {\n        \"fingerprint\": \"200C271E4E680FFE62E008931554E4BF600B1E3C\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAL4uN551SiYiVLrHoK1QGMDmN1xq42u8o2dmnKFkArW5KfBvBFoX\\\
-        nZX5LnOj9hKKEEmeGX5beS9h+fjsWvx86M2kQj/5xhOmHw0GGESEPQBSUc+Lyohpc\\nUmBoNNBfWIouEQ+IVS0gmrOwiS7wdItMby1lLDlDBoiEm4aRnRw36NIpABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEhPUDNaU05LUFgzNE1MV09QMkVPQkJRVVc2QjZPS0ZFMzZa\\nVktOV0VWNEhXVTVMUlZGQlFENjVKTEtYUENHRE1LVEFTTDM2N0NOT1ZDN0hBRUxF\\\
-        nWVQyWU5LMkJHM0ZWNlZWUUlMMlE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBVU5L9gCx482IED/2w6yFqz19zTBX72qN0MUTq5\\\
-        nCavQIBhhWrbsc1m0p+cxuVJ16TYxiE3S/Lp/rd4r1Q9MQg9BP0+/qjOA541kNq5A\\nmR2Y0teqWonDqeY/660kEFIbio0HbOTjsBhEZxtglJ1wz70tUpd40ZVMsu+Z32Mw\\\
-        n2kSiCclJYHk7uy1eis57\\n=pz11\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:24:42.042205Z\"\
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"pleasant rearguard\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"FF9007318CCAB4DC6149B1B38B7907A15818269D\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAM8jaDDbt3lQQVUEk+MduWYmJHa3eME1Y9C4yj+6n9V9Sksakj3B\\\
+        nWcl9uKzXLtZIP1rdvkW+Bg/P64vTgi+I+pcL5+e5gpF/KdNhrksovmhzc/ASgrn7\\nEcNCwIk+Iyym255IOEsZ8j9SvpzG1VyUdJxlK+P6bmbkFgDDwHjF0QzDABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPEtHQUFQVlNISjJLS0lMV0daTUlBWUFHMlhXU0ZWRlJRQ1pJ\\nNE5QTVBVUEVKNDNIQ1hJVUdPUk9XUEhLUldXRkxRTk5LTko3WEk1Tk9JUkpFTERQ\\\
+        nU0pZN0JMTk9ETk0yTUxNSjRPMkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEIt5B6FYGCadjpUD/1IiTV3TAyduG0UkaxcTT+Bp\\\
+        nKZRsNsK+HhYBCu/VjBcybLkuccDaonnm99OyaWZAZ/F/E/DxRENTxs0OL47GbHG7\\n9hSFWj99MZACMs3aKAmqxZEnQmm0B0xDIlHyd9mQBSieUw6aVMVjxK8p0Z21R7cz\\\
+        nc+DfEuCbShQ6b5+9X308\\n=RU3O\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:26:48.423985Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\
-        , \n      \"uuid\": \"4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/add_star\"\
+        \      \"remove_star_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"uuid\": \"505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\n    }, \n  \
+        \  {\n      \"add_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/add_star\"\
         , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"red-rimmed\
-        \ applejack\", \n      \"key\": {\n        \"fingerprint\": \"D449222A7B7B0AC1E134A1FF01203DD2D2636A37\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAOaUXyLQCaUSR4HTaBVGZp1mi3jn3BExTTe2UCBYjsn1zhkOBDf9\\\
-        ncZNBQGjEBIYlOioC4XY1TkQep4L2DdmqO5lBfbyNG6LpGiNo7DvNBxeo5WNDa42C\\n8YcfTaVL9aWm07G12uwwc1WFNb0y86PzuAS1ek0k5B7jUfjNxFN9t0dhABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEtCTEEyQTRDUEtETEVURDM2MllWQUZVRVdRQlJLUzJWRjVG\\nUEs2SElBWFBXQUFNSURMUkZHUEdLU0dFSDJJUUtBUVdZUFdFS0xRWVpaTDZMU1JY\\\
-        nRFRUTUdPUlFFWFA0WE1EUlJJM0E9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEAEgPdLSY2o3LmUD/i+JqgIWc2SzA5OTX9Qo0g/r\\\
-        nqxDmi2NQMXob0fEEcP/GGnbiFE1P77AC6JWxSKPQStlfwvffhYmK2q7JBc71Jj8O\\nRqFRT5WSRpXUCq8tZkIYyoCXKQPlwSb3S1NQ3yM00kbkCM4dArLIFuQ/ZI1xG+l9\\\
-        nIqxWwXYY8SpO8uKDXFd7\\n=FjUe\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:23.753433Z\"\
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"unlawful spectrum\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"CE2A06285C9B1FDB43BFEB853EC2D036DDCA8CD4\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANJ0h2W7p0bViTLpY9w/PDd8sBHR56OVg+EGdXZ51Wuqt8ZUkF8W\\\
+        njSLrjsiOrcQ1lRFEgERFfIBJvlxfB/EMP4wcTY7vg7WQN/rvSJynBW0T6iHI3Rhi\\n/3v35LEuX9tLU/B1e11mRevgHTLRUms38Y5DBSkWACngvH4jWP+kwylJABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPDUyNzdCNDVDNExFUFdJWU9NQlY0VE5FVEI1WjdaVFpERTZK\\nQTJSTlhVNE5HM0g3R0NRVEJYRUdVWkdSRkpSRVZGN01BTzZDUUpWWVpBN0NOSEw3\\\
+        nS0JKVzMyS01XNEJaSVROU0dBVkk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJED7C0DbdyozULzEEALbYIlKPW3wXMi/9V2c/fYJc\\\
+        naX9UE94JwAdfntqAkEF8dL/P6fD5J1BPqQILK4crX6LN6h8g2y1vnrTTg9odsa1L\\nD0JqSpGfIWscGRuzY6b2WngLCgsudMqJgPZUdm/wbxp3Q8Daa8U99mL9jXr9Ia9j\\\
+        n8BFeiB6fb0VoIDgM7UTv\\n=j+JQ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:27:03.031475Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"uuid\": \"70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"potential\
-        \ freshness\", \n      \"key\": {\n        \"fingerprint\": \"06FFA85715E89C0AFBA927A78EA34965AC896EEA\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAMHR1pM94xuFw+GiTQI7RyUN/sKYmupDhwWj1nVricMXRbM7nIXk\\\
-        nsBnqTx0pTkITPxjszoVyFFxG+Uw8TXMZEZdCOhcC2AieHV0mgWsXxLAbD9Sw3VmQ\\ngOQ3S2C/MBrimrK4bkpoKXxKIV5v5Rgku5Pjxzw50HH4e1pYhgW2C+knABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEg3TVJTVUZHWFVKRldQQlM0UjdISk1JNE5HTUREQ0FaRzJL\\nVlIyTTM3RkFTQk9BRjIyUkFYNzdMUVdZNFZJNTJLSlBOQldaRjUyQTdHWFJVN1lQ\\\
-        nN0dQQU5QSFNNUUkzSUFVN1VGNEk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEI6jSWWsiW7qZeYD/ReRVU5y0nssc0+OlRy6M/im\\\
-        nHY9oHex0tSGt1fTuDVqsAKKHMDrZLKkkhJg42wcINwbXTj/vRu7n199IwbSUoDiE\\nJlnO6ZaIG996AUFS64eZBA+kXczqJbsWgdQQpwQJn8LiQUF8iwFhTThltjRSuXqf\\\
-        nMxyFevvxbIvYcs6il7Ip\\n=cZe8\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:36.194245Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"uuid\": \"6db98582-dd69-48ea-879e-5afc5aa388d6\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"inexpressible\
-        \ sepsis\", \n      \"key\": {\n        \"fingerprint\": \"380C70D1C7930985411415B31A1B751385404CC5\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANhgLtWR4jFlhHEPGJjcupkGrNymWv9wFlFM8YppKs6nNXaQdoKf\\\
-        n7+NESFVdkm89/7FWD/It0B49jEBjjs7GOmxhffomt1NVHocYGDBQjMAlKOYQgCnR\\neZDnHCFORSrQcfiNhgKm1/eFOZlNJDZn2Cwpmdk8ZV6B78fGVz+3B+tFABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEo0VFRaVzY2QlBRTFRRVVlNS0hIVzZZTjRGVkJIVFlVQ0ZW\\nNVNWNjNRWlQyT0Y3Wjc2NUxEWk1TVDJNR1JBVFpYSVZJVzVBR1M0N0RFU0hTRUhY\\\
-        nWDZFQVlISkFWTFBZRzc1VFlKQkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBobdROFQEzFd3gD/RUhGdZUriO3QqYTqvH7EZdZ\\\
-        n4r3iFUJVP3xhru9HYBtksepsKzUHYZn4nK29689AdV1A9o/X4YcKWrxFRbMuZs0E\\nTj2Je4jrw3WNf3O3COAWwFa75HOXIhGfFVuJ4Ni2/NVJGDPA6NNIfZfFMIj/NZF3\\\
-        n3RBZhDmxS21yJs9daQfs\\n=NQQJ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:44.877597Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"uuid\": \"f3a61359-1919-4bf0-b6f7-da902a935160\"\n    }\n  ]\n\
+        \      \"remove_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"f9b4da97-a077-412e-8e54-4ef4984a8540\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '6421'
+      - '3214'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:28:34 GMT
+      - Tue, 25 Aug 2020 17:27:26 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -141,7 +107,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczMTMsImlhdCI6MTU5NzQ1ODUxMywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.RozZEVV3hF4sYBBuWEXsMxBVVdBNvVsemLtm33rWJLw
+      - Token eyJleHAiOjE1OTg0MDUyNDYsImlhdCI6MTU5ODM3NjQ0NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.RJOIk4zqY-bce24Z_YKNrp0z5-Obi9fFFamNWxBSYZA
       Connection:
       - keep-alive
       Content-Type:
@@ -152,55 +118,34 @@ interactions:
     uri: http://localhost:8081/api/v1/submissions
   response:
     body:
-      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96/download\"\
-        , \n      \"filename\": \"1-out-of-town_primogeniture-msg.gpg\", \n      \"\
-        is_read\": true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\
-        , \n      \"submission_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96\"\
-        , \n      \"uuid\": \"f836676a-c1aa-49a8-90c2-bb171f60cd96\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/99509e6d-62dd-48f3-8208-623f9290bc03/download\"\
-        , \n      \"filename\": \"2-out-of-town_primogeniture-doc.gz.gpg\", \n   \
-        \   \"is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"\
-        /api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\", \n      \"submission_url\"\
-        : \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/99509e6d-62dd-48f3-8208-623f9290bc03\"\
-        , \n      \"uuid\": \"99509e6d-62dd-48f3-8208-623f9290bc03\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download\"\
-        , \n      \"filename\": \"1-red-rimmed_applejack-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170\"\
-        , \n      \"uuid\": \"ceb44744-68cd-4b29-ada9-4c6ed4127170\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015/download\"\
-        , \n      \"filename\": \"2-red-rimmed_applejack-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015\"\
-        , \n      \"uuid\": \"1deb4f4f-1094-49ec-b0da-5d714b60c015\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download\"\
-        , \n      \"filename\": \"1-potential_freshness-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e\"\
-        , \n      \"uuid\": \"da095cb7-5a81-4b57-912c-14b0501dc00e\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d/download\"\
-        , \n      \"filename\": \"2-potential_freshness-doc.gz.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d\"\
-        , \n      \"uuid\": \"ed460264-f0e9-415f-8247-738eb482c75d\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download\"\
-        , \n      \"filename\": \"1-inexpressible_sepsis-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a\"\
-        , \n      \"uuid\": \"a3bb0937-6240-4200-99d5-b514c465e56a\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01/download\"\
-        , \n      \"filename\": \"2-inexpressible_sepsis-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\
-        , \n      \"uuid\": \"1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\n    }\n  ]\n\
+      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442/download\"\
+        , \n      \"filename\": \"1-pleasant_rearguard-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"submission_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442\"\
+        , \n      \"uuid\": \"bbc25300-917a-4b73-b0f4-10f3d6957442\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/a8699ca4-55a5-4737-b8f1-c9e170ec8250/download\"\
+        , \n      \"filename\": \"2-pleasant_rearguard-doc.gz.gpg\", \n      \"is_read\"\
+        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"submission_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/a8699ca4-55a5-4737-b8f1-c9e170ec8250\"\
+        , \n      \"uuid\": \"a8699ca4-55a5-4737-b8f1-c9e170ec8250\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download\"\
+        , \n      \"filename\": \"1-unlawful_spectrum-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\
+        , \n      \"uuid\": \"d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a/download\"\
+        , \n      \"filename\": \"2-unlawful_spectrum-doc.gz.gpg\", \n      \"is_read\"\
+        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a\"\
+        , \n      \"uuid\": \"55e459bd-cf4e-45f9-adce-95d79998254a\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '4113'
+      - '2055'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:28:34 GMT
+      - Tue, 25 Aug 2020 17:27:26 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -214,7 +159,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczMTMsImlhdCI6MTU5NzQ1ODUxMywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.RozZEVV3hF4sYBBuWEXsMxBVVdBNvVsemLtm33rWJLw
+      - Token eyJleHAiOjE1OTg0MDUyNDYsImlhdCI6MTU5ODM3NjQ0NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.RJOIk4zqY-bce24Z_YKNrp0z5-Obi9fFFamNWxBSYZA
       Connection:
       - keep-alive
       Content-Type:
@@ -232,7 +177,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:28:34 GMT
+      - Tue, 25 Aug 2020 17:27:26 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -246,7 +191,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczMTMsImlhdCI6MTU5NzQ1ODUxMywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.RozZEVV3hF4sYBBuWEXsMxBVVdBNvVsemLtm33rWJLw
+      - Token eyJleHAiOjE1OTg0MDUyNDYsImlhdCI6MTU5ODM3NjQ0NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.RJOIk4zqY-bce24Z_YKNrp0z5-Obi9fFFamNWxBSYZA
       Connection:
       - keep-alive
       Content-Type:
@@ -254,38 +199,20 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download
+    uri: http://localhost:8081/api/v1/user
   response:
     body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqAQ//Z/S89kAgGiAOh+UVD2ePgDvU/l/JnvR2DkCEnnqTivaWTKetbcTOxv8D
-        iHQFUvQKPTADA4g5u56foRmzC0Yb2mP36vRMUqLq87hb/XfZFfr3Ak7E169EyaCN6ht5he28mLV0
-        j9brHPGxQWt2vrE4FFdwnUVQWNfAp13rFMm0IDFsHN3o3lNSjywJ62jlr1rce3mdkC+rXkwDh3zs
-        0ZDvxqFGx4X8YPbQiAStvUsK1n3u9NBnKE3cyeHe70xnMdQxq1N4NuACJZkNovKet6C3s8LTvj58
-        XiK6+/AgtbO9Pk6c89s1WW0x3hUGFtWVI+GqSUSQda5CDlWaq6Fq7mBURfuW7yD/rOJ0EypOOJED
-        b1GoyTiK6V1gC/mktb6u/Ei16SmPOjcsAzW7BFn5tsvl3lZULN+b4Bs+E7/Pxl4ymVaPDgbcsAh9
-        Ipp0thhF1a2A3MobRsTtNidryxvfzUTj5ou70vguzn7zthzog2sijyM9hBI0FPr6YRVWXvrS7BEQ
-        Ly9BA1AuzGy0kS1B6MUYdcWAaxQZHWNne02zDHZqe2sBFLM04tJU4myKrXlBOok4YILQ7OWDSoa8
-        Whkyohid0Eympcv+6YMaKI+9yBzHFWgcpu27rlrAuRGRXi9ibBxovyCRg5SSYc1Guo0jalDJWdDy
-        lRdLGsmqJAcWq2PUvNLSTAGpSiJRM+Iwxr77j/lapCOSRGfVJaivW59X5+ZQa6BN57DKWvcgPtCb
-        xDfXOBD4hOG9w/Qv5iKwgOcj/ckygOpvtrcQosdK9ZzrrdY=
+      string: "{\n  \"first_name\": \"\", \n  \"is_admin\": true, \n  \"last_login\"\
+        : \"2020-08-25T17:27:26.388085Z\", \n  \"last_name\": \"\", \n  \"username\"\
+        : \"journalist\", \n  \"uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\n\
+        }\n"
     headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-inexpressible_sepsis-msg.gpg
       Content-Length:
-      - '605'
+      - '192'
       Content-Type:
-      - application/pgp-encrypted
+      - application/json
       Date:
-      - Sat, 15 Aug 2020 02:28:34 GMT
-      Etag:
-      - sha256:20db26d5f8240c2efbc83f40184bd03e74f0b927394627fe24bc2954cb4a6c2a
-      Expires:
-      - Sat, 15 Aug 2020 14:28:34 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:25:44 GMT
+      - Tue, 25 Aug 2020 17:27:26 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -299,7 +226,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczMTMsImlhdCI6MTU5NzQ1ODUxMywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.RozZEVV3hF4sYBBuWEXsMxBVVdBNvVsemLtm33rWJLw
+      - Token eyJleHAiOjE1OTg0MDUyNDYsImlhdCI6MTU5ODM3NjQ0NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.RJOIk4zqY-bce24Z_YKNrp0z5-Obi9fFFamNWxBSYZA
       Connection:
       - keep-alive
       Content-Type:
@@ -307,38 +234,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAs+tSZVdjh2H5sgW3rQYsinaTUd1To3XLy/EC0UcNed15/OLbU142ic10
-        6l41iWmBW44aOmjYFIY46VfqPxQSM0G7fl2g5A0SZdmckTqzu141v/+BoTmvbzzZ8sXmpxKjbP/A
-        1F6aBPQ2qX7HcUVyGOadyMRjuKB+IO1pROBeFB5R0hE+FD+y4/yq2y4J9SVeYcdcwcsWJytFUm73
-        emXQ6vcBspvlgSjE1gywgfPFkmOLIKxv9INHFTT/FrfPvJ/yeFZ7jKtG0wxBQYPL4DG5QiVi1Gyz
-        Ln039tgWjFVnM5FhJ+XNhLbLHuISii/0CrKq9TeRea85xFHR6UGKgTm3/fOeWtEhC6FKa0XstXhU
-        T0E9dmh80Rd3myvN0HU3eyNFvmjyZ1weVguXjg4Ao1yWZ8a8AmqlA6m4conr4bbscqQKXCJSF1D+
-        g/i5ng78t0+4wnWMiKtN9rNTJkVBzXpaoYzOn+14EJbkYa+zkCyQS8TbjMBpLaP0aTFO4VXk7OAU
-        ygtKj6P8KmkfqivWrQ047DjqwVot+wBpKT+3t8ASscApC7KaSF0+d/fBvb05ZLzLtfSXM+Ts6pQ8
-        sn60uh2dnW/12nbqAdzFnrEPtDdtz5PFWn8brJpvhhMids/A7dkmbbLK6oirkLSRMF7Wdp8Stz2m
-        aI8Xz6brh2GQeKZafWnSTAHRguSmKDs+h+zUuP/hFFyLlLy2TWX3VLR2rLCEHhm82jP4UcMTpBkU
-        sgsFKxLyPddNYl+9D7kh9NLhzaLsXc2RihQWRvXYM9f3E0Y=
+        hQIMA8PnxMCiIBsqAQ//Rw1NPH3mwdBg9NnblanYiQgqmPuHTY9ha8sR24r6Cbv4UunDrGcjIMeT
+        qUZfK1zok/ZjbbLMo+yVWG2my899P8meyJS9C9MzmPC/x8hpoSUVdxyRorBDja9qNtZUyhOrm5Dz
+        rsiuEaqB1T5iYPinyCzeOcGKxTlrDJE78s5aHQVGQeBjXN+7BqZXsGCWrUueXTF10QrC8u0T/Fnw
+        T+BLvR8FmCIEilEDQESn653nL2wbkTz/7OMxUJJUDkG9xO6VHsTcH4KAzVsonMaan2RVXarJ1393
+        esjkZJ3vMiKXSMNIdsdDQ8WbP/2JGL8rhdg3WZqRbX7ePEJ5C7moUGiJsXmYwNMDarImp/be0O+1
+        YGk1Bfig2smMD280G8vYNykGvLkiGWJU0tGQQBbc5NeM3WZ8chZsyKofidoc9CIY7NLVHGg5u6zf
+        AEe1bjVuWveL5NaUJUpzWxDQzkIBuvX/E9stjEvqb0fZCRkGqPQLOix/YVUjUzj2i1zGAgL/w3xw
+        jhadu4aN05dbf5cBeKRIUS43HnrDXluA0vq0HbX30xuFpoo/noZUiZ8uNfR2UKLQfIK0gNVH1ydw
+        MhHIDKyiUWm/0YQgzcozy14n9OCGtLCucWfxXy7nozJ7JnVJpSYPgAmozMOoqEiz3C0Dnsax/PRV
+        AvwhOEGda6nAIosZZ6nSTAGpDbf6bksYyI2J4JEtY4b7jBvCz6Qmg+n4ZIIH7IEeIBCkhnUtU8xz
+        JHiwor7B/FnoP6RymaVAKyAPqoKGfrJ/XGbwPXJRvQl2PeM=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-potential_freshness-msg.gpg
+      - attachment; filename=1-unlawful_spectrum-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:28:34 GMT
+      - Tue, 25 Aug 2020 17:27:26 GMT
       Etag:
-      - sha256:624b8cc271f0bc4a153ff893f14d4b63464577579c0baa49ca2e6f5b2fb715a8
+      - sha256:dd82012b8656a3f7175b619f2875895a11071daf681b996cdc2704ddf5388664
       Expires:
-      - Sat, 15 Aug 2020 14:28:34 GMT
+      - Wed, 26 Aug 2020 05:27:26 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:35 GMT
+      - Tue, 25 Aug 2020 17:27:02 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -352,7 +279,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczMTMsImlhdCI6MTU5NzQ1ODUxMywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.RozZEVV3hF4sYBBuWEXsMxBVVdBNvVsemLtm33rWJLw
+      - Token eyJleHAiOjE1OTg0MDUyNDYsImlhdCI6MTU5ODM3NjQ0NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.RJOIk4zqY-bce24Z_YKNrp0z5-Obi9fFFamNWxBSYZA
       Connection:
       - keep-alive
       Content-Type:
@@ -360,38 +287,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download
+    uri: http://localhost:8081/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAp+9fU8qzd8lBJJJeTGUfrTvtC7bBj77m96ioEWln23lreSXOi7W1E++i
-        X3mCeNg6hLC0PSAtuO0QTw+LE6TGqLJtQh5y14fIxzgIX5G02eaoOlsayjQbVfXHTJ6HBSFx1VkS
-        ImILNuS170DhYiOyW91R3OJ2zg4DeTlPkyegMGScWCued6EcBBL+/EOrvZLDoXtpFAHFkGGcoQSD
-        p/6L5/pp8AuB5N43NRCtslfsD8D4gpZT7L9gkvNIJbMrBQ4FVUzjB/XI5mkOhXAubjKzgGcpqiM+
-        N2k5nqSPFzotGHmKDy77Bq4D3Sk4fcLzvWMe9hY+Prp6QqW5/F3uvFhJdpdOR9JZ4WqY6pWk0VsA
-        jeIuaxGH3rRqFegi59AiZV+EvpORA7tx8qmkVHch5UifaJCsHthaxOrBk1D/rgutgmoQvVaCN+UA
-        6So9D0H/w6RIE0vE3SAsCpXV3XQJWwsya8O5R5jCuETvi1s5NnMXrtxRuBqkFZUcRSNZyzrUWLGA
-        8djkwjYcO5lP7qt40ztUosMmb2y+4z8ad3zhWP71SKA+chx8lUvY7ziiSmFOpRJOr0OEgKMU59lR
-        ovyT6mu5yB1d5d8G9ns8s5H8/ymV5WE/MdG+o472wWPKoKHnIu0zlj1Qqso8l/khM5wIjs8XvICl
-        pm7uojnWqaFcIaJg4EvSTAEw45cGmA90NotlV9qwHi0fJ0qlbFKf6FAyeDaRL0TPoLKx9JbGf+9M
-        +wwWhoyWoWili+hOxuju3sNSeN1iYkv3fEIyKyEy5rXvf/0=
+        hQIMA8PnxMCiIBsqAQ//RtWsdfVE8eGi8sFqp1/cmLdkiut2OkXfs7DdjD0CBr6qfYUG8woosTjZ
+        +bdA5IIg1ewECF+eOZbfgW3EGzq/xN9rKaE+yTEbrR2swkoHNv1tUTrBoRGwUfHOYl3LOWlftNHt
+        8HbCVEZ/TAs1NQolRpSXj9o+mR6wjPvXtArQkW0io6D8ah9YO+YkEEkl4B2CwK1BwUQHj4B1TXw+
+        QGubNNIfGeXM9OkSCQMZapmumEt4m+8KImF1ncNMINXO/WV3tbTKDrCO63R/K6ibSuq//vd72Q2z
+        DFalhfcmnu7ksX0/4TFsrsvfuQoppTqepI6YklIKhTRkoRuY5fQeoK2w93qrZh0dmsVvlhx13/xl
+        19wcO1vASiZzfSHT/XDaXoS+3XmgW/xKr+Y0IJq+PZSs/EZ/2mr6zXePR8HtdFuvCnGiNjPFsRsE
+        sRIB1iq6FEV3zKxLU7FI46MTNrBpTYj3xAn2MqGM0UgCvwC1v73s6mMe6njwvYak8V0J/ny3sd/J
+        NHnbftRaGOmlrQbiXhoRIDEV5Kric9qBJG5R12kxDHHqce/viMEnZ1543+2snmsGrmWvX3Kxsbq4
+        cm1rmE/1dwYYtUaTpj1j4HDr7OY0PUN4F2BXK1gOSOONWiKd8hRAbY4Emwv60g+36ZtwY6kQu4v3
+        pQhKYVCTt8xL1gZkYYfSTAFnY4M6ViJKpbRI6FGnAQsYaB74rBUx6FatdEvztAN5VHarQPHN9uDF
+        TLPp+suitZOgA4wsgUWL+sUze53pOc/MCAUfBwrk2YD7hO8=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-red-rimmed_applejack-msg.gpg
+      - attachment; filename=1-pleasant_rearguard-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:28:34 GMT
+      - Tue, 25 Aug 2020 17:27:26 GMT
       Etag:
-      - sha256:2e1bdbd452ce54d49602552182cb0146b2334c58a7c5aec0c0565645e2ab4286
+      - sha256:cecd2591b0a9a0315f320e9878f68fdaec03c70b286da162c4416fab137ec00e
       Expires:
-      - Sat, 15 Aug 2020 14:28:34 GMT
+      - Wed, 26 Aug 2020 05:27:26 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:23 GMT
+      - Tue, 25 Aug 2020 17:26:47 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -405,60 +332,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczMTMsImlhdCI6MTU5NzQ1ODUxMywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.RozZEVV3hF4sYBBuWEXsMxBVVdBNvVsemLtm33rWJLw
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.20.0
-    method: GET
-    uri: http://localhost:8081/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96/download
-  response:
-    body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqARAAqBkguUOJVhB1E0rEBd3bIvbOJe9umLBp5QVPye5M4nsh0yl0IWnltszf
-        edV/FKB+H0YdtACRB57Zur0vTrOWAA4o1cC9tyUi18aWslfgDvVwJXLjELZYOQiDv//vmcWEG4Mw
-        ckXqK+/zvkgGLST9xjubdcQozWQNW8mXNzqLzLPLYd57oejEzr73iwn2UwQbQjXb31YI5ZsvCB0y
-        sltvyQevn92quua31WmlxjwzTndQ9u9mGQ5zZSxwK39HaZ3oEmPZlWelrnUfbodPJw5wQqGBN++n
-        lwGMVphNGN+EssKtSUb5Hmutd6jTajcfPWPf0yU6AYtJ3v/1wiOyXCaN3tnPStKUzP6w/htB2nFz
-        irbFi2VQ5v1Lg/nAYl0n3cVU4A8O8P8nhIX5KOsxNhYqNyuyjZsJgFAiKtCzEcXxlpyCQiPwpHbo
-        PM7nDr1JtS7w+IY4xlOkwdOmTIjq+WYjfwbOMd8GlwMQmpp2s6n4S7whSIcYI5acs14DERizF7lG
-        vY8XG7/ExbA0zt9B8j0MKTDsAxgkEEMALTPtINMmuc3xaDoTP7HA8e/X6tyPvrVarY8zFuPVxKuY
-        VXdPQuf6in/3uzja0QlWwq+Ibm+I/gBtQPRM1cDpW5n7XdYkzRcTIluElj8U8VnbECvkFNLt8NUk
-        IF792WIIe570TmeeRXfSTAE9fPtTykzrDiTy5LSwqQ91J/Og4d484LO+VkYSPGe37sfcFRSAOSL6
-        KHNlQb9u2IoOgkORHi/6PABz5ty5K45/OvEOhlB4/xbxkbA=
-    headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-out-of-town_primogeniture-msg.gpg
-      Content-Length:
-      - '605'
-      Content-Type:
-      - application/pgp-encrypted
-      Date:
-      - Sat, 15 Aug 2020 02:28:34 GMT
-      Etag:
-      - sha256:64f0c214fab76a0aa8a1407daf0c0478f7851bd7b5c0aaca5b5c8de53aae9336
-      Expires:
-      - Sat, 15 Aug 2020 14:28:34 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:24:41 GMT
-      Server:
-      - Werkzeug/0.16.0 Python/3.5.2
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Token eyJleHAiOjE1OTc0ODczMTMsImlhdCI6MTU5NzQ1ODUxMywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.RozZEVV3hF4sYBBuWEXsMxBVVdBNvVsemLtm33rWJLw
+      - Token eyJleHAiOjE1OTg0MDUyNDYsImlhdCI6MTU5ODM3NjQ0NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.RJOIk4zqY-bce24Z_YKNrp0z5-Obi9fFFamNWxBSYZA
       Connection:
       - keep-alive
       Content-Length:
@@ -478,7 +352,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:28:44 GMT
+      - Tue, 25 Aug 2020 17:27:37 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:

--- a/tests/functional/cassettes/test_receive_message_from_source.yaml
+++ b/tests/functional/cassettes/test_receive_message_from_source.yaml
@@ -17,9 +17,9 @@ interactions:
     uri: http://localhost:8081/api/v1/token
   response:
     body:
-      string: "{\n  \"expiration\": \"2020-08-15T10:30:28.429867Z\", \n  \"journalist_first_name\"\
-        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"b5e001de-19f1-4a93-885b-e0932aa2d441\"\
-        , \n  \"token\": \"eyJleHAiOjE1OTc0ODc0MjgsImlhdCI6MTU5NzQ1ODYyOCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.KjjGIByWqWKzvwi-43jQKJz591tVPlWt2DpeAA1LPBQ\"\
+      string: "{\n  \"expiration\": \"2020-08-26T01:27:22.431443Z\", \n  \"journalist_first_name\"\
+        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n  \"token\": \"eyJleHAiOjE1OTg0MDUyNDIsImlhdCI6MTU5ODM3NjQ0MiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.PoK6doK57pe1LP8dO446BMJcfE1uVSqhP_AWiVeIQEY\"\
         \n}\n"
     headers:
       Content-Length:
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:28 GMT
+      - Tue, 25 Aug 2020 17:27:22 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -41,7 +41,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MjgsImlhdCI6MTU5NzQ1ODYyOCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.KjjGIByWqWKzvwi-43jQKJz591tVPlWt2DpeAA1LPBQ
+      - Token eyJleHAiOjE1OTg0MDUyNDIsImlhdCI6MTU5ODM3NjQ0MiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.PoK6doK57pe1LP8dO446BMJcfE1uVSqhP_AWiVeIQEY
       Connection:
       - keep-alive
       Content-Type:
@@ -52,65 +52,48 @@ interactions:
     uri: http://localhost:8081/api/v1/sources
   response:
     body:
-      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/add_star\"\
+      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/add_star\"\
         , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"red-rimmed\
-        \ applejack\", \n      \"key\": {\n        \"fingerprint\": \"D449222A7B7B0AC1E134A1FF01203DD2D2636A37\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAOaUXyLQCaUSR4HTaBVGZp1mi3jn3BExTTe2UCBYjsn1zhkOBDf9\\\
-        ncZNBQGjEBIYlOioC4XY1TkQep4L2DdmqO5lBfbyNG6LpGiNo7DvNBxeo5WNDa42C\\n8YcfTaVL9aWm07G12uwwc1WFNb0y86PzuAS1ek0k5B7jUfjNxFN9t0dhABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEtCTEEyQTRDUEtETEVURDM2MllWQUZVRVdRQlJLUzJWRjVG\\nUEs2SElBWFBXQUFNSURMUkZHUEdLU0dFSDJJUUtBUVdZUFdFS0xRWVpaTDZMU1JY\\\
-        nRFRUTUdPUlFFWFA0WE1EUlJJM0E9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEAEgPdLSY2o3LmUD/i+JqgIWc2SzA5OTX9Qo0g/r\\\
-        nqxDmi2NQMXob0fEEcP/GGnbiFE1P77AC6JWxSKPQStlfwvffhYmK2q7JBc71Jj8O\\nRqFRT5WSRpXUCq8tZkIYyoCXKQPlwSb3S1NQ3yM00kbkCM4dArLIFuQ/ZI1xG+l9\\\
-        nIqxWwXYY8SpO8uKDXFd7\\n=FjUe\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:23.753433Z\"\
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"pleasant rearguard\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"FF9007318CCAB4DC6149B1B38B7907A15818269D\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAM8jaDDbt3lQQVUEk+MduWYmJHa3eME1Y9C4yj+6n9V9Sksakj3B\\\
+        nWcl9uKzXLtZIP1rdvkW+Bg/P64vTgi+I+pcL5+e5gpF/KdNhrksovmhzc/ASgrn7\\nEcNCwIk+Iyym255IOEsZ8j9SvpzG1VyUdJxlK+P6bmbkFgDDwHjF0QzDABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPEtHQUFQVlNISjJLS0lMV0daTUlBWUFHMlhXU0ZWRlJRQ1pJ\\nNE5QTVBVUEVKNDNIQ1hJVUdPUk9XUEhLUldXRkxRTk5LTko3WEk1Tk9JUkpFTERQ\\\
+        nU0pZN0JMTk9ETk0yTUxNSjRPMkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEIt5B6FYGCadjpUD/1IiTV3TAyduG0UkaxcTT+Bp\\\
+        nKZRsNsK+HhYBCu/VjBcybLkuccDaonnm99OyaWZAZ/F/E/DxRENTxs0OL47GbHG7\\n9hSFWj99MZACMs3aKAmqxZEnQmm0B0xDIlHyd9mQBSieUw6aVMVjxK8p0Z21R7cz\\\
+        nc+DfEuCbShQ6b5+9X308\\n=RU3O\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:26:48.423985Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"uuid\": \"70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/add_star\"\
+        \      \"remove_star_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"uuid\": \"505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\n    }, \n  \
+        \  {\n      \"add_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/add_star\"\
         , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"potential\
-        \ freshness\", \n      \"key\": {\n        \"fingerprint\": \"06FFA85715E89C0AFBA927A78EA34965AC896EEA\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAMHR1pM94xuFw+GiTQI7RyUN/sKYmupDhwWj1nVricMXRbM7nIXk\\\
-        nsBnqTx0pTkITPxjszoVyFFxG+Uw8TXMZEZdCOhcC2AieHV0mgWsXxLAbD9Sw3VmQ\\ngOQ3S2C/MBrimrK4bkpoKXxKIV5v5Rgku5Pjxzw50HH4e1pYhgW2C+knABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEg3TVJTVUZHWFVKRldQQlM0UjdISk1JNE5HTUREQ0FaRzJL\\nVlIyTTM3RkFTQk9BRjIyUkFYNzdMUVdZNFZJNTJLSlBOQldaRjUyQTdHWFJVN1lQ\\\
-        nN0dQQU5QSFNNUUkzSUFVN1VGNEk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEI6jSWWsiW7qZeYD/ReRVU5y0nssc0+OlRy6M/im\\\
-        nHY9oHex0tSGt1fTuDVqsAKKHMDrZLKkkhJg42wcINwbXTj/vRu7n199IwbSUoDiE\\nJlnO6ZaIG996AUFS64eZBA+kXczqJbsWgdQQpwQJn8LiQUF8iwFhTThltjRSuXqf\\\
-        nMxyFevvxbIvYcs6il7Ip\\n=cZe8\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:36.194245Z\"\
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"unlawful spectrum\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"CE2A06285C9B1FDB43BFEB853EC2D036DDCA8CD4\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANJ0h2W7p0bViTLpY9w/PDd8sBHR56OVg+EGdXZ51Wuqt8ZUkF8W\\\
+        njSLrjsiOrcQ1lRFEgERFfIBJvlxfB/EMP4wcTY7vg7WQN/rvSJynBW0T6iHI3Rhi\\n/3v35LEuX9tLU/B1e11mRevgHTLRUms38Y5DBSkWACngvH4jWP+kwylJABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPDUyNzdCNDVDNExFUFdJWU9NQlY0VE5FVEI1WjdaVFpERTZK\\nQTJSTlhVNE5HM0g3R0NRVEJYRUdVWkdSRkpSRVZGN01BTzZDUUpWWVpBN0NOSEw3\\\
+        nS0JKVzMyS01XNEJaSVROU0dBVkk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJED7C0DbdyozULzEEALbYIlKPW3wXMi/9V2c/fYJc\\\
+        naX9UE94JwAdfntqAkEF8dL/P6fD5J1BPqQILK4crX6LN6h8g2y1vnrTTg9odsa1L\\nD0JqSpGfIWscGRuzY6b2WngLCgsudMqJgPZUdm/wbxp3Q8Daa8U99mL9jXr9Ia9j\\\
+        n8BFeiB6fb0VoIDgM7UTv\\n=j+JQ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:27:03.031475Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"uuid\": \"6db98582-dd69-48ea-879e-5afc5aa388d6\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"inexpressible\
-        \ sepsis\", \n      \"key\": {\n        \"fingerprint\": \"380C70D1C7930985411415B31A1B751385404CC5\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANhgLtWR4jFlhHEPGJjcupkGrNymWv9wFlFM8YppKs6nNXaQdoKf\\\
-        n7+NESFVdkm89/7FWD/It0B49jEBjjs7GOmxhffomt1NVHocYGDBQjMAlKOYQgCnR\\neZDnHCFORSrQcfiNhgKm1/eFOZlNJDZn2Cwpmdk8ZV6B78fGVz+3B+tFABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEo0VFRaVzY2QlBRTFRRVVlNS0hIVzZZTjRGVkJIVFlVQ0ZW\\nNVNWNjNRWlQyT0Y3Wjc2NUxEWk1TVDJNR1JBVFpYSVZJVzVBR1M0N0RFU0hTRUhY\\\
-        nWDZFQVlISkFWTFBZRzc1VFlKQkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBobdROFQEzFd3gD/RUhGdZUriO3QqYTqvH7EZdZ\\\
-        n4r3iFUJVP3xhru9HYBtksepsKzUHYZn4nK29689AdV1A9o/X4YcKWrxFRbMuZs0E\\nTj2Je4jrw3WNf3O3COAWwFa75HOXIhGfFVuJ4Ni2/NVJGDPA6NNIfZfFMIj/NZF3\\\
-        n3RBZhDmxS21yJs9daQfs\\n=NQQJ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:44.877597Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"uuid\": \"f3a61359-1919-4bf0-b6f7-da902a935160\"\n    }\n  ]\n\
+        \      \"remove_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"f9b4da97-a077-412e-8e54-4ef4984a8540\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '4817'
+      - '3214'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:28 GMT
+      - Tue, 25 Aug 2020 17:27:22 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -124,7 +107,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MjgsImlhdCI6MTU5NzQ1ODYyOCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.KjjGIByWqWKzvwi-43jQKJz591tVPlWt2DpeAA1LPBQ
+      - Token eyJleHAiOjE1OTg0MDUyNDIsImlhdCI6MTU5ODM3NjQ0MiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.PoK6doK57pe1LP8dO446BMJcfE1uVSqhP_AWiVeIQEY
       Connection:
       - keep-alive
       Content-Type:
@@ -135,44 +118,34 @@ interactions:
     uri: http://localhost:8081/api/v1/submissions
   response:
     body:
-      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download\"\
-        , \n      \"filename\": \"1-red-rimmed_applejack-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170\"\
-        , \n      \"uuid\": \"ceb44744-68cd-4b29-ada9-4c6ed4127170\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015/download\"\
-        , \n      \"filename\": \"2-red-rimmed_applejack-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015\"\
-        , \n      \"uuid\": \"1deb4f4f-1094-49ec-b0da-5d714b60c015\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download\"\
-        , \n      \"filename\": \"1-potential_freshness-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e\"\
-        , \n      \"uuid\": \"da095cb7-5a81-4b57-912c-14b0501dc00e\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d/download\"\
-        , \n      \"filename\": \"2-potential_freshness-doc.gz.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d\"\
-        , \n      \"uuid\": \"ed460264-f0e9-415f-8247-738eb482c75d\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download\"\
-        , \n      \"filename\": \"1-inexpressible_sepsis-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a\"\
-        , \n      \"uuid\": \"a3bb0937-6240-4200-99d5-b514c465e56a\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01/download\"\
-        , \n      \"filename\": \"2-inexpressible_sepsis-doc.gz.gpg\", \n      \"\
-        is_read\": true, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\
-        , \n      \"uuid\": \"1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\n    }\n  ]\n\
+      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442/download\"\
+        , \n      \"filename\": \"1-pleasant_rearguard-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"submission_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442\"\
+        , \n      \"uuid\": \"bbc25300-917a-4b73-b0f4-10f3d6957442\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/a8699ca4-55a5-4737-b8f1-c9e170ec8250/download\"\
+        , \n      \"filename\": \"2-pleasant_rearguard-doc.gz.gpg\", \n      \"is_read\"\
+        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"submission_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/a8699ca4-55a5-4737-b8f1-c9e170ec8250\"\
+        , \n      \"uuid\": \"a8699ca4-55a5-4737-b8f1-c9e170ec8250\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download\"\
+        , \n      \"filename\": \"1-unlawful_spectrum-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\
+        , \n      \"uuid\": \"d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a/download\"\
+        , \n      \"filename\": \"2-unlawful_spectrum-doc.gz.gpg\", \n      \"is_read\"\
+        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a\"\
+        , \n      \"uuid\": \"55e459bd-cf4e-45f9-adce-95d79998254a\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '3082'
+      - '2055'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:28 GMT
+      - Tue, 25 Aug 2020 17:27:22 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -186,7 +159,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MjgsImlhdCI6MTU5NzQ1ODYyOCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.KjjGIByWqWKzvwi-43jQKJz591tVPlWt2DpeAA1LPBQ
+      - Token eyJleHAiOjE1OTg0MDUyNDIsImlhdCI6MTU5ODM3NjQ0MiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.PoK6doK57pe1LP8dO446BMJcfE1uVSqhP_AWiVeIQEY
       Connection:
       - keep-alive
       Content-Type:
@@ -204,7 +177,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:28 GMT
+      - Tue, 25 Aug 2020 17:27:22 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -218,7 +191,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MjgsImlhdCI6MTU5NzQ1ODYyOCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.KjjGIByWqWKzvwi-43jQKJz591tVPlWt2DpeAA1LPBQ
+      - Token eyJleHAiOjE1OTg0MDUyNDIsImlhdCI6MTU5ODM3NjQ0MiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.PoK6doK57pe1LP8dO446BMJcfE1uVSqhP_AWiVeIQEY
       Connection:
       - keep-alive
       Content-Type:
@@ -226,38 +199,20 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download
+    uri: http://localhost:8081/api/v1/user
   response:
     body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqAQ//Z/S89kAgGiAOh+UVD2ePgDvU/l/JnvR2DkCEnnqTivaWTKetbcTOxv8D
-        iHQFUvQKPTADA4g5u56foRmzC0Yb2mP36vRMUqLq87hb/XfZFfr3Ak7E169EyaCN6ht5he28mLV0
-        j9brHPGxQWt2vrE4FFdwnUVQWNfAp13rFMm0IDFsHN3o3lNSjywJ62jlr1rce3mdkC+rXkwDh3zs
-        0ZDvxqFGx4X8YPbQiAStvUsK1n3u9NBnKE3cyeHe70xnMdQxq1N4NuACJZkNovKet6C3s8LTvj58
-        XiK6+/AgtbO9Pk6c89s1WW0x3hUGFtWVI+GqSUSQda5CDlWaq6Fq7mBURfuW7yD/rOJ0EypOOJED
-        b1GoyTiK6V1gC/mktb6u/Ei16SmPOjcsAzW7BFn5tsvl3lZULN+b4Bs+E7/Pxl4ymVaPDgbcsAh9
-        Ipp0thhF1a2A3MobRsTtNidryxvfzUTj5ou70vguzn7zthzog2sijyM9hBI0FPr6YRVWXvrS7BEQ
-        Ly9BA1AuzGy0kS1B6MUYdcWAaxQZHWNne02zDHZqe2sBFLM04tJU4myKrXlBOok4YILQ7OWDSoa8
-        Whkyohid0Eympcv+6YMaKI+9yBzHFWgcpu27rlrAuRGRXi9ibBxovyCRg5SSYc1Guo0jalDJWdDy
-        lRdLGsmqJAcWq2PUvNLSTAGpSiJRM+Iwxr77j/lapCOSRGfVJaivW59X5+ZQa6BN57DKWvcgPtCb
-        xDfXOBD4hOG9w/Qv5iKwgOcj/ckygOpvtrcQosdK9ZzrrdY=
+      string: "{\n  \"first_name\": \"\", \n  \"is_admin\": true, \n  \"last_login\"\
+        : \"2020-08-25T17:27:22.431831Z\", \n  \"last_name\": \"\", \n  \"username\"\
+        : \"journalist\", \n  \"uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\n\
+        }\n"
     headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-inexpressible_sepsis-msg.gpg
       Content-Length:
-      - '605'
+      - '192'
       Content-Type:
-      - application/pgp-encrypted
+      - application/json
       Date:
-      - Sat, 15 Aug 2020 02:30:28 GMT
-      Etag:
-      - sha256:20db26d5f8240c2efbc83f40184bd03e74f0b927394627fe24bc2954cb4a6c2a
-      Expires:
-      - Sat, 15 Aug 2020 14:30:28 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:25:44 GMT
+      - Tue, 25 Aug 2020 17:27:22 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -271,7 +226,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MjgsImlhdCI6MTU5NzQ1ODYyOCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.KjjGIByWqWKzvwi-43jQKJz591tVPlWt2DpeAA1LPBQ
+      - Token eyJleHAiOjE1OTg0MDUyNDIsImlhdCI6MTU5ODM3NjQ0MiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.PoK6doK57pe1LP8dO446BMJcfE1uVSqhP_AWiVeIQEY
       Connection:
       - keep-alive
       Content-Type:
@@ -279,38 +234,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAs+tSZVdjh2H5sgW3rQYsinaTUd1To3XLy/EC0UcNed15/OLbU142ic10
-        6l41iWmBW44aOmjYFIY46VfqPxQSM0G7fl2g5A0SZdmckTqzu141v/+BoTmvbzzZ8sXmpxKjbP/A
-        1F6aBPQ2qX7HcUVyGOadyMRjuKB+IO1pROBeFB5R0hE+FD+y4/yq2y4J9SVeYcdcwcsWJytFUm73
-        emXQ6vcBspvlgSjE1gywgfPFkmOLIKxv9INHFTT/FrfPvJ/yeFZ7jKtG0wxBQYPL4DG5QiVi1Gyz
-        Ln039tgWjFVnM5FhJ+XNhLbLHuISii/0CrKq9TeRea85xFHR6UGKgTm3/fOeWtEhC6FKa0XstXhU
-        T0E9dmh80Rd3myvN0HU3eyNFvmjyZ1weVguXjg4Ao1yWZ8a8AmqlA6m4conr4bbscqQKXCJSF1D+
-        g/i5ng78t0+4wnWMiKtN9rNTJkVBzXpaoYzOn+14EJbkYa+zkCyQS8TbjMBpLaP0aTFO4VXk7OAU
-        ygtKj6P8KmkfqivWrQ047DjqwVot+wBpKT+3t8ASscApC7KaSF0+d/fBvb05ZLzLtfSXM+Ts6pQ8
-        sn60uh2dnW/12nbqAdzFnrEPtDdtz5PFWn8brJpvhhMids/A7dkmbbLK6oirkLSRMF7Wdp8Stz2m
-        aI8Xz6brh2GQeKZafWnSTAHRguSmKDs+h+zUuP/hFFyLlLy2TWX3VLR2rLCEHhm82jP4UcMTpBkU
-        sgsFKxLyPddNYl+9D7kh9NLhzaLsXc2RihQWRvXYM9f3E0Y=
+        hQIMA8PnxMCiIBsqAQ//Rw1NPH3mwdBg9NnblanYiQgqmPuHTY9ha8sR24r6Cbv4UunDrGcjIMeT
+        qUZfK1zok/ZjbbLMo+yVWG2my899P8meyJS9C9MzmPC/x8hpoSUVdxyRorBDja9qNtZUyhOrm5Dz
+        rsiuEaqB1T5iYPinyCzeOcGKxTlrDJE78s5aHQVGQeBjXN+7BqZXsGCWrUueXTF10QrC8u0T/Fnw
+        T+BLvR8FmCIEilEDQESn653nL2wbkTz/7OMxUJJUDkG9xO6VHsTcH4KAzVsonMaan2RVXarJ1393
+        esjkZJ3vMiKXSMNIdsdDQ8WbP/2JGL8rhdg3WZqRbX7ePEJ5C7moUGiJsXmYwNMDarImp/be0O+1
+        YGk1Bfig2smMD280G8vYNykGvLkiGWJU0tGQQBbc5NeM3WZ8chZsyKofidoc9CIY7NLVHGg5u6zf
+        AEe1bjVuWveL5NaUJUpzWxDQzkIBuvX/E9stjEvqb0fZCRkGqPQLOix/YVUjUzj2i1zGAgL/w3xw
+        jhadu4aN05dbf5cBeKRIUS43HnrDXluA0vq0HbX30xuFpoo/noZUiZ8uNfR2UKLQfIK0gNVH1ydw
+        MhHIDKyiUWm/0YQgzcozy14n9OCGtLCucWfxXy7nozJ7JnVJpSYPgAmozMOoqEiz3C0Dnsax/PRV
+        AvwhOEGda6nAIosZZ6nSTAGpDbf6bksYyI2J4JEtY4b7jBvCz6Qmg+n4ZIIH7IEeIBCkhnUtU8xz
+        JHiwor7B/FnoP6RymaVAKyAPqoKGfrJ/XGbwPXJRvQl2PeM=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-potential_freshness-msg.gpg
+      - attachment; filename=1-unlawful_spectrum-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:30:28 GMT
+      - Tue, 25 Aug 2020 17:27:22 GMT
       Etag:
-      - sha256:624b8cc271f0bc4a153ff893f14d4b63464577579c0baa49ca2e6f5b2fb715a8
+      - sha256:dd82012b8656a3f7175b619f2875895a11071daf681b996cdc2704ddf5388664
       Expires:
-      - Sat, 15 Aug 2020 14:30:28 GMT
+      - Wed, 26 Aug 2020 05:27:22 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:35 GMT
+      - Tue, 25 Aug 2020 17:27:02 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -324,7 +279,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODc0MjgsImlhdCI6MTU5NzQ1ODYyOCwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.KjjGIByWqWKzvwi-43jQKJz591tVPlWt2DpeAA1LPBQ
+      - Token eyJleHAiOjE1OTg0MDUyNDIsImlhdCI6MTU5ODM3NjQ0MiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.PoK6doK57pe1LP8dO446BMJcfE1uVSqhP_AWiVeIQEY
       Connection:
       - keep-alive
       Content-Type:
@@ -332,38 +287,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download
+    uri: http://localhost:8081/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAp+9fU8qzd8lBJJJeTGUfrTvtC7bBj77m96ioEWln23lreSXOi7W1E++i
-        X3mCeNg6hLC0PSAtuO0QTw+LE6TGqLJtQh5y14fIxzgIX5G02eaoOlsayjQbVfXHTJ6HBSFx1VkS
-        ImILNuS170DhYiOyW91R3OJ2zg4DeTlPkyegMGScWCued6EcBBL+/EOrvZLDoXtpFAHFkGGcoQSD
-        p/6L5/pp8AuB5N43NRCtslfsD8D4gpZT7L9gkvNIJbMrBQ4FVUzjB/XI5mkOhXAubjKzgGcpqiM+
-        N2k5nqSPFzotGHmKDy77Bq4D3Sk4fcLzvWMe9hY+Prp6QqW5/F3uvFhJdpdOR9JZ4WqY6pWk0VsA
-        jeIuaxGH3rRqFegi59AiZV+EvpORA7tx8qmkVHch5UifaJCsHthaxOrBk1D/rgutgmoQvVaCN+UA
-        6So9D0H/w6RIE0vE3SAsCpXV3XQJWwsya8O5R5jCuETvi1s5NnMXrtxRuBqkFZUcRSNZyzrUWLGA
-        8djkwjYcO5lP7qt40ztUosMmb2y+4z8ad3zhWP71SKA+chx8lUvY7ziiSmFOpRJOr0OEgKMU59lR
-        ovyT6mu5yB1d5d8G9ns8s5H8/ymV5WE/MdG+o472wWPKoKHnIu0zlj1Qqso8l/khM5wIjs8XvICl
-        pm7uojnWqaFcIaJg4EvSTAEw45cGmA90NotlV9qwHi0fJ0qlbFKf6FAyeDaRL0TPoLKx9JbGf+9M
-        +wwWhoyWoWili+hOxuju3sNSeN1iYkv3fEIyKyEy5rXvf/0=
+        hQIMA8PnxMCiIBsqAQ//RtWsdfVE8eGi8sFqp1/cmLdkiut2OkXfs7DdjD0CBr6qfYUG8woosTjZ
+        +bdA5IIg1ewECF+eOZbfgW3EGzq/xN9rKaE+yTEbrR2swkoHNv1tUTrBoRGwUfHOYl3LOWlftNHt
+        8HbCVEZ/TAs1NQolRpSXj9o+mR6wjPvXtArQkW0io6D8ah9YO+YkEEkl4B2CwK1BwUQHj4B1TXw+
+        QGubNNIfGeXM9OkSCQMZapmumEt4m+8KImF1ncNMINXO/WV3tbTKDrCO63R/K6ibSuq//vd72Q2z
+        DFalhfcmnu7ksX0/4TFsrsvfuQoppTqepI6YklIKhTRkoRuY5fQeoK2w93qrZh0dmsVvlhx13/xl
+        19wcO1vASiZzfSHT/XDaXoS+3XmgW/xKr+Y0IJq+PZSs/EZ/2mr6zXePR8HtdFuvCnGiNjPFsRsE
+        sRIB1iq6FEV3zKxLU7FI46MTNrBpTYj3xAn2MqGM0UgCvwC1v73s6mMe6njwvYak8V0J/ny3sd/J
+        NHnbftRaGOmlrQbiXhoRIDEV5Kric9qBJG5R12kxDHHqce/viMEnZ1543+2snmsGrmWvX3Kxsbq4
+        cm1rmE/1dwYYtUaTpj1j4HDr7OY0PUN4F2BXK1gOSOONWiKd8hRAbY4Emwv60g+36ZtwY6kQu4v3
+        pQhKYVCTt8xL1gZkYYfSTAFnY4M6ViJKpbRI6FGnAQsYaB74rBUx6FatdEvztAN5VHarQPHN9uDF
+        TLPp+suitZOgA4wsgUWL+sUze53pOc/MCAUfBwrk2YD7hO8=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-red-rimmed_applejack-msg.gpg
+      - attachment; filename=1-pleasant_rearguard-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:30:28 GMT
+      - Tue, 25 Aug 2020 17:27:22 GMT
       Etag:
-      - sha256:2e1bdbd452ce54d49602552182cb0146b2334c58a7c5aec0c0565645e2ab4286
+      - sha256:cecd2591b0a9a0315f320e9878f68fdaec03c70b286da162c4416fab137ec00e
       Expires:
-      - Sat, 15 Aug 2020 14:30:28 GMT
+      - Wed, 26 Aug 2020 05:27:22 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:23 GMT
+      - Tue, 25 Aug 2020 17:26:47 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:

--- a/tests/functional/cassettes/test_send_reply_to_source.yaml
+++ b/tests/functional/cassettes/test_send_reply_to_source.yaml
@@ -17,9 +17,9 @@ interactions:
     uri: http://localhost:8081/api/v1/token
   response:
     body:
-      string: "{\n  \"expiration\": \"2020-08-15T10:26:35.428829Z\", \n  \"journalist_first_name\"\
-        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"b5e001de-19f1-4a93-885b-e0932aa2d441\"\
-        , \n  \"token\": \"eyJleHAiOjE1OTc0ODcxOTUsImlhdCI6MTU5NzQ1ODM5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ih89P26f7E358aoOqLoNcH6ErE8G3V6UenhvJDBCLpw\"\
+      string: "{\n  \"expiration\": \"2020-08-26T01:28:13.360055Z\", \n  \"journalist_first_name\"\
+        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n  \"token\": \"eyJleHAiOjE1OTg0MDUyOTMsImlhdCI6MTU5ODM3NjQ5MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.UYMpEZ3IMxjRHe6ISL5X2VDlNLmEsljZ-JiQGlIzdqE\"\
         \n}\n"
     headers:
       Content-Length:
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:35 GMT
+      - Tue, 25 Aug 2020 17:28:13 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -41,7 +41,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxOTUsImlhdCI6MTU5NzQ1ODM5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ih89P26f7E358aoOqLoNcH6ErE8G3V6UenhvJDBCLpw
+      - Token eyJleHAiOjE1OTg0MDUyOTMsImlhdCI6MTU5ODM3NjQ5MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.UYMpEZ3IMxjRHe6ISL5X2VDlNLmEsljZ-JiQGlIzdqE
       Connection:
       - keep-alive
       Content-Type:
@@ -52,99 +52,48 @@ interactions:
     uri: http://localhost:8081/api/v1/sources
   response:
     body:
-      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/add_star\"\
+      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/add_star\"\
         , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"out-of-town\
-        \ primogeniture\", \n      \"key\": {\n        \"fingerprint\": \"200C271E4E680FFE62E008931554E4BF600B1E3C\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAL4uN551SiYiVLrHoK1QGMDmN1xq42u8o2dmnKFkArW5KfBvBFoX\\\
-        nZX5LnOj9hKKEEmeGX5beS9h+fjsWvx86M2kQj/5xhOmHw0GGESEPQBSUc+Lyohpc\\nUmBoNNBfWIouEQ+IVS0gmrOwiS7wdItMby1lLDlDBoiEm4aRnRw36NIpABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEhPUDNaU05LUFgzNE1MV09QMkVPQkJRVVc2QjZPS0ZFMzZa\\nVktOV0VWNEhXVTVMUlZGQlFENjVKTEtYUENHRE1LVEFTTDM2N0NOT1ZDN0hBRUxF\\\
-        nWVQyWU5LMkJHM0ZWNlZWUUlMMlE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBVU5L9gCx482IED/2w6yFqz19zTBX72qN0MUTq5\\\
-        nCavQIBhhWrbsc1m0p+cxuVJ16TYxiE3S/Lp/rd4r1Q9MQg9BP0+/qjOA541kNq5A\\nmR2Y0teqWonDqeY/660kEFIbio0HbOTjsBhEZxtglJ1wz70tUpd40ZVMsu+Z32Mw\\\
-        n2kSiCclJYHk7uy1eis57\\n=pz11\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:24:42.042205Z\"\
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"pleasant rearguard\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"FF9007318CCAB4DC6149B1B38B7907A15818269D\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAM8jaDDbt3lQQVUEk+MduWYmJHa3eME1Y9C4yj+6n9V9Sksakj3B\\\
+        nWcl9uKzXLtZIP1rdvkW+Bg/P64vTgi+I+pcL5+e5gpF/KdNhrksovmhzc/ASgrn7\\nEcNCwIk+Iyym255IOEsZ8j9SvpzG1VyUdJxlK+P6bmbkFgDDwHjF0QzDABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPEtHQUFQVlNISjJLS0lMV0daTUlBWUFHMlhXU0ZWRlJRQ1pJ\\nNE5QTVBVUEVKNDNIQ1hJVUdPUk9XUEhLUldXRkxRTk5LTko3WEk1Tk9JUkpFTERQ\\\
+        nU0pZN0JMTk9ETk0yTUxNSjRPMkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEIt5B6FYGCadjpUD/1IiTV3TAyduG0UkaxcTT+Bp\\\
+        nKZRsNsK+HhYBCu/VjBcybLkuccDaonnm99OyaWZAZ/F/E/DxRENTxs0OL47GbHG7\\n9hSFWj99MZACMs3aKAmqxZEnQmm0B0xDIlHyd9mQBSieUw6aVMVjxK8p0Z21R7cz\\\
+        nc+DfEuCbShQ6b5+9X308\\n=RU3O\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:26:48.423985Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\
-        , \n      \"uuid\": \"4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/add_star\"\
+        \      \"remove_star_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"uuid\": \"505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\n    }, \n  \
+        \  {\n      \"add_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/add_star\"\
         , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"red-rimmed\
-        \ applejack\", \n      \"key\": {\n        \"fingerprint\": \"D449222A7B7B0AC1E134A1FF01203DD2D2636A37\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAOaUXyLQCaUSR4HTaBVGZp1mi3jn3BExTTe2UCBYjsn1zhkOBDf9\\\
-        ncZNBQGjEBIYlOioC4XY1TkQep4L2DdmqO5lBfbyNG6LpGiNo7DvNBxeo5WNDa42C\\n8YcfTaVL9aWm07G12uwwc1WFNb0y86PzuAS1ek0k5B7jUfjNxFN9t0dhABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEtCTEEyQTRDUEtETEVURDM2MllWQUZVRVdRQlJLUzJWRjVG\\nUEs2SElBWFBXQUFNSURMUkZHUEdLU0dFSDJJUUtBUVdZUFdFS0xRWVpaTDZMU1JY\\\
-        nRFRUTUdPUlFFWFA0WE1EUlJJM0E9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEAEgPdLSY2o3LmUD/i+JqgIWc2SzA5OTX9Qo0g/r\\\
-        nqxDmi2NQMXob0fEEcP/GGnbiFE1P77AC6JWxSKPQStlfwvffhYmK2q7JBc71Jj8O\\nRqFRT5WSRpXUCq8tZkIYyoCXKQPlwSb3S1NQ3yM00kbkCM4dArLIFuQ/ZI1xG+l9\\\
-        nIqxWwXYY8SpO8uKDXFd7\\n=FjUe\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:23.753433Z\"\
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"unlawful spectrum\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"CE2A06285C9B1FDB43BFEB853EC2D036DDCA8CD4\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANJ0h2W7p0bViTLpY9w/PDd8sBHR56OVg+EGdXZ51Wuqt8ZUkF8W\\\
+        njSLrjsiOrcQ1lRFEgERFfIBJvlxfB/EMP4wcTY7vg7WQN/rvSJynBW0T6iHI3Rhi\\n/3v35LEuX9tLU/B1e11mRevgHTLRUms38Y5DBSkWACngvH4jWP+kwylJABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPDUyNzdCNDVDNExFUFdJWU9NQlY0VE5FVEI1WjdaVFpERTZK\\nQTJSTlhVNE5HM0g3R0NRVEJYRUdVWkdSRkpSRVZGN01BTzZDUUpWWVpBN0NOSEw3\\\
+        nS0JKVzMyS01XNEJaSVROU0dBVkk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJED7C0DbdyozULzEEALbYIlKPW3wXMi/9V2c/fYJc\\\
+        naX9UE94JwAdfntqAkEF8dL/P6fD5J1BPqQILK4crX6LN6h8g2y1vnrTTg9odsa1L\\nD0JqSpGfIWscGRuzY6b2WngLCgsudMqJgPZUdm/wbxp3Q8Daa8U99mL9jXr9Ia9j\\\
+        n8BFeiB6fb0VoIDgM7UTv\\n=j+JQ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:27:03.031475Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"uuid\": \"70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"potential\
-        \ freshness\", \n      \"key\": {\n        \"fingerprint\": \"06FFA85715E89C0AFBA927A78EA34965AC896EEA\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAMHR1pM94xuFw+GiTQI7RyUN/sKYmupDhwWj1nVricMXRbM7nIXk\\\
-        nsBnqTx0pTkITPxjszoVyFFxG+Uw8TXMZEZdCOhcC2AieHV0mgWsXxLAbD9Sw3VmQ\\ngOQ3S2C/MBrimrK4bkpoKXxKIV5v5Rgku5Pjxzw50HH4e1pYhgW2C+knABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEg3TVJTVUZHWFVKRldQQlM0UjdISk1JNE5HTUREQ0FaRzJL\\nVlIyTTM3RkFTQk9BRjIyUkFYNzdMUVdZNFZJNTJLSlBOQldaRjUyQTdHWFJVN1lQ\\\
-        nN0dQQU5QSFNNUUkzSUFVN1VGNEk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEI6jSWWsiW7qZeYD/ReRVU5y0nssc0+OlRy6M/im\\\
-        nHY9oHex0tSGt1fTuDVqsAKKHMDrZLKkkhJg42wcINwbXTj/vRu7n199IwbSUoDiE\\nJlnO6ZaIG996AUFS64eZBA+kXczqJbsWgdQQpwQJn8LiQUF8iwFhTThltjRSuXqf\\\
-        nMxyFevvxbIvYcs6il7Ip\\n=cZe8\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:36.194245Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"uuid\": \"6db98582-dd69-48ea-879e-5afc5aa388d6\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"inexpressible\
-        \ sepsis\", \n      \"key\": {\n        \"fingerprint\": \"380C70D1C7930985411415B31A1B751385404CC5\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANhgLtWR4jFlhHEPGJjcupkGrNymWv9wFlFM8YppKs6nNXaQdoKf\\\
-        n7+NESFVdkm89/7FWD/It0B49jEBjjs7GOmxhffomt1NVHocYGDBQjMAlKOYQgCnR\\neZDnHCFORSrQcfiNhgKm1/eFOZlNJDZn2Cwpmdk8ZV6B78fGVz+3B+tFABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEo0VFRaVzY2QlBRTFRRVVlNS0hIVzZZTjRGVkJIVFlVQ0ZW\\nNVNWNjNRWlQyT0Y3Wjc2NUxEWk1TVDJNR1JBVFpYSVZJVzVBR1M0N0RFU0hTRUhY\\\
-        nWDZFQVlISkFWTFBZRzc1VFlKQkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBobdROFQEzFd3gD/RUhGdZUriO3QqYTqvH7EZdZ\\\
-        n4r3iFUJVP3xhru9HYBtksepsKzUHYZn4nK29689AdV1A9o/X4YcKWrxFRbMuZs0E\\nTj2Je4jrw3WNf3O3COAWwFa75HOXIhGfFVuJ4Ni2/NVJGDPA6NNIfZfFMIj/NZF3\\\
-        n3RBZhDmxS21yJs9daQfs\\n=NQQJ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:44.877597Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"uuid\": \"f3a61359-1919-4bf0-b6f7-da902a935160\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"newfound necessity\"\
-        , \n      \"key\": {\n        \"fingerprint\": \"7FBC4515353AE647D938C764EEE9B96CF5D1BE8E\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAL5F4eU1lEB3y0oi3X6T8FU3jjZjLrsuh7pO8UcwNtQX4SccJ++B\\\
-        nHChPo4OarAIfmIENAL3aP2/IVGM0w6BvHFOJvztQpEagiwf1g5voHC8mlr0m9maq\\n/pFAIbFSsTKh+nCwEvXjwxGfUt8l5w0P59kpRp/1j2DzIrwjvFomK1DZABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEtZWEZDUldUM1hSSU1MRzdDU0NJN1paVVFaRkxMSldLMlhP\\nWEFCNVdHVkRPNEVOSEY3NTJZSzJBU0lFWktYUVBHRUJXRk02NlVRSFpBVUhBMjQy\\\
-        nUkQ2NjVZQzRHQlk2UEZFVFRLWVk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEO7puWz10b6O+F0EAKBLCQEcRuGffqEjWHS+B2QO\\\
-        nXWvovvU1mWTDvGPFLzyq92iQUVe+fAjgfEcEyX6btD0ivZDctfhImVqqXQj23zP7\\n8j1lvDXFBbU41AfZbBljEk69MIPicdviWnZaWZ2hk7ScO9Lc6D+CcU+3/l3hlh6X\\\
-        ngQPZEQ30NO7w2/7ADAvs\\n=P6eJ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:53.136494Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1\"\
-        , \n      \"uuid\": \"5fb61bc7-8819-4f66-99b0-538a389f8fa1\"\n    }\n  ]\n\
+        \      \"remove_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"f9b4da97-a077-412e-8e54-4ef4984a8540\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '8018'
+      - '3214'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:35 GMT
+      - Tue, 25 Aug 2020 17:28:13 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -158,7 +107,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxOTUsImlhdCI6MTU5NzQ1ODM5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ih89P26f7E358aoOqLoNcH6ErE8G3V6UenhvJDBCLpw
+      - Token eyJleHAiOjE1OTg0MDUyOTMsImlhdCI6MTU5ODM3NjQ5MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.UYMpEZ3IMxjRHe6ISL5X2VDlNLmEsljZ-JiQGlIzdqE
       Connection:
       - keep-alive
       Content-Type:
@@ -169,65 +118,34 @@ interactions:
     uri: http://localhost:8081/api/v1/submissions
   response:
     body:
-      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96/download\"\
-        , \n      \"filename\": \"1-out-of-town_primogeniture-msg.gpg\", \n      \"\
-        is_read\": true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\
-        , \n      \"submission_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96\"\
-        , \n      \"uuid\": \"f836676a-c1aa-49a8-90c2-bb171f60cd96\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/99509e6d-62dd-48f3-8208-623f9290bc03/download\"\
-        , \n      \"filename\": \"2-out-of-town_primogeniture-doc.gz.gpg\", \n   \
-        \   \"is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"\
-        /api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\", \n      \"submission_url\"\
-        : \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/99509e6d-62dd-48f3-8208-623f9290bc03\"\
-        , \n      \"uuid\": \"99509e6d-62dd-48f3-8208-623f9290bc03\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download\"\
-        , \n      \"filename\": \"1-red-rimmed_applejack-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170\"\
-        , \n      \"uuid\": \"ceb44744-68cd-4b29-ada9-4c6ed4127170\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015/download\"\
-        , \n      \"filename\": \"2-red-rimmed_applejack-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015\"\
-        , \n      \"uuid\": \"1deb4f4f-1094-49ec-b0da-5d714b60c015\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download\"\
-        , \n      \"filename\": \"1-potential_freshness-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e\"\
-        , \n      \"uuid\": \"da095cb7-5a81-4b57-912c-14b0501dc00e\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d/download\"\
-        , \n      \"filename\": \"2-potential_freshness-doc.gz.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d\"\
-        , \n      \"uuid\": \"ed460264-f0e9-415f-8247-738eb482c75d\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download\"\
-        , \n      \"filename\": \"1-inexpressible_sepsis-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a\"\
-        , \n      \"uuid\": \"a3bb0937-6240-4200-99d5-b514c465e56a\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01/download\"\
-        , \n      \"filename\": \"2-inexpressible_sepsis-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\
-        , \n      \"uuid\": \"1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions/2b1dce9e-852d-40a5-8148-d4e54cf3c322/download\"\
-        , \n      \"filename\": \"1-newfound_necessity-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1\"\
-        , \n      \"submission_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions/2b1dce9e-852d-40a5-8148-d4e54cf3c322\"\
-        , \n      \"uuid\": \"2b1dce9e-852d-40a5-8148-d4e54cf3c322\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions/9cc1760b-3d1e-4cd2-8f0e-5af35661509a/download\"\
-        , \n      \"filename\": \"2-newfound_necessity-doc.gz.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1\"\
-        , \n      \"submission_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions/9cc1760b-3d1e-4cd2-8f0e-5af35661509a\"\
-        , \n      \"uuid\": \"9cc1760b-3d1e-4cd2-8f0e-5af35661509a\"\n    }\n  ]\n\
+      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442/download\"\
+        , \n      \"filename\": \"1-pleasant_rearguard-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"submission_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442\"\
+        , \n      \"uuid\": \"bbc25300-917a-4b73-b0f4-10f3d6957442\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/a8699ca4-55a5-4737-b8f1-c9e170ec8250/download\"\
+        , \n      \"filename\": \"2-pleasant_rearguard-doc.gz.gpg\", \n      \"is_read\"\
+        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"submission_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/a8699ca4-55a5-4737-b8f1-c9e170ec8250\"\
+        , \n      \"uuid\": \"a8699ca4-55a5-4737-b8f1-c9e170ec8250\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download\"\
+        , \n      \"filename\": \"1-unlawful_spectrum-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\
+        , \n      \"uuid\": \"d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a/download\"\
+        , \n      \"filename\": \"2-unlawful_spectrum-doc.gz.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a\"\
+        , \n      \"uuid\": \"55e459bd-cf4e-45f9-adce-95d79998254a\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '5129'
+      - '2054'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:35 GMT
+      - Tue, 25 Aug 2020 17:28:13 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -241,7 +159,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxOTUsImlhdCI6MTU5NzQ1ODM5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ih89P26f7E358aoOqLoNcH6ErE8G3V6UenhvJDBCLpw
+      - Token eyJleHAiOjE1OTg0MDUyOTMsImlhdCI6MTU5ODM3NjQ5MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.UYMpEZ3IMxjRHe6ISL5X2VDlNLmEsljZ-JiQGlIzdqE
       Connection:
       - keep-alive
       Content-Type:
@@ -259,7 +177,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:35 GMT
+      - Tue, 25 Aug 2020 17:28:13 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -273,7 +191,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxOTUsImlhdCI6MTU5NzQ1ODM5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ih89P26f7E358aoOqLoNcH6ErE8G3V6UenhvJDBCLpw
+      - Token eyJleHAiOjE1OTg0MDUyOTMsImlhdCI6MTU5ODM3NjQ5MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.UYMpEZ3IMxjRHe6ISL5X2VDlNLmEsljZ-JiQGlIzdqE
       Connection:
       - keep-alive
       Content-Type:
@@ -281,38 +199,20 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions/2b1dce9e-852d-40a5-8148-d4e54cf3c322/download
+    uri: http://localhost:8081/api/v1/user
   response:
     body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqARAArL7MGys+bU7mIl18TJs5rSTC9NvcRhYXjmB/UMdxG2z6sYPXOrpcIJgO
-        fJwQMwe0Osu5iYDmaGVZ+5oYmVdaCTt2inZKxn1Li8iCV4RnbXWItYlt03WeLO8Mfa/k8LMqwGb2
-        RWoW3yOPZm4NsTc30c60z7PBnjsgXuCbCjLCZs1uXQnOXqr4f6C4hq3S+CCvxqOfytPY4vBtVkvN
-        pcbaBm4jCgMAuyg/f3cXLt4w0b2TZ5LHejmppv1cOkpq/ia8cmyv0kW+hTh5uKnRiZtu+PlEWCEI
-        QhkNF7uVT1xoNDQZJE/wze0ni7u5V8Afze7oEEqbOJg/nLjUrAKdPM/08yB3CIiHU66LF5lsQMcc
-        eg/lpcMRja9YgkPYfOjWYxyZqYH9gHKykMlbjr5c2mGSswpkANw3wmuS9DIB96EYpPc2ebqDLKkt
-        8+yC5vDu81VBlxC0xPlRzb7bK81jFvzwavb86T4HEEl/n69QwiuPeiFNpw48tNSK6l2oDVyq6TjU
-        uRjyC/ICo8D4V1LYFp4fy8WdNG96AGADwMFNTTmxOuY1Gi8Qn8XXpeOzxPPiwPv/P+W7SAGM08dt
-        LuEdA9U+0GoHEGqIrzSy4B/EUaVby947Lz15FQzjS2AfNIx32PDcCnw80l5i/rV2v1G+qF7Iv1Kc
-        e5sYaAZ1FJ91j6S+VXvSTAEY9XnwSOWdtr//CvagOwodz5TtI/TXCt7yEiGJBGwz3dnAxWwlziOs
-        5yBjLzVsDX+GHrPL3cc/VbXd7be3fi/7omVkmeHmLma8vmI=
+      string: "{\n  \"first_name\": \"\", \n  \"is_admin\": true, \n  \"last_login\"\
+        : \"2020-08-25T17:28:13.360308Z\", \n  \"last_name\": \"\", \n  \"username\"\
+        : \"journalist\", \n  \"uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\n\
+        }\n"
     headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-newfound_necessity-msg.gpg
       Content-Length:
-      - '605'
+      - '192'
       Content-Type:
-      - application/pgp-encrypted
+      - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:35 GMT
-      Etag:
-      - sha256:cd8ca8320d46a9d2654a353aec5bec455d4afed05744d0ca95e47c7ccf358c1b
-      Expires:
-      - Sat, 15 Aug 2020 14:26:35 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:25:52 GMT
+      - Tue, 25 Aug 2020 17:28:13 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -326,7 +226,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxOTUsImlhdCI6MTU5NzQ1ODM5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ih89P26f7E358aoOqLoNcH6ErE8G3V6UenhvJDBCLpw
+      - Token eyJleHAiOjE1OTg0MDUyOTMsImlhdCI6MTU5ODM3NjQ5MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.UYMpEZ3IMxjRHe6ISL5X2VDlNLmEsljZ-JiQGlIzdqE
       Connection:
       - keep-alive
       Content-Type:
@@ -334,38 +234,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqAQ//Z/S89kAgGiAOh+UVD2ePgDvU/l/JnvR2DkCEnnqTivaWTKetbcTOxv8D
-        iHQFUvQKPTADA4g5u56foRmzC0Yb2mP36vRMUqLq87hb/XfZFfr3Ak7E169EyaCN6ht5he28mLV0
-        j9brHPGxQWt2vrE4FFdwnUVQWNfAp13rFMm0IDFsHN3o3lNSjywJ62jlr1rce3mdkC+rXkwDh3zs
-        0ZDvxqFGx4X8YPbQiAStvUsK1n3u9NBnKE3cyeHe70xnMdQxq1N4NuACJZkNovKet6C3s8LTvj58
-        XiK6+/AgtbO9Pk6c89s1WW0x3hUGFtWVI+GqSUSQda5CDlWaq6Fq7mBURfuW7yD/rOJ0EypOOJED
-        b1GoyTiK6V1gC/mktb6u/Ei16SmPOjcsAzW7BFn5tsvl3lZULN+b4Bs+E7/Pxl4ymVaPDgbcsAh9
-        Ipp0thhF1a2A3MobRsTtNidryxvfzUTj5ou70vguzn7zthzog2sijyM9hBI0FPr6YRVWXvrS7BEQ
-        Ly9BA1AuzGy0kS1B6MUYdcWAaxQZHWNne02zDHZqe2sBFLM04tJU4myKrXlBOok4YILQ7OWDSoa8
-        Whkyohid0Eympcv+6YMaKI+9yBzHFWgcpu27rlrAuRGRXi9ibBxovyCRg5SSYc1Guo0jalDJWdDy
-        lRdLGsmqJAcWq2PUvNLSTAGpSiJRM+Iwxr77j/lapCOSRGfVJaivW59X5+ZQa6BN57DKWvcgPtCb
-        xDfXOBD4hOG9w/Qv5iKwgOcj/ckygOpvtrcQosdK9ZzrrdY=
+        hQIMA8PnxMCiIBsqAQ//Rw1NPH3mwdBg9NnblanYiQgqmPuHTY9ha8sR24r6Cbv4UunDrGcjIMeT
+        qUZfK1zok/ZjbbLMo+yVWG2my899P8meyJS9C9MzmPC/x8hpoSUVdxyRorBDja9qNtZUyhOrm5Dz
+        rsiuEaqB1T5iYPinyCzeOcGKxTlrDJE78s5aHQVGQeBjXN+7BqZXsGCWrUueXTF10QrC8u0T/Fnw
+        T+BLvR8FmCIEilEDQESn653nL2wbkTz/7OMxUJJUDkG9xO6VHsTcH4KAzVsonMaan2RVXarJ1393
+        esjkZJ3vMiKXSMNIdsdDQ8WbP/2JGL8rhdg3WZqRbX7ePEJ5C7moUGiJsXmYwNMDarImp/be0O+1
+        YGk1Bfig2smMD280G8vYNykGvLkiGWJU0tGQQBbc5NeM3WZ8chZsyKofidoc9CIY7NLVHGg5u6zf
+        AEe1bjVuWveL5NaUJUpzWxDQzkIBuvX/E9stjEvqb0fZCRkGqPQLOix/YVUjUzj2i1zGAgL/w3xw
+        jhadu4aN05dbf5cBeKRIUS43HnrDXluA0vq0HbX30xuFpoo/noZUiZ8uNfR2UKLQfIK0gNVH1ydw
+        MhHIDKyiUWm/0YQgzcozy14n9OCGtLCucWfxXy7nozJ7JnVJpSYPgAmozMOoqEiz3C0Dnsax/PRV
+        AvwhOEGda6nAIosZZ6nSTAGpDbf6bksYyI2J4JEtY4b7jBvCz6Qmg+n4ZIIH7IEeIBCkhnUtU8xz
+        JHiwor7B/FnoP6RymaVAKyAPqoKGfrJ/XGbwPXJRvQl2PeM=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-inexpressible_sepsis-msg.gpg
+      - attachment; filename=1-unlawful_spectrum-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:26:35 GMT
+      - Tue, 25 Aug 2020 17:28:13 GMT
       Etag:
-      - sha256:20db26d5f8240c2efbc83f40184bd03e74f0b927394627fe24bc2954cb4a6c2a
+      - sha256:dd82012b8656a3f7175b619f2875895a11071daf681b996cdc2704ddf5388664
       Expires:
-      - Sat, 15 Aug 2020 14:26:35 GMT
+      - Wed, 26 Aug 2020 05:28:13 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:44 GMT
+      - Tue, 25 Aug 2020 17:27:02 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -379,7 +279,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxOTUsImlhdCI6MTU5NzQ1ODM5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ih89P26f7E358aoOqLoNcH6ErE8G3V6UenhvJDBCLpw
+      - Token eyJleHAiOjE1OTg0MDUyOTMsImlhdCI6MTU5ODM3NjQ5MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.UYMpEZ3IMxjRHe6ISL5X2VDlNLmEsljZ-JiQGlIzdqE
       Connection:
       - keep-alive
       Content-Type:
@@ -387,159 +287,53 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download
+    uri: http://localhost:8081/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAs+tSZVdjh2H5sgW3rQYsinaTUd1To3XLy/EC0UcNed15/OLbU142ic10
-        6l41iWmBW44aOmjYFIY46VfqPxQSM0G7fl2g5A0SZdmckTqzu141v/+BoTmvbzzZ8sXmpxKjbP/A
-        1F6aBPQ2qX7HcUVyGOadyMRjuKB+IO1pROBeFB5R0hE+FD+y4/yq2y4J9SVeYcdcwcsWJytFUm73
-        emXQ6vcBspvlgSjE1gywgfPFkmOLIKxv9INHFTT/FrfPvJ/yeFZ7jKtG0wxBQYPL4DG5QiVi1Gyz
-        Ln039tgWjFVnM5FhJ+XNhLbLHuISii/0CrKq9TeRea85xFHR6UGKgTm3/fOeWtEhC6FKa0XstXhU
-        T0E9dmh80Rd3myvN0HU3eyNFvmjyZ1weVguXjg4Ao1yWZ8a8AmqlA6m4conr4bbscqQKXCJSF1D+
-        g/i5ng78t0+4wnWMiKtN9rNTJkVBzXpaoYzOn+14EJbkYa+zkCyQS8TbjMBpLaP0aTFO4VXk7OAU
-        ygtKj6P8KmkfqivWrQ047DjqwVot+wBpKT+3t8ASscApC7KaSF0+d/fBvb05ZLzLtfSXM+Ts6pQ8
-        sn60uh2dnW/12nbqAdzFnrEPtDdtz5PFWn8brJpvhhMids/A7dkmbbLK6oirkLSRMF7Wdp8Stz2m
-        aI8Xz6brh2GQeKZafWnSTAHRguSmKDs+h+zUuP/hFFyLlLy2TWX3VLR2rLCEHhm82jP4UcMTpBkU
-        sgsFKxLyPddNYl+9D7kh9NLhzaLsXc2RihQWRvXYM9f3E0Y=
+        hQIMA8PnxMCiIBsqAQ//RtWsdfVE8eGi8sFqp1/cmLdkiut2OkXfs7DdjD0CBr6qfYUG8woosTjZ
+        +bdA5IIg1ewECF+eOZbfgW3EGzq/xN9rKaE+yTEbrR2swkoHNv1tUTrBoRGwUfHOYl3LOWlftNHt
+        8HbCVEZ/TAs1NQolRpSXj9o+mR6wjPvXtArQkW0io6D8ah9YO+YkEEkl4B2CwK1BwUQHj4B1TXw+
+        QGubNNIfGeXM9OkSCQMZapmumEt4m+8KImF1ncNMINXO/WV3tbTKDrCO63R/K6ibSuq//vd72Q2z
+        DFalhfcmnu7ksX0/4TFsrsvfuQoppTqepI6YklIKhTRkoRuY5fQeoK2w93qrZh0dmsVvlhx13/xl
+        19wcO1vASiZzfSHT/XDaXoS+3XmgW/xKr+Y0IJq+PZSs/EZ/2mr6zXePR8HtdFuvCnGiNjPFsRsE
+        sRIB1iq6FEV3zKxLU7FI46MTNrBpTYj3xAn2MqGM0UgCvwC1v73s6mMe6njwvYak8V0J/ny3sd/J
+        NHnbftRaGOmlrQbiXhoRIDEV5Kric9qBJG5R12kxDHHqce/viMEnZ1543+2snmsGrmWvX3Kxsbq4
+        cm1rmE/1dwYYtUaTpj1j4HDr7OY0PUN4F2BXK1gOSOONWiKd8hRAbY4Emwv60g+36ZtwY6kQu4v3
+        pQhKYVCTt8xL1gZkYYfSTAFnY4M6ViJKpbRI6FGnAQsYaB74rBUx6FatdEvztAN5VHarQPHN9uDF
+        TLPp+suitZOgA4wsgUWL+sUze53pOc/MCAUfBwrk2YD7hO8=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-potential_freshness-msg.gpg
+      - attachment; filename=1-pleasant_rearguard-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:26:35 GMT
+      - Tue, 25 Aug 2020 17:28:13 GMT
       Etag:
-      - sha256:624b8cc271f0bc4a153ff893f14d4b63464577579c0baa49ca2e6f5b2fb715a8
+      - sha256:cecd2591b0a9a0315f320e9878f68fdaec03c70b286da162c4416fab137ec00e
       Expires:
-      - Sat, 15 Aug 2020 14:26:35 GMT
+      - Wed, 26 Aug 2020 05:28:13 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:35 GMT
+      - Tue, 25 Aug 2020 17:26:47 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"reply": "-----BEGIN PGP MESSAGE-----\n\nhIwDPsLQNt3KjNQBA/9ojtfC9t1XqWV3wWgAlu95dTxfMqqYczw6sQSmgcEkg9+P\nvCeb05aaW5jMMlYXkUm62SVqdw/KJW1Dg8trcMvRFIeCKNZQhA01Rsqb7jzDLzD/\nkqJ0JGGZk01wDAdRZwWHtA96PY6Qp7mpEJcQTfliBzdWhe03KWfPEJxzZCfT84UC\nDAPD58TAoiAbKgEP/RRt/jqDFFWYxpc4SrqshMubiyh/GImTEOePHfhgQujDvKLu\nkRQovxq1xujHfCuVaBHUgCpm3jWcKCQPrpNT8xLNngu8Uem1degoqstCk+0MVVpC\n+YkmUCajX9X7J98xxuJ/evZMWgWzbk3kD2AuTlYolXqNB6nY50RWQwt1Si/k9p7Y\nRO1ERKa9M99a+lReuF2E2dEYW0Ru3YdTbz/sYuX65Hl/UM6lEhdq9A2EDBElDoiH\n0wkY+YybjFMJlfKnK97nxJ2rwfPQqIiRFEWRbHci+pbtjcPxPjEM37aM/9urM6WR\nCJ3leluB9ZYHzKAFA5VGHH1W1/xPe8STvySggG/cjb4jIxqyu9rV+dkrwK0xjfhN\n15G7B5gvJmXWAp5IDvQD3Pux128hpJYzLUBMURAK1oVf0SCjqWFwQeAIEOE67eJ6\nNu046qIKcTz6jSH6JrxSneHyDySZaM8DwV9u24voInDGGjEwAbuLfvOGYu6yawAX\nJkD7tAHHpEnsqfOYcH/dMFDLjaE1ybzrD1W2JmJUitMjL449QrTQS8ABpZvZvNl7\negjy2PgtxHkGvLZ52xv4gGq0Q+5eXquL8uE/zFEi8cUuCj1Q0owvkfqia1j+ZU5p\nJnCZY4UkEivnwu9pbRXu1nuUlPo+/HQSpO9a7SEpIWo4WbnQPxZ9f5LgCiIl0lMB\n/uKyfBrojiN6UOwbopz3CqwC+C3QKzbnKpV6LfyweT8hBt8nYZCp+vDcQ+iucyxb\n1C7h2wAzePF2VFz/1plVSNOGVwqzf8Qf7wCBfJpAt+z7UQ==\n=EqXV\n-----END
+      PGP MESSAGE-----\n", "uuid": "b8bfb5d1-7a5a-4413-9df2-52205fffa5b5"}'
     headers:
       Accept:
       - application/json
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxOTUsImlhdCI6MTU5NzQ1ODM5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ih89P26f7E358aoOqLoNcH6ErE8G3V6UenhvJDBCLpw
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.20.0
-    method: GET
-    uri: http://localhost:8081/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download
-  response:
-    body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqARAAp+9fU8qzd8lBJJJeTGUfrTvtC7bBj77m96ioEWln23lreSXOi7W1E++i
-        X3mCeNg6hLC0PSAtuO0QTw+LE6TGqLJtQh5y14fIxzgIX5G02eaoOlsayjQbVfXHTJ6HBSFx1VkS
-        ImILNuS170DhYiOyW91R3OJ2zg4DeTlPkyegMGScWCued6EcBBL+/EOrvZLDoXtpFAHFkGGcoQSD
-        p/6L5/pp8AuB5N43NRCtslfsD8D4gpZT7L9gkvNIJbMrBQ4FVUzjB/XI5mkOhXAubjKzgGcpqiM+
-        N2k5nqSPFzotGHmKDy77Bq4D3Sk4fcLzvWMe9hY+Prp6QqW5/F3uvFhJdpdOR9JZ4WqY6pWk0VsA
-        jeIuaxGH3rRqFegi59AiZV+EvpORA7tx8qmkVHch5UifaJCsHthaxOrBk1D/rgutgmoQvVaCN+UA
-        6So9D0H/w6RIE0vE3SAsCpXV3XQJWwsya8O5R5jCuETvi1s5NnMXrtxRuBqkFZUcRSNZyzrUWLGA
-        8djkwjYcO5lP7qt40ztUosMmb2y+4z8ad3zhWP71SKA+chx8lUvY7ziiSmFOpRJOr0OEgKMU59lR
-        ovyT6mu5yB1d5d8G9ns8s5H8/ymV5WE/MdG+o472wWPKoKHnIu0zlj1Qqso8l/khM5wIjs8XvICl
-        pm7uojnWqaFcIaJg4EvSTAEw45cGmA90NotlV9qwHi0fJ0qlbFKf6FAyeDaRL0TPoLKx9JbGf+9M
-        +wwWhoyWoWili+hOxuju3sNSeN1iYkv3fEIyKyEy5rXvf/0=
-    headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-red-rimmed_applejack-msg.gpg
-      Content-Length:
-      - '605'
-      Content-Type:
-      - application/pgp-encrypted
-      Date:
-      - Sat, 15 Aug 2020 02:26:35 GMT
-      Etag:
-      - sha256:2e1bdbd452ce54d49602552182cb0146b2334c58a7c5aec0c0565645e2ab4286
-      Expires:
-      - Sat, 15 Aug 2020 14:26:35 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:25:23 GMT
-      Server:
-      - Werkzeug/0.16.0 Python/3.5.2
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxOTUsImlhdCI6MTU5NzQ1ODM5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ih89P26f7E358aoOqLoNcH6ErE8G3V6UenhvJDBCLpw
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.20.0
-    method: GET
-    uri: http://localhost:8081/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96/download
-  response:
-    body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqARAAqBkguUOJVhB1E0rEBd3bIvbOJe9umLBp5QVPye5M4nsh0yl0IWnltszf
-        edV/FKB+H0YdtACRB57Zur0vTrOWAA4o1cC9tyUi18aWslfgDvVwJXLjELZYOQiDv//vmcWEG4Mw
-        ckXqK+/zvkgGLST9xjubdcQozWQNW8mXNzqLzLPLYd57oejEzr73iwn2UwQbQjXb31YI5ZsvCB0y
-        sltvyQevn92quua31WmlxjwzTndQ9u9mGQ5zZSxwK39HaZ3oEmPZlWelrnUfbodPJw5wQqGBN++n
-        lwGMVphNGN+EssKtSUb5Hmutd6jTajcfPWPf0yU6AYtJ3v/1wiOyXCaN3tnPStKUzP6w/htB2nFz
-        irbFi2VQ5v1Lg/nAYl0n3cVU4A8O8P8nhIX5KOsxNhYqNyuyjZsJgFAiKtCzEcXxlpyCQiPwpHbo
-        PM7nDr1JtS7w+IY4xlOkwdOmTIjq+WYjfwbOMd8GlwMQmpp2s6n4S7whSIcYI5acs14DERizF7lG
-        vY8XG7/ExbA0zt9B8j0MKTDsAxgkEEMALTPtINMmuc3xaDoTP7HA8e/X6tyPvrVarY8zFuPVxKuY
-        VXdPQuf6in/3uzja0QlWwq+Ibm+I/gBtQPRM1cDpW5n7XdYkzRcTIluElj8U8VnbECvkFNLt8NUk
-        IF792WIIe570TmeeRXfSTAE9fPtTykzrDiTy5LSwqQ91J/Og4d484LO+VkYSPGe37sfcFRSAOSL6
-        KHNlQb9u2IoOgkORHi/6PABz5ty5K45/OvEOhlB4/xbxkbA=
-    headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-out-of-town_primogeniture-msg.gpg
-      Content-Length:
-      - '605'
-      Content-Type:
-      - application/pgp-encrypted
-      Date:
-      - Sat, 15 Aug 2020 02:26:35 GMT
-      Etag:
-      - sha256:64f0c214fab76a0aa8a1407daf0c0478f7851bd7b5c0aaca5b5c8de53aae9336
-      Expires:
-      - Sat, 15 Aug 2020 14:26:35 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:24:41 GMT
-      Server:
-      - Werkzeug/0.16.0 Python/3.5.2
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"reply": "-----BEGIN PGP MESSAGE-----\n\nhIwD7um5bPXRvo4BA/0fDoW4+8nm6TAIGSx0sNpr+d3xSMcC8kM+dCGispw2UbiP\nwZDNfo2XGYSDowksA8F+HYZX0mWdMyUwNvZekZU9i6oR3Dr4hW4VdE6aGvsxmsIv\nirNKArPbkBwUjpAKtG7LyhICGRo7PVdlfabGst8ex60WR3T7aQfgieLNIqkoUIUC\nDAPD58TAoiAbKgEP/Rv/5GQrz9M1ARusZ3u1anLKIEFIJLyWETShSdWVcmDp9mLw\nYrIcDB8f+s/g5PUSTV4UlJ75jQdgOa+omte+BMzmyCVGvZVbh+fbOCJcE9IGm2uF\nmcwe5zmAaWpfGWORDDPcmcY4SkunoKSAMSLhraEPNQRGE1FMWBnOCdTiRxNIsIBk\nGrfCYfxOZliEloCMcaORppPNfhK5zVhIYqo0Ls4rlP5hMzibgjcCjeN3PSqLmSyn\nuB7Zffsv8DiazgYFIgyQ6H3siNo0Ljj/uLJAEkCw+gY6EntP6UirTWTXl75l3P0d\nGY8dDgBV/iPT4zYm+Ypz7esSQHhi0dBxZel7Q1gY53fHQPEV85xNavKOtJjS8UHX\ntv4AtzrHUWA/1miydqL42u7piRr5Mkd3fwvQBVBHbtqhGHsN9SPNed+M93TPtQ+s\nkZv/Hj/AMowZ8WDB4uEZS6aRqFHbd3/HNLSK4WTD//2jpVF5RYvxuDT9HmPSJLiL\nIpoYz57wwQfyltZ0rSlDAE4b3eoHTlx0XBztZ3ewBvHgWk6SIHohrjg08UkiyeLQ\n30JPi5wT2m32ItLXrgL1M0/czf53DfioO3uOy7ej9INJtSjdnsWA3F5ZF7G/PVM1\n6+Q/GKydx3RMFV2GLfUq2KnDerWWAse5SxCWxE9bm4leXjyhIJAD1dikd4Wz0lMB\ntaClSRkQ6Asc6RUd2Rb433LAZMFpmHl1aQaVq453+RyftXHzvTkaKh4d3vL5Bh8e\nyvhkikpn5Nci9A+bNeLj0cUE+e2wTyejBjwDXSpwi2RktQ==\n=PRvf\n-----END
-      PGP MESSAGE-----\n", "uuid": "7985ed2f-bcbf-40a6-953b-ebea0fba1376"}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxOTUsImlhdCI6MTU5NzQ1ODM5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ih89P26f7E358aoOqLoNcH6ErE8G3V6UenhvJDBCLpw
+      - Token eyJleHAiOjE1OTg0MDUyOTMsImlhdCI6MTU5ODM3NjQ5MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.UYMpEZ3IMxjRHe6ISL5X2VDlNLmEsljZ-JiQGlIzdqE
       Connection:
       - keep-alive
       Content-Length:
@@ -549,261 +343,22 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: POST
-    uri: http://localhost:8081/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/replies
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies
   response:
     body:
-      string: "{\n  \"filename\": \"3-newfound_necessity-reply.gpg\", \n  \"message\"\
-        : \"Your reply has been stored\", \n  \"uuid\": \"7985ed2f-bcbf-40a6-953b-ebea0fba1376\"\
+      string: "{\n  \"filename\": \"3-unlawful_spectrum-reply.gpg\", \n  \"message\"\
+        : \"Your reply has been stored\", \n  \"uuid\": \"b8bfb5d1-7a5a-4413-9df2-52205fffa5b5\"\
         \n}\n"
     headers:
       Content-Length:
-      - '146'
+      - '145'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:38 GMT
+      - Tue, 25 Aug 2020 17:28:16 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
       code: 201
       message: CREATED
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxOTUsImlhdCI6MTU5NzQ1ODM5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ih89P26f7E358aoOqLoNcH6ErE8G3V6UenhvJDBCLpw
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.20.0
-    method: DELETE
-    uri: http://localhost:8081/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1
-  response:
-    body:
-      string: "{\n  \"message\": \"Source and submissions deleted\"\n}\n"
-    headers:
-      Content-Length:
-      - '50'
-      Content-Type:
-      - application/json
-      Date:
-      - Sat, 15 Aug 2020 02:26:39 GMT
-      Server:
-      - Werkzeug/0.16.0 Python/3.5.2
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxOTUsImlhdCI6MTU5NzQ1ODM5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ih89P26f7E358aoOqLoNcH6ErE8G3V6UenhvJDBCLpw
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.20.0
-    method: GET
-    uri: http://localhost:8081/api/v1/sources
-  response:
-    body:
-      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"out-of-town\
-        \ primogeniture\", \n      \"key\": {\n        \"fingerprint\": \"200C271E4E680FFE62E008931554E4BF600B1E3C\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAL4uN551SiYiVLrHoK1QGMDmN1xq42u8o2dmnKFkArW5KfBvBFoX\\\
-        nZX5LnOj9hKKEEmeGX5beS9h+fjsWvx86M2kQj/5xhOmHw0GGESEPQBSUc+Lyohpc\\nUmBoNNBfWIouEQ+IVS0gmrOwiS7wdItMby1lLDlDBoiEm4aRnRw36NIpABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEhPUDNaU05LUFgzNE1MV09QMkVPQkJRVVc2QjZPS0ZFMzZa\\nVktOV0VWNEhXVTVMUlZGQlFENjVKTEtYUENHRE1LVEFTTDM2N0NOT1ZDN0hBRUxF\\\
-        nWVQyWU5LMkJHM0ZWNlZWUUlMMlE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBVU5L9gCx482IED/2w6yFqz19zTBX72qN0MUTq5\\\
-        nCavQIBhhWrbsc1m0p+cxuVJ16TYxiE3S/Lp/rd4r1Q9MQg9BP0+/qjOA541kNq5A\\nmR2Y0teqWonDqeY/660kEFIbio0HbOTjsBhEZxtglJ1wz70tUpd40ZVMsu+Z32Mw\\\
-        n2kSiCclJYHk7uy1eis57\\n=pz11\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:24:42.042205Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\
-        , \n      \"uuid\": \"4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"red-rimmed\
-        \ applejack\", \n      \"key\": {\n        \"fingerprint\": \"D449222A7B7B0AC1E134A1FF01203DD2D2636A37\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAOaUXyLQCaUSR4HTaBVGZp1mi3jn3BExTTe2UCBYjsn1zhkOBDf9\\\
-        ncZNBQGjEBIYlOioC4XY1TkQep4L2DdmqO5lBfbyNG6LpGiNo7DvNBxeo5WNDa42C\\n8YcfTaVL9aWm07G12uwwc1WFNb0y86PzuAS1ek0k5B7jUfjNxFN9t0dhABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEtCTEEyQTRDUEtETEVURDM2MllWQUZVRVdRQlJLUzJWRjVG\\nUEs2SElBWFBXQUFNSURMUkZHUEdLU0dFSDJJUUtBUVdZUFdFS0xRWVpaTDZMU1JY\\\
-        nRFRUTUdPUlFFWFA0WE1EUlJJM0E9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEAEgPdLSY2o3LmUD/i+JqgIWc2SzA5OTX9Qo0g/r\\\
-        nqxDmi2NQMXob0fEEcP/GGnbiFE1P77AC6JWxSKPQStlfwvffhYmK2q7JBc71Jj8O\\nRqFRT5WSRpXUCq8tZkIYyoCXKQPlwSb3S1NQ3yM00kbkCM4dArLIFuQ/ZI1xG+l9\\\
-        nIqxWwXYY8SpO8uKDXFd7\\n=FjUe\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:23.753433Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"uuid\": \"70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"potential\
-        \ freshness\", \n      \"key\": {\n        \"fingerprint\": \"06FFA85715E89C0AFBA927A78EA34965AC896EEA\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAMHR1pM94xuFw+GiTQI7RyUN/sKYmupDhwWj1nVricMXRbM7nIXk\\\
-        nsBnqTx0pTkITPxjszoVyFFxG+Uw8TXMZEZdCOhcC2AieHV0mgWsXxLAbD9Sw3VmQ\\ngOQ3S2C/MBrimrK4bkpoKXxKIV5v5Rgku5Pjxzw50HH4e1pYhgW2C+knABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEg3TVJTVUZHWFVKRldQQlM0UjdISk1JNE5HTUREQ0FaRzJL\\nVlIyTTM3RkFTQk9BRjIyUkFYNzdMUVdZNFZJNTJLSlBOQldaRjUyQTdHWFJVN1lQ\\\
-        nN0dQQU5QSFNNUUkzSUFVN1VGNEk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEI6jSWWsiW7qZeYD/ReRVU5y0nssc0+OlRy6M/im\\\
-        nHY9oHex0tSGt1fTuDVqsAKKHMDrZLKkkhJg42wcINwbXTj/vRu7n199IwbSUoDiE\\nJlnO6ZaIG996AUFS64eZBA+kXczqJbsWgdQQpwQJn8LiQUF8iwFhTThltjRSuXqf\\\
-        nMxyFevvxbIvYcs6il7Ip\\n=cZe8\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:36.194245Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"uuid\": \"6db98582-dd69-48ea-879e-5afc5aa388d6\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"inexpressible\
-        \ sepsis\", \n      \"key\": {\n        \"fingerprint\": \"380C70D1C7930985411415B31A1B751385404CC5\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANhgLtWR4jFlhHEPGJjcupkGrNymWv9wFlFM8YppKs6nNXaQdoKf\\\
-        n7+NESFVdkm89/7FWD/It0B49jEBjjs7GOmxhffomt1NVHocYGDBQjMAlKOYQgCnR\\neZDnHCFORSrQcfiNhgKm1/eFOZlNJDZn2Cwpmdk8ZV6B78fGVz+3B+tFABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEo0VFRaVzY2QlBRTFRRVVlNS0hIVzZZTjRGVkJIVFlVQ0ZW\\nNVNWNjNRWlQyT0Y3Wjc2NUxEWk1TVDJNR1JBVFpYSVZJVzVBR1M0N0RFU0hTRUhY\\\
-        nWDZFQVlISkFWTFBZRzc1VFlKQkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBobdROFQEzFd3gD/RUhGdZUriO3QqYTqvH7EZdZ\\\
-        n4r3iFUJVP3xhru9HYBtksepsKzUHYZn4nK29689AdV1A9o/X4YcKWrxFRbMuZs0E\\nTj2Je4jrw3WNf3O3COAWwFa75HOXIhGfFVuJ4Ni2/NVJGDPA6NNIfZfFMIj/NZF3\\\
-        n3RBZhDmxS21yJs9daQfs\\n=NQQJ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:44.877597Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"uuid\": \"f3a61359-1919-4bf0-b6f7-da902a935160\"\n    }\n  ]\n\
-        }\n"
-    headers:
-      Content-Length:
-      - '6421'
-      Content-Type:
-      - application/json
-      Date:
-      - Sat, 15 Aug 2020 02:26:50 GMT
-      Server:
-      - Werkzeug/0.16.0 Python/3.5.2
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxOTUsImlhdCI6MTU5NzQ1ODM5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ih89P26f7E358aoOqLoNcH6ErE8G3V6UenhvJDBCLpw
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.20.0
-    method: GET
-    uri: http://localhost:8081/api/v1/submissions
-  response:
-    body:
-      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96/download\"\
-        , \n      \"filename\": \"1-out-of-town_primogeniture-msg.gpg\", \n      \"\
-        is_read\": true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\
-        , \n      \"submission_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96\"\
-        , \n      \"uuid\": \"f836676a-c1aa-49a8-90c2-bb171f60cd96\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/99509e6d-62dd-48f3-8208-623f9290bc03/download\"\
-        , \n      \"filename\": \"2-out-of-town_primogeniture-doc.gz.gpg\", \n   \
-        \   \"is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"\
-        /api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\", \n      \"submission_url\"\
-        : \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/99509e6d-62dd-48f3-8208-623f9290bc03\"\
-        , \n      \"uuid\": \"99509e6d-62dd-48f3-8208-623f9290bc03\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download\"\
-        , \n      \"filename\": \"1-red-rimmed_applejack-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170\"\
-        , \n      \"uuid\": \"ceb44744-68cd-4b29-ada9-4c6ed4127170\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015/download\"\
-        , \n      \"filename\": \"2-red-rimmed_applejack-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015\"\
-        , \n      \"uuid\": \"1deb4f4f-1094-49ec-b0da-5d714b60c015\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download\"\
-        , \n      \"filename\": \"1-potential_freshness-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e\"\
-        , \n      \"uuid\": \"da095cb7-5a81-4b57-912c-14b0501dc00e\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d/download\"\
-        , \n      \"filename\": \"2-potential_freshness-doc.gz.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d\"\
-        , \n      \"uuid\": \"ed460264-f0e9-415f-8247-738eb482c75d\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download\"\
-        , \n      \"filename\": \"1-inexpressible_sepsis-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a\"\
-        , \n      \"uuid\": \"a3bb0937-6240-4200-99d5-b514c465e56a\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01/download\"\
-        , \n      \"filename\": \"2-inexpressible_sepsis-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\
-        , \n      \"uuid\": \"1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\n    }\n  ]\n\
-        }\n"
-    headers:
-      Content-Length:
-      - '4113'
-      Content-Type:
-      - application/json
-      Date:
-      - Sat, 15 Aug 2020 02:26:50 GMT
-      Server:
-      - Werkzeug/0.16.0 Python/3.5.2
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxOTUsImlhdCI6MTU5NzQ1ODM5NSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.Ih89P26f7E358aoOqLoNcH6ErE8G3V6UenhvJDBCLpw
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.20.0
-    method: GET
-    uri: http://localhost:8081/api/v1/replies
-  response:
-    body:
-      string: "{\n  \"replies\": []\n}\n"
-    headers:
-      Content-Length:
-      - '20'
-      Content-Type:
-      - application/json
-      Date:
-      - Sat, 15 Aug 2020 02:26:50 GMT
-      Server:
-      - Werkzeug/0.16.0 Python/3.5.2
-    status:
-      code: 200
-      message: OK
 version: 1

--- a/tests/functional/cassettes/test_star_source.yaml
+++ b/tests/functional/cassettes/test_star_source.yaml
@@ -17,9 +17,9 @@ interactions:
     uri: http://localhost:8081/api/v1/token
   response:
     body:
-      string: "{\n  \"expiration\": \"2020-08-15T10:26:01.251953Z\", \n  \"journalist_first_name\"\
-        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"b5e001de-19f1-4a93-885b-e0932aa2d441\"\
-        , \n  \"token\": \"eyJleHAiOjE1OTc0ODcxNjEsImlhdCI6MTU5NzQ1ODM2MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.LUiHeimg2JygsIyiX_QQOiT9pwwpIViInlhAfEFAsjk\"\
+      string: "{\n  \"expiration\": \"2020-08-26T01:27:43.384481Z\", \n  \"journalist_first_name\"\
+        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n  \"token\": \"eyJleHAiOjE1OTg0MDUyNjMsImlhdCI6MTU5ODM3NjQ2MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.HiTmfOpfGz4NZLH8kgtdw-Lu08ZXLUnregghkH0BAfE\"\
         \n}\n"
     headers:
       Content-Length:
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:01 GMT
+      - Tue, 25 Aug 2020 17:27:43 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -41,7 +41,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxNjEsImlhdCI6MTU5NzQ1ODM2MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.LUiHeimg2JygsIyiX_QQOiT9pwwpIViInlhAfEFAsjk
+      - Token eyJleHAiOjE1OTg0MDUyNjMsImlhdCI6MTU5ODM3NjQ2MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.HiTmfOpfGz4NZLH8kgtdw-Lu08ZXLUnregghkH0BAfE
       Connection:
       - keep-alive
       Content-Type:
@@ -52,99 +52,48 @@ interactions:
     uri: http://localhost:8081/api/v1/sources
   response:
     body:
-      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/add_star\"\
+      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/add_star\"\
         , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"out-of-town\
-        \ primogeniture\", \n      \"key\": {\n        \"fingerprint\": \"200C271E4E680FFE62E008931554E4BF600B1E3C\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAL4uN551SiYiVLrHoK1QGMDmN1xq42u8o2dmnKFkArW5KfBvBFoX\\\
-        nZX5LnOj9hKKEEmeGX5beS9h+fjsWvx86M2kQj/5xhOmHw0GGESEPQBSUc+Lyohpc\\nUmBoNNBfWIouEQ+IVS0gmrOwiS7wdItMby1lLDlDBoiEm4aRnRw36NIpABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEhPUDNaU05LUFgzNE1MV09QMkVPQkJRVVc2QjZPS0ZFMzZa\\nVktOV0VWNEhXVTVMUlZGQlFENjVKTEtYUENHRE1LVEFTTDM2N0NOT1ZDN0hBRUxF\\\
-        nWVQyWU5LMkJHM0ZWNlZWUUlMMlE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBVU5L9gCx482IED/2w6yFqz19zTBX72qN0MUTq5\\\
-        nCavQIBhhWrbsc1m0p+cxuVJ16TYxiE3S/Lp/rd4r1Q9MQg9BP0+/qjOA541kNq5A\\nmR2Y0teqWonDqeY/660kEFIbio0HbOTjsBhEZxtglJ1wz70tUpd40ZVMsu+Z32Mw\\\
-        n2kSiCclJYHk7uy1eis57\\n=pz11\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:24:42.042205Z\"\
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"pleasant rearguard\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"FF9007318CCAB4DC6149B1B38B7907A15818269D\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAM8jaDDbt3lQQVUEk+MduWYmJHa3eME1Y9C4yj+6n9V9Sksakj3B\\\
+        nWcl9uKzXLtZIP1rdvkW+Bg/P64vTgi+I+pcL5+e5gpF/KdNhrksovmhzc/ASgrn7\\nEcNCwIk+Iyym255IOEsZ8j9SvpzG1VyUdJxlK+P6bmbkFgDDwHjF0QzDABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPEtHQUFQVlNISjJLS0lMV0daTUlBWUFHMlhXU0ZWRlJRQ1pJ\\nNE5QTVBVUEVKNDNIQ1hJVUdPUk9XUEhLUldXRkxRTk5LTko3WEk1Tk9JUkpFTERQ\\\
+        nU0pZN0JMTk9ETk0yTUxNSjRPMkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEIt5B6FYGCadjpUD/1IiTV3TAyduG0UkaxcTT+Bp\\\
+        nKZRsNsK+HhYBCu/VjBcybLkuccDaonnm99OyaWZAZ/F/E/DxRENTxs0OL47GbHG7\\n9hSFWj99MZACMs3aKAmqxZEnQmm0B0xDIlHyd9mQBSieUw6aVMVjxK8p0Z21R7cz\\\
+        nc+DfEuCbShQ6b5+9X308\\n=RU3O\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:26:48.423985Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\
-        , \n      \"uuid\": \"4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/add_star\"\
+        \      \"remove_star_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"uuid\": \"505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\n    }, \n  \
+        \  {\n      \"add_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/add_star\"\
         , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"red-rimmed\
-        \ applejack\", \n      \"key\": {\n        \"fingerprint\": \"D449222A7B7B0AC1E134A1FF01203DD2D2636A37\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAOaUXyLQCaUSR4HTaBVGZp1mi3jn3BExTTe2UCBYjsn1zhkOBDf9\\\
-        ncZNBQGjEBIYlOioC4XY1TkQep4L2DdmqO5lBfbyNG6LpGiNo7DvNBxeo5WNDa42C\\n8YcfTaVL9aWm07G12uwwc1WFNb0y86PzuAS1ek0k5B7jUfjNxFN9t0dhABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEtCTEEyQTRDUEtETEVURDM2MllWQUZVRVdRQlJLUzJWRjVG\\nUEs2SElBWFBXQUFNSURMUkZHUEdLU0dFSDJJUUtBUVdZUFdFS0xRWVpaTDZMU1JY\\\
-        nRFRUTUdPUlFFWFA0WE1EUlJJM0E9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEAEgPdLSY2o3LmUD/i+JqgIWc2SzA5OTX9Qo0g/r\\\
-        nqxDmi2NQMXob0fEEcP/GGnbiFE1P77AC6JWxSKPQStlfwvffhYmK2q7JBc71Jj8O\\nRqFRT5WSRpXUCq8tZkIYyoCXKQPlwSb3S1NQ3yM00kbkCM4dArLIFuQ/ZI1xG+l9\\\
-        nIqxWwXYY8SpO8uKDXFd7\\n=FjUe\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:23.753433Z\"\
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"unlawful spectrum\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"CE2A06285C9B1FDB43BFEB853EC2D036DDCA8CD4\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANJ0h2W7p0bViTLpY9w/PDd8sBHR56OVg+EGdXZ51Wuqt8ZUkF8W\\\
+        njSLrjsiOrcQ1lRFEgERFfIBJvlxfB/EMP4wcTY7vg7WQN/rvSJynBW0T6iHI3Rhi\\n/3v35LEuX9tLU/B1e11mRevgHTLRUms38Y5DBSkWACngvH4jWP+kwylJABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPDUyNzdCNDVDNExFUFdJWU9NQlY0VE5FVEI1WjdaVFpERTZK\\nQTJSTlhVNE5HM0g3R0NRVEJYRUdVWkdSRkpSRVZGN01BTzZDUUpWWVpBN0NOSEw3\\\
+        nS0JKVzMyS01XNEJaSVROU0dBVkk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJED7C0DbdyozULzEEALbYIlKPW3wXMi/9V2c/fYJc\\\
+        naX9UE94JwAdfntqAkEF8dL/P6fD5J1BPqQILK4crX6LN6h8g2y1vnrTTg9odsa1L\\nD0JqSpGfIWscGRuzY6b2WngLCgsudMqJgPZUdm/wbxp3Q8Daa8U99mL9jXr9Ia9j\\\
+        n8BFeiB6fb0VoIDgM7UTv\\n=j+JQ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:27:03.031475Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"uuid\": \"70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"potential\
-        \ freshness\", \n      \"key\": {\n        \"fingerprint\": \"06FFA85715E89C0AFBA927A78EA34965AC896EEA\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAMHR1pM94xuFw+GiTQI7RyUN/sKYmupDhwWj1nVricMXRbM7nIXk\\\
-        nsBnqTx0pTkITPxjszoVyFFxG+Uw8TXMZEZdCOhcC2AieHV0mgWsXxLAbD9Sw3VmQ\\ngOQ3S2C/MBrimrK4bkpoKXxKIV5v5Rgku5Pjxzw50HH4e1pYhgW2C+knABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEg3TVJTVUZHWFVKRldQQlM0UjdISk1JNE5HTUREQ0FaRzJL\\nVlIyTTM3RkFTQk9BRjIyUkFYNzdMUVdZNFZJNTJLSlBOQldaRjUyQTdHWFJVN1lQ\\\
-        nN0dQQU5QSFNNUUkzSUFVN1VGNEk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEI6jSWWsiW7qZeYD/ReRVU5y0nssc0+OlRy6M/im\\\
-        nHY9oHex0tSGt1fTuDVqsAKKHMDrZLKkkhJg42wcINwbXTj/vRu7n199IwbSUoDiE\\nJlnO6ZaIG996AUFS64eZBA+kXczqJbsWgdQQpwQJn8LiQUF8iwFhTThltjRSuXqf\\\
-        nMxyFevvxbIvYcs6il7Ip\\n=cZe8\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:36.194245Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"uuid\": \"6db98582-dd69-48ea-879e-5afc5aa388d6\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"inexpressible\
-        \ sepsis\", \n      \"key\": {\n        \"fingerprint\": \"380C70D1C7930985411415B31A1B751385404CC5\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANhgLtWR4jFlhHEPGJjcupkGrNymWv9wFlFM8YppKs6nNXaQdoKf\\\
-        n7+NESFVdkm89/7FWD/It0B49jEBjjs7GOmxhffomt1NVHocYGDBQjMAlKOYQgCnR\\neZDnHCFORSrQcfiNhgKm1/eFOZlNJDZn2Cwpmdk8ZV6B78fGVz+3B+tFABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEo0VFRaVzY2QlBRTFRRVVlNS0hIVzZZTjRGVkJIVFlVQ0ZW\\nNVNWNjNRWlQyT0Y3Wjc2NUxEWk1TVDJNR1JBVFpYSVZJVzVBR1M0N0RFU0hTRUhY\\\
-        nWDZFQVlISkFWTFBZRzc1VFlKQkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBobdROFQEzFd3gD/RUhGdZUriO3QqYTqvH7EZdZ\\\
-        n4r3iFUJVP3xhru9HYBtksepsKzUHYZn4nK29689AdV1A9o/X4YcKWrxFRbMuZs0E\\nTj2Je4jrw3WNf3O3COAWwFa75HOXIhGfFVuJ4Ni2/NVJGDPA6NNIfZfFMIj/NZF3\\\
-        n3RBZhDmxS21yJs9daQfs\\n=NQQJ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:44.877597Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"uuid\": \"f3a61359-1919-4bf0-b6f7-da902a935160\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"newfound necessity\"\
-        , \n      \"key\": {\n        \"fingerprint\": \"7FBC4515353AE647D938C764EEE9B96CF5D1BE8E\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAL5F4eU1lEB3y0oi3X6T8FU3jjZjLrsuh7pO8UcwNtQX4SccJ++B\\\
-        nHChPo4OarAIfmIENAL3aP2/IVGM0w6BvHFOJvztQpEagiwf1g5voHC8mlr0m9maq\\n/pFAIbFSsTKh+nCwEvXjwxGfUt8l5w0P59kpRp/1j2DzIrwjvFomK1DZABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEtZWEZDUldUM1hSSU1MRzdDU0NJN1paVVFaRkxMSldLMlhP\\nWEFCNVdHVkRPNEVOSEY3NTJZSzJBU0lFWktYUVBHRUJXRk02NlVRSFpBVUhBMjQy\\\
-        nUkQ2NjVZQzRHQlk2UEZFVFRLWVk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEO7puWz10b6O+F0EAKBLCQEcRuGffqEjWHS+B2QO\\\
-        nXWvovvU1mWTDvGPFLzyq92iQUVe+fAjgfEcEyX6btD0ivZDctfhImVqqXQj23zP7\\n8j1lvDXFBbU41AfZbBljEk69MIPicdviWnZaWZ2hk7ScO9Lc6D+CcU+3/l3hlh6X\\\
-        ngQPZEQ30NO7w2/7ADAvs\\n=P6eJ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:53.136494Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1\"\
-        , \n      \"uuid\": \"5fb61bc7-8819-4f66-99b0-538a389f8fa1\"\n    }\n  ]\n\
+        \      \"remove_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"f9b4da97-a077-412e-8e54-4ef4984a8540\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '8018'
+      - '3214'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:01 GMT
+      - Tue, 25 Aug 2020 17:27:43 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -158,7 +107,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxNjEsImlhdCI6MTU5NzQ1ODM2MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.LUiHeimg2JygsIyiX_QQOiT9pwwpIViInlhAfEFAsjk
+      - Token eyJleHAiOjE1OTg0MDUyNjMsImlhdCI6MTU5ODM3NjQ2MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.HiTmfOpfGz4NZLH8kgtdw-Lu08ZXLUnregghkH0BAfE
       Connection:
       - keep-alive
       Content-Type:
@@ -169,65 +118,34 @@ interactions:
     uri: http://localhost:8081/api/v1/submissions
   response:
     body:
-      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96/download\"\
-        , \n      \"filename\": \"1-out-of-town_primogeniture-msg.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\
-        , \n      \"submission_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96\"\
-        , \n      \"uuid\": \"f836676a-c1aa-49a8-90c2-bb171f60cd96\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/99509e6d-62dd-48f3-8208-623f9290bc03/download\"\
-        , \n      \"filename\": \"2-out-of-town_primogeniture-doc.gz.gpg\", \n   \
-        \   \"is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"\
-        /api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\", \n      \"submission_url\"\
-        : \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/99509e6d-62dd-48f3-8208-623f9290bc03\"\
-        , \n      \"uuid\": \"99509e6d-62dd-48f3-8208-623f9290bc03\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download\"\
-        , \n      \"filename\": \"1-red-rimmed_applejack-msg.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170\"\
-        , \n      \"uuid\": \"ceb44744-68cd-4b29-ada9-4c6ed4127170\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015/download\"\
-        , \n      \"filename\": \"2-red-rimmed_applejack-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015\"\
-        , \n      \"uuid\": \"1deb4f4f-1094-49ec-b0da-5d714b60c015\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download\"\
-        , \n      \"filename\": \"1-potential_freshness-msg.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e\"\
-        , \n      \"uuid\": \"da095cb7-5a81-4b57-912c-14b0501dc00e\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d/download\"\
-        , \n      \"filename\": \"2-potential_freshness-doc.gz.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d\"\
-        , \n      \"uuid\": \"ed460264-f0e9-415f-8247-738eb482c75d\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download\"\
-        , \n      \"filename\": \"1-inexpressible_sepsis-msg.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a\"\
-        , \n      \"uuid\": \"a3bb0937-6240-4200-99d5-b514c465e56a\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01/download\"\
-        , \n      \"filename\": \"2-inexpressible_sepsis-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\
-        , \n      \"uuid\": \"1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions/2b1dce9e-852d-40a5-8148-d4e54cf3c322/download\"\
-        , \n      \"filename\": \"1-newfound_necessity-msg.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1\"\
-        , \n      \"submission_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions/2b1dce9e-852d-40a5-8148-d4e54cf3c322\"\
-        , \n      \"uuid\": \"2b1dce9e-852d-40a5-8148-d4e54cf3c322\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions/9cc1760b-3d1e-4cd2-8f0e-5af35661509a/download\"\
-        , \n      \"filename\": \"2-newfound_necessity-doc.gz.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1\"\
-        , \n      \"submission_url\": \"/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions/9cc1760b-3d1e-4cd2-8f0e-5af35661509a\"\
-        , \n      \"uuid\": \"9cc1760b-3d1e-4cd2-8f0e-5af35661509a\"\n    }\n  ]\n\
+      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442/download\"\
+        , \n      \"filename\": \"1-pleasant_rearguard-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"submission_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442\"\
+        , \n      \"uuid\": \"bbc25300-917a-4b73-b0f4-10f3d6957442\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/a8699ca4-55a5-4737-b8f1-c9e170ec8250/download\"\
+        , \n      \"filename\": \"2-pleasant_rearguard-doc.gz.gpg\", \n      \"is_read\"\
+        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f\"\
+        , \n      \"submission_url\": \"/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/a8699ca4-55a5-4737-b8f1-c9e170ec8250\"\
+        , \n      \"uuid\": \"a8699ca4-55a5-4737-b8f1-c9e170ec8250\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download\"\
+        , \n      \"filename\": \"1-unlawful_spectrum-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\
+        , \n      \"uuid\": \"d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a/download\"\
+        , \n      \"filename\": \"2-unlawful_spectrum-doc.gz.gpg\", \n      \"is_read\"\
+        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a\"\
+        , \n      \"uuid\": \"55e459bd-cf4e-45f9-adce-95d79998254a\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '5134'
+      - '2055'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:01 GMT
+      - Tue, 25 Aug 2020 17:27:43 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -241,7 +159,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxNjEsImlhdCI6MTU5NzQ1ODM2MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.LUiHeimg2JygsIyiX_QQOiT9pwwpIViInlhAfEFAsjk
+      - Token eyJleHAiOjE1OTg0MDUyNjMsImlhdCI6MTU5ODM3NjQ2MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.HiTmfOpfGz4NZLH8kgtdw-Lu08ZXLUnregghkH0BAfE
       Connection:
       - keep-alive
       Content-Type:
@@ -259,7 +177,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:01 GMT
+      - Tue, 25 Aug 2020 17:27:43 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -273,7 +191,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxNjEsImlhdCI6MTU5NzQ1ODM2MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.LUiHeimg2JygsIyiX_QQOiT9pwwpIViInlhAfEFAsjk
+      - Token eyJleHAiOjE1OTg0MDUyNjMsImlhdCI6MTU5ODM3NjQ2MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.HiTmfOpfGz4NZLH8kgtdw-Lu08ZXLUnregghkH0BAfE
       Connection:
       - keep-alive
       Content-Type:
@@ -281,38 +199,20 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/submissions/2b1dce9e-852d-40a5-8148-d4e54cf3c322/download
+    uri: http://localhost:8081/api/v1/user
   response:
     body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqARAArL7MGys+bU7mIl18TJs5rSTC9NvcRhYXjmB/UMdxG2z6sYPXOrpcIJgO
-        fJwQMwe0Osu5iYDmaGVZ+5oYmVdaCTt2inZKxn1Li8iCV4RnbXWItYlt03WeLO8Mfa/k8LMqwGb2
-        RWoW3yOPZm4NsTc30c60z7PBnjsgXuCbCjLCZs1uXQnOXqr4f6C4hq3S+CCvxqOfytPY4vBtVkvN
-        pcbaBm4jCgMAuyg/f3cXLt4w0b2TZ5LHejmppv1cOkpq/ia8cmyv0kW+hTh5uKnRiZtu+PlEWCEI
-        QhkNF7uVT1xoNDQZJE/wze0ni7u5V8Afze7oEEqbOJg/nLjUrAKdPM/08yB3CIiHU66LF5lsQMcc
-        eg/lpcMRja9YgkPYfOjWYxyZqYH9gHKykMlbjr5c2mGSswpkANw3wmuS9DIB96EYpPc2ebqDLKkt
-        8+yC5vDu81VBlxC0xPlRzb7bK81jFvzwavb86T4HEEl/n69QwiuPeiFNpw48tNSK6l2oDVyq6TjU
-        uRjyC/ICo8D4V1LYFp4fy8WdNG96AGADwMFNTTmxOuY1Gi8Qn8XXpeOzxPPiwPv/P+W7SAGM08dt
-        LuEdA9U+0GoHEGqIrzSy4B/EUaVby947Lz15FQzjS2AfNIx32PDcCnw80l5i/rV2v1G+qF7Iv1Kc
-        e5sYaAZ1FJ91j6S+VXvSTAEY9XnwSOWdtr//CvagOwodz5TtI/TXCt7yEiGJBGwz3dnAxWwlziOs
-        5yBjLzVsDX+GHrPL3cc/VbXd7be3fi/7omVkmeHmLma8vmI=
+      string: "{\n  \"first_name\": \"\", \n  \"is_admin\": true, \n  \"last_login\"\
+        : \"2020-08-25T17:27:43.384806Z\", \n  \"last_name\": \"\", \n  \"username\"\
+        : \"journalist\", \n  \"uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\n\
+        }\n"
     headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-newfound_necessity-msg.gpg
       Content-Length:
-      - '605'
+      - '192'
       Content-Type:
-      - application/pgp-encrypted
+      - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:01 GMT
-      Etag:
-      - sha256:cd8ca8320d46a9d2654a353aec5bec455d4afed05744d0ca95e47c7ccf358c1b
-      Expires:
-      - Sat, 15 Aug 2020 14:26:01 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:25:52 GMT
+      - Tue, 25 Aug 2020 17:27:43 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -326,7 +226,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxNjEsImlhdCI6MTU5NzQ1ODM2MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.LUiHeimg2JygsIyiX_QQOiT9pwwpIViInlhAfEFAsjk
+      - Token eyJleHAiOjE1OTg0MDUyNjMsImlhdCI6MTU5ODM3NjQ2MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.HiTmfOpfGz4NZLH8kgtdw-Lu08ZXLUnregghkH0BAfE
       Connection:
       - keep-alive
       Content-Type:
@@ -334,38 +234,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqAQ//Z/S89kAgGiAOh+UVD2ePgDvU/l/JnvR2DkCEnnqTivaWTKetbcTOxv8D
-        iHQFUvQKPTADA4g5u56foRmzC0Yb2mP36vRMUqLq87hb/XfZFfr3Ak7E169EyaCN6ht5he28mLV0
-        j9brHPGxQWt2vrE4FFdwnUVQWNfAp13rFMm0IDFsHN3o3lNSjywJ62jlr1rce3mdkC+rXkwDh3zs
-        0ZDvxqFGx4X8YPbQiAStvUsK1n3u9NBnKE3cyeHe70xnMdQxq1N4NuACJZkNovKet6C3s8LTvj58
-        XiK6+/AgtbO9Pk6c89s1WW0x3hUGFtWVI+GqSUSQda5CDlWaq6Fq7mBURfuW7yD/rOJ0EypOOJED
-        b1GoyTiK6V1gC/mktb6u/Ei16SmPOjcsAzW7BFn5tsvl3lZULN+b4Bs+E7/Pxl4ymVaPDgbcsAh9
-        Ipp0thhF1a2A3MobRsTtNidryxvfzUTj5ou70vguzn7zthzog2sijyM9hBI0FPr6YRVWXvrS7BEQ
-        Ly9BA1AuzGy0kS1B6MUYdcWAaxQZHWNne02zDHZqe2sBFLM04tJU4myKrXlBOok4YILQ7OWDSoa8
-        Whkyohid0Eympcv+6YMaKI+9yBzHFWgcpu27rlrAuRGRXi9ibBxovyCRg5SSYc1Guo0jalDJWdDy
-        lRdLGsmqJAcWq2PUvNLSTAGpSiJRM+Iwxr77j/lapCOSRGfVJaivW59X5+ZQa6BN57DKWvcgPtCb
-        xDfXOBD4hOG9w/Qv5iKwgOcj/ckygOpvtrcQosdK9ZzrrdY=
+        hQIMA8PnxMCiIBsqAQ//Rw1NPH3mwdBg9NnblanYiQgqmPuHTY9ha8sR24r6Cbv4UunDrGcjIMeT
+        qUZfK1zok/ZjbbLMo+yVWG2my899P8meyJS9C9MzmPC/x8hpoSUVdxyRorBDja9qNtZUyhOrm5Dz
+        rsiuEaqB1T5iYPinyCzeOcGKxTlrDJE78s5aHQVGQeBjXN+7BqZXsGCWrUueXTF10QrC8u0T/Fnw
+        T+BLvR8FmCIEilEDQESn653nL2wbkTz/7OMxUJJUDkG9xO6VHsTcH4KAzVsonMaan2RVXarJ1393
+        esjkZJ3vMiKXSMNIdsdDQ8WbP/2JGL8rhdg3WZqRbX7ePEJ5C7moUGiJsXmYwNMDarImp/be0O+1
+        YGk1Bfig2smMD280G8vYNykGvLkiGWJU0tGQQBbc5NeM3WZ8chZsyKofidoc9CIY7NLVHGg5u6zf
+        AEe1bjVuWveL5NaUJUpzWxDQzkIBuvX/E9stjEvqb0fZCRkGqPQLOix/YVUjUzj2i1zGAgL/w3xw
+        jhadu4aN05dbf5cBeKRIUS43HnrDXluA0vq0HbX30xuFpoo/noZUiZ8uNfR2UKLQfIK0gNVH1ydw
+        MhHIDKyiUWm/0YQgzcozy14n9OCGtLCucWfxXy7nozJ7JnVJpSYPgAmozMOoqEiz3C0Dnsax/PRV
+        AvwhOEGda6nAIosZZ6nSTAGpDbf6bksYyI2J4JEtY4b7jBvCz6Qmg+n4ZIIH7IEeIBCkhnUtU8xz
+        JHiwor7B/FnoP6RymaVAKyAPqoKGfrJ/XGbwPXJRvQl2PeM=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-inexpressible_sepsis-msg.gpg
+      - attachment; filename=1-unlawful_spectrum-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:26:01 GMT
+      - Tue, 25 Aug 2020 17:27:43 GMT
       Etag:
-      - sha256:20db26d5f8240c2efbc83f40184bd03e74f0b927394627fe24bc2954cb4a6c2a
+      - sha256:dd82012b8656a3f7175b619f2875895a11071daf681b996cdc2704ddf5388664
       Expires:
-      - Sat, 15 Aug 2020 14:26:01 GMT
+      - Wed, 26 Aug 2020 05:27:43 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:44 GMT
+      - Tue, 25 Aug 2020 17:27:02 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -379,7 +279,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxNjEsImlhdCI6MTU5NzQ1ODM2MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.LUiHeimg2JygsIyiX_QQOiT9pwwpIViInlhAfEFAsjk
+      - Token eyJleHAiOjE1OTg0MDUyNjMsImlhdCI6MTU5ODM3NjQ2MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.HiTmfOpfGz4NZLH8kgtdw-Lu08ZXLUnregghkH0BAfE
       Connection:
       - keep-alive
       Content-Type:
@@ -387,38 +287,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download
+    uri: http://localhost:8081/api/v1/sources/505f62fa-585f-4e95-b8e4-0d2f3b2e7a8f/submissions/bbc25300-917a-4b73-b0f4-10f3d6957442/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAs+tSZVdjh2H5sgW3rQYsinaTUd1To3XLy/EC0UcNed15/OLbU142ic10
-        6l41iWmBW44aOmjYFIY46VfqPxQSM0G7fl2g5A0SZdmckTqzu141v/+BoTmvbzzZ8sXmpxKjbP/A
-        1F6aBPQ2qX7HcUVyGOadyMRjuKB+IO1pROBeFB5R0hE+FD+y4/yq2y4J9SVeYcdcwcsWJytFUm73
-        emXQ6vcBspvlgSjE1gywgfPFkmOLIKxv9INHFTT/FrfPvJ/yeFZ7jKtG0wxBQYPL4DG5QiVi1Gyz
-        Ln039tgWjFVnM5FhJ+XNhLbLHuISii/0CrKq9TeRea85xFHR6UGKgTm3/fOeWtEhC6FKa0XstXhU
-        T0E9dmh80Rd3myvN0HU3eyNFvmjyZ1weVguXjg4Ao1yWZ8a8AmqlA6m4conr4bbscqQKXCJSF1D+
-        g/i5ng78t0+4wnWMiKtN9rNTJkVBzXpaoYzOn+14EJbkYa+zkCyQS8TbjMBpLaP0aTFO4VXk7OAU
-        ygtKj6P8KmkfqivWrQ047DjqwVot+wBpKT+3t8ASscApC7KaSF0+d/fBvb05ZLzLtfSXM+Ts6pQ8
-        sn60uh2dnW/12nbqAdzFnrEPtDdtz5PFWn8brJpvhhMids/A7dkmbbLK6oirkLSRMF7Wdp8Stz2m
-        aI8Xz6brh2GQeKZafWnSTAHRguSmKDs+h+zUuP/hFFyLlLy2TWX3VLR2rLCEHhm82jP4UcMTpBkU
-        sgsFKxLyPddNYl+9D7kh9NLhzaLsXc2RihQWRvXYM9f3E0Y=
+        hQIMA8PnxMCiIBsqAQ//RtWsdfVE8eGi8sFqp1/cmLdkiut2OkXfs7DdjD0CBr6qfYUG8woosTjZ
+        +bdA5IIg1ewECF+eOZbfgW3EGzq/xN9rKaE+yTEbrR2swkoHNv1tUTrBoRGwUfHOYl3LOWlftNHt
+        8HbCVEZ/TAs1NQolRpSXj9o+mR6wjPvXtArQkW0io6D8ah9YO+YkEEkl4B2CwK1BwUQHj4B1TXw+
+        QGubNNIfGeXM9OkSCQMZapmumEt4m+8KImF1ncNMINXO/WV3tbTKDrCO63R/K6ibSuq//vd72Q2z
+        DFalhfcmnu7ksX0/4TFsrsvfuQoppTqepI6YklIKhTRkoRuY5fQeoK2w93qrZh0dmsVvlhx13/xl
+        19wcO1vASiZzfSHT/XDaXoS+3XmgW/xKr+Y0IJq+PZSs/EZ/2mr6zXePR8HtdFuvCnGiNjPFsRsE
+        sRIB1iq6FEV3zKxLU7FI46MTNrBpTYj3xAn2MqGM0UgCvwC1v73s6mMe6njwvYak8V0J/ny3sd/J
+        NHnbftRaGOmlrQbiXhoRIDEV5Kric9qBJG5R12kxDHHqce/viMEnZ1543+2snmsGrmWvX3Kxsbq4
+        cm1rmE/1dwYYtUaTpj1j4HDr7OY0PUN4F2BXK1gOSOONWiKd8hRAbY4Emwv60g+36ZtwY6kQu4v3
+        pQhKYVCTt8xL1gZkYYfSTAFnY4M6ViJKpbRI6FGnAQsYaB74rBUx6FatdEvztAN5VHarQPHN9uDF
+        TLPp+suitZOgA4wsgUWL+sUze53pOc/MCAUfBwrk2YD7hO8=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-potential_freshness-msg.gpg
+      - attachment; filename=1-pleasant_rearguard-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:26:01 GMT
+      - Tue, 25 Aug 2020 17:27:44 GMT
       Etag:
-      - sha256:624b8cc271f0bc4a153ff893f14d4b63464577579c0baa49ca2e6f5b2fb715a8
+      - sha256:cecd2591b0a9a0315f320e9878f68fdaec03c70b286da162c4416fab137ec00e
       Expires:
-      - Sat, 15 Aug 2020 14:26:01 GMT
+      - Wed, 26 Aug 2020 05:27:44 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:35 GMT
+      - Tue, 25 Aug 2020 17:26:47 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -432,113 +332,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxNjEsImlhdCI6MTU5NzQ1ODM2MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.LUiHeimg2JygsIyiX_QQOiT9pwwpIViInlhAfEFAsjk
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.20.0
-    method: GET
-    uri: http://localhost:8081/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download
-  response:
-    body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqARAAp+9fU8qzd8lBJJJeTGUfrTvtC7bBj77m96ioEWln23lreSXOi7W1E++i
-        X3mCeNg6hLC0PSAtuO0QTw+LE6TGqLJtQh5y14fIxzgIX5G02eaoOlsayjQbVfXHTJ6HBSFx1VkS
-        ImILNuS170DhYiOyW91R3OJ2zg4DeTlPkyegMGScWCued6EcBBL+/EOrvZLDoXtpFAHFkGGcoQSD
-        p/6L5/pp8AuB5N43NRCtslfsD8D4gpZT7L9gkvNIJbMrBQ4FVUzjB/XI5mkOhXAubjKzgGcpqiM+
-        N2k5nqSPFzotGHmKDy77Bq4D3Sk4fcLzvWMe9hY+Prp6QqW5/F3uvFhJdpdOR9JZ4WqY6pWk0VsA
-        jeIuaxGH3rRqFegi59AiZV+EvpORA7tx8qmkVHch5UifaJCsHthaxOrBk1D/rgutgmoQvVaCN+UA
-        6So9D0H/w6RIE0vE3SAsCpXV3XQJWwsya8O5R5jCuETvi1s5NnMXrtxRuBqkFZUcRSNZyzrUWLGA
-        8djkwjYcO5lP7qt40ztUosMmb2y+4z8ad3zhWP71SKA+chx8lUvY7ziiSmFOpRJOr0OEgKMU59lR
-        ovyT6mu5yB1d5d8G9ns8s5H8/ymV5WE/MdG+o472wWPKoKHnIu0zlj1Qqso8l/khM5wIjs8XvICl
-        pm7uojnWqaFcIaJg4EvSTAEw45cGmA90NotlV9qwHi0fJ0qlbFKf6FAyeDaRL0TPoLKx9JbGf+9M
-        +wwWhoyWoWili+hOxuju3sNSeN1iYkv3fEIyKyEy5rXvf/0=
-    headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-red-rimmed_applejack-msg.gpg
-      Content-Length:
-      - '605'
-      Content-Type:
-      - application/pgp-encrypted
-      Date:
-      - Sat, 15 Aug 2020 02:26:01 GMT
-      Etag:
-      - sha256:2e1bdbd452ce54d49602552182cb0146b2334c58a7c5aec0c0565645e2ab4286
-      Expires:
-      - Sat, 15 Aug 2020 14:26:01 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:25:23 GMT
-      Server:
-      - Werkzeug/0.16.0 Python/3.5.2
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxNjEsImlhdCI6MTU5NzQ1ODM2MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.LUiHeimg2JygsIyiX_QQOiT9pwwpIViInlhAfEFAsjk
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.20.0
-    method: GET
-    uri: http://localhost:8081/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96/download
-  response:
-    body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqARAAqBkguUOJVhB1E0rEBd3bIvbOJe9umLBp5QVPye5M4nsh0yl0IWnltszf
-        edV/FKB+H0YdtACRB57Zur0vTrOWAA4o1cC9tyUi18aWslfgDvVwJXLjELZYOQiDv//vmcWEG4Mw
-        ckXqK+/zvkgGLST9xjubdcQozWQNW8mXNzqLzLPLYd57oejEzr73iwn2UwQbQjXb31YI5ZsvCB0y
-        sltvyQevn92quua31WmlxjwzTndQ9u9mGQ5zZSxwK39HaZ3oEmPZlWelrnUfbodPJw5wQqGBN++n
-        lwGMVphNGN+EssKtSUb5Hmutd6jTajcfPWPf0yU6AYtJ3v/1wiOyXCaN3tnPStKUzP6w/htB2nFz
-        irbFi2VQ5v1Lg/nAYl0n3cVU4A8O8P8nhIX5KOsxNhYqNyuyjZsJgFAiKtCzEcXxlpyCQiPwpHbo
-        PM7nDr1JtS7w+IY4xlOkwdOmTIjq+WYjfwbOMd8GlwMQmpp2s6n4S7whSIcYI5acs14DERizF7lG
-        vY8XG7/ExbA0zt9B8j0MKTDsAxgkEEMALTPtINMmuc3xaDoTP7HA8e/X6tyPvrVarY8zFuPVxKuY
-        VXdPQuf6in/3uzja0QlWwq+Ibm+I/gBtQPRM1cDpW5n7XdYkzRcTIluElj8U8VnbECvkFNLt8NUk
-        IF792WIIe570TmeeRXfSTAE9fPtTykzrDiTy5LSwqQ91J/Og4d484LO+VkYSPGe37sfcFRSAOSL6
-        KHNlQb9u2IoOgkORHi/6PABz5ty5K45/OvEOhlB4/xbxkbA=
-    headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-out-of-town_primogeniture-msg.gpg
-      Content-Length:
-      - '605'
-      Content-Type:
-      - application/pgp-encrypted
-      Date:
-      - Sat, 15 Aug 2020 02:26:01 GMT
-      Etag:
-      - sha256:64f0c214fab76a0aa8a1407daf0c0478f7851bd7b5c0aaca5b5c8de53aae9336
-      Expires:
-      - Sat, 15 Aug 2020 14:26:01 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:24:41 GMT
-      Server:
-      - Werkzeug/0.16.0 Python/3.5.2
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxNjEsImlhdCI6MTU5NzQ1ODM2MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.LUiHeimg2JygsIyiX_QQOiT9pwwpIViInlhAfEFAsjk
+      - Token eyJleHAiOjE1OTg0MDUyNjMsImlhdCI6MTU5ODM3NjQ2MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.HiTmfOpfGz4NZLH8kgtdw-Lu08ZXLUnregghkH0BAfE
       Connection:
       - keep-alive
       Content-Length:
@@ -548,7 +342,7 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: POST
-    uri: http://localhost:8081/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/add_star
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/add_star
   response:
     body:
       string: "{\n  \"message\": \"Star added\"\n}\n"
@@ -558,7 +352,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:03 GMT
+      - Tue, 25 Aug 2020 17:27:45 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -572,7 +366,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODcxNjEsImlhdCI6MTU5NzQ1ODM2MSwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.LUiHeimg2JygsIyiX_QQOiT9pwwpIViInlhAfEFAsjk
+      - Token eyJleHAiOjE1OTg0MDUyNjMsImlhdCI6MTU5ODM3NjQ2MywiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.HiTmfOpfGz4NZLH8kgtdw-Lu08ZXLUnregghkH0BAfE
       Connection:
       - keep-alive
       Content-Length:
@@ -582,7 +376,7 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: DELETE
-    uri: http://localhost:8081/api/v1/sources/5fb61bc7-8819-4f66-99b0-538a389f8fa1/remove_star
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/remove_star
   response:
     body:
       string: "{\n  \"message\": \"Star removed\"\n}\n"
@@ -592,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:26:04 GMT
+      - Tue, 25 Aug 2020 17:27:46 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:

--- a/tests/functional/cassettes/test_user_icon_click.yaml
+++ b/tests/functional/cassettes/test_user_icon_click.yaml
@@ -17,9 +17,9 @@ interactions:
     uri: http://localhost:8081/api/v1/token
   response:
     body:
-      string: "{\n  \"expiration\": \"2020-08-15T10:29:46.429136Z\", \n  \"journalist_first_name\"\
-        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"b5e001de-19f1-4a93-885b-e0932aa2d441\"\
-        , \n  \"token\": \"eyJleHAiOjE1OTc0ODczODYsImlhdCI6MTU5NzQ1ODU4NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.4cAVvx_cN2jxC_GRGtAvCA9JYdrslW1QsDfbYNUL5X4\"\
+      string: "{\n  \"expiration\": \"2020-08-26T01:29:06.414774Z\", \n  \"journalist_first_name\"\
+        : \"\", \n  \"journalist_last_name\": \"\", \n  \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n  \"token\": \"eyJleHAiOjE1OTg0MDUzNDYsImlhdCI6MTU5ODM3NjU0NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.vZUFgU-x-z0JYbTZ7bMdAxgbqm_CvKfIt0oz01Sd0pA\"\
         \n}\n"
     headers:
       Content-Length:
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:29:46 GMT
+      - Tue, 25 Aug 2020 17:29:06 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -41,7 +41,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczODYsImlhdCI6MTU5NzQ1ODU4NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.4cAVvx_cN2jxC_GRGtAvCA9JYdrslW1QsDfbYNUL5X4
+      - Token eyJleHAiOjE1OTg0MDUzNDYsImlhdCI6MTU5ODM3NjU0NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.vZUFgU-x-z0JYbTZ7bMdAxgbqm_CvKfIt0oz01Sd0pA
       Connection:
       - keep-alive
       Content-Type:
@@ -52,82 +52,31 @@ interactions:
     uri: http://localhost:8081/api/v1/sources
   response:
     body:
-      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"out-of-town\
-        \ primogeniture\", \n      \"key\": {\n        \"fingerprint\": \"200C271E4E680FFE62E008931554E4BF600B1E3C\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAL4uN551SiYiVLrHoK1QGMDmN1xq42u8o2dmnKFkArW5KfBvBFoX\\\
-        nZX5LnOj9hKKEEmeGX5beS9h+fjsWvx86M2kQj/5xhOmHw0GGESEPQBSUc+Lyohpc\\nUmBoNNBfWIouEQ+IVS0gmrOwiS7wdItMby1lLDlDBoiEm4aRnRw36NIpABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEhPUDNaU05LUFgzNE1MV09QMkVPQkJRVVc2QjZPS0ZFMzZa\\nVktOV0VWNEhXVTVMUlZGQlFENjVKTEtYUENHRE1LVEFTTDM2N0NOT1ZDN0hBRUxF\\\
-        nWVQyWU5LMkJHM0ZWNlZWUUlMMlE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBVU5L9gCx482IED/2w6yFqz19zTBX72qN0MUTq5\\\
-        nCavQIBhhWrbsc1m0p+cxuVJ16TYxiE3S/Lp/rd4r1Q9MQg9BP0+/qjOA541kNq5A\\nmR2Y0teqWonDqeY/660kEFIbio0HbOTjsBhEZxtglJ1wz70tUpd40ZVMsu+Z32Mw\\\
-        n2kSiCclJYHk7uy1eis57\\n=pz11\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:24:42.042205Z\"\
+      string: "{\n  \"sources\": [\n    {\n      \"add_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/add_star\"\
+        , \n      \"interaction_count\": 3, \n      \"is_flagged\": false, \n    \
+        \  \"is_starred\": false, \n      \"journalist_designation\": \"unlawful spectrum\"\
+        , \n      \"key\": {\n        \"fingerprint\": \"CE2A06285C9B1FDB43BFEB853EC2D036DDCA8CD4\"\
+        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANJ0h2W7p0bViTLpY9w/PDd8sBHR56OVg+EGdXZ51Wuqt8ZUkF8W\\\
+        njSLrjsiOrcQ1lRFEgERFfIBJvlxfB/EMP4wcTY7vg7WQN/rvSJynBW0T6iHI3Rhi\\n/3v35LEuX9tLU/B1e11mRevgHTLRUms38Y5DBSkWACngvH4jWP+kwylJABEBAAG0\\\
+        ndVNvdXJjZSBLZXkgPDUyNzdCNDVDNExFUFdJWU9NQlY0VE5FVEI1WjdaVFpERTZK\\nQTJSTlhVNE5HM0g3R0NRVEJYRUdVWkdSRkpSRVZGN01BTzZDUUpWWVpBN0NOSEw3\\\
+        nS0JKVzMyS01XNEJaSVROU0dBVkk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJED7C0DbdyozULzEEALbYIlKPW3wXMi/9V2c/fYJc\\\
+        naX9UE94JwAdfntqAkEF8dL/P6fD5J1BPqQILK4crX6LN6h8g2y1vnrTTg9odsa1L\\nD0JqSpGfIWscGRuzY6b2WngLCgsudMqJgPZUdm/wbxp3Q8Daa8U99mL9jXr9Ia9j\\\
+        n8BFeiB6fb0VoIDgM7UTv\\n=j+JQ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
+        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-25T17:27:03.031475Z\"\
         , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\
-        , \n      \"uuid\": \"4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"red-rimmed\
-        \ applejack\", \n      \"key\": {\n        \"fingerprint\": \"D449222A7B7B0AC1E134A1FF01203DD2D2636A37\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAOaUXyLQCaUSR4HTaBVGZp1mi3jn3BExTTe2UCBYjsn1zhkOBDf9\\\
-        ncZNBQGjEBIYlOioC4XY1TkQep4L2DdmqO5lBfbyNG6LpGiNo7DvNBxeo5WNDa42C\\n8YcfTaVL9aWm07G12uwwc1WFNb0y86PzuAS1ek0k5B7jUfjNxFN9t0dhABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEtCTEEyQTRDUEtETEVURDM2MllWQUZVRVdRQlJLUzJWRjVG\\nUEs2SElBWFBXQUFNSURMUkZHUEdLU0dFSDJJUUtBUVdZUFdFS0xRWVpaTDZMU1JY\\\
-        nRFRUTUdPUlFFWFA0WE1EUlJJM0E9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEAEgPdLSY2o3LmUD/i+JqgIWc2SzA5OTX9Qo0g/r\\\
-        nqxDmi2NQMXob0fEEcP/GGnbiFE1P77AC6JWxSKPQStlfwvffhYmK2q7JBc71Jj8O\\nRqFRT5WSRpXUCq8tZkIYyoCXKQPlwSb3S1NQ3yM00kbkCM4dArLIFuQ/ZI1xG+l9\\\
-        nIqxWwXYY8SpO8uKDXFd7\\n=FjUe\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:23.753433Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"uuid\": \"70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"potential\
-        \ freshness\", \n      \"key\": {\n        \"fingerprint\": \"06FFA85715E89C0AFBA927A78EA34965AC896EEA\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEAMHR1pM94xuFw+GiTQI7RyUN/sKYmupDhwWj1nVricMXRbM7nIXk\\\
-        nsBnqTx0pTkITPxjszoVyFFxG+Uw8TXMZEZdCOhcC2AieHV0mgWsXxLAbD9Sw3VmQ\\ngOQ3S2C/MBrimrK4bkpoKXxKIV5v5Rgku5Pjxzw50HH4e1pYhgW2C+knABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEg3TVJTVUZHWFVKRldQQlM0UjdISk1JNE5HTUREQ0FaRzJL\\nVlIyTTM3RkFTQk9BRjIyUkFYNzdMUVdZNFZJNTJLSlBOQldaRjUyQTdHWFJVN1lQ\\\
-        nN0dQQU5QSFNNUUkzSUFVN1VGNEk9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEI6jSWWsiW7qZeYD/ReRVU5y0nssc0+OlRy6M/im\\\
-        nHY9oHex0tSGt1fTuDVqsAKKHMDrZLKkkhJg42wcINwbXTj/vRu7n199IwbSUoDiE\\nJlnO6ZaIG996AUFS64eZBA+kXczqJbsWgdQQpwQJn8LiQUF8iwFhTThltjRSuXqf\\\
-        nMxyFevvxbIvYcs6il7Ip\\n=cZe8\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:36.194245Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"uuid\": \"6db98582-dd69-48ea-879e-5afc5aa388d6\"\n    }, \n  \
-        \  {\n      \"add_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/add_star\"\
-        , \n      \"interaction_count\": 2, \n      \"is_flagged\": false, \n    \
-        \  \"is_starred\": false, \n      \"journalist_designation\": \"inexpressible\
-        \ sepsis\", \n      \"key\": {\n        \"fingerprint\": \"380C70D1C7930985411415B31A1B751385404CC5\"\
-        , \n        \"public\": \"-----BEGIN PGP PUBLIC KEY BLOCK-----\\n\\nmI0EUZF+gAEEANhgLtWR4jFlhHEPGJjcupkGrNymWv9wFlFM8YppKs6nNXaQdoKf\\\
-        n7+NESFVdkm89/7FWD/It0B49jEBjjs7GOmxhffomt1NVHocYGDBQjMAlKOYQgCnR\\neZDnHCFORSrQcfiNhgKm1/eFOZlNJDZn2Cwpmdk8ZV6B78fGVz+3B+tFABEBAAG0\\\
-        ndVNvdXJjZSBLZXkgPEo0VFRaVzY2QlBRTFRRVVlNS0hIVzZZTjRGVkJIVFlVQ0ZW\\nNVNWNjNRWlQyT0Y3Wjc2NUxEWk1TVDJNR1JBVFpYSVZJVzVBR1M0N0RFU0hTRUhY\\\
-        nWDZFQVlISkFWTFBZRzc1VFlKQkE9Poi3BBMBCgAhBQJRkX6AAhsvBQsJCAcCBhUI\\nCQoLAgQWAgMBAh4BAheAAAoJEBobdROFQEzFd3gD/RUhGdZUriO3QqYTqvH7EZdZ\\\
-        n4r3iFUJVP3xhru9HYBtksepsKzUHYZn4nK29689AdV1A9o/X4YcKWrxFRbMuZs0E\\nTj2Je4jrw3WNf3O3COAWwFa75HOXIhGfFVuJ4Ni2/NVJGDPA6NNIfZfFMIj/NZF3\\\
-        n3RBZhDmxS21yJs9daQfs\\n=NQQJ\\n-----END PGP PUBLIC KEY BLOCK-----\\n\", \n\
-        \        \"type\": \"PGP\"\n      }, \n      \"last_updated\": \"2020-08-15T02:25:44.877597Z\"\
-        , \n      \"number_of_documents\": 1, \n      \"number_of_messages\": 1, \n\
-        \      \"remove_star_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/remove_star\"\
-        , \n      \"replies_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/replies\"\
-        , \n      \"submissions_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions\"\
-        , \n      \"url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"uuid\": \"f3a61359-1919-4bf0-b6f7-da902a935160\"\n    }\n  ]\n\
+        \      \"remove_star_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/remove_star\"\
+        , \n      \"replies_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies\"\
+        , \n      \"submissions_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions\"\
+        , \n      \"url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"f9b4da97-a077-412e-8e54-4ef4984a8540\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '6421'
+      - '1617'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:29:46 GMT
+      - Tue, 25 Aug 2020 17:29:06 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -141,7 +90,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczODYsImlhdCI6MTU5NzQ1ODU4NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.4cAVvx_cN2jxC_GRGtAvCA9JYdrslW1QsDfbYNUL5X4
+      - Token eyJleHAiOjE1OTg0MDUzNDYsImlhdCI6MTU5ODM3NjU0NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.vZUFgU-x-z0JYbTZ7bMdAxgbqm_CvKfIt0oz01Sd0pA
       Connection:
       - keep-alive
       Content-Type:
@@ -152,55 +101,24 @@ interactions:
     uri: http://localhost:8081/api/v1/submissions
   response:
     body:
-      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96/download\"\
-        , \n      \"filename\": \"1-out-of-town_primogeniture-msg.gpg\", \n      \"\
-        is_read\": true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\"\
-        , \n      \"submission_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96\"\
-        , \n      \"uuid\": \"f836676a-c1aa-49a8-90c2-bb171f60cd96\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/99509e6d-62dd-48f3-8208-623f9290bc03/download\"\
-        , \n      \"filename\": \"2-out-of-town_primogeniture-doc.gz.gpg\", \n   \
-        \   \"is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"\
-        /api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a\", \n      \"submission_url\"\
-        : \"/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/99509e6d-62dd-48f3-8208-623f9290bc03\"\
-        , \n      \"uuid\": \"99509e6d-62dd-48f3-8208-623f9290bc03\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download\"\
-        , \n      \"filename\": \"1-red-rimmed_applejack-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170\"\
-        , \n      \"uuid\": \"ceb44744-68cd-4b29-ada9-4c6ed4127170\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015/download\"\
-        , \n      \"filename\": \"2-red-rimmed_applejack-doc.gz.gpg\", \n      \"\
-        is_read\": false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f\"\
-        , \n      \"submission_url\": \"/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/1deb4f4f-1094-49ec-b0da-5d714b60c015\"\
-        , \n      \"uuid\": \"1deb4f4f-1094-49ec-b0da-5d714b60c015\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download\"\
-        , \n      \"filename\": \"1-potential_freshness-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e\"\
-        , \n      \"uuid\": \"da095cb7-5a81-4b57-912c-14b0501dc00e\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d/download\"\
-        , \n      \"filename\": \"2-potential_freshness-doc.gz.gpg\", \n      \"is_read\"\
-        : false, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6\"\
-        , \n      \"submission_url\": \"/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/ed460264-f0e9-415f-8247-738eb482c75d\"\
-        , \n      \"uuid\": \"ed460264-f0e9-415f-8247-738eb482c75d\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download\"\
-        , \n      \"filename\": \"1-inexpressible_sepsis-msg.gpg\", \n      \"is_read\"\
-        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a\"\
-        , \n      \"uuid\": \"a3bb0937-6240-4200-99d5-b514c465e56a\"\n    }, \n  \
-        \  {\n      \"download_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01/download\"\
-        , \n      \"filename\": \"2-inexpressible_sepsis-doc.gz.gpg\", \n      \"\
-        is_read\": true, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160\"\
-        , \n      \"submission_url\": \"/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\
-        , \n      \"uuid\": \"1ce2e0c2-c28c-4bd4-8d27-aea48e29dd01\"\n    }\n  ]\n\
+      string: "{\n  \"submissions\": [\n    {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download\"\
+        , \n      \"filename\": \"1-unlawful_spectrum-msg.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 605, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\
+        , \n      \"uuid\": \"d03224b2-d0ed-4327-8d5d-313e2bbfbccb\"\n    }, \n  \
+        \  {\n      \"download_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a/download\"\
+        , \n      \"filename\": \"2-unlawful_spectrum-doc.gz.gpg\", \n      \"is_read\"\
+        : true, \n      \"size\": 622, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"submission_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/55e459bd-cf4e-45f9-adce-95d79998254a\"\
+        , \n      \"uuid\": \"55e459bd-cf4e-45f9-adce-95d79998254a\"\n    }\n  ]\n\
         }\n"
     headers:
       Content-Length:
-      - '4112'
+      - '1038'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:29:46 GMT
+      - Tue, 25 Aug 2020 17:29:06 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -214,7 +132,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczODYsImlhdCI6MTU5NzQ1ODU4NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.4cAVvx_cN2jxC_GRGtAvCA9JYdrslW1QsDfbYNUL5X4
+      - Token eyJleHAiOjE1OTg0MDUzNDYsImlhdCI6MTU5ODM3NjU0NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.vZUFgU-x-z0JYbTZ7bMdAxgbqm_CvKfIt0oz01Sd0pA
       Connection:
       - keep-alive
       Content-Type:
@@ -225,14 +143,21 @@ interactions:
     uri: http://localhost:8081/api/v1/replies
   response:
     body:
-      string: "{\n  \"replies\": []\n}\n"
+      string: "{\n  \"replies\": [\n    {\n      \"filename\": \"3-unlawful_spectrum-reply.gpg\"\
+        , \n      \"is_deleted_by_source\": false, \n      \"journalist_first_name\"\
+        : \"\", \n      \"journalist_last_name\": \"\", \n      \"journalist_username\"\
+        : \"journalist\", \n      \"journalist_uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\
+        , \n      \"reply_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies/b8bfb5d1-7a5a-4413-9df2-52205fffa5b5\"\
+        , \n      \"size\": 1085, \n      \"source_url\": \"/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540\"\
+        , \n      \"uuid\": \"b8bfb5d1-7a5a-4413-9df2-52205fffa5b5\"\n    }\n  ]\n\
+        }\n"
     headers:
       Content-Length:
-      - '20'
+      - '578'
       Content-Type:
       - application/json
       Date:
-      - Sat, 15 Aug 2020 02:29:46 GMT
+      - Tue, 25 Aug 2020 17:29:06 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -246,7 +171,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczODYsImlhdCI6MTU5NzQ1ODU4NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.4cAVvx_cN2jxC_GRGtAvCA9JYdrslW1QsDfbYNUL5X4
+      - Token eyJleHAiOjE1OTg0MDUzNDYsImlhdCI6MTU5ODM3NjU0NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.vZUFgU-x-z0JYbTZ7bMdAxgbqm_CvKfIt0oz01Sd0pA
       Connection:
       - keep-alive
       Content-Type:
@@ -254,38 +179,20 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/f3a61359-1919-4bf0-b6f7-da902a935160/submissions/a3bb0937-6240-4200-99d5-b514c465e56a/download
+    uri: http://localhost:8081/api/v1/user
   response:
     body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqAQ//Z/S89kAgGiAOh+UVD2ePgDvU/l/JnvR2DkCEnnqTivaWTKetbcTOxv8D
-        iHQFUvQKPTADA4g5u56foRmzC0Yb2mP36vRMUqLq87hb/XfZFfr3Ak7E169EyaCN6ht5he28mLV0
-        j9brHPGxQWt2vrE4FFdwnUVQWNfAp13rFMm0IDFsHN3o3lNSjywJ62jlr1rce3mdkC+rXkwDh3zs
-        0ZDvxqFGx4X8YPbQiAStvUsK1n3u9NBnKE3cyeHe70xnMdQxq1N4NuACJZkNovKet6C3s8LTvj58
-        XiK6+/AgtbO9Pk6c89s1WW0x3hUGFtWVI+GqSUSQda5CDlWaq6Fq7mBURfuW7yD/rOJ0EypOOJED
-        b1GoyTiK6V1gC/mktb6u/Ei16SmPOjcsAzW7BFn5tsvl3lZULN+b4Bs+E7/Pxl4ymVaPDgbcsAh9
-        Ipp0thhF1a2A3MobRsTtNidryxvfzUTj5ou70vguzn7zthzog2sijyM9hBI0FPr6YRVWXvrS7BEQ
-        Ly9BA1AuzGy0kS1B6MUYdcWAaxQZHWNne02zDHZqe2sBFLM04tJU4myKrXlBOok4YILQ7OWDSoa8
-        Whkyohid0Eympcv+6YMaKI+9yBzHFWgcpu27rlrAuRGRXi9ibBxovyCRg5SSYc1Guo0jalDJWdDy
-        lRdLGsmqJAcWq2PUvNLSTAGpSiJRM+Iwxr77j/lapCOSRGfVJaivW59X5+ZQa6BN57DKWvcgPtCb
-        xDfXOBD4hOG9w/Qv5iKwgOcj/ckygOpvtrcQosdK9ZzrrdY=
+      string: "{\n  \"first_name\": \"\", \n  \"is_admin\": true, \n  \"last_login\"\
+        : \"2020-08-25T17:29:06.415254Z\", \n  \"last_name\": \"\", \n  \"username\"\
+        : \"journalist\", \n  \"uuid\": \"f668c3f3-7f5c-46d5-91c3-43528ca602ca\"\n\
+        }\n"
     headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-inexpressible_sepsis-msg.gpg
       Content-Length:
-      - '605'
+      - '192'
       Content-Type:
-      - application/pgp-encrypted
+      - application/json
       Date:
-      - Sat, 15 Aug 2020 02:29:46 GMT
-      Etag:
-      - sha256:20db26d5f8240c2efbc83f40184bd03e74f0b927394627fe24bc2954cb4a6c2a
-      Expires:
-      - Sat, 15 Aug 2020 14:29:46 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:25:44 GMT
+      - Tue, 25 Aug 2020 17:29:06 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -299,7 +206,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczODYsImlhdCI6MTU5NzQ1ODU4NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.4cAVvx_cN2jxC_GRGtAvCA9JYdrslW1QsDfbYNUL5X4
+      - Token eyJleHAiOjE1OTg0MDUzNDYsImlhdCI6MTU5ODM3NjU0NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.vZUFgU-x-z0JYbTZ7bMdAxgbqm_CvKfIt0oz01Sd0pA
       Connection:
       - keep-alive
       Content-Type:
@@ -307,38 +214,38 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/6db98582-dd69-48ea-879e-5afc5aa388d6/submissions/da095cb7-5a81-4b57-912c-14b0501dc00e/download
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/submissions/d03224b2-d0ed-4327-8d5d-313e2bbfbccb/download
   response:
     body:
       string: !!binary |
-        hQIMA8PnxMCiIBsqARAAs+tSZVdjh2H5sgW3rQYsinaTUd1To3XLy/EC0UcNed15/OLbU142ic10
-        6l41iWmBW44aOmjYFIY46VfqPxQSM0G7fl2g5A0SZdmckTqzu141v/+BoTmvbzzZ8sXmpxKjbP/A
-        1F6aBPQ2qX7HcUVyGOadyMRjuKB+IO1pROBeFB5R0hE+FD+y4/yq2y4J9SVeYcdcwcsWJytFUm73
-        emXQ6vcBspvlgSjE1gywgfPFkmOLIKxv9INHFTT/FrfPvJ/yeFZ7jKtG0wxBQYPL4DG5QiVi1Gyz
-        Ln039tgWjFVnM5FhJ+XNhLbLHuISii/0CrKq9TeRea85xFHR6UGKgTm3/fOeWtEhC6FKa0XstXhU
-        T0E9dmh80Rd3myvN0HU3eyNFvmjyZ1weVguXjg4Ao1yWZ8a8AmqlA6m4conr4bbscqQKXCJSF1D+
-        g/i5ng78t0+4wnWMiKtN9rNTJkVBzXpaoYzOn+14EJbkYa+zkCyQS8TbjMBpLaP0aTFO4VXk7OAU
-        ygtKj6P8KmkfqivWrQ047DjqwVot+wBpKT+3t8ASscApC7KaSF0+d/fBvb05ZLzLtfSXM+Ts6pQ8
-        sn60uh2dnW/12nbqAdzFnrEPtDdtz5PFWn8brJpvhhMids/A7dkmbbLK6oirkLSRMF7Wdp8Stz2m
-        aI8Xz6brh2GQeKZafWnSTAHRguSmKDs+h+zUuP/hFFyLlLy2TWX3VLR2rLCEHhm82jP4UcMTpBkU
-        sgsFKxLyPddNYl+9D7kh9NLhzaLsXc2RihQWRvXYM9f3E0Y=
+        hQIMA8PnxMCiIBsqAQ//Rw1NPH3mwdBg9NnblanYiQgqmPuHTY9ha8sR24r6Cbv4UunDrGcjIMeT
+        qUZfK1zok/ZjbbLMo+yVWG2my899P8meyJS9C9MzmPC/x8hpoSUVdxyRorBDja9qNtZUyhOrm5Dz
+        rsiuEaqB1T5iYPinyCzeOcGKxTlrDJE78s5aHQVGQeBjXN+7BqZXsGCWrUueXTF10QrC8u0T/Fnw
+        T+BLvR8FmCIEilEDQESn653nL2wbkTz/7OMxUJJUDkG9xO6VHsTcH4KAzVsonMaan2RVXarJ1393
+        esjkZJ3vMiKXSMNIdsdDQ8WbP/2JGL8rhdg3WZqRbX7ePEJ5C7moUGiJsXmYwNMDarImp/be0O+1
+        YGk1Bfig2smMD280G8vYNykGvLkiGWJU0tGQQBbc5NeM3WZ8chZsyKofidoc9CIY7NLVHGg5u6zf
+        AEe1bjVuWveL5NaUJUpzWxDQzkIBuvX/E9stjEvqb0fZCRkGqPQLOix/YVUjUzj2i1zGAgL/w3xw
+        jhadu4aN05dbf5cBeKRIUS43HnrDXluA0vq0HbX30xuFpoo/noZUiZ8uNfR2UKLQfIK0gNVH1ydw
+        MhHIDKyiUWm/0YQgzcozy14n9OCGtLCucWfxXy7nozJ7JnVJpSYPgAmozMOoqEiz3C0Dnsax/PRV
+        AvwhOEGda6nAIosZZ6nSTAGpDbf6bksYyI2J4JEtY4b7jBvCz6Qmg+n4ZIIH7IEeIBCkhnUtU8xz
+        JHiwor7B/FnoP6RymaVAKyAPqoKGfrJ/XGbwPXJRvQl2PeM=
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-potential_freshness-msg.gpg
+      - attachment; filename=1-unlawful_spectrum-msg.gpg
       Content-Length:
       - '605'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:29:46 GMT
+      - Tue, 25 Aug 2020 17:29:06 GMT
       Etag:
-      - sha256:624b8cc271f0bc4a153ff893f14d4b63464577579c0baa49ca2e6f5b2fb715a8
+      - sha256:dd82012b8656a3f7175b619f2875895a11071daf681b996cdc2704ddf5388664
       Expires:
-      - Sat, 15 Aug 2020 14:29:46 GMT
+      - Wed, 26 Aug 2020 05:29:06 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:35 GMT
+      - Tue, 25 Aug 2020 17:27:02 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:
@@ -352,7 +259,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Token eyJleHAiOjE1OTc0ODczODYsImlhdCI6MTU5NzQ1ODU4NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.4cAVvx_cN2jxC_GRGtAvCA9JYdrslW1QsDfbYNUL5X4
+      - Token eyJleHAiOjE1OTg0MDUzNDYsImlhdCI6MTU5ODM3NjU0NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.vZUFgU-x-z0JYbTZ7bMdAxgbqm_CvKfIt0oz01Sd0pA
       Connection:
       - keep-alive
       Content-Type:
@@ -360,91 +267,66 @@ interactions:
       User-Agent:
       - python-requests/2.20.0
     method: GET
-    uri: http://localhost:8081/api/v1/sources/70c12ee8-816b-4d6b-aa38-ff6ce3a05c4f/submissions/ceb44744-68cd-4b29-ada9-4c6ed4127170/download
+    uri: http://localhost:8081/api/v1/sources/f9b4da97-a077-412e-8e54-4ef4984a8540/replies/b8bfb5d1-7a5a-4413-9df2-52205fffa5b5/download
   response:
     body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqARAAp+9fU8qzd8lBJJJeTGUfrTvtC7bBj77m96ioEWln23lreSXOi7W1E++i
-        X3mCeNg6hLC0PSAtuO0QTw+LE6TGqLJtQh5y14fIxzgIX5G02eaoOlsayjQbVfXHTJ6HBSFx1VkS
-        ImILNuS170DhYiOyW91R3OJ2zg4DeTlPkyegMGScWCued6EcBBL+/EOrvZLDoXtpFAHFkGGcoQSD
-        p/6L5/pp8AuB5N43NRCtslfsD8D4gpZT7L9gkvNIJbMrBQ4FVUzjB/XI5mkOhXAubjKzgGcpqiM+
-        N2k5nqSPFzotGHmKDy77Bq4D3Sk4fcLzvWMe9hY+Prp6QqW5/F3uvFhJdpdOR9JZ4WqY6pWk0VsA
-        jeIuaxGH3rRqFegi59AiZV+EvpORA7tx8qmkVHch5UifaJCsHthaxOrBk1D/rgutgmoQvVaCN+UA
-        6So9D0H/w6RIE0vE3SAsCpXV3XQJWwsya8O5R5jCuETvi1s5NnMXrtxRuBqkFZUcRSNZyzrUWLGA
-        8djkwjYcO5lP7qt40ztUosMmb2y+4z8ad3zhWP71SKA+chx8lUvY7ziiSmFOpRJOr0OEgKMU59lR
-        ovyT6mu5yB1d5d8G9ns8s5H8/ymV5WE/MdG+o472wWPKoKHnIu0zlj1Qqso8l/khM5wIjs8XvICl
-        pm7uojnWqaFcIaJg4EvSTAEw45cGmA90NotlV9qwHi0fJ0qlbFKf6FAyeDaRL0TPoLKx9JbGf+9M
-        +wwWhoyWoWili+hOxuju3sNSeN1iYkv3fEIyKyEy5rXvf/0=
+      string: '-----BEGIN PGP MESSAGE-----
+
+
+        hIwDPsLQNt3KjNQBA/9ojtfC9t1XqWV3wWgAlu95dTxfMqqYczw6sQSmgcEkg9+P
+
+        vCeb05aaW5jMMlYXkUm62SVqdw/KJW1Dg8trcMvRFIeCKNZQhA01Rsqb7jzDLzD/
+
+        kqJ0JGGZk01wDAdRZwWHtA96PY6Qp7mpEJcQTfliBzdWhe03KWfPEJxzZCfT84UC
+
+        DAPD58TAoiAbKgEP/RRt/jqDFFWYxpc4SrqshMubiyh/GImTEOePHfhgQujDvKLu
+
+        kRQovxq1xujHfCuVaBHUgCpm3jWcKCQPrpNT8xLNngu8Uem1degoqstCk+0MVVpC
+
+        +YkmUCajX9X7J98xxuJ/evZMWgWzbk3kD2AuTlYolXqNB6nY50RWQwt1Si/k9p7Y
+
+        RO1ERKa9M99a+lReuF2E2dEYW0Ru3YdTbz/sYuX65Hl/UM6lEhdq9A2EDBElDoiH
+
+        0wkY+YybjFMJlfKnK97nxJ2rwfPQqIiRFEWRbHci+pbtjcPxPjEM37aM/9urM6WR
+
+        CJ3leluB9ZYHzKAFA5VGHH1W1/xPe8STvySggG/cjb4jIxqyu9rV+dkrwK0xjfhN
+
+        15G7B5gvJmXWAp5IDvQD3Pux128hpJYzLUBMURAK1oVf0SCjqWFwQeAIEOE67eJ6
+
+        Nu046qIKcTz6jSH6JrxSneHyDySZaM8DwV9u24voInDGGjEwAbuLfvOGYu6yawAX
+
+        JkD7tAHHpEnsqfOYcH/dMFDLjaE1ybzrD1W2JmJUitMjL449QrTQS8ABpZvZvNl7
+
+        egjy2PgtxHkGvLZ52xv4gGq0Q+5eXquL8uE/zFEi8cUuCj1Q0owvkfqia1j+ZU5p
+
+        JnCZY4UkEivnwu9pbRXu1nuUlPo+/HQSpO9a7SEpIWo4WbnQPxZ9f5LgCiIl0lMB
+
+        /uKyfBrojiN6UOwbopz3CqwC+C3QKzbnKpV6LfyweT8hBt8nYZCp+vDcQ+iucyxb
+
+        1C7h2wAzePF2VFz/1plVSNOGVwqzf8Qf7wCBfJpAt+z7UQ==
+
+        =EqXV
+
+        -----END PGP MESSAGE-----
+
+        '
     headers:
       Cache-Control:
       - max-age=43200, public
       Content-Disposition:
-      - attachment; filename=1-red-rimmed_applejack-msg.gpg
+      - attachment; filename=3-unlawful_spectrum-reply.gpg
       Content-Length:
-      - '605'
+      - '1085'
       Content-Type:
       - application/pgp-encrypted
       Date:
-      - Sat, 15 Aug 2020 02:29:46 GMT
+      - Tue, 25 Aug 2020 17:29:06 GMT
       Etag:
-      - sha256:2e1bdbd452ce54d49602552182cb0146b2334c58a7c5aec0c0565645e2ab4286
+      - sha256:8055a4fea7b7e8e4bf0e3ea6d3e4ee5959899e7f4732b0585b5b4ae5b58231e0
       Expires:
-      - Sat, 15 Aug 2020 14:29:46 GMT
+      - Wed, 26 Aug 2020 05:29:06 GMT
       Last-Modified:
-      - Sat, 15 Aug 2020 02:25:23 GMT
-      Server:
-      - Werkzeug/0.16.0 Python/3.5.2
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Token eyJleHAiOjE1OTc0ODczODYsImlhdCI6MTU5NzQ1ODU4NiwiYWxnIjoiSFMyNTYifQ.eyJpZCI6MX0.4cAVvx_cN2jxC_GRGtAvCA9JYdrslW1QsDfbYNUL5X4
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.20.0
-    method: GET
-    uri: http://localhost:8081/api/v1/sources/4c0d0202-154f-4a18-880d-e4dd3c253f2a/submissions/f836676a-c1aa-49a8-90c2-bb171f60cd96/download
-  response:
-    body:
-      string: !!binary |
-        hQIMA8PnxMCiIBsqARAAqBkguUOJVhB1E0rEBd3bIvbOJe9umLBp5QVPye5M4nsh0yl0IWnltszf
-        edV/FKB+H0YdtACRB57Zur0vTrOWAA4o1cC9tyUi18aWslfgDvVwJXLjELZYOQiDv//vmcWEG4Mw
-        ckXqK+/zvkgGLST9xjubdcQozWQNW8mXNzqLzLPLYd57oejEzr73iwn2UwQbQjXb31YI5ZsvCB0y
-        sltvyQevn92quua31WmlxjwzTndQ9u9mGQ5zZSxwK39HaZ3oEmPZlWelrnUfbodPJw5wQqGBN++n
-        lwGMVphNGN+EssKtSUb5Hmutd6jTajcfPWPf0yU6AYtJ3v/1wiOyXCaN3tnPStKUzP6w/htB2nFz
-        irbFi2VQ5v1Lg/nAYl0n3cVU4A8O8P8nhIX5KOsxNhYqNyuyjZsJgFAiKtCzEcXxlpyCQiPwpHbo
-        PM7nDr1JtS7w+IY4xlOkwdOmTIjq+WYjfwbOMd8GlwMQmpp2s6n4S7whSIcYI5acs14DERizF7lG
-        vY8XG7/ExbA0zt9B8j0MKTDsAxgkEEMALTPtINMmuc3xaDoTP7HA8e/X6tyPvrVarY8zFuPVxKuY
-        VXdPQuf6in/3uzja0QlWwq+Ibm+I/gBtQPRM1cDpW5n7XdYkzRcTIluElj8U8VnbECvkFNLt8NUk
-        IF792WIIe570TmeeRXfSTAE9fPtTykzrDiTy5LSwqQ91J/Og4d484LO+VkYSPGe37sfcFRSAOSL6
-        KHNlQb9u2IoOgkORHi/6PABz5ty5K45/OvEOhlB4/xbxkbA=
-    headers:
-      Cache-Control:
-      - max-age=43200, public
-      Content-Disposition:
-      - attachment; filename=1-out-of-town_primogeniture-msg.gpg
-      Content-Length:
-      - '605'
-      Content-Type:
-      - application/pgp-encrypted
-      Date:
-      - Sat, 15 Aug 2020 02:29:46 GMT
-      Etag:
-      - sha256:64f0c214fab76a0aa8a1407daf0c0478f7851bd7b5c0aaca5b5c8de53aae9336
-      Expires:
-      - Sat, 15 Aug 2020 14:29:46 GMT
-      Last-Modified:
-      - Sat, 15 Aug 2020 02:24:41 GMT
+      - Tue, 25 Aug 2020 17:28:16 GMT
       Server:
       - Werkzeug/0.16.0 Python/3.5.2
     status:


### PR DESCRIPTION
# Description

Towards https://github.com/freedomofpress/securedrop-client/issues/76

Next step (after this PR): update gui auth widget to show updated name

# Test Plan

1. log in
2. change first and last name of the account you're logged into from the admin UI
3. wait until next sync then check local client db
   - [ ] verify local db shows updated first and last name
4. change first and last name to empty string
5. wait until next sync then check local client db
   - [ ] verify local db shows updated first and last name
6. change first and last name from journalist UI (not admin UI)
7. wait until next sync then check local client db
   - [ ] verify local db shows updated first and last name
8. change username from admin UI (can't do this from journalist UI)
   - [ ] verify local db shows updated username