### PR TITLE
Client 0.4.0 qa bug fix

### DIFF
--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -194,10 +194,12 @@ class Message(Base):
     @property
     def seen(self) -> bool:
         """
-        If the submission has been downloaded or seen by any journalist, then the submssion is
-        considered seen.
+        If the message has seen by any journalist, then the message is considered seen.
+
+        The `is_read` boolean is used in order to recognize messages that have been downloaded
+        before SecureDrop 1.6.0 (before the seen-by feature).
         """
-        if self.seen_messages.count():
+        if self.seen_messages.count() or self.is_read:
             return True
 
         return False
@@ -293,10 +295,12 @@ class File(Base):
     @property
     def seen(self) -> bool:
         """
-        If the submission has been downloaded or seen by any journalist, then the submssion is
-        considered seen.
+        If the file has been seen by any journalist, then the file is considered seen.
+
+        The `is_read` boolean is used in order to recognize files that have been downloaded before
+        SecureDrop 1.6.0 (before the seen-by feature).
         """
-        if self.seen_files.count():
+        if self.seen_files.count() or self.is_read:
             return True
 
         return False

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -276,6 +276,7 @@ def __update_submissions(
                     size=submission.size,
                     filename=submission.filename,
                     download_url=submission.download_url,
+                    is_read=submission.is_read,
                 )
                 session.add(ns)
                 session.flush()


### PR DESCRIPTION
# Description

Towards #1189 

Fixes issue caught here during QA:

> Global read/unread
>    - :x: A source shows up as read (not bold) when someone other than the logged-in user has read the source from the web JI

# Test Plan

* See the regression tests adding to this PR fail on `main` but succeed on the PR branch.
* See that both STRs [reported by @eloquence during QA](https://github.com/freedomofpress/securedrop-client/issues/1189#issuecomment-741423671) are fixed:

## STR 1
1. Download all submissions of an unseen source via the JI as a user who has _never sent a reply_
### Expected
The source is no longer bold in the source list of the client
### Actual
The source remains bold

## STR 2
1. Set `downloaded` to `1` for a message of an unseen source on the server db - make sure no seen records exist for this message.
2. Download all submissions of the unseen source via the JI
### Expected
The source is no longer bold in the source list of the client
### Actual
The source remains bold

(repeat STR 2 for a file instead of a message)

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed
