### PR TITLE
Minor fix Qt TAB order warning

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3346,15 +3346,15 @@ class ReplyBoxWidget(QWidget):
         self.send_button.setShortcut(QKeySequence("Ctrl+Return"))
         self.send_button.setDefault(True)
 
-        # Ensure TAB order from text edit -> send button
-        self.setTabOrder(self.text_edit, self.send_button)
-
         # Set cursor.
         self.send_button.setCursor(QCursor(Qt.PointingHandCursor))
 
         # Add widgets to replybox
         replybox_layout.addWidget(self.text_edit)
         replybox_layout.addWidget(self.send_button, alignment=Qt.AlignBottom)
+
+        # Ensure TAB order from text edit -> send button
+        self.setTabOrder(self.text_edit, self.send_button)
 
         # Add widgets
         main_layout.addWidget(horizontal_line)


### PR DESCRIPTION
# Description

**Summary**: Prevents a Qt warning from being printed to stderr when selecting each source from the list of sources for the first time. As far as I can tell, the TAB order was properly applied anyway, but it was an opportunity for me to start reading Qt code.

**Reproduction steps**

0. Checkout the `main` branch
1. Run the client: `./run.sh`
2. Log in (for example as `journalist`)
3. Select one or more sources from the list of sources
4. Observe that the following warning is printed to stderr the first time each source is selected:
    ```
    QWidget::setTabOrder: 'first' and 'second' must be in the same window
    ```

**Explanation**

The TAB order only makes sense when two widgets belong to the same parent. Because `QWidget::setTabOrder` only receives the widgets themselves as parameters, it relies implicitly on the widgets having been previously added to a common parent.
In this case, that happens when both widgets are added to the `replybox`.

# Test Plan

- [ ] Cross-check that the TAB order is applied as expected
- [ ] Verify that the warnings are indeed resolved

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
