### PR TITLE
Fix journalist association bug in draftreplies

### DIFF
--- a/tests/migrations/utils.py
+++ b/tests/migrations/utils.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 from sqlalchemy import text
 from sqlalchemy.orm.session import Session
 
-from securedrop_client.db import DownloadError, Source
+from securedrop_client.db import DownloadError, ReplySendStatus, Source
 
 random.seed("ᕕ( ᐛ )ᕗ")
 
@@ -287,5 +287,50 @@ def mark_reply_as_seen(session: Session, reply_id: int, journalist_id: int):
     sql = """
     INSERT INTO seen_replies (reply_id, journalist_id)
     VALUES (:reply_id, :journalist_id)
+    """
+    session.execute(text(sql), params)
+
+
+def add_draft_reply(session: Session, journalist_id: int, source_id: int) -> None:
+    reply_send_statuses = session.query(ReplySendStatus).all()
+    reply_send_status_ids = [reply_send_status.id for reply_send_status in reply_send_statuses]
+
+    content = random_chars(1000)
+
+    source = session.query(Source).filter_by(id=source_id).one()
+
+    file_counter = len(source.collection) + 1
+
+    params = {
+        "uuid": str(uuid4()),
+        "journalist_id": journalist_id,
+        "source_id": source_id,
+        "file_counter": file_counter,
+        "content": content,
+        "send_status_id": random.choice(reply_send_status_ids),
+        "timestamp": random_datetime(),
+    }
+
+    sql = """
+    INSERT INTO draftreplies
+    (
+        uuid,
+        journalist_id,
+        source_id,
+        file_counter,
+        content,
+        send_status_id,
+        timestamp
+    )
+    VALUES
+    (
+        :uuid,
+        :journalist_id,
+        :source_id,
+        :file_counter,
+        :content,
+        :send_status_id,
+        :timestamp
+    )
     """
     session.execute(text(sql), params)


### PR DESCRIPTION
(cherry picked from commit 824e0a2c1fe147ca25f66455aecef953a4a05f92)

# Description

Fixes #1185, backport changes from #1184

# Test Plan

- [ ] CI is passing
- [ ] Migration successful
- [ ] Conflicts in backport have been successfully resolved

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [x] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [x] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed
