### PR TITLE
make relpath traversal check clearer

### DIFF
--- a/securedrop_client/utils.py
+++ b/securedrop_client/utils.py
@@ -129,10 +129,11 @@ def check_path_traversal(filename_or_filepath: Union[str, Path]) -> None:
     relative paths, and absolute paths.
     """
     filename_or_filepath = Path(filename_or_filepath)
+
     if filename_or_filepath.is_absolute():
         base_path = filename_or_filepath
     else:
-        base_path = Path().resolve()
+        base_path = Path.cwd()  # use cwd so we can next ensure relative path does not traverse up
 
     try:
         relative_path = relative_filepath(filename_or_filepath, base_path)


### PR DESCRIPTION
# Description

Resolves https://github.com/freedomofpress/securedrop-client/issues/1227

Also first review and merge: https://github.com/freedomofpress/securedrop-export/pull/74

# Test Plan

- [x] ensure tests pass
- [x] ensure `Path().resolve() == Path.cwd()`
- [x] new code+comment is clearer?
