### PR TITLE
fix flaky integrity errors during test

### DIFF
--- a/tests/factory.py
+++ b/tests/factory.py
@@ -218,21 +218,23 @@ def RemoteReply(**attrs):
 
 
 def RemoteFile(**attrs):
-    source_url = "/api/v1/sources/{}".format(str(uuid.uuid4()))
+    global FILE_COUNT
+    FILE_COUNT += 1
+    src_uuid = str(uuid.uuid4())
     defaults = dict(
-        source_uuid="user-uuid-1",
+        uuid="file-uuid-{}".format(FILE_COUNT),
+        filename="{}-doc.gz.gpg".format(FILE_COUNT),
+        source_uuid=src_uuid,
         download_url="test",
         submission_url="test",
-        filename="1-submission.filename",
         is_read=False,
-        file_counter=1,
+        file_counter=FILE_COUNT,
         is_deleted_by_source=False,
         reply_url="test",
         size=1234,
         is_decrypted=True,
         is_downloaded=True,
-        uuid=str(uuid.uuid4()),
-        source_url=source_url,
+        source_url=f"/api/v1/sources/{src_uuid}",
         seen_by=[],
     )
 
@@ -242,21 +244,23 @@ def RemoteFile(**attrs):
 
 
 def RemoteMessage(**attrs):
-    source_url = "/api/v1/sources/{}".format(str(uuid.uuid4()))
+    global MESSAGE_COUNT
+    MESSAGE_COUNT += 1
+    src_uuid = str(uuid.uuid4())
     defaults = dict(
-        source_uuid="user-uuid-1",
+        uuid="msg-uuid-{}".format(MESSAGE_COUNT),
+        filename="{}-msg.gpg".format(MESSAGE_COUNT),
+        source_uuid=src_uuid,
         download_url="test",
         submission_url="test",
-        filename="1-submission.filename",
         is_read=False,
-        file_counter=1,
+        file_counter=MESSAGE_COUNT,
         is_deleted_by_source=False,
         reply_url="test",
         size=1234,
         is_decrypted=True,
         is_downloaded=True,
-        uuid=str(uuid.uuid4()),
-        source_url=source_url,
+        source_url=f"/api/v1/sources/{src_uuid}",
         seen_by=[],
     )
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -951,16 +951,15 @@ def test_update_messages_marks_read_messages_as_seen_without_seen_records(homedi
 
     # Create a remote file that will be used to update one of the local files.
     remote_message_to_update = factory.RemoteMessage(
-        uuid=local_message_to_update.uuid, source_uuid=source.uuid, is_read=1
+        uuid=local_message_to_update.uuid,
+        source_uuid=source.uuid,
+        source_url="/api/v1/sources/{}".format(source.uuid),
+        is_read=1,
     )
 
     # Create a remote file that will be used to create a new local file.
     remote_message_to_create = factory.RemoteMessage(
-        source_uuid=source.uuid,
-        source_url="/api/v1/sources/{}".format(source.uuid),
-        file_counter=factory.FILE_COUNT + 1,
-        filename="{}-msg.gpg".format(2),
-        is_read=1,
+        source_uuid=source.uuid, source_url="/api/v1/sources/{}".format(source.uuid), is_read=1,
     )
 
     remote_messages = [remote_message_to_update, remote_message_to_create]
@@ -1024,6 +1023,7 @@ def test_update_messages_adds_seen_record(homedir, mocker, session):
     remote_message_to_update = factory.RemoteMessage(
         uuid=local_message_to_update.uuid,
         source_uuid=source.uuid,
+        source_url="/api/v1/sources/{}".format(source.uuid),
         seen_by=[journalist_1.uuid, journalist_2.uuid],
     )
 
@@ -1031,8 +1031,6 @@ def test_update_messages_adds_seen_record(homedir, mocker, session):
     remote_message_to_create = factory.RemoteMessage(
         source_uuid=source.uuid,
         source_url="/api/v1/sources/{}".format(source.uuid),
-        file_counter=factory.MESSAGE_COUNT + 1,
-        filename="{}-msg.gpg".format(factory.MESSAGE_COUNT + 1),
         seen_by=[journalist_1.uuid, journalist_2.uuid],
     )
 
@@ -1040,8 +1038,6 @@ def test_update_messages_adds_seen_record(homedir, mocker, session):
     remote_message_t0_create_with_unknown_journalist = factory.RemoteMessage(
         source_uuid=source.uuid,
         source_url="/api/v1/sources/{}".format(source.uuid),
-        file_counter=factory.MESSAGE_COUNT + 2,
-        filename="{}-msg.gpg".format(factory.MESSAGE_COUNT + 2),
         seen_by=["unknown-journalist-uuid"],
     )
 


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/1247

# Test Plan

Confirm that https://github.com/freedomofpress/securedrop-client/issues/1247 is fixed when testing locally.