### PR TITLE
Update dev mac requirements

### DIFF
--- a/requirements/dev-mac-requirements.txt
+++ b/requirements/dev-mac-requirements.txt
@@ -255,6 +255,481 @@ pygetwindow==0.0.8 \
 pymsgbox==1.0.8 \
     --hash=sha256:8e088903a3b1e4f46edd3b23cccf20609d0d06e52d559056482a6e8b75f0dc1a \
     # via pyautogui
+pyobjc-core==6.2 ; platform_system == "Darwin" \
+    --hash=sha256:6af32dc491c575346400c29649fffe6e0a1911553b9218529deafc56fa357bdd \
+    --hash=sha256:843b175e6bd6309c4457090ca52ca8e20cb1e6be19df1bc74d1ed1889f52149c \
+    --hash=sha256:8dd816c03fcbcbd8da8beb30dffe3aaaf8077d852cca4d636e3d7dd0ab48d39d \
+    --hash=sha256:cb130c953c79cb2df4eb3976b7fe28c336b0de0dc550b0574eca8856c76cd147 \
+    --hash=sha256:ccfad6cba29652b005bc41e819ad70d203cc3e57a16e75e27bc4e6979034c7c0 \
+    # via -r requirements/dev-requirements.in, pyautogui, pyobjc, pyobjc-framework-accounts, pyobjc-framework-addressbook, pyobjc-framework-adsupport, pyobjc-framework-applescriptkit, pyobjc-framework-applescriptobjc, pyobjc-framework-applicationservices, pyobjc-framework-authenticationservices, pyobjc-framework-automaticassessmentconfiguration, pyobjc-framework-automator, pyobjc-framework-avfoundation, pyobjc-framework-avkit, pyobjc-framework-businesschat, pyobjc-framework-calendarstore, pyobjc-framework-cfnetwork, pyobjc-framework-cloudkit, pyobjc-framework-cocoa, pyobjc-framework-collaboration, pyobjc-framework-colorsync, pyobjc-framework-contacts, pyobjc-framework-contactsui, pyobjc-framework-coreaudio, pyobjc-framework-coreaudiokit, pyobjc-framework-corebluetooth, pyobjc-framework-coredata, pyobjc-framework-corehaptics, pyobjc-framework-corelocation, pyobjc-framework-coremedia, pyobjc-framework-coremediaio, pyobjc-framework-coreml, pyobjc-framework-coremotion, pyobjc-framework-coreservices, pyobjc-framework-corespotlight, pyobjc-framework-coretext, pyobjc-framework-corewlan, pyobjc-framework-cryptotokenkit, pyobjc-framework-devicecheck, pyobjc-framework-dictionaryservices, pyobjc-framework-discrecording, pyobjc-framework-discrecordingui, pyobjc-framework-diskarbitration, pyobjc-framework-dvdplayback, pyobjc-framework-eventkit, pyobjc-framework-exceptionhandling, pyobjc-framework-executionpolicy, pyobjc-framework-externalaccessory, pyobjc-framework-fileprovider, pyobjc-framework-fileproviderui, pyobjc-framework-findersync, pyobjc-framework-fsevents, pyobjc-framework-gamecenter, pyobjc-framework-gamecontroller, pyobjc-framework-gamekit, pyobjc-framework-gameplaykit, pyobjc-framework-imagecapturecore, pyobjc-framework-imserviceplugin, pyobjc-framework-inputmethodkit, pyobjc-framework-installerplugins, pyobjc-framework-instantmessage, pyobjc-framework-intents, pyobjc-framework-iosurface, pyobjc-framework-ituneslibrary, pyobjc-framework-latentsemanticmapping, pyobjc-framework-launchservices, pyobjc-framework-libdispatch, pyobjc-framework-linkpresentation, pyobjc-framework-localauthentication, pyobjc-framework-mapkit, pyobjc-framework-mediaaccessibility, pyobjc-framework-medialibrary, pyobjc-framework-mediaplayer, pyobjc-framework-mediatoolbox, pyobjc-framework-metal, pyobjc-framework-metalkit, pyobjc-framework-modelio, pyobjc-framework-multipeerconnectivity, pyobjc-framework-naturallanguage, pyobjc-framework-netfs, pyobjc-framework-network, pyobjc-framework-networkextension, pyobjc-framework-notificationcenter, pyobjc-framework-opendirectory, pyobjc-framework-osakit, pyobjc-framework-oslog, pyobjc-framework-pencilkit, pyobjc-framework-photos, pyobjc-framework-photosui, pyobjc-framework-preferencepanes, pyobjc-framework-pubsub, pyobjc-framework-pushkit, pyobjc-framework-quartz, pyobjc-framework-quicklookthumbnailing, pyobjc-framework-safariservices, pyobjc-framework-scenekit, pyobjc-framework-screensaver, pyobjc-framework-scriptingbridge, pyobjc-framework-searchkit, pyobjc-framework-security, pyobjc-framework-securityfoundation, pyobjc-framework-securityinterface, pyobjc-framework-servicemanagement, pyobjc-framework-social, pyobjc-framework-soundanalysis, pyobjc-framework-speech, pyobjc-framework-spritekit, pyobjc-framework-storekit, pyobjc-framework-syncservices, pyobjc-framework-systemconfiguration, pyobjc-framework-systemextensions, pyobjc-framework-usernotifications, pyobjc-framework-videosubscriberaccount, pyobjc-framework-videotoolbox, pyobjc-framework-vision, pyobjc-framework-webkit
+pyobjc-framework-accounts==6.2 \
+    --hash=sha256:18485911cedbca358cf574fd7738e3e9281ec3a36c221e69467c6bc08527f30d \
+    --hash=sha256:f60e3cc36dd0999c51790e993e4dae45b78c11f1155539264e372dcd18e1a54e \
+    # via pyobjc, pyobjc-framework-cloudkit
+pyobjc-framework-addressbook==6.2 \
+    --hash=sha256:2600ec289d867337845b115c469d60d2e2bf75dad792b6a2a007f7627cfcbcc9 \
+    --hash=sha256:d622150a1cb9b23d0bbb93225354c316fb953806c0df4b43c99d6ee7614e75b3 \
+    # via pyobjc
+pyobjc-framework-adsupport==6.2 \
+    --hash=sha256:797c44ba43b391a75d655075dfb50cf5ee03ac1292442c9d3d36d3ccf7efdf0a \
+    --hash=sha256:c4ffbf85e3aa9d0d251e2654137560d2ff963f132e4f2943e8002328b8b73d39 \
+    # via pyobjc
+pyobjc-framework-applescriptkit==6.2 \
+    --hash=sha256:25bb6ceb7f3e64c8a24d475d94c7eb5f2c9c4777c3a822d604956af862ff5fd0 \
+    --hash=sha256:35cab7a40e67007d20516f7282fa0bea0bd71f2244c3dbafbfc1069c051b59e3 \
+    # via pyobjc
+pyobjc-framework-applescriptobjc==6.2 \
+    --hash=sha256:b9f7da5f52dcc3d764e43f6dc6358e8aabcdf446ab83b2d14b0e16000dfeea12 \
+    --hash=sha256:fa9cfd05477b9d5ca13c141261e495ba4eb88de2d33cd1889d932c60f9c4696b \
+    # via pyobjc
+pyobjc-framework-applicationservices==6.2 \
+    --hash=sha256:0558740898dc63e35a5d85570d5837307158a675366a7fef7bd756056d70287e \
+    --hash=sha256:f234905b687ebdf9c1eeae1a6e00ad7f97c1735b3c16b4a12e782cb6e334b2fc \
+    # via pyobjc
+pyobjc-framework-authenticationservices==6.2 \
+    --hash=sha256:2af9607a069b6787ca720e6c4becbe27153c8d2492bf972936ce87ff6b33b6a6 \
+    --hash=sha256:2b5dd9c137a2864239c7d0cea3c710a4b3c0e5b8338ba71fdd296884cc7b5cc5 \
+    # via pyobjc
+pyobjc-framework-automaticassessmentconfiguration==6.2 \
+    --hash=sha256:4095581ace2984a36ccf0d028ad845510dfe3f5f3866576ec99fcb1d290bcbaa \
+    --hash=sha256:d5739b9e66da3a45b3e566b2681b817e771631ccfb4424838f868d679a7f4f34 \
+    # via pyobjc
+pyobjc-framework-automator==6.2 \
+    --hash=sha256:67d54aa3a12d9bd8c3cc6adc265a51e48f6daf4686abee9ca7ea890d1813eba0 \
+    --hash=sha256:6ebb99bd88ddcbc823bbdaf1eee32e27d0ab92c7d399b376c1ac35ef7a91640f \
+    # via pyobjc
+pyobjc-framework-avfoundation==6.2 \
+    --hash=sha256:3b6bab7607e3d7053f2dec36c7c48515d9b2fb20413130900b7ecc369f619594 \
+    --hash=sha256:f7828996722e554bbcd7aaba1fdac2aca5bb9b79feabd3a8c3d0f53dbb55cd6f \
+    # via pyobjc, pyobjc-framework-mediaplayer
+pyobjc-framework-avkit==6.2 \
+    --hash=sha256:53cfab2cc10ec4a49bab8bb349c1572fd5d2cfc5cb0807632b6810cc331d0a8f \
+    --hash=sha256:9e7b4952288cb751ffcf76d1fad683c5bbaa85a9b6c4355439297d03d8ab15f0 \
+    # via pyobjc
+pyobjc-framework-businesschat==6.2 \
+    --hash=sha256:5cdcaf75189f2cde10808ba7467c95afd9df336ef56ac31ad779fbe8ee60ba67 \
+    --hash=sha256:bc1ae9dc11a5bd5518e4685e52c7e25d43ac34e8a53dc1b4c58591fac542f99a \
+    # via pyobjc
+pyobjc-framework-calendarstore==6.2 \
+    --hash=sha256:17f4bc57cc043d848736385e957c5f88a385fa2f250b87fb57c517ce146e5c21 \
+    --hash=sha256:1fa53d966a083ffd43ae396b8e69d22da3c783a334435297bd48baeff8414476 \
+    # via pyobjc
+pyobjc-framework-cfnetwork==6.2 \
+    --hash=sha256:3e7c630c8f4b76b8758975e9f785ae8da33f20fc090b27d26103baff0dec1c53 \
+    --hash=sha256:feb5da4721e75e6e6103ad0d49fcf312767247e6cce9bcf0c7e435beb0665327 \
+    # via pyobjc
+pyobjc-framework-cloudkit==6.2 \
+    --hash=sha256:1025951157597d1e2889e55c9b99c57ccd47fb5eb4c354a0de79a28ae2c1a9bc \
+    --hash=sha256:3d35c16a0d1847a36d9b506d17b1879a74ca9102d02b98113401536b8276d970 \
+    # via pyobjc
+pyobjc-framework-cocoa==6.2 \
+    --hash=sha256:04b994a26bc30c912f2f5165d57a987f35889a36dd9c104674bc449c53649629 \
+    --hash=sha256:09612dd81fafb6e1a8eb597b5e523c9de103a50af79e95afbf13b8a5937e3cfa \
+    --hash=sha256:cbe4f1917aa5def4a77fd4199a9697f3b4224acf59acf4e01fe9a7c73d49b08c \
+    --hash=sha256:e15bbf82bfe3a14dfd29c7465cc5d8edab16d546410239b7e1a4db62ded4a5b2 \
+    --hash=sha256:ef3c21a8b37519e3a3880fc0c5539fe27afd3e0235c8ebc9c87b3d0354cbb4ea \
+    # via pyobjc, pyobjc-framework-accounts, pyobjc-framework-addressbook, pyobjc-framework-adsupport, pyobjc-framework-applescriptkit, pyobjc-framework-applescriptobjc, pyobjc-framework-applicationservices, pyobjc-framework-authenticationservices, pyobjc-framework-automaticassessmentconfiguration, pyobjc-framework-automator, pyobjc-framework-avfoundation, pyobjc-framework-avkit, pyobjc-framework-businesschat, pyobjc-framework-calendarstore, pyobjc-framework-cfnetwork, pyobjc-framework-cloudkit, pyobjc-framework-collaboration, pyobjc-framework-colorsync, pyobjc-framework-contacts, pyobjc-framework-contactsui, pyobjc-framework-coreaudio, pyobjc-framework-coreaudiokit, pyobjc-framework-corebluetooth, pyobjc-framework-coredata, pyobjc-framework-corehaptics, pyobjc-framework-corelocation, pyobjc-framework-coremedia, pyobjc-framework-coremediaio, pyobjc-framework-coreml, pyobjc-framework-coremotion, pyobjc-framework-corespotlight, pyobjc-framework-coretext, pyobjc-framework-corewlan, pyobjc-framework-cryptotokenkit, pyobjc-framework-devicecheck, pyobjc-framework-discrecording, pyobjc-framework-discrecordingui, pyobjc-framework-diskarbitration, pyobjc-framework-dvdplayback, pyobjc-framework-eventkit, pyobjc-framework-exceptionhandling, pyobjc-framework-executionpolicy, pyobjc-framework-externalaccessory, pyobjc-framework-fileprovider, pyobjc-framework-findersync, pyobjc-framework-fsevents, pyobjc-framework-gamecenter, pyobjc-framework-gamecontroller, pyobjc-framework-gamekit, pyobjc-framework-gameplaykit, pyobjc-framework-imagecapturecore, pyobjc-framework-imserviceplugin, pyobjc-framework-inputmethodkit, pyobjc-framework-installerplugins, pyobjc-framework-instantmessage, pyobjc-framework-intents, pyobjc-framework-iosurface, pyobjc-framework-ituneslibrary, pyobjc-framework-latentsemanticmapping, pyobjc-framework-linkpresentation, pyobjc-framework-localauthentication, pyobjc-framework-mapkit, pyobjc-framework-mediaaccessibility, pyobjc-framework-medialibrary, pyobjc-framework-mediatoolbox, pyobjc-framework-metal, pyobjc-framework-metalkit, pyobjc-framework-modelio, pyobjc-framework-multipeerconnectivity, pyobjc-framework-naturallanguage, pyobjc-framework-netfs, pyobjc-framework-network, pyobjc-framework-networkextension, pyobjc-framework-notificationcenter, pyobjc-framework-opendirectory, pyobjc-framework-osakit, pyobjc-framework-oslog, pyobjc-framework-pencilkit, pyobjc-framework-photos, pyobjc-framework-photosui, pyobjc-framework-preferencepanes, pyobjc-framework-pubsub, pyobjc-framework-pushkit, pyobjc-framework-quartz, pyobjc-framework-quicklookthumbnailing, pyobjc-framework-safariservices, pyobjc-framework-scenekit, pyobjc-framework-screensaver, pyobjc-framework-scriptingbridge, pyobjc-framework-security, pyobjc-framework-securityfoundation, pyobjc-framework-securityinterface, pyobjc-framework-servicemanagement, pyobjc-framework-social, pyobjc-framework-soundanalysis, pyobjc-framework-speech, pyobjc-framework-spritekit, pyobjc-framework-storekit, pyobjc-framework-syncservices, pyobjc-framework-systemconfiguration, pyobjc-framework-systemextensions, pyobjc-framework-usernotifications, pyobjc-framework-videosubscriberaccount, pyobjc-framework-videotoolbox, pyobjc-framework-vision, pyobjc-framework-webkit
+pyobjc-framework-collaboration==6.2 \
+    --hash=sha256:8801c99afb959072029007f707b94e413db4f40d872189d9f8e6443d1947b5c2 \
+    --hash=sha256:9aa9f09853a07465bb9dd88670e8a3a90ef6283016dd7257c5830b88755f34e6 \
+    # via pyobjc
+pyobjc-framework-colorsync==6.2 \
+    --hash=sha256:0c96dbc004c36f6d62b0d737e5f88e3a6d77716760942812026b6aeaef5bf308 \
+    --hash=sha256:b1187e8445badd35f3c5263ea90700e4d2a5be707c8952521eeddf1cc7f38b1d \
+    # via pyobjc
+pyobjc-framework-contacts==6.2 \
+    --hash=sha256:707812edc9f7b0e91355fef08d643f2f2be7f8093d4d380932274240e597d260 \
+    --hash=sha256:e7251f93108c66114c9fafe48c5256652b541e0e70ecef7a09882e1c50665e5e \
+    # via pyobjc, pyobjc-framework-contactsui
+pyobjc-framework-contactsui==6.2 \
+    --hash=sha256:0ef9e716c0ca403ff59bbce9434f218d0868cba556cbbc45ebdd1b747254abfd \
+    --hash=sha256:c8cb2961b3eb7cd3927f96626ea3d601adc26bcd47d09550561df4a90a7b83ff \
+    # via pyobjc
+pyobjc-framework-coreaudio==6.2 \
+    --hash=sha256:40170897715e2dfd6d60387fb5eba7fd31c0eed32718c06488eae082a6562454 \
+    --hash=sha256:526eccf410df487540d04a0d6e55a4f137063d0041dab331575e92c0320fd2b0 \
+    --hash=sha256:5fbe0564cfd52ad2029380ddcf67681fc5cb26d0a5d8bcbc36f64f6a9102a9f4 \
+    --hash=sha256:6368ca7654efa2b4dd0bc425f125efd3c86144463ac8f54ec967a58280a626b5 \
+    --hash=sha256:7d4746ea5fe4b14636bb2864c22c01ed2e39a5ec1c78c0efdd52436c87324cf3 \
+    # via pyobjc, pyobjc-framework-coreaudiokit
+pyobjc-framework-coreaudiokit==6.2 \
+    --hash=sha256:12f81a0291b50a0d8e1b14eeaead29b974174815ecf49a1865312640e8993f01 \
+    --hash=sha256:e560774fe65f61a577ff8c4909e76447ad1d52d79a3d2c7816a9b1ec4caa7700 \
+    # via pyobjc
+pyobjc-framework-corebluetooth==6.2 \
+    --hash=sha256:ae75b990635d5d99a08466a7a0d82ed4f70cf8fedb325e049d8fb8c96f35a185 \
+    --hash=sha256:e1bd37de50d52052b0ea3036e911e90b02e9fcccbf49a3f6b77c18d8c34d0eae \
+    # via pyobjc
+pyobjc-framework-coredata==6.2 \
+    --hash=sha256:7eb57ec9dac13f3b62f2964a9d80c2572761f5ad6a69542365ced973cc922f56 \
+    --hash=sha256:b1a2dd923c828eb668cfb3b0369d2596c34c60d00450d7b786ac5b585fb03f1a \
+    # via pyobjc, pyobjc-framework-cloudkit, pyobjc-framework-syncservices
+pyobjc-framework-corehaptics==6.2 \
+    --hash=sha256:274e3bbc247d2f7e6824025c6f7d02aaeb5ec3751d007ef6d480461dec5ab63a \
+    --hash=sha256:c8501a9c867865e94d6743a8c1ff62e4b1ae569f9e0f5b8eb13110bda230cfd9 \
+    # via pyobjc
+pyobjc-framework-corelocation==6.2 \
+    --hash=sha256:def1b255585b45eac93b6c309c68cd625b263d95f299018ce3728434f2618cca \
+    --hash=sha256:fb3e92e5bc970035548861d76197f3bfd03a15aae3ad263fe81de4a0709466f5 \
+    # via pyobjc, pyobjc-framework-cloudkit, pyobjc-framework-mapkit
+pyobjc-framework-coremedia==6.2 \
+    --hash=sha256:9cd8d5a7cc2c5c530032ffb7934bb67fe7c302be7394efd7ad3290fee2ff2b2c \
+    --hash=sha256:c69e273a6d16806b3415c0c82163a20a7f1f9081c38027b6941744e3ac77f1ba \
+    # via pyobjc, pyobjc-framework-avfoundation, pyobjc-framework-oslog, pyobjc-framework-videotoolbox
+pyobjc-framework-coremediaio==6.2 \
+    --hash=sha256:227e4cec91407c17eeb60cac7fa6ecaf0b0214f3a4158ad53ebca939a9aadb1b \
+    --hash=sha256:c2b3d47a33158474c9fca6e22ab65477b1f04a818beaf6cdc2a7434e4c2cc39b \
+    # via pyobjc
+pyobjc-framework-coreml==6.2 \
+    --hash=sha256:11bbb5f5c0c64322da1877612def440434989fb9f2bb9aa4a13cf50dc79630ba \
+    --hash=sha256:b4426f9b36f927de6918976d6daf9cc011e9be792aaa6fca472a264dd91d097a \
+    # via pyobjc, pyobjc-framework-vision
+pyobjc-framework-coremotion==6.2 \
+    --hash=sha256:900c6e16dd7591635195c3a69473b4d2ff976e83cd1c500881a422ff916ce658 \
+    --hash=sha256:a0560a34f898fbbbb06c99b44f6542e4af0f1d71b9723b7562daf0e386219c40 \
+    # via pyobjc
+pyobjc-framework-coreservices==6.2 \
+    --hash=sha256:9eda26223108190415cd528470a35d9633be215b32e50995d6c00c6e6a452272 \
+    --hash=sha256:c347b716af946221b83ba67f9e7cdb2e220ae2f11a267d03e99acf81e17e8551 \
+    # via pyobjc, pyobjc-framework-dictionaryservices, pyobjc-framework-launchservices, pyobjc-framework-searchkit
+pyobjc-framework-corespotlight==6.2 \
+    --hash=sha256:06c1e7abbf1e84d27d623182d57da031b67bf20bde05b34977de75f8b3c52222 \
+    --hash=sha256:b0e48669199ed1b84141a3e76325937556c96066086b092c18856f2ccef0d2ad \
+    # via pyobjc
+pyobjc-framework-coretext==6.2 \
+    --hash=sha256:a65723e7c08b1eebbeb1ed97cec070943bcef1df4caa2f9edeeeeff50f534559 \
+    --hash=sha256:e3484efc65deac453d0ff6f9070b2a5a928b351be8b0ffbd9b214eda9d93dc87 \
+    # via pyobjc
+pyobjc-framework-corewlan==6.2 \
+    --hash=sha256:6cfe548c083675db758a66632313bb7127ac415399b6e3453894526a2b8201bc \
+    --hash=sha256:ec34e40c10120f54cf8a102b7fc03749a203842d3903501179e56cce9d5d1656 \
+    # via pyobjc
+pyobjc-framework-cryptotokenkit==6.2 \
+    --hash=sha256:ab77e6d63e94c408643c6ad0be56bf4f3efcecbc5ceb79d5d3353746cd17d222 \
+    --hash=sha256:e75a3f7e11541a5196242c03b5ba78900c6d621946a0a7ab8de126de92ef7261 \
+    # via pyobjc
+pyobjc-framework-devicecheck==6.2 \
+    --hash=sha256:48e4b8e739ee1d91531386f551c203e8e603babbd2b6de3776353083a46325f8 \
+    --hash=sha256:ade7e5fbae5b46d892e0bbe5d9a65cafe3464d9ae72343a03f870b67b5a0cf91 \
+    # via pyobjc
+pyobjc-framework-dictionaryservices==6.2 \
+    --hash=sha256:099a49d044b7db056dfd798cd45110adf6e83c504e06f21cb54012872da6fe71 \
+    --hash=sha256:3c33f509ea615d3d32ad3789ef6d2ef074d0f7422fec0c14402834397db85141 \
+    # via pyobjc
+pyobjc-framework-discrecording==6.2 \
+    --hash=sha256:441a77edfcb7f4bdb1e30ff9d864cce5e0b835c1ba3be02af21c7612af5cdde5 \
+    --hash=sha256:cd722935dd1f3dcf457e20fa67e183eb89e196ee2b9d85f6a52bfc90831d656d \
+    # via pyobjc, pyobjc-framework-discrecordingui
+pyobjc-framework-discrecordingui==6.2 \
+    --hash=sha256:7b3a7f9e9023470d6070a91858192f94748d0bc060667b29b48bce029e696298 \
+    --hash=sha256:a034cd37e95ae143bbad352adb6e8ebe2ff816555c94ce7ec667f4d3019465ec \
+    # via pyobjc
+pyobjc-framework-diskarbitration==6.2 \
+    --hash=sha256:2dfc773967583572bde365364a9b1ed1ca8a6ae41850d87aa8fc9911a66f6678 \
+    --hash=sha256:a6e1119a7c09ba5f88abcaa13d93a9a78d56a6e78479f1f7cc0a24cd934c50f3 \
+    # via pyobjc
+pyobjc-framework-dvdplayback==6.2 \
+    --hash=sha256:8519d0d74d3cbaa117f91591bbd3bd22f8d4b280604f8f8c28c95ef8eaa23e32 \
+    --hash=sha256:a20afec285de36b623bb504622586ceb46b0794496f1016e22346fda22290ce9 \
+    # via pyobjc
+pyobjc-framework-eventkit==6.2 \
+    --hash=sha256:15b4523e303f924250f3f0b09d37eaee63b3ff5400aa96a0dca543231aba70e0 \
+    --hash=sha256:c9eca8149aaf69dbcd2807685c5325942744b96fbfffb41eb190fa6b1843277c \
+    # via pyobjc
+pyobjc-framework-exceptionhandling==6.2 \
+    --hash=sha256:033415d9cca0c3b5a1ea14d1beb9598c49bcea6491e7eeee841786cb20ce4ecd \
+    --hash=sha256:eb48177ca81fdce6727266e94324cbaab5e22a70e065726709ffd98ecbe6f1fa \
+    # via pyobjc
+pyobjc-framework-executionpolicy==6.2 \
+    --hash=sha256:b1cac389a4d0d0f9df5bb225ebd9f41e531be0082cda7a95b62bae1341825b4b \
+    --hash=sha256:f944b2355aa6c09847035bbb01a4209c6ed0fe2265775cfda60fd7c382ba1f5d \
+    # via pyobjc
+pyobjc-framework-externalaccessory==6.2 \
+    --hash=sha256:4d5d66d5ba5d374a21a1b651ccf0de5e0379ef52436749932cea59782f656198 \
+    --hash=sha256:6df3d4046ed23a5ff87bc177ce881f791d762ea60052174882d47d9289ddb5a6 \
+    # via pyobjc
+pyobjc-framework-fileprovider==6.2 \
+    --hash=sha256:723da7b860127da38d32b6cf0188274c93427a8c2e857b9b958337f30f95585b \
+    --hash=sha256:d1f1f963275f0cd3ded2cd4012d056f4fc020e0b8f2a42b18dd8522aa2e01d5b \
+    # via pyobjc, pyobjc-framework-fileproviderui
+pyobjc-framework-fileproviderui==6.2 \
+    --hash=sha256:8feb0dd2a1b82156c083f65731893dc435f1b9538ebca40a45b02c1570867b09 \
+    --hash=sha256:de36c2f757322158d8f179045569e408bf33590c5a673a20b4d576d76202da79 \
+    # via pyobjc
+pyobjc-framework-findersync==6.2 \
+    --hash=sha256:b3a338ec557bb8c8800fe9b9b595fe05c92353d18264793495fe656c0e44f955 \
+    --hash=sha256:c90da6da3ceb11a2d8b811098883a6507032935095d0c1838c80ca5c7deabf04 \
+    # via pyobjc
+pyobjc-framework-fsevents==6.2 \
+    --hash=sha256:dbe66ac66e6425af20b5790c630e31d630320fb201c6b81800635ff1143efc9b \
+    --hash=sha256:e61f7f31bdc8cb4857d379d03dfc7eb8077b5b66e19bddae94ab53202a87f27e \
+    # via pyobjc, pyobjc-framework-coreservices
+pyobjc-framework-gamecenter==6.2 \
+    --hash=sha256:b4e8f4748d319adb65e2a7eed59b1b2ceef43d62b4062c39c4051ec616369d58 \
+    --hash=sha256:cdf98ad1586c96572699561788aa8a9d0dda11d7f0c0562adaf99d8feddf0f3b \
+    # via pyobjc
+pyobjc-framework-gamecontroller==6.2 \
+    --hash=sha256:2e9f3dda5e03766c7cb6b6781bd3564da839c3e1c40cca9a9bda99b54593c030 \
+    --hash=sha256:7fb65a62c38203c899a9c76bd261a79b19312aa78831579c6a72766eb6cef83f \
+    # via pyobjc
+pyobjc-framework-gamekit==6.2 \
+    --hash=sha256:47c7b6093ad787df5af6bf6f1f48c46209c112722fc5ad5bb7cc97730e8e05b4 \
+    --hash=sha256:e4f9ff9fae66dc4fc1bba327794396b479ea5bae1f6366493d2c5ffe5aa96934 \
+    # via pyobjc
+pyobjc-framework-gameplaykit==6.2 \
+    --hash=sha256:a999d34fe49a586608e5046cc759848978ce1d41e406e7fb77fb5376df8faaad \
+    --hash=sha256:f75e3577d56b4d7f4e96ea45a87685632006e6c7f5a130370ec2c33ec49be013 \
+    # via pyobjc
+pyobjc-framework-imagecapturecore==6.2 \
+    --hash=sha256:7f40b5b6c1859ff5589dfd00073fb94bde59c7567a455cd25f088cf0f84bf7f5 \
+    --hash=sha256:a796f5b37b954883a7216ba357dfba73cf6cf326279ab47e70e518b2767f258a \
+    # via pyobjc
+pyobjc-framework-imserviceplugin==6.2 \
+    --hash=sha256:1d5c866a13f883c5a549822c344fa49b431929e7fac7a1e536cf82ccbeae4523 \
+    --hash=sha256:ffb120ba42f1c96fa0162edaece443d2d8fd0c81c198dd85aa75d3bce84bc527 \
+    # via pyobjc
+pyobjc-framework-inputmethodkit==6.2 \
+    --hash=sha256:1f1c7620be47af72fb450ee391f7d3300d19859dad7f2c94fb5d29ee37fd9437 \
+    --hash=sha256:300caed9d7a6ea092ff24c90e19497bffe6d0cd176849ada51644596e2d1f6a3 \
+    # via pyobjc
+pyobjc-framework-installerplugins==6.2 \
+    --hash=sha256:3671b6d6408fb1af538eaba0e343afc9a9fa2dee73cd539396804d6993152123 \
+    --hash=sha256:701a76acbcba53051ef12e2bd45bc1c30f9eff22c388a8e18a7dd7331b1bb924 \
+    # via pyobjc
+pyobjc-framework-instantmessage==6.2 \
+    --hash=sha256:31daa2f6a2476262d256fc13a5c905f4605637fc12ff0f7187021fa8be7749ee \
+    --hash=sha256:6b4f3ec559262d3007c67f9705a8c7720cb30a4ec63983ab70c5e4d031cbb47b \
+    # via pyobjc
+pyobjc-framework-intents==6.2 \
+    --hash=sha256:1f55e8032313e45c7db3d2ba24f14214c2655ee3ca51c83181cc261a0e91928a \
+    --hash=sha256:31bc71555313a0a0d45b3a9baa6cd3381a96125a1cc5710a25d3071ef20d772a \
+    # via pyobjc
+pyobjc-framework-iosurface==6.2 \
+    --hash=sha256:97f05ba88ebed6e83dd822458096040b37ff7e011e49788ed868bc7cd9424ed4 \
+    --hash=sha256:b935b19855432521649f62d324adeda5f1f9e2edf79a3f655e245abff0f7e7d2 \
+    # via pyobjc
+pyobjc-framework-ituneslibrary==6.2 \
+    --hash=sha256:a0eae36d650c49259a0283e0bed08cafad236b248b811f40a9465603ccab548d \
+    --hash=sha256:e673853879a72979796f132351f229b0ddb80877623a79fe9ef101dd475edc1a \
+    # via pyobjc
+pyobjc-framework-latentsemanticmapping==6.2 \
+    --hash=sha256:17766d38ba25dd941316fcda5f12bd0338c65888cb0e95aadd1ccf4e3b3ebdc1 \
+    --hash=sha256:e6a7f73adebbc049eeea8bb25d5645aab8d9ceb70c7f833545ff847d2c0be1ba \
+    # via pyobjc
+pyobjc-framework-launchservices==6.2 \
+    --hash=sha256:77f3d5e0b94763a20e902cf873392694bd6291720efc7c506f771e9d3f4c6013 \
+    --hash=sha256:f431b88e4aceded7bfbfb201f88a7bed9403bdf20134eb1faa202c12d0fe58a4 \
+    # via pyobjc
+pyobjc-framework-libdispatch==6.2 \
+    --hash=sha256:016e688a7d60651f0413aff5381e86dc26016e34a2c07d50038bb8c770abe9ee \
+    --hash=sha256:1a7ff5b5a62d98e3ff98c6720847546c23b6fc566519c0b3d68da8f3a3ee2b71 \
+    --hash=sha256:4593cec44be53fd8b028d605fe29832a7881db24d7b5da96aa208f4666a369b8 \
+    --hash=sha256:9dd883d536c39c0592b60fe24b5d527862eda54a3dc3d46f5847e2718d88d917 \
+    --hash=sha256:c6cfad2f252d2bf1f18d93ae9dca09813020cbfa73ddf6fa233757d572a44b41 \
+    # via pyobjc
+pyobjc-framework-linkpresentation==6.2 \
+    --hash=sha256:67c33246bfd7788bc67e5fb3930aa1140a4194907546cde4442632ee9606d312 \
+    --hash=sha256:97d86ef9dff8fb31dc597f260b3371e92d85790c3c4a4680c13ce947d28c17aa \
+    # via pyobjc
+pyobjc-framework-localauthentication==6.2 \
+    --hash=sha256:012ed3b36be55889b387f2f2c5c06694f4bb0489e2227734a6bfeffa04b2a489 \
+    --hash=sha256:6994d4ffacafe2b491af8742bf32246d7fda1b18d95351538cec5700961ed3c9 \
+    # via pyobjc
+pyobjc-framework-mapkit==6.2 \
+    --hash=sha256:3cab3e5138f3c0329df2f475cc9ebf57e5d014cac5ac8523a1bfd8bf38012dc6 \
+    --hash=sha256:485f0e6e287b36f5a458da1f014b52b4f0e9870fedc85dc3f2938f59f9138a0d \
+    # via pyobjc
+pyobjc-framework-mediaaccessibility==6.2 \
+    --hash=sha256:7263f10546dc0f571376f4a8105e8fca853beed4a6b9b8a109db2dca3f83425e \
+    --hash=sha256:f9889619625ad15feab00b2ff018b36f0c240cf200c2cfd7d0693eb6a1f034fe \
+    # via pyobjc
+pyobjc-framework-medialibrary==6.2 \
+    --hash=sha256:251e61433faffd127714e53f037ded5fdef02183e7587c9d1d27bd6d6b2fae40 \
+    --hash=sha256:49b00059d16d83ad5fe5c91915bdcbcf24a81366b70164fc3aa7b1cb798a487f \
+    # via pyobjc
+pyobjc-framework-mediaplayer==6.2 \
+    --hash=sha256:12c8cf0e19e89f0ddf2bfd2886952c672b3896123b55a3bf6c84b4fed774beda \
+    --hash=sha256:ef01d6853263a73ff123db348e4ac344d68487f2111d0bcb7119530b2bd06197 \
+    # via pyobjc
+pyobjc-framework-mediatoolbox==6.2 \
+    --hash=sha256:863bb4f77b1e9f49513f99f7423739185abe0de2e458b0bbf35c14f104f3eb05 \
+    --hash=sha256:e48bfbafa5c6a5b9b174ed4b54625328adada0149ec6d4f0110e90c49a341169 \
+    # via pyobjc
+pyobjc-framework-metal==6.2 \
+    --hash=sha256:9b4fc1669e03449b709ec64ef5b4e60fcfef85f80eeaccf574d4843eaa52d761 \
+    --hash=sha256:b68935631ccdeb9a7f09b10cdcc0fc744f8c09913eef8aa82b9c65ddd84de94e \
+    # via pyobjc, pyobjc-framework-metalkit
+pyobjc-framework-metalkit==6.2 \
+    --hash=sha256:aace7ceb1e69f0696fd2156b795fc18c30458c7b89fd2ddf53556ccd58875d29 \
+    --hash=sha256:df2fc94086c0b6122cdfe0fbaddf807223e272330df97f6c4142d67260ccef6e \
+    # via pyobjc
+pyobjc-framework-modelio==6.2 \
+    --hash=sha256:5d40d247afe14be9486dd4007a37bff86d2c7ea559fb5cfbf4ef0d1de098b20a \
+    --hash=sha256:e2fb0ac457c82dc0b3c43fc6236c2ba006d0608187d6dc9e3b0739ab43927fad \
+    # via pyobjc
+pyobjc-framework-multipeerconnectivity==6.2 \
+    --hash=sha256:b08991c2bf802532709f214a2d72dd7d04496560e99a9e4dc7aae546802d8de1 \
+    --hash=sha256:d95e6e1dbb757013733850944720329921485b13d9cbb41b9b156379ae72d4d7 \
+    # via pyobjc
+pyobjc-framework-naturallanguage==6.2 \
+    --hash=sha256:0f127ab97a5d3d9ef0182869061794d8b1789b8c1739bb905fc437f29b63a849 \
+    --hash=sha256:308332c89956c13de24b5fb2401b4ae945330e6529ccf3477a1c2137e580680b \
+    # via pyobjc
+pyobjc-framework-netfs==6.2 \
+    --hash=sha256:671352eac4606ab3ed617e0e63c187f131d3dbf481cee24f56ed5f206ebf47d7 \
+    --hash=sha256:e637a1a872e4a039257dabd729a40be6544c7fc091f5d51637e9c0c22c5970dd \
+    # via pyobjc
+pyobjc-framework-network==6.2 \
+    --hash=sha256:1fc5ea3cfe7ef343df7f52c1c2055dca13879d0ac3f75ce1f3efcdcbe036548f \
+    --hash=sha256:882e6aaae2a3545e26d8079dde8faeba9cd8d9e41c0157f3ef5cc768f143092a \
+    # via pyobjc
+pyobjc-framework-networkextension==6.2 \
+    --hash=sha256:1d53b0dbdf413f87fa62620b84fca2ffc1b67f134bf611e078160194cf64641e \
+    --hash=sha256:5e15c6f0bd0387f6d9ad8382aa07b922a55125534a8e585f0f855301967b9a27 \
+    # via pyobjc
+pyobjc-framework-notificationcenter==6.2 \
+    --hash=sha256:81acbb211302ab95ce79d25b0774dd2394680b5cc3871e8713c64d055533489b \
+    --hash=sha256:968d743c585f105050d871cc8bc8e7302ff96dd79bd63d2d6dd130584dc5399d \
+    # via pyobjc
+pyobjc-framework-opendirectory==6.2 \
+    --hash=sha256:0958e18f40af84e994abdad75aa0ac8af96b79bbfa6dbfaaa6b188deb9c6549e \
+    --hash=sha256:4802308b5b5aebf1a99b9fd9578e60285586800e59cffbd7ac007626455dac19 \
+    # via pyobjc
+pyobjc-framework-osakit==6.2 \
+    --hash=sha256:52ccb0af719f5cbbb188db7dcfaf3677a37efaf47e4d7ea63b3b970c76724356 \
+    --hash=sha256:cbb53ab89983451a60cde3393121d5a5786a4b7c1deaec7ddfdbd3404c3eee02 \
+    # via pyobjc
+pyobjc-framework-oslog==6.2 \
+    --hash=sha256:18dd8093e7531210fe12f9425229ae2392ab83bc30e697d97cf6e4a26ef23357 \
+    --hash=sha256:23ce893877d2f5befa7b0f7088cce069f0134f1685d12a6c4b2111716c949427 \
+    # via pyobjc
+pyobjc-framework-pencilkit==6.2 \
+    --hash=sha256:3f7cf2b5ca25c88e434e6eacf6b39e65a79c44e2bda956adc144bd9e8923ef6b \
+    --hash=sha256:a9a3f9e6dbd1c9a33155b7db2b61e171d617b2e69ba4d7a5ad9970cb4f1148a6 \
+    # via pyobjc
+pyobjc-framework-photos==6.2 \
+    --hash=sha256:a037f2fc5bc3d2cd6a20f32a6e41543ef85404a1e120cec8d2e795d6ec690b9a \
+    --hash=sha256:f3b59418a7b80d195b235d88068befda50a07616e6e5d81dc5a364547183b84c \
+    # via pyobjc
+pyobjc-framework-photosui==6.2 \
+    --hash=sha256:01468c445f77d76fb9f5edc3929d25030e1ce5386cc953d0aa90ca64f0c6aeda \
+    --hash=sha256:50be57218fa3ac2545314396553b7a59f404e8220d60cc9cb7f857384b169314 \
+    # via pyobjc
+pyobjc-framework-preferencepanes==6.2 \
+    --hash=sha256:bd68df8fbf8923fd4a9ca7a2d0fc0b7b088f7a66b06d1339206505b49597819a \
+    --hash=sha256:c6e1878e7b585b881f7042e323480cb4dd9ceaee3a9efcb00cb972ffeb46aa18 \
+    # via pyobjc
+pyobjc-framework-pubsub==6.2 \
+    --hash=sha256:18e85b78a14baea119c8d59147aef67119533d1bebb30cc69ffede4ed5f65a70 \
+    --hash=sha256:f65f05375cea2fd0589e6b6fd927b0c6c74e384ce396da584b68d5581577d828 \
+    # via pyobjc
+pyobjc-framework-pushkit==6.2 \
+    --hash=sha256:baed8ebaa084a20eb68c9397201fadcfd892cebcfc202807f77e3df145131ddc \
+    --hash=sha256:e25f049dc3521406b5280f3329f4e6a7147fc092bbe3435b4d2920cf026965fa \
+    # via pyobjc
+pyobjc-framework-quartz==6.2 \
+    --hash=sha256:08ebaa3a9f4cf5a4de89e0df50d5bd535706900471f14ac42a3f4af1a7398ebb \
+    --hash=sha256:2b64baf09bde8864f5d858b51a28b724ea908638f30b50d5b3f1f82f0dc4835e \
+    --hash=sha256:5133eef934143ed68014d73f7b3b8113441b3631d7a2c17f66839ea4b426c518 \
+    --hash=sha256:5250961ce781d6f9ee65486cd206cf6a7814b27e9e3eef1a73032cfb69ec4e5f \
+    --hash=sha256:906fb0d35e63057157816409b4eb0503ef1fa8e1a0a7176b637905076434379c \
+    # via pyobjc, pyobjc-framework-applicationservices, pyobjc-framework-avfoundation, pyobjc-framework-avkit, pyobjc-framework-coretext, pyobjc-framework-gamekit, pyobjc-framework-instantmessage, pyobjc-framework-linkpresentation, pyobjc-framework-mapkit, pyobjc-framework-medialibrary, pyobjc-framework-modelio, pyobjc-framework-oslog, pyobjc-framework-quicklookthumbnailing, pyobjc-framework-scenekit, pyobjc-framework-spritekit, pyobjc-framework-videotoolbox, pyobjc-framework-vision
+pyobjc-framework-quicklookthumbnailing==6.2 \
+    --hash=sha256:4221bd67f38a163628a2e581328b319dc1aece0381859e33d8de94951a6520fa \
+    --hash=sha256:b3376402e410915a27c00f98631430d146dc60dbf53bc1720ece5ac6f0cfd148 \
+    # via pyobjc
+pyobjc-framework-safariservices==6.2 \
+    --hash=sha256:4a5ab6d9c4d4089456edaa82d5549b40725f14f6507091255fc7d228ff84d9d3 \
+    --hash=sha256:4cfe104faeacf5eecec37fe05fb8eb43e8239fc2207fe60ad558408d0a2df8ab \
+    # via pyobjc
+pyobjc-framework-scenekit==6.2 \
+    --hash=sha256:a249ca4c218068815c6a0a0000788b0d861226de3ec81fbabc58e802ce6f1c2c \
+    --hash=sha256:b6a026a35294a284c39687a9b2be007586d0a9739d9c604b9fea6f2ef6fcbfd3 \
+    # via pyobjc
+pyobjc-framework-screensaver==6.2 \
+    --hash=sha256:b65d427821ee319fc1a08e5b741747496f2cfea59f4e285e5fbdda9ad9abb1ba \
+    --hash=sha256:eb1751ca8a04b2b5f5be5d7348db8c933e83619bdc7aff4fdcaa53cc147447c9 \
+    # via pyobjc
+pyobjc-framework-scriptingbridge==6.2 \
+    --hash=sha256:30262d16390af4c15647473966d1cd20480e83dca337a55f474076c991dce009 \
+    --hash=sha256:b5798691be4f876354b0da6e60974d65245f216f2f30edf58e874f59a02fd3d9 \
+    # via pyobjc
+pyobjc-framework-searchkit==6.2 \
+    --hash=sha256:34fb3bae3a4fefedd286c87545065c0b79b105273989715a3378d474b1c72a67 \
+    --hash=sha256:eb83a0de184a8dba0f4b3a0973c00529d3f78cea46a9112cf91e4a870408a8f0 \
+    # via pyobjc
+pyobjc-framework-security==6.2 \
+    --hash=sha256:0ee1e55ce1e2120eea752c8bfdc003e0b206d50301c4fb29ce47dc8b0fbc14d4 \
+    --hash=sha256:2c5e5bf37e22317a82bd6d37ecc088db92ba81a9b9da99b31131dbf2e2751808 \
+    # via pyobjc, pyobjc-framework-securityfoundation, pyobjc-framework-securityinterface
+pyobjc-framework-securityfoundation==6.2 \
+    --hash=sha256:8e9b6e29bc0dd0476dd34365a2eb53e0495aaf6f6778933f8d698e02e9aad889 \
+    --hash=sha256:ff63ed66ca9a2830bdad7128ec5c279535c19a347439b89fa8922347e7f77602 \
+    # via pyobjc
+pyobjc-framework-securityinterface==6.2 \
+    --hash=sha256:44b59e57d8c1a1bfadd5e17c3cdf361f84cc7afdaabc7333394d0276d4c85f53 \
+    --hash=sha256:a9e0eed51c5d247150742bd4d8e9fe6418ca56156165d92334a3d76320de7dc8 \
+    # via pyobjc
+pyobjc-framework-servicemanagement==6.2 \
+    --hash=sha256:7bc4e9e6fa8d3adf0c96cb6bb5ed3c8ebbd6c8139a4aeff4f4f9d8ec037ce724 \
+    --hash=sha256:effd5288f1b74290cdfaafefc228f1acf302236cd83b220136fe8a1316971df9 \
+    # via pyobjc
+pyobjc-framework-social==6.2 \
+    --hash=sha256:630843cd9000b3b679e2ea3f85d43bf4bf42a5016a36f11bef2bf714f91d2c20 \
+    --hash=sha256:8893048833e89d5f637fafae86ab1f16017ccd7767560849a096bc83f511d9c7 \
+    # via pyobjc
+pyobjc-framework-soundanalysis==6.2 \
+    --hash=sha256:716174fc66c0957ff4540c253babc751121f06d4fede815d02d2e5e281bee904 \
+    --hash=sha256:d43907be509f76dcc64e43b5abc66265d6d02e9fed11611796c4fcc2417e0f12 \
+    # via pyobjc
+pyobjc-framework-speech==6.2 \
+    --hash=sha256:46b37dd881c61da88f1718723cc433e7d93b2f66ed3f1fa835135dbe8fe1e44a \
+    --hash=sha256:5a05ceaf046a59df62b126d35a5af346dc7b29bda60a0566cfad80b20004ef5e \
+    # via pyobjc
+pyobjc-framework-spritekit==6.2 \
+    --hash=sha256:84f71a12559505e6b83950281ef9f639abaef34dcd6f940f2ec72ca099ff4d68 \
+    --hash=sha256:c52b23097fcce1580b7337292c8cd5c04f87b8f500da7f31d2a681e314bbbb9b \
+    # via pyobjc, pyobjc-framework-gameplaykit
+pyobjc-framework-storekit==6.2 \
+    --hash=sha256:8b641448aa18802f9b4dfe02869a3d4c32d6fa942438add973aec52d6460672b \
+    --hash=sha256:b5bd177b6b0a02e32c2ae4dae18c6a914536d1f131a0e62cb0393e54359f483a \
+    # via pyobjc
+pyobjc-framework-syncservices==6.2 \
+    --hash=sha256:219981cfa7f032fe7411bd78bbe9366eee8b47f8f21225de1a1451d314a9b2ee \
+    --hash=sha256:bbf485127c22d49fc2e75e502a2862239fd9d51a46fb9ddbf95d25e728fc0c4a \
+    # via pyobjc
+pyobjc-framework-systemconfiguration==6.2 \
+    --hash=sha256:3d6b293a159d6a73d6393b01a5d6c7e646e120c1c3b821c051527048058c66c3 \
+    --hash=sha256:99a4b127925ed99958b28ad6fae95f764fe821be62e033b48d7b2d71c28fe58b \
+    # via pyobjc
+pyobjc-framework-systemextensions==6.2 \
+    --hash=sha256:501d98115cf676c1a9c3c7971792a231a17374a89babc1cc6f0f1a9488b5b843 \
+    --hash=sha256:836e8201b1584f8d2b7bbb5e3a1d112e76ff754165b9a6e8804abf3f0a260b25 \
+    # via pyobjc
+pyobjc-framework-usernotifications==6.2 \
+    --hash=sha256:76caf647bb9da878ab16cad0b92ac503b2420fd98044356ce01c2ebdc69efb42 \
+    --hash=sha256:c2b0376e49317ad79f3535048537701cbfd8be937700e5ea0667d5c189bb1716 \
+    # via pyobjc
+pyobjc-framework-videosubscriberaccount==6.2 \
+    --hash=sha256:17faf37adc4493f15abde2b10a724616656cc660251a531a0b3f5fd27c6c1a18 \
+    --hash=sha256:2b471fdd15c7e86fce1fc6e6a838d52291d059dab47543d0a17fb859982698f7 \
+    # via pyobjc
+pyobjc-framework-videotoolbox==6.2 \
+    --hash=sha256:0b0bbef1561e8bd5847a052233f87082827acdbcacad6e332084e631e4c5a2ea \
+    --hash=sha256:c630965f25d6ca5557bc9712adcf3221ec3b2664751b528618f2e0cba7781872 \
+    # via pyobjc
+pyobjc-framework-vision==6.2 \
+    --hash=sha256:4fdf0304e3ca266a4feddcc1c1ce491ffde25a4649193061e9f80bf9d7888565 \
+    --hash=sha256:51d1eabbdc4676720d44886af99a78de07cb69b23c1f519aa1de0ac2188ef5ab \
+    # via pyobjc
+pyobjc-framework-webkit==6.2 \
+    --hash=sha256:b7f04248bafdf22dfb2ce1556c0cfabe6ab42f28d3fe46002683f65ae1dd646c \
+    --hash=sha256:f977ba7ef4e48dc3174e35d4997f5c4d6963f6bf9a9c9b2d37bde5ac6e9b3dc2 \
+    # via pyobjc
+pyobjc==6.2 ; platform_system == "Darwin" \
+    --hash=sha256:6b514136f538fb5c9c80e310641907d0196c8381602395ac2ee407f32f07ba13 \
+    --hash=sha256:93c42e0b6e5355256da6615ded3a8023de2716f02a16e589fda0d9bf7e42900e \
+    # via -r requirements/dev-requirements.in, pyautogui
 pyparsing==2.4.7 \
     --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
     --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b \
@@ -331,9 +806,6 @@ python-dateutil==2.7.5 \
 python-editor==1.0.3 \
     --hash=sha256:a3c066acee22a1c94f63938341d4fb374e3fdd69366ed6603d7b24bed1efc565 \
     # via -r requirements/requirements.in, alembic
-python3-xlib==0.15 \
-    --hash=sha256:dc4245f3ae4aa5949c1d112ee4723901ade37a96721ba9645f2bfa56e5b383f8 \
-    # via mouseinfo, pyautogui
 pytweening==1.0.3 \
     --hash=sha256:4b608a570f4dccf2201e898f643c2a12372eb1d71a3dbc7e778771b603ca248b \
     # via pyautogui
@@ -383,6 +855,10 @@ requests==2.22.0 \
     --hash=sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4 \
     --hash=sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31 \
     # via -r requirements/requirements.in, securedrop-sdk
+rubicon-objc==0.4.0 \
+    --hash=sha256:010a567ecc1c5891ce1edee7b7b305648b8bc97fb3da4c5745d20c4b5fadf45f \
+    --hash=sha256:a54be431be212c95106b3f9dbb3903fd96683caca926613ba7dd8b4605cb87cc \
+    # via mouseinfo
 securedrop-sdk==0.2.0 \
     --hash=sha256:c4a343077e8c0a38914e17f6369b830f1e361f9d66699b20803c07b39472357f \
     # via -r requirements/requirements.in


### PR DESCRIPTION
# Description

Related to https://github.com/freedomofpress/securedrop-client/pull/1172 , some requirements were dropped from the requirements file due to lack of access to a mac computer.

# Test Plan

- [ ] pip install --require-hashes --no-deps -r requirements/dev-mac-requirements.txt works and the client dev env is working on a Mac
- [ ] No other requirements files were changed

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
