### PR TITLE
Fix message/reply/file counter in dialogs

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3259,6 +3259,11 @@ class DeleteConversationDialog(ModalDialog):
             source=source,
         )
 
+    def exec(self):
+        # Refresh counters
+        self.body.setText(self.make_body_text())
+        super().exec()
+
     @pyqtSlot()
     def delete_conversation(self):
         self.controller.delete_conversation(self.source)

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -4878,6 +4878,21 @@ def test_DeleteConversationDialog_continue(mocker, source, session):
     mock_controller.delete_conversation.assert_called_once_with(source)
 
 
+def test_DeleteConversationDialog_exec(mocker, source, session):
+    """
+    Test that the dialog body is updated every time it is opened, to ensure
+    that the file, message and reply counters are up-to-date.
+    """
+    source = source["source"]  # to get the Source object
+
+    mock_controller = mocker.MagicMock()
+    dialog = DeleteConversationDialog(source, mock_controller)
+    mocker.patch.object(dialog.body, "setText")
+    mocker.patch("securedrop_client.gui.widgets.ModalDialog.exec")
+    dialog.exec()
+    dialog.body.setText.assert_called_once()
+
+
 def test_DeleteSourceDialog_init(mocker, source):
     mock_controller = mocker.MagicMock()
     DeleteSourceDialog(source["source"], mock_controller)


### PR DESCRIPTION
# Status
Ready for review

# Description

Fixes #1307

The message was only set in the constructor, causing it to not be updated on state changes.

# Test Plan

1. Log into the app and sync
2. Open the "files and messages" deletion dialog for a source 
3. - [ ] Observe that counters are correct
4. Change the count by making submissions, deleting stuff, or sending reply
5. Open the dialog again
6. - [ ] Observe that the counters are correct


# Checklist
 - [x] These changes should not need testing in Qubes
 - [x] No update to the AppArmor profile is required for these changes
 - [x] No database schema changes are needed
