### PR TITLE
add more spacing between tear and other widgets

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3327,7 +3327,7 @@ class DeletedConversationItemsMarker(QWidget):
     """
 
     TOP_MARGIN = 28
-    BOTTOM_MARGIN = 0
+    BOTTOM_MARGIN = 4  # Add some spacing at the bottom between other widgets during scroll
 
     def __init__(self):
         super().__init__()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1968,7 +1968,7 @@ class SpeechBubble(QWidget):
     MIN_CONTAINER_WIDTH = 750
 
     TOP_MARGIN = 28
-    BOTTOM_MARGIN = 10
+    BOTTOM_MARGIN = 0
 
     def __init__(
         self,
@@ -2310,8 +2310,8 @@ class FileWidget(QWidget):
 
     DOWNLOAD_BUTTON_CSS = load_css("file_download_button.css")
 
-    TOP_MARGIN = 4
-    BOTTOM_MARGIN = 14
+    TOP_MARGIN = 18
+    BOTTOM_MARGIN = 0
     FILE_FONT_SPACING = 2
     FILE_OPTIONS_FONT_SPACING = 1.6
     FILENAME_WIDTH_PX = 360
@@ -3326,6 +3326,9 @@ class DeletedConversationItemsMarker(QWidget):
     Shown when earlier conversation items have been deleted.
     """
 
+    TOP_MARGIN = 28
+    BOTTOM_MARGIN = 0
+
     def __init__(self):
         super().__init__()
 
@@ -3347,7 +3350,7 @@ class DeletedConversationItemsMarker(QWidget):
         right_tear.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
         layout = QGridLayout()
-        layout.setContentsMargins(0, 30, 0, 0)
+        layout.setContentsMargins(0, self.TOP_MARGIN, 0, self.BOTTOM_MARGIN)
 
         layout.addWidget(left_tear, 0, 0, Qt.AlignRight)
         layout.addWidget(deletion_message, 0, 1, Qt.AlignCenter)


### PR DESCRIPTION
# Description

Fixes #1289

# Test Plan

1. Set up client with the following sources:
  * Source with one file widget 
  * Source with tear
  * Source with tear followed by one file widget
  * Source with tear followed by message or reply widget (for reference)
- [ ] Confirm spacing looks correct for each scenario above
2. Now add lots of messages, replies, and/or files until you can scroll for each scenario above
- [ ] Confirm no padding exists between conversation item widgets and the top/bottom of the scroll window 

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
