### PR TITLE
Add CI job to make easier to spot linting issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,14 @@ common-steps:
         export PYTHONPATH=$PYTHONPATH:.  # so alembic can get to Base metadata
         make check --keep-going
 
+  - &run_lint
+    run:
+      name: Run lint, then static analysis on source code to find security issues
+      command: |
+        set -e
+        source .venv/bin/activate
+        make check-black check-isort lint bandit
+
   - &check_python_dependencies_for_vulns
     run:
       name: Check Python dependencies for known vulnerabilities
@@ -23,14 +31,6 @@ common-steps:
         set -e
         source .venv/bin/activate
         make safety
-
-  - &run_static_analysis
-    run:
-      name: Run static analysis on source code to find security issues
-      command: |
-        set -e
-        source .venv/bin/activate
-        make bandit
 
   - &install_packaging_dependencies
     run:
@@ -89,8 +89,8 @@ jobs:
       - checkout
       - run: sudo apt-get install -y sqlite3 libqt5x11extras5
       - *run_tests
+      - *run_lint
       - *check_python_dependencies_for_vulns
-      - *run_static_analysis
 
 workflows:
   version: 2


### PR DESCRIPTION
# Description

Adds a **Run lint** jobs to the CI pipeline, to make it easier to spot linting issues.

- I added the job to the `test-buster` group to take advantage of the fact that dependencies need to be installed for testing purposes.
    - **Trade-off**: while a separate `lint-buster` group could run concurrently, I don't like much the idea of spending CPU cycles downloading and installing dependencies too often. YMMV
- I added the job _after_ **Run tests**, because I'd likely fix the test suite first, then lint the code.
    - Note that on the other hand, linting is significantly faster than running the test suite. Depending on how automated code formatting / import sorting is in people's editors, it may be nicer to fail fast.
- I added the checks in the order they were run in `make check`.

Fixes https://github.com/freedomofpress/securedrop-client/issues/1212

# Test Plan

- [ ] Review the position of the **Run lint** job in the CI pipeline
- [ ] Review the list of linting tasks
- [ ] Review the order of the linting tasks
- [ ] Check that you can make the job fail when expected
- [ ] Is **Run lint** an adequate name?

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [x] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
