### PR TITLE
Incorporate recent Code of Conduct updates

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -105,7 +105,7 @@ following behaviors:
   - Unwelcome sexual attention
   - Posting (or threatening to post) other people's personally identifying
     information ("doxing")
-  - Respect people's stated personal boundaries
+  - Violation of people's stated personal boundaries
 
 - Following the letter of this Code of Conduct while disregarding its spirit.
   When judging whether certain behavior represents a violation of this code, we
@@ -134,7 +134,8 @@ assist with resolving conflicts within the community.
 
 Currently the Community Team consists of:
 
-- Jen Helsby (`@redshiftzero`) - Lead Engineer - [jen@freedom.press](mailto:jen@freedom.press)
+- Jen Helsby (`@redshiftzero`) - Principal Research Engineer - [jen@freedom.press](mailto:jen@freedom.press)
+- Mickael E. (`@emkll`) - Lead Engineer - [mickael@freedom.press](mailto:mickael@freedom.press)
 
 You can contact the whole Community Team or members individually.
 


### PR DESCRIPTION
Fix miswording in list of unacceptable behavior

The intent was clear but given the list is introduced as a list of behaviors people are expected to never engage into, the meaning was the opposite of the intention.

(authored by @gonzalo-bulnes, reviewed in https://github.com/freedomofpress/securedrop/pull/5372)

add mickael to CoC

(authored by @emkll, reviewed in https://github.com/freedomofpress/securedrop/pull/5405)

# Description

Ready for review