### PR TITLE
run mypy on all .py files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-omit = securedrop_client/__init__.py

--- a/Makefile
+++ b/Makefile
@@ -39,23 +39,12 @@ check-isort: ## Check Python import organization with isort
 	@isort --check-only --diff --recursive ./
 
 .PHONY: mypy
-mypy: ## Run static type checker
-	@mypy --ignore-missing-imports securedrop_client
-	@# Add files that are 100% typed to the below call (eventually just the below line will run so that code without static type hints will fail CI)
+mypy: ## Run static type checker on all .py files in project
 	@mypy --ignore-missing-imports \
-		--disallow-incomplete-defs \
-		--disallow-untyped-defs \
-		securedrop_client/db.py \
-		securedrop_client/crypto.py \
-		securedrop_client/config.py \
-		securedrop_client/gui/__init__.py \
-		securedrop_client/resources/__init__.py \
-		securedrop_client/storage.py \
-		securedrop_client/queue.py \
-		securedrop_client/api_jobs/__init__.py \
-		securedrop_client/api_jobs/base.py \
-		securedrop_client/api_jobs/downloads.py \
-		securedrop_client/api_jobs/uploads.py
+		*.py \
+		**/*.py \
+		securedrop_client/**/*.py \
+		tests/**/*.py
 
 .PHONY: clean
 clean:  ## Clean the workspace of generated resources


### PR DESCRIPTION
# Description

Towards https://github.com/freedomofpress/securedrop-client/issues/25

Use regular expressions to run mypy against all .py files in root directory, tests/, and securerdop_client/. This makes it so that we don't have to manually update our makefile to include new files.

# Test Plan

- [ ] CI passes
