### PR TITLE
Source widget ui polish

### DIFF
--- a/securedrop_client/resources/css/sdclient.css
+++ b/securedrop_client/resources/css/sdclient.css
@@ -150,7 +150,7 @@
 #MainView_view_holder {
     min-width: 500;
     border: none;
-    background-color: #f3f5f9;
+    background-color: #f9f9ff;
 }
 
 #EmptyConversationView QLabel {
@@ -187,11 +187,11 @@ QListView#SourceList {
 }
 
 QListView#SourceList::item:selected {
-    background-color: #f3f5f9;
+    background-color: rgba(244, 245, 255, 0.84);
 }
 
-QListView#SourceList::item:hover{
-    border: 500px solid #f9f9f9;
+QListView#SourceList::item:hover {
+    border: 500px solid #f9f9ff;
 }
 
 #SourceWidget_container {
@@ -204,15 +204,6 @@ QListView#SourceList::item:hover{
 
 #StarToggleButton {
     border: none;
-}
-
-#SourceWidget_gutter {
-    min-width: 40px;
-    max-width: 40px;
-}
-
-#SourceWidget_metadata {
-    max-width: 60px;
 }
 
 #SourceWidget_source_deleted {
@@ -242,7 +233,7 @@ QListView#SourceList::item:hover{
 }
 
 #ReplyBoxWidget_replybox::disabled {
-    background-color: #efefef;
+    background-color: #ffffff;
 }
 
 #ReplyBoxWidget QPushButton {
@@ -266,6 +257,14 @@ QWidget#ReplyBoxWidget_horizontal_line {
     font-weight: 400;
     font-size: 18px;
     border: none;
+}
+
+#ReplyTextEdit::disabled {
+    font-family: 'Montserrat';
+    font-weight: 400;
+    font-size: 18px;
+    border: none;
+    background-color: #ffffff;
 }
 
 #ReplyTextEditPlaceholder_text {
@@ -317,11 +316,11 @@ QToolButton#SourceMenuButton::menu-indicator {
 
 #ConversationScrollArea {
     border: 0;
-    background: #f3f5f9;
+    background: #f9f9ff;
 }
 
 #ConversationScrollArea_conversation {
-    background: #f3f5f9;
+    background: #f9f9ff;
 }
 
 #FileWidget {
@@ -360,7 +359,7 @@ QLabel#FileWidget_no_file_name {
     font-family: 'Source Sans Pro';
     font-weight: 300;
     font-size: 13px;
-    color: #a5b3e9;
+    color: #7481b4;
 }
 
 QLabel#FileWidget_file_size {

--- a/securedrop_client/resources/css/source_name.css
+++ b/securedrop_client/resources/css/source_name.css
@@ -11,3 +11,10 @@
     font-size: 13px;
     color: #000;
 }
+
+#SourceWidget_name_selected {
+    font-family: 'Montserrat';
+    font-weight: 500;
+    font-size: 13px;
+    color: #2a319d;
+}

--- a/securedrop_client/resources/css/source_preview.css
+++ b/securedrop_client/resources/css/source_preview.css
@@ -7,7 +7,7 @@
 
 #SourceWidget_preview_unread {
     font-family: 'Source Sans Pro';
-    font-weight: 600;
+    font-weight: 500;
     font-size: 13px;
     color: #000;
 }

--- a/securedrop_client/resources/css/speech_bubble_message.css
+++ b/securedrop_client/resources/css/speech_bubble_message.css
@@ -5,6 +5,19 @@
     background-color: #fff;
     color: #3b3b3b;
     padding: 16px;
+    border-top: 1px solid rgba(211, 216, 234, 0.55);
+    border-right: 1px solid rgba(211, 216, 234, 0.55);
+}
+
+#SpeechBubble_reply {
+    font-family: 'Source Sans Pro';
+    font-weight: 400;
+    font-size: 15px;
+    background-color: #fff;
+    color: #3b3b3b;
+    padding: 16px;
+    border-top: 1px solid rgba(211, 216, 234, 0.55);
+    border-left: 1px solid rgba(211, 216, 234, 0.55);
 }
 
 #ReplyWidget_message_pending {
@@ -14,6 +27,8 @@
     color: #a9aaad;
     background-color: #f7f8fc;
     padding: 16px;
+    border-top: 1px solid rgba(211, 216, 234, 0.55);
+    border-left: 1px solid rgba(211, 216, 234, 0.55);
 }
 
 #ReplyWidget_message_failed {
@@ -23,6 +38,8 @@
     background-color: #fff;
     color: #3b3b3b;
     padding: 16px;
+    border-top: 1px solid rgba(211, 216, 234, 0.55);
+    border-left: 1px solid rgba(211, 216, 234, 0.55);
 }
 
 #ReplyWidget_message_decryption_error {
@@ -33,6 +50,8 @@
     background-color: rgba(255, 255, 255, 0.6);
     color: #3b3b3b;
     padding: 16px;
+    border-top: 1px solid rgba(211, 216, 234, 0.55);
+    border-left: 1px solid rgba(211, 216, 234, 0.55);
 }
 
 #SpeechBubble_message_decryption_error {
@@ -43,4 +62,6 @@
     background-color: rgba(255, 255, 255, 0.6);
     color: #3b3b3b;
     padding: 16px;
+    border-top: 1px solid rgba(211, 216, 234, 0.55);
+    border-left: 1px solid rgba(211, 216, 234, 0.55);
 }

--- a/securedrop_client/resources/images/paperclip.svg
+++ b/securedrop_client/resources/images/paperclip.svg
@@ -1,11 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="18px" height="18px" viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 52.3 (67297) - http://www.bohemiancoding.com/sketch -->
-    <title>Fill 1</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Spex" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="ICONZZZ" transform="translate(-297.000000, -100.000000)" fill="#383838">
-            <path d="M296,108.5 C296,105.46 298.46,103 301.5,103 L312,103 C314.21,103 316,104.79 316,107 C316,109.21 314.21,111 312,111 L303.5,111 C302.12,111 301,109.88 301,108.5 C301,107.12 302.12,106 303.5,106 L311,106 L311,108 L303.41,108 C302.86,108 302.86,109 303.41,109 L312,109 C313.1,109 314,108.1 314,107 C314,105.9 313.1,105 312,105 L301.5,105 C299.57,105 298,106.57 298,108.5 C298,110.43 299.57,112 301.5,112 L311,112 L311,114 L301.5,114 C298.46,114 296,111.54 296,108.5" id="Fill-1" transform="translate(306.000000, 108.500000) rotate(-128.000000) translate(-306.000000, -108.500000) "></path>
-        </g>
-    </g>
-</svg>
+<svg width="11" height="17" viewBox="0 0 11 17" xmlns="http://www.w3.org/2000/svg"><title>  Group 3</title><defs><polygon points="0 0 11 0 11 17 0 17"/></defs><g fill="none"><g transform="translate(-496 -9)translate(496 9)"><mask fill="white"></mask><path d="M0 4C0 3.8-0.1 2.2 1 1 1.4 0.5 2.2 0 3.5 0 5.7 0 7 1.7 7 4.3L7 10.4 4.9 10.4 4.9 4.3C4.9 2.9 4.4 2.1 3.5 2.1 2.8 2.1 2.6 2.4 2.5 2.5 2.1 2.9 2.1 3.6 2.1 3.9L2.3 11.5C2.5 13.8 3.6 14.9 5.7 14.9 6.7 14.9 7.4 14.6 7.9 14.1 9 13 8.9 11.1 8.9 11.1L8.9 5.9 11 5.9 11 11C11 11.1 11.1 13.8 9.5 15.5 8.5 16.5 7.3 17 5.7 17 2.8 17 0.2 15.3 0.2 11.8L0 4Z" mask="url(#mask-2)" fill="#353535"/></g></g></svg>

--- a/tests/integration/test_styles_sdclient.py
+++ b/tests/integration/test_styles_sdclient.py
@@ -70,12 +70,9 @@ def test_class_name_matches_css_object_name(mocker, main_window):
 
     source_widget = source_list.itemWidget(source_list.item(0))
     assert "SourceWidget" == source_widget.__class__.__name__
-    assert "SourceWidget" in source_widget.gutter.objectName()
-    assert "SourceWidget" in source_widget.summary.objectName()
     assert "SourceWidget" in source_widget.name.objectName()
     assert "SourceWidget" in source_widget.preview.objectName()
     assert "SourceWidget" in source_widget.waiting_delete_confirmation.objectName()
-    assert "SourceWidget" in source_widget.metadata.objectName()
     assert "SourceWidget" in source_widget.paperclip.objectName()
     assert "SourceWidget" in source_widget.timestamp.objectName()
     assert "SourceWidget" in source_widget.source_widget.objectName()
@@ -231,7 +228,7 @@ def test_styles_for_main_view(mocker, main_window):
     main_view = main_window.main_view
     assert 558 == main_view.height()
     assert 500 == main_view.view_holder.width()
-    assert "#f3f5f9" == main_view.view_holder.palette().color(QPalette.Background).name()
+    assert "#f9f9ff" == main_view.view_holder.palette().color(QPalette.Background).name()
 
     no_sources = main_view.empty_conversation_view.no_sources
     assert 5 == no_sources.layout().count()
@@ -295,9 +292,6 @@ def test_styles_for_main_view(mocker, main_window):
 def test_styles_source_list(mocker, main_window):
     source_list = main_window.main_view.source_list
     source_widget = source_list.itemWidget(source_list.item(0))
-    assert 40 == source_widget.gutter.minimumSize().width()
-    assert 40 == source_widget.gutter.maximumSize().width()
-    assert 60 == source_widget.metadata.maximumSize().width()
     preview = source_widget.preview
     assert "Source Sans Pro" == preview.font().family()
     QFont.Normal == preview.font().weight()
@@ -312,7 +306,7 @@ def test_styles_source_list(mocker, main_window):
     assert "Montserrat" == name.font().family()
     QFont.Normal == name.font().weight()
     13 == name.font().pixelSize()
-    assert "#383838" == name.palette().color(QPalette.Foreground).name()
+    assert "#2a319d" == name.palette().color(QPalette.Foreground).name()
     timestamp = source_widget.timestamp
     assert "Montserrat" == timestamp.font().family()
     QFont.Normal == timestamp.font().weight()
@@ -330,7 +324,8 @@ def test_styles_for_conversation_view(mocker, main_window):
     reply_box = wrapper.reply_box
     assert 173 == reply_box.minimumSize().height()
     assert 173 == reply_box.maximumSize().height()
-    assert "#efefef" == reply_box.replybox.palette().color(QPalette.Background).name()
+    assert "#ffffff" == reply_box.replybox.palette().color(QPalette.Background).name()
+    assert "#ffffff" == reply_box.text_edit.palette().color(QPalette.Background).name()
     reply_box.set_logged_in()
     assert "#ffffff" == reply_box.replybox.palette().color(QPalette.Background).name()
     reply_box_children = reply_box.findChildren(QPushButton)
@@ -350,6 +345,7 @@ def test_styles_for_conversation_view(mocker, main_window):
     assert QFont.Normal == reply_text_edit.font().weight()
     assert 18 == reply_text_edit.font().pixelSize()
     assert (0, 0, 0, 0) == reply_text_edit.getContentsMargins()
+
     # See test_placeholder.py for placeholder tests
 
     conversation_title_bar = wrapper.conversation_title_bar
@@ -374,8 +370,8 @@ def test_styles_for_conversation_view(mocker, main_window):
     assert "#2a319d" == title.palette().color(QPalette.Foreground).name()
 
     conversation_scrollarea = wrapper.conversation_view.scroll
-    assert "#f3f5f9" == conversation_scrollarea.palette().color(QPalette.Background).name()
-    assert "#f3f5f9" == conversation_scrollarea.widget().palette().color(QPalette.Background).name()
+    assert "#f9f9ff" == conversation_scrollarea.palette().color(QPalette.Background).name()
+    assert "#f9f9ff" == conversation_scrollarea.widget().palette().color(QPalette.Background).name()
     file_widget = conversation_scrollarea.widget().layout().itemAt(0).widget()
     assert 540 == file_widget.minimumSize().width()
     assert 540 == file_widget.maximumSize().width()
@@ -391,7 +387,7 @@ def test_styles_for_conversation_view(mocker, main_window):
     assert "Source Sans Pro" == file_widget.no_file_name.font().family()
     assert QFont.Light + 12 == file_widget.no_file_name.font().weight()
     assert 13 == file_widget.no_file_name.font().pixelSize()
-    assert "#a5b3e9" == file_widget.no_file_name.palette().color(QPalette.Foreground).name()
+    assert "#7481b4" == file_widget.no_file_name.palette().color(QPalette.Foreground).name()
 
     assert 48 == file_widget.file_size.minimumSize().width()
     assert 48 == file_widget.file_size.maximumSize().width()


### PR DESCRIPTION
# Description

Resolves https://github.com/freedomofpress/securedrop-client/issues/1174

# Test Plan

1. Log into the client select sources and see source name turn blue when selected
2. Log out and verify the same behavior ^
3. Compare layout to https://scene.zeplin.io/project/5c807ea562f734bd2756b243/screen/5f35fbb85de1037e11c88dab or the image in #1174 (make sure it's zoomed out to 100% to match the client size)
