### PR TITLE
includes compiled translation catalogs in Python source distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,4 +35,5 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     entry_points={"console_scripts": ["sd-client = securedrop_client.app:run"]},
+    package_data={"": ["locale/*/*/*.mo", "locale/*/*/*.po"]},
 )


### PR DESCRIPTION
# Description

*Draft pending ~#1282 #1302~ #1317*

Closes #1283 by ~overriding~ configuring `python setup.py sdist` to ~run and~ include the ~outputs of `make compile-translation-catalogs`~ gettext portable and machine catalogs produced by Weblate after #1348.

**Depends for merge on:**
1. [x] ~#1282~
2. [x] ~freedomofpress/securedrop-debian-packaging#270~
3. [x] Rebase out eaf7142b2066739bbf891c915371f70fbce5bedd
4. [x] #1302
5. [x] #1348

# Test Plan

1. [ ] Build a source distribution (`python setup.py sdist`) and Debian package (per `freedomofpress/securedrop-debian-packaging`) in this directory.  Confirm that `.po` and `.mo` files are listed in the output of both build processes.
2. [ ] Install the Debian package (e.g., in a disposable VM) and run `LANG=es_ES securedrop-client`.
3. [ ] Observe that the Client's UI is translated.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - I need help writing a database migration
 - [x] No database schema changes are needed
