### PR TITLE
Remove AppArmor profile enforcement in profile.d, into postinst

### DIFF
--- a/files/sd-app-qubes-gpg-domain.sh
+++ b/files/sd-app-qubes-gpg-domain.sh
@@ -1,1 +1,1 @@
-if [ "$(qubesdb-read /name)" = "sd-app" ]; then export QUBES_GPG_DOMAIN="sd-gpg" && sudo aa-enforce /usr/bin/securedrop-client; fi
+if [ "$(qubesdb-read /name)" = "sd-app" ]; then export QUBES_GPG_DOMAIN="sd-gpg"; fi


### PR DESCRIPTION
# Description

Towards https://github.com/freedomofpress/securedrop-workstation/issues/621

Changes in #1153 required changes to the AppArmor profile. In order to apply these changes prior to running the client, running aa-enforce was required to ensure the profile was updated prior to running the client. We should instead handle this in the postinst for this package.

# Test Plan

See test plan in https://github.com/freedomofpress/securedrop-workstation/pull/623

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
