### PR TITLE
fix exporting twice on pressing the Enter key

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2535,9 +2535,8 @@ class ModalDialog(QDialog):
                 self.cancel_button.click()
             else:
                 self.continue_button.click()
-            event.ignore()  # Don't allow Enter to close dialog
-
-        super().keyPressEvent(event)
+        else:
+            super().keyPressEvent(event)
 
     def animate_activestate(self):
         self.continue_button.setIcon(QIcon(self.button_animation.currentPixmap()))


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/1240

# Test Plan

1. Export a file, any file, just press the Enter key (instead of clicking the Continue button) after typing in the password to unlock your luks-encrypted export device.
2. See that the file is no longer exported twice

Review issue #1240 and see if there are other ways to trigger a double export.