### PR TITLE
pypi.securedrop.org is no more

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ securedrop-client
 
 ## Updating dependencies
 
-`dev-requirements.txt` and `requirements.txt` point to python software foundation hashes, and `build-requirements.txt` points to our builds of the wheels from our own pip mirror (https://pypi.securedrop.org/). Whenever a dependency in `build-requirements.txt` changes, our team needs to manually review the code in the dependency diff with a focus on spotting vulnerabilities.
+`dev-requirements.txt` and `requirements.txt` point to python software foundation hashes, and `build-requirements.txt` points to our builds of the wheels from our own pip mirror (https://github.com/freedomofpress/securedrop-debian-packaging/tree/main/localwheels). Whenever a dependency in `build-requirements.txt` changes, our team needs to manually review the code in the dependency diff with a focus on spotting vulnerabilities.
 
 If you're adding or updating a dependency, you need to:
 


### PR DESCRIPTION
We've replaced pypi.securedrop.org with an LFS repo. Update README accordingly.