### PR TITLE
set is_authenticated first on login success

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -469,6 +469,10 @@ class Controller(QObject):
         """
         Handles a successful authentication call against the API.
         """
+        # First set is_authenticated before calling GUI methods or emitting signals to the GUI
+        # since the GUI has to check authentication state in several places.
+        self.is_authenticated = True
+
         logger.info("{} successfully logged in".format(self.api.username))
         self.gui.hide_login()
         user = storage.create_or_update_user(
@@ -488,7 +492,6 @@ class Controller(QObject):
         self.update_sources()
         self.api_job_queue.start(self.api)
         self.api_sync.start(self.api)
-        self.is_authenticated = True
 
     def on_authenticate_failure(self, result: Exception) -> None:
         # Failed to authenticate. Reset state with failure message.
@@ -505,13 +508,15 @@ class Controller(QObject):
         """
         Allow user to view in offline mode without authentication.
         """
+        # First set is_authenticated before calling GUI methods or emitting signals to the GUI
+        # since the GUI has to check authentication state in several places.
+        self.is_authenticated = False
         self.gui.hide_login()
         # Clear clipboard contents in case of previously pasted creds (user
         # may have attempted online mode login, then switched to offline)
         self.gui.clear_clipboard()
         self.gui.show_main_window()
         storage.mark_all_pending_drafts_as_failed(self.session)
-        self.is_authenticated = False
         self.update_sources()
         self.show_last_sync()
         self.show_last_sync_timer.start(TIME_BETWEEN_SHOWING_LAST_SYNC_MS)


### PR DESCRIPTION
# Description

Fixes issue reported during QA by @eloquence:

> *However, note that when going online, I have to wait until the next sync for the change to be correct again.*

### STR
Log into the client
#### Expected
For the client to immediately display sources as seen/unseen according to what's in the local db
#### Actual
The client displays the sources as all seen until the first sync completes

(Also test by starting off in offline mode then switching to online mode. And test once more by logging out and logging back in - do not close the client.)

# Test Plan

Test the the STRs above are now seeing the expected state.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed
