### PR TITLE
hide ReplyTextEdit when deletion of conversation in progress

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3750,6 +3750,7 @@ class SourceConversationWrapper(QWidget):
         self.setStyleSheet(css)
 
         self.reply_box.text_edit.setDisabled(True)
+        self.reply_box.text_edit.hide()
         self.reply_box.send_button.setDisabled(True)
         self.conversation_title_bar.setDisabled(True)
         self.conversation_view.hide()
@@ -3768,7 +3769,8 @@ class SourceConversationWrapper(QWidget):
         self.reply_box.setStyleSheet(css)
         self.setStyleSheet(css)
 
-        self.reply_box.setEnabled(True)
+        self.reply_box.text_edit.setEnabled(True)
+        self.reply_box.text_edit.show()
         self.reply_box.send_button.setEnabled(True)
         self.conversation_title_bar.setEnabled(True)
         self.conversation_view.show()
@@ -3924,6 +3926,10 @@ class ReplyTextEdit(QPlainTextEdit):
         self.source = source
 
         self.setObjectName("ReplyTextEdit")
+
+        retain_space = self.sizePolicy()
+        retain_space.setRetainSizeWhenHidden(True)
+        self.setSizePolicy(retain_space)
 
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setTabChangesFocus(True)  # Needed so we can TAB to send button.


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/1286

As followup, instead of hiding text in the replybox when a conversation is being deleted, we can show the text as disabled. We can continue conversation about this as needed here: https://github.com/freedomofpress/securedrop-client/issues/1303

# Test Plan

1. using the `venv-debian` virtual environment, run the client (or package the client from this PR branch and install it in `sd-app`)
2. apply this diff to make testing easier: https://gist.github.com/creviera/8ed991737752a35785033ceac903d878
3. delete all files and messages for a source
- [ ] confirm bug is fixed both visually and functionally: 
   - the replybox does not show a white textarea 
   - you cannot type into the replybox and send replies during the deletion operation

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed
