### PR TITLE
uses repository secret `GH_TOKEN` for push privileges to `main`

### DIFF
--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -12,6 +12,12 @@ jobs:
     steps:
       - name: Check out securedrop-client
         uses: actions/checkout@v2
+        with:
+          # Expectation: GH_TOKEN belongs to a bot user allowed to push to
+          # "main".  By design, this token will NOT be available to forks,
+          # in which this workflow will fail
+          # (https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow).
+          token: ${{ secrets.GH_TOKEN }}
       - name: Set Git identity
         run: |
           git config user.name github-actions


### PR DESCRIPTION
# Description

Towards #1302.  After freedomofpress/infrastructure#3604, uses a GitHub personal access token belonging to a bot account allowed to push to `freedomofpress/securedrop-client@main`.

# Test Plan

- [x] `l10n` GitHub Actions workflow [succeeded](https://github.com/freedomofpress/securedrop-client/actions/runs/1292132252) on this branch `1302-push-with-token`.
    * **NB.**  The resulting `update-translation-catalogs` commit has been rebased out for this pull request.
- `l10n` GitHub Actions workflow succeeds on `main`: cannot be tested prior to merge *into* `main`.  :-(