### PR TITLE
show outline for active unselected stars

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1041,7 +1041,7 @@ class SourceWidget(QWidget):
 
         retain_space = self.sizePolicy()
         retain_space.setRetainSizeWhenHidden(True)
-        self.star = StarToggleButton(self.controller, self.source_uuid, source.is_starred)
+        self.star = StarToggleButton(self.controller, self.source_uuid, source.is_starred, self.selected)
         self.star.setSizePolicy(retain_space)
         self.star.setFixedWidth(self.STAR_WIDTH)
         self.name = QLabel()
@@ -1182,6 +1182,8 @@ class SourceWidget(QWidget):
             self.preview.setObjectName("SourceWidget_preview_unread")
             self.preview.setStyleSheet(self.SOURCE_PREVIEW_CSS)
 
+        self.star.update_styles(self.selected)
+
     @pyqtSlot(bool)
     def _on_authentication_changed(self, authenticated: bool) -> None:
         """
@@ -1228,12 +1230,13 @@ class StarToggleButton(SvgToggleButton):
     A button that shows whether or not a source is starred
     """
 
-    def __init__(self, controller: Controller, source_uuid: str, is_starred: bool):
+    def __init__(self, controller: Controller, source_uuid: str, is_starred: bool, selected: bool):
         super().__init__(on="star_on.svg", off="star_off.svg", svg_size=QSize(16, 16))
 
         self.controller = controller
         self.source_uuid = source_uuid
         self.is_starred = is_starred
+        self.selected = selected
         self.pending_count = 0
         self.wait_until_next_sync = False
 
@@ -1293,7 +1296,10 @@ class StarToggleButton(SvgToggleButton):
         if t == QEvent.HoverEnter:
             self.setIcon(load_icon("star_hover.svg"))
         elif t == QEvent.HoverLeave or t == QEvent.MouseButtonPress:
-            self.set_icon(on="star_on.svg", off="star_off.svg")
+            if self.selected:
+                self.set_icon(on="star_on.svg", off="star_off_active.svg")
+            else:
+                self.set_icon(on="star_on.svg", off="star_off.svg")
 
         return QObject.event(obj, event)
 
@@ -1367,6 +1373,13 @@ class StarToggleButton(SvgToggleButton):
         """
         if self.source_uuid == source_uuid:
             self.pending_count = self.pending_count - 1
+
+    def update_styles(self, selected: bool) -> None:
+        self.selected = selected
+        if self.selected:
+            self.set_icon(on="star_on.svg", off="star_off_active.svg")
+        else:
+            self.set_icon(on="star_on.svg", off="star_off.svg")
 
 
 class DeleteSourceMessageBox:

--- a/securedrop_client/resources/images/star_off_active.svg
+++ b/securedrop_client/resources/images/star_off_active.svg
@@ -1,0 +1,1 @@
+<svg width="17" height="16" viewBox="0 0 17 16" xmlns="http://www.w3.org/2000/svg"><title>  Starre</title><desc>  Created with Sketch.</desc><g fill="none"><g style="fill:#FFF;stroke:#2A319D"><path d="M8.5 1.2L6.3 5.8 1.1 6.5 4.9 10 3.9 15 8.5 12.5 13.1 15 12.1 10 15.9 6.5 10.7 5.8 8.5 1.2Z"/></g></g></svg>


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/986

- [ ] Confirm unselected un-starred sources show stars with outlines now when that source is selected (meaning the source conversation is active)