### PR TITLE
Prevent event handler from being triggered twice

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2295,8 +2295,6 @@ class FileWidget(QWidget):
         file_ready_signal.connect(self._on_file_downloaded, type=Qt.QueuedConnection)
         file_missing.connect(self._on_file_missing, type=Qt.QueuedConnection)
 
-        self.installEventFilter(self)
-
     def adjust_width(self, container_width):
         """
         This is a workaround to the workaround for https://bugreports.qt.io/browse/QTBUG-85498.


### PR DESCRIPTION
# Description

Fixes #1217 

# Test Plan

Must be tested in Qubes or with local modifications, as clicking files in a development environment will have no effect.

1. Run the SecureDrop client from this branch
2. Connect to a server with file submissions
3. Download a file submission and attempt to open it
- [ ] Observe that only a single diposable VM is opened
- [ ] Observe that print/export actions still start dialogs as expected
4. Resize the client window to its minimum size
5. Observe that #1061 and #1204 are still fixed and that there are no regressions in resize behavior.

# Checklist

 - [x] I have tested these changes in the appropriate Qubes environment
 - [x] No update to the AppArmor profile is required for these changes
 - [x] No database schema changes are needed
