### PR TITLE
Remove obsolete MIME setup in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -47,11 +47,6 @@ if [[ -n "$is_qubes" ]]; then
     echo "Detected QubesOS, enabling DispVMs for submission handling..."
     qubes_flag=""
 
-    # Ensure we have mime handlers for open-in-dvm
-    local_apps_dir="$HOME/.local/share/applications"
-    mkdir -p "$local_apps_dir"
-    cp files/open-in-dvm.desktop "$local_apps_dir"
-
     # Ensure desktop files are read from local dir
     export XDG_CONFIG_HOME="$PWD/files"
 else


### PR DESCRIPTION
# Description

Fixes #1214.

# Test Plan

- `make venv`
- `. .venv/bin/activate`
- `./run.sh`

The client should start.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
