### PR TITLE
Introduce immediate sync upon source/conversation deletion

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -993,6 +993,7 @@ class Controller(QObject):
 
     def on_delete_conversation_success(self, uuid: str) -> None:
         logger.info("Conversation %s successfully deleted at server", uuid)
+        self.api_sync.sync()
 
     def on_delete_conversation_failure(self, e: Exception) -> None:
         if isinstance(e, DeleteConversationJobException):
@@ -1005,7 +1006,8 @@ class Controller(QObject):
         """
         Rely on sync to delete the source locally so we know for sure it was deleted
         """
-        pass
+        logger.info("Source %s successfully deleted at server", source_uuid)
+        self.api_sync.sync()
 
     def on_delete_source_failure(self, e: Exception) -> None:
         if isinstance(e, DeleteSourceJobException):

--- a/securedrop_client/sync.py
+++ b/securedrop_client/sync.py
@@ -42,11 +42,17 @@ class ApiSync(QObject):
 
         self.sync_thread.started.connect(self.api_sync_bg_task.sync)
 
+        self.timer = QTimer()
+        self.timer.setInterval(self.TIME_BETWEEN_SYNCS_MS)
+        self.timer.timeout.connect(self.sync)
+
     def start(self, api_client: API) -> None:
         """
         Start metadata syncs.
         """
         self.api_client = api_client
+
+        self.timer.start()
 
         if not self.sync_thread.isRunning():
             logger.debug("Starting sync thread")
@@ -68,14 +74,18 @@ class ApiSync(QObject):
         Start another sync on success.
         """
         self.sync_success.emit()
-        QTimer.singleShot(self.TIME_BETWEEN_SYNCS_MS, self.api_sync_bg_task.sync)
 
     def on_sync_failure(self, result: Exception) -> None:
         """
         Only start another sync on failure if the reason is a timeout request.
         """
         self.sync_failure.emit(result)
-        QTimer.singleShot(self.TIME_BETWEEN_SYNCS_MS, self.api_sync_bg_task.sync)
+
+    def sync(self) -> None:
+        """
+        Start an immediate sync.
+        """
+        QTimer.singleShot(1, self.api_sync_bg_task.sync)
 
 
 class ApiSyncBackgroundTask(QObject):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -158,14 +158,12 @@ def test_ApiSync_on_sync_failure(mocker, session_maker, homedir):
     """
     api_sync = ApiSync(mocker.MagicMock(), session_maker, mocker.MagicMock(), homedir)
     sync_failure = mocker.patch.object(api_sync, "sync_failure")
-    singleShot_fn = mocker.patch("securedrop_client.sync.QTimer.singleShot")
 
     error = Exception()
 
     api_sync.on_sync_failure(error)
 
     sync_failure.emit.assert_called_once_with(error)
-    singleShot_fn.assert_called_once_with(15000, api_sync.api_sync_bg_task.sync)
 
 
 @pytest.mark.parametrize("exception", [RequestTimeoutError, ServerConnectionError])
@@ -177,10 +175,8 @@ def test_ApiSync_on_sync_failure_because_of_timeout(mocker, session_maker, homed
     """
     api_sync = ApiSync(mocker.MagicMock(), session_maker, mocker.MagicMock(), homedir)
     sync_failure = mocker.patch.object(api_sync, "sync_failure")
-    singleShot_fn = mocker.patch("securedrop_client.sync.QTimer.singleShot")
     error = exception()
 
     api_sync.on_sync_failure(error)
 
     sync_failure.emit.assert_called_once_with(error)
-    singleShot_fn.assert_called_once_with(15000, api_sync.api_sync_bg_task.sync)


### PR DESCRIPTION
# Description

When we have confirmation that a conversation or source was successfully deleted on the server, schedule an immediate sync to get the change reflected in the UI as soon as possible.

# Test Plan

Run the client. Watch the logs. Verify that:

- [ ] the regularly scheduled syncs are still happening every 15 seconds.
- [ ] when deleting a source or its conversation, a sync is scheduled immediately, and the UI is updated very soon after deletion. It's helpful to delete immediately after a scheduled sync happens.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
