### PR TITLE
 scale source list and preview as window resizes

### DIFF
--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -148,6 +148,9 @@ class SvgLabel(QLabel):
 
 
 class SecureQLabel(QLabel):
+
+    MAX_PREVIEW_LENGTH = 200
+
     def __init__(
         self,
         text: str = "",
@@ -168,12 +171,16 @@ class SecureQLabel(QLabel):
     def setText(self, text: str) -> None:
         text = text.strip()
         self.setTextFormat(Qt.PlainText)
+        self.preview_text = text[: self.MAX_PREVIEW_LENGTH]
         elided_text = self.get_elided_text(text)
         self.elided = True if elided_text != text else False
         if self.elided and self.with_tooltip:
             tooltip_label = SecureQLabel(text)
             self.setToolTip(tooltip_label.text())
         super().setText(elided_text)
+
+    def refresh_preview_text(self) -> None:
+        self.setText(self.preview_text)
 
     def get_elided_text(self, full_text: str) -> str:
         if not self.max_length:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -596,8 +596,8 @@ class MainView(QWidget):
         self.view_layout.addWidget(self.empty_conversation_view)
 
         # Add widgets to layout
-        self.layout.addWidget(self.source_list)
-        self.layout.addWidget(self.view_holder)
+        self.layout.addWidget(self.source_list, stretch=1)
+        self.layout.addWidget(self.view_holder, stretch=2)
 
         # Note: We should not delete SourceConversationWrapper when its source is unselected. This
         # is a temporary solution to keep copies of our objects since we do delete them.
@@ -802,8 +802,10 @@ class SourceList(QListWidget):
     """
 
     NUM_SOURCES_TO_ADD_AT_A_TIME = 32
+    INITIAL_UPDATE_SCROLLBAR_WIDTH = 20
 
     source_selected = pyqtSignal(str)
+    adjust_preview = pyqtSignal(int)
 
     def __init__(self):
         super().__init__()
@@ -815,11 +817,18 @@ class SourceList(QListWidget):
         layout = QVBoxLayout(self)
         self.setLayout(layout)
 
+        # Disable horizontal scrollbar for SourceList widget
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+
         # Enable ordering.
         self.setSortingEnabled(True)
 
         # To hold references to SourceListWidgetItem instances indexed by source UUID.
         self.source_items = {}
+
+    def resizeEvent(self, event):
+        self.adjust_preview.emit(event.size().width())
+        super().resizeEvent(event)
 
     def setup(self, controller):
         self.controller = controller
@@ -876,13 +885,14 @@ class SourceList(QListWidget):
         # Add widgets for new sources
         for uuid in sources_to_add:
             source_widget = SourceWidget(
-                self.controller, sources_to_add[uuid], self.source_selected
+                self.controller, sources_to_add[uuid], self.source_selected, self.adjust_preview
             )
             source_item = SourceListWidgetItem(self)
             source_item.setSizeHint(source_widget.sizeHint())
             self.insertItem(0, source_item)
             self.setItemWidget(source_item, source_widget)
             self.source_items[uuid] = source_item
+            self.adjust_preview.emit(self.width() - self.INITIAL_UPDATE_SCROLLBAR_WIDTH)
 
         # Re-sort SourceList to make sure the most recently-updated sources appear at the top
         self.sortItems(Qt.DescendingOrder)
@@ -905,6 +915,7 @@ class SourceList(QListWidget):
 
         def schedule_source_management(slice_size=slice_size):
             if not sources:
+                self.adjust_preview.emit(self.width() - self.INITIAL_UPDATE_SCROLLBAR_WIDTH)
                 return
 
             # Process the remaining "slice_size" number of sources.
@@ -912,7 +923,9 @@ class SourceList(QListWidget):
             for source in sources_slice:
                 try:
                     source_uuid = source.uuid
-                    source_widget = SourceWidget(self.controller, source, self.source_selected)
+                    source_widget = SourceWidget(
+                        self.controller, source, self.source_selected, self.adjust_preview
+                    )
                     source_item = SourceListWidgetItem(self)
                     source_item.setSizeHint(source_widget.sizeHint())
                     self.insertItem(0, source_item)
@@ -975,6 +988,28 @@ class SourceList(QListWidget):
             source_widget.set_snippet(source_uuid, collection_item_uuid, content)
 
 
+class SourcePreview(SecureQLabel):
+    PREVIEW_WIDTH_DIFFERENCE = 140
+
+    def __init__(self):
+        super().__init__()
+
+    def adjust_preview(self, width):
+        """
+        This is a workaround to the workaround for https://bugreports.qt.io/browse/QTBUG-85498.
+        Since QLabels containing text with long strings that cannot be wrapped have to have a fixed
+        width in order to fit within the scroll list widget, we have to override the normal resizing
+        logic.
+        """
+        new_width = width - self.PREVIEW_WIDTH_DIFFERENCE
+        if self.width() == new_width:
+            return
+
+        self.setFixedWidth(new_width)
+        self.max_length = self.width()
+        self.refresh_preview_text()
+
+
 class SourceWidget(QWidget):
     """
     Used to display summary information about a source in the list view.
@@ -983,9 +1018,6 @@ class SourceWidget(QWidget):
     TOP_MARGIN = 11
     BOTTOM_MARGIN = 7
     SIDE_MARGIN = 10
-    PREVIEW_WIDTH = 360
-    PREVIEW_WIDGET_WIDTH = 380
-    PREVIEW_WIDGET_HEIGHT = 22
     SPACER = 14
     BOTTOM_SPACER = 11
     STAR_WIDTH = 20
@@ -995,7 +1027,13 @@ class SourceWidget(QWidget):
     SOURCE_PREVIEW_CSS = load_css("source_preview.css")
     SOURCE_TIMESTAMP_CSS = load_css("source_timestamp.css")
 
-    def __init__(self, controller: Controller, source: Source, source_selected_signal: pyqtSignal):
+    def __init__(
+        self,
+        controller: Controller,
+        source: Source,
+        source_selected_signal: pyqtSignal,
+        adjust_preview: pyqtSignal,
+    ):
         super().__init__()
 
         self.controller = controller
@@ -1003,15 +1041,14 @@ class SourceWidget(QWidget):
         self.controller.source_deletion_failed.connect(self._on_source_deletion_failed)
         self.controller.authentication_state.connect(self._on_authentication_changed)
         source_selected_signal.connect(self._on_source_selected)
+        adjust_preview.connect(self._on_adjust_preview)
 
-        # Store source
         self.source = source
         self.seen = self.source.seen
         self.source_uuid = self.source.uuid
         self.last_updated = self.source.last_updated
         self.selected = False
 
-        # Set cursor.
         self.setCursor(QCursor(Qt.PointingHandCursor))
 
         retain_space = self.sizePolicy()
@@ -1021,14 +1058,10 @@ class SourceWidget(QWidget):
         self.star.setFixedWidth(self.STAR_WIDTH)
         self.name = QLabel()
         self.name.setObjectName("SourceWidget_name")
-        self.preview = SecureQLabel(max_length=self.PREVIEW_WIDTH)
+        self.preview = SourcePreview()
         self.preview.setObjectName("SourceWidget_preview")
-        self.preview.setFixedSize(QSize(self.PREVIEW_WIDGET_WIDTH, self.PREVIEW_WIDGET_HEIGHT))
         self.waiting_delete_confirmation = QLabel("Deletion in progress")
         self.waiting_delete_confirmation.setObjectName("SourceWidget_source_deleted")
-        self.waiting_delete_confirmation.setFixedSize(
-            QSize(self.PREVIEW_WIDGET_WIDTH, self.PREVIEW_WIDGET_HEIGHT)
-        )
         self.waiting_delete_confirmation.hide()
         self.paperclip = SvgLabel("paperclip.svg", QSize(11, 17))  # Set to size provided in the svg
         self.paperclip.setObjectName("SourceWidget_paperclip")
@@ -1056,9 +1089,9 @@ class SourceWidget(QWidget):
         source_widget_layout.setSpacing(0)
         source_widget_layout.setContentsMargins(0, self.TOP_MARGIN, 0, self.BOTTOM_MARGIN)
         source_widget_layout.addWidget(self.star, 0, 0, 1, 1)
-        self.spacer_widget = QWidget()
-        self.spacer_widget.setFixedWidth(self.SPACER)
-        source_widget_layout.addWidget(self.spacer_widget, 0, 1, 1, 1)
+        self.spacer = QWidget()
+        self.spacer.setFixedWidth(self.SPACER)
+        source_widget_layout.addWidget(self.spacer, 0, 1, 1, 1)
         source_widget_layout.addWidget(self.name, 0, 2, 1, 1)
         source_widget_layout.addWidget(self.paperclip, 0, 3, 1, 1)
         source_widget_layout.addWidget(self.preview, 1, 2, 1, 1, alignment=Qt.AlignLeft)
@@ -1075,6 +1108,11 @@ class SourceWidget(QWidget):
         layout.addWidget(self.source_widget)
 
         self.update()
+
+    @pyqtSlot(int)
+    def _on_adjust_preview(self, width):
+        self.setFixedWidth(width)
+        self.preview.adjust_preview(width)
 
     def update(self):
         """
@@ -1117,6 +1155,7 @@ class SourceWidget(QWidget):
             content = str(last_activity)
 
         self.preview.setText(content)
+        self.preview.adjust_preview(self.width())
 
     def delete_source(self, event):
         if self.controller.api is None:
@@ -2886,7 +2925,6 @@ class ConversationScrollArea(QScrollArea):
     def __init__(self):
         super().__init__()
 
-        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setWidgetResizable(True)
 
         self.setObjectName("ConversationScrollArea")

--- a/securedrop_client/resources/css/sdclient.css
+++ b/securedrop_client/resources/css/sdclient.css
@@ -182,7 +182,7 @@ QListView#SourceList {
     border: none;
     show-decoration-selected: 0;
     border-right: 3px solid #f3f5f9;
-    min-width: 500px;
+    min-width: 400px;
     max-width: 540px;
 }
 
@@ -191,7 +191,7 @@ QListView#SourceList::item:selected {
 }
 
 QListView#SourceList::item:hover {
-    border: 500px solid #f9f9ff;
+    background-color: #f9f9ff;
 }
 
 #SourceWidget_container {


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/1207
Towards scalable client
Merge before https://github.com/freedomofpress/securedrop-client/pull/1206
Known issue: #815

# Test Plan

1. Run the client against a server with some sources
2. Log in
3. Select a source and resize the client window, try double clicking and resizing to the smallest width and height
    - [ ] Confirm there is never horizontal scrollbar in the source list
    - [ ] Confirm that preview adjusts width as you resize the client window
4. Replace existing sources with 200 new sources while still logged in
    - [ ] Confirm there is never horizontal scrollbar in the source list
    - [ ] Confirm that preview adjusts width as you resize the client window (make sure to scroll down the source list as the previews are updating and resize)
5. Log out
    - [ ] Confirm there is never horizontal scrollbar in the source list
    - [ ] Confirm that preview adjusts width as you resize the client window
6. Close client and log in in offline mode
    - [ ] Ensure https://github.com/freedomofpress/securedrop-client/issues/1207 is fixed
7. Log in, restart the server with new sources, wait until the client picks up the new sources and creates new source widgets while logged in
    - [ ] Confirm there is never horizontal scrollbar in the source list
    - [ ] Confirm that preview adjusts width as you resize the client window
    

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed
