### PR TITLE
Remove nonexistent Python 3.5 path

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -16,8 +16,6 @@ fileConfig(config.config_file_name)
 # add your model's MetaData object here
 # for 'autogenerate' support
 sys.path.insert(0, path.realpath(path.join(path.dirname(__file__), '..')))
-# This path is purely for alembic to work on the packaged application
-sys.path.insert(1, "/opt/venvs/securedrop-client/lib/python3.5/site-packages")
 from securedrop_client.db import Base  # noqa
 target_metadata = Base.metadata
 


### PR DESCRIPTION
# Description

Our virtualenv is based on Python 3.7, so this path does not in fact exist on the `sd-app` VM.

Note that this is an informational finding from the 2020 SecureDrop Workstation audit (`TOB-SDW-013`). Per the finding, the correct path already exists in `sys.path` at the time the incorrect path is inserted.

# Test Plan

1. Build a package from this branch and install it in `sd-app`
2. Initialize a fresh `.securedrop_client` directory in `sd-app`
3. Observe that migrations are still correctly applied

# Checklist
- [ ] I have tested these changes in the appropriate Qubes environment
- [x] No update to the AppArmor profile is required for these changes
- [x] No database schema changes are needed
