### PR TITLE
[wip] experiments with flaky dialog tests

### DIFF
--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -101,11 +101,8 @@ class Window(QMainWindow):
         """
         Show main application window.
         """
-        if not self.controller.qubes:
-            self.showMaximized()
-        else:
-            self.setWindowState(Qt.WindowFullScreen)
-            self.show()
+        self.setWindowState(Qt.WindowFullScreen)
+        self.show()
 
         if db_user:
             self.set_logged_in_as(db_user)

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -4,7 +4,6 @@ Check the core Window UI class works as expected.
 from PyQt5.QtWidgets import QApplication, QHBoxLayout
 
 from securedrop_client.gui.main import Window
-from securedrop_client.logic import Controller
 from securedrop_client.resources import load_icon
 
 app = QApplication([])
@@ -34,79 +33,48 @@ def test_init(mocker):
     load_css.assert_called_once_with("sdclient.css")
 
 
-def test_setup(mocker, homedir, session_maker):
+def test_setup(mocker):
     """
     Ensure the passed in controller is referenced and the various views are
     instantiated as expected.
     """
+    mock_controller = mocker.MagicMock()
+
     w = Window()
     w.show_login = mocker.MagicMock()
     w.top_pane = mocker.MagicMock()
     w.left_pane = mocker.MagicMock()
     w.main_view = mocker.MagicMock()
-    controller = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir)
 
-    w.setup(controller)
+    w.setup(mock_controller)
 
-    assert w.controller == controller
-    w.top_pane.setup.assert_called_once_with(controller)
-    w.left_pane.setup.assert_called_once_with(w, controller)
-    w.main_view.setup.assert_called_once_with(controller)
+    assert w.controller == mock_controller
+    w.top_pane.setup.assert_called_once_with(mock_controller)
+    w.left_pane.setup.assert_called_once_with(w, mock_controller)
+    w.main_view.setup.assert_called_once_with(mock_controller)
     w.show_login.assert_called_once_with()
 
 
-def test_show_main_window(mocker, homedir, session_maker):
+def test_show_main_window(mocker):
     w = Window()
-    controller = Controller("http://localhost", w, session_maker, homedir)
-    w.setup(controller)
     w.show = mocker.MagicMock()
-    w.showMaximized = mocker.MagicMock()
     w.set_logged_in_as = mocker.MagicMock()
     user = mocker.MagicMock()
 
     w.show_main_window(db_user=user)
 
     w.show.assert_called_once_with()
-    w.showMaximized.assert_not_called()
-    w.set_logged_in_as.assert_called_once_with(user)
-
-    controller.qubes = False
-    w.setup(controller)
-    w.show.reset_mock()
-    w.showMaximized.reset_mock()
-    w.set_logged_in_as.reset_mock()
-
-    w.show_main_window(db_user=user)
-
-    w.show.assert_not_called()
-    w.showMaximized.assert_called_once_with()
     w.set_logged_in_as.assert_called_once_with(user)
 
 
-def test_show_main_window_without_username(mocker, homedir, session_maker):
+def test_show_main_window_without_username(mocker):
     w = Window()
-    controller = Controller("http://localhost", w, session_maker, homedir)
-    w.setup(controller)
     w.show = mocker.MagicMock()
-    w.showMaximized = mocker.MagicMock()
     w.set_logged_in_as = mocker.MagicMock()
 
     w.show_main_window()
 
     w.show.assert_called_once_with()
-    w.showMaximized.assert_not_called()
-    w.set_logged_in_as.called is False
-
-    controller.qubes = False
-    w.setup(controller)
-    w.show.reset_mock()
-    w.showMaximized.reset_mock()
-    w.set_logged_in_as.reset_mock()
-
-    w.show_main_window()
-
-    w.show.assert_not_called()
-    w.showMaximized.assert_called_once_with()
     w.set_logged_in_as.called is False
 
 


### PR DESCRIPTION
This reverts commit 2993f19e126602a71914cdd17e9eb66a0e495953.

We're going to see if CI on this branch flakes any less on the dialog tests.

# Description

Fixes #issue.

# Test Plan


# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed
