### PR TITLE
improve readability of test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,24 +67,25 @@ clean:  ## Clean the workspace of generated resources
 TESTS ?= tests
 ITESTS ?= tests/integration
 FTESTS ?= tests/functional
-TESTOPTS ?= -v
+TESTOPTS ?= -v --cov-config .coveragerc --cov-report html --cov-report term-missing --cov=securedrop_client --cov-fail-under 100
+
 .PHONY: test
 test: ## Run the application tests in parallel (for rapid development)
-	@TEST_CMD="python -m pytest -v -n 4 --ignore=$(FTESTS) --ignore=$(ITESTS) --cov-config .coveragerc --cov-report html --cov-report term-missing --cov=securedrop_client --cov-fail-under 100 $(TESTOPTS) $(TESTS)" ; \
+	@TEST_CMD="python -m pytest -v -n 4 --ignore=$(FTESTS) --ignore=$(ITESTS) $(TESTOPTS) $(TESTS)" ; \
 		if command -v xvfb-run > /dev/null; then \
 		xvfb-run -a $$TEST_CMD ; else \
 		$$TEST_CMD ; fi
 
 .PHONY: test-random
 test-random: ## Run the application tests in random order
-	@TEST_CMD="python -m pytest -v --ignore=$(FTESTS) --ignore=$(ITESTS) --random-order-bucket=global --cov-config .coveragerc --cov-report html --cov-report term-missing --cov=securedrop_client --cov-fail-under 100 $(TESTOPTS) $(TESTS)" ; \
+	@TEST_CMD="python -m pytest -v --random-order-bucket=global --ignore=$(FTESTS) --ignore=$(ITESTS) $(TESTOPTS) $(TESTS)" ; \
 		if command -v xvfb-run > /dev/null; then \
 		xvfb-run -a $$TEST_CMD ; else \
 		$$TEST_CMD ; fi
 
 .PHONY: test-integration
 test-integration: ## Run the integration tests
-	@TEST_CMD="python -m pytest -v -n 4	 $(TESTOPTS) $(ITESTS)" ; \
+	@TEST_CMD="python -m pytest -v -n 4 $(ITESTS)" ; \
 		if command -v xvfb-run > /dev/null; then \
 		xvfb-run -a $$TEST_CMD ; else \
 		$$TEST_CMD ; fi
@@ -116,7 +117,7 @@ bandit: ## Run bandit with medium level excluding test-related folders
 	bandit -ll --recursive . --exclude ./tests,./.venv
 
 .PHONY: check
-check: clean check-black check-isort bandit lint mypy test-random test-integration test-functional ## Run the full CI test suite
+check: clean check-black check-isort semgrep bandit lint mypy test-random test-integration test-functional ## Run the full CI test suite
 
 .PHONY: update-pip-requirements
 update-pip-requirements: ## Updates all Python requirements files via pip-compile for Linux.


### PR DESCRIPTION
# Description

Use `TESTOPTS` to improve readability.
Run semgrep in `make test` and `make test-random` which means we run semgrep in CI.

# Test Plan

- [ ] `make test` and `make test-random` still work
- [ ] confirm semgrep ran in CI