### PR TITLE
Disable client and vault config in VMs other than sd-app

### DIFF
--- a/files/sd-app-qubes-gpg-domain.sh
+++ b/files/sd-app-qubes-gpg-domain.sh
@@ -1,1 +1,1 @@
-export QUBES_GPG_DOMAIN="sd-gpg"
+if [ "$(qubesdb-read /name)" = "sd-app" ]; then export QUBES_GPG_DOMAIN="sd-gpg" && sudo aa-enforce /usr/bin/securedrop-client; fi

--- a/files/securedrop-client
+++ b/files/securedrop-client
@@ -7,5 +7,8 @@ cd /opt/venvs/securedrop-client
 # Now let us try to run alembic first
 ./bin/alembic -c /usr/share/securedrop-client/alembic.ini upgrade head
 
-# Now execute the actual client
-./bin/sd-client
+# Check if qubes-db exists (and we are running in qubes)
+if [ ! -f "/usr/bin/qubesdb-read" ]; then echo "Not running in Qubes, client not starting." && exit; fi
+
+# Now execute the actual client, only if running in an sd-app
+if [ "$(qubesdb-read /name)" = "sd-app" ]; then ./bin/sd-client; else echo "Not running in sd-app, client not starting."; fi

--- a/files/usr.bin.securedrop-client
+++ b/files/usr.bin.securedrop-client
@@ -1,4 +1,4 @@
-# Last Modified: Tue Dec 10 11:57:59 2019
+# Last Modified: Thu Oct  1 17:02:42 2020
 #include <tunables/global>
 
 /usr/bin/securedrop-client {
@@ -37,6 +37,7 @@
   /usr/bin/qrexec-client-vm mrix,
   /usr/bin/qubes-gpg-client mrix,
   /usr/bin/qubes-gpg-import-key mrix,
+  /usr/bin/qubesdb-cmd mrix,
   /usr/bin/qvm-open-in-vm mrix,
   /usr/bin/securedrop-client r,
   /usr/bin/uname mrix,


### PR DESCRIPTION
# Description

Fixes #1141 
Towards https://github.com/freedomofpress/securedrop-workstation/issues/471

# Test Plan

Install this package in sd-app-buster-template.

- [ ] This package installs in sd-app-buster-template TemplateVM
-  [ ] The client does not start in sd-app-buster-template TemplateVM (you can also try installing it in other VMs)
- [ ] The client starts in sd-app AppVm

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [x] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)

