### PR TITLE
remove recommendation to merge migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,12 +240,6 @@ alembic upgrade head
 alembic revision --autogenerate -m "describe your revision here"
 ```
 
-### Merging Migrations
-
-This project aims to have at most one migration per release. There may be cases where this is not feasible,
-but developers should merge their migration into the latest migration that has been generated since the last
-release. The above mentioned autogenerate command will not do this for you.
-
 ## AppArmor support
 
 An AppArmor profile is available for mandatory access control. When installing securedrop-client from a .deb package, the AppArmor profile will automatically be copied and enforced. Below are instructions to use the profile in non-production scenarios.


### PR DESCRIPTION
# Description

This was recommended to reduce migration run time by reducing the number of times data had to be transferred between tables. If someone is on an old version of the client and has a lot of data, it does make sense that combining the schema migrations and then doing one single data migration would save time, however it's harder to maintain and reason about the merged migration. It's probably worth the extra time to keep these migrations logically separate, and in the average case, there isn't any performance gain anyway.