### PR TITLE
Elide source designation at lower window widths

### DIFF
--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -184,8 +184,8 @@ class SecureQLabel(QLabel):
             full_text = full_text.split("\n", 1)[0]
 
         fm = self.fontMetrics()
-        filename_width = fm.horizontalAdvance(full_text)
-        if filename_width > self.max_length:
+        px_width = fm.horizontalAdvance(full_text)
+        if px_width > self.max_length:
             elided_text = ""
             for c in full_text:
                 if fm.horizontalAdvance(elided_text) > self.max_length:


### PR DESCRIPTION
Resolves #1120

## Status

Ready for review

## Description

Elides the source designation if needed as the window is resized, while allocating a fixed width to the label to ensure that layout is not disrupted.

## Testing

- Test resizing the window on Qubes for multiple sources to ensure it behaves as shown in the GIF animation below.
- Test switching to offline mode and back to online mode to ensure no regression in the placeholder display.
- Test sending replies from multiple sources to ensure no regression in placeholder hide/show behavior.

![resize](https://user-images.githubusercontent.com/213636/92285348-ec0eaf80-eeb8-11ea-88e3-00ddf6602277.gif)

## Checklist

- [x] No update to the AppArmor profile is required for these changes
- [x] No database schema changes are needed
