### PR TITLE
Update db/flag perms 700 -> 600

### DIFF
--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -37,8 +37,8 @@ Base = declarative_base(metadata=metadata)  # type: Any
 def make_session_maker(home: str) -> scoped_session:
     db_path = os.path.join(home, "svs.sqlite")
     engine = create_engine("sqlite:///{}".format(db_path))
-    if os.path.exists(db_path) and oct(os.stat(db_path).st_mode) != "0o100700":
-        os.chmod(db_path, 0o700)
+    if os.path.exists(db_path) and oct(os.stat(db_path).st_mode) != "0o100600":
+        os.chmod(db_path, 0o600)
     maker = sessionmaker(bind=engine)
     return scoped_session(maker)
 

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -362,9 +362,9 @@ class Controller(QObject):
         self.last_sync_filepath = os.path.join(home, "sync_flag")
         if (
             os.path.exists(self.last_sync_filepath)
-            and oct(os.stat(self.last_sync_filepath).st_mode) != "0o100700"
+            and oct(os.stat(self.last_sync_filepath).st_mode) != "0o100600"
         ):
-            os.chmod(self.last_sync_filepath, 0o700)
+            os.chmod(self.last_sync_filepath, 0o600)
 
     @property
     def is_authenticated(self) -> bool:

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -96,7 +96,7 @@ def test_Controller_init(homedir, config, mocker, session_maker):
         assert co.session_maker == session_maker
         assert co.api_threads == {}
         assert co.last_sync_filepath == insecure_sync_flag_path
-        assert oct(os.stat(co.last_sync_filepath).st_mode) == "0o100700"
+        assert oct(os.stat(co.last_sync_filepath).st_mode) == "0o100600"
 
 
 def test_Controller_setup(homedir, config, mocker, session_maker, session):


### PR DESCRIPTION


# Description

Fixes #1291 

Follow-up to [0]. The original intention was to remove perms for
group/other, which was accomplished, but we inadvertently added an
executable bit on these files, which shouldn't be there.

There are still a few 644-mode files created by the tests, but I consider these artifacts of the testing logic and not representative of behavior in prod. You can see yourself with:

```
$ find -s /tmp -type d -name 'sdc-*' | xargs -r rm -r # to make sure there are no old tmpdirs polluting results
$ make test
$ find /tmp -type f -iname 'svs.sqlite' | xargs stat -c %a | sort | uniq -c
    108 600
    178 644
$ find /tmp -type f -iname 'sync_flag' | xargs stat -c %a | sort | uniq -c
      3 600
      2 644
```

# Test Plan

Use the find/grep commands above and ensure you see zero 700-mode files. I don't think it's necessary to build a package as part of review: we can let the nightlies do that, and confirm on the test plan as part of QA check-ins.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes
 - [x] These changes should be tested in Qubes, but I haven't yet, and propose we do that as part of ongoing release QA

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
