### PR TITLE
Prevent content from re-appearing after "Files and Messages" deletion

### DIFF
--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -168,10 +168,6 @@ class Window(QMainWindow):
         """
         self.main_view.show_sources(sources)
 
-        selected_source = self.main_view.source_list.get_selected_source()
-        if selected_source:
-            self.main_view.empty_conversation_view.hide()
-
     def show_last_sync(self, updated_on):  # type: ignore [no-untyped-def]
         """
         Display a message indicating the time of last sync with the server.

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import html
 import logging
+from datetime import datetime
 from gettext import gettext as _
 from gettext import ngettext
 from typing import Dict, List, Optional, Union  # noqa: F401
@@ -248,8 +249,8 @@ class SyncIcon(QLabel):
         self.controller.sync_started.connect(self._on_sync_started)
         self.controller.sync_succeeded.connect(self._on_sync_succeeded)
 
-    @pyqtSlot()
-    def _on_sync_started(self) -> None:
+    @pyqtSlot(datetime)
+    def _on_sync_started(self, timestamp: datetime) -> None:
         self.sync_animation = load_movie("sync_active.gif")
         self.sync_animation.setScaledSize(QSize(24, 20))
         self.setMovie(self.sync_animation)
@@ -3726,8 +3727,8 @@ class ReplyBoxWidget(QWidget):
         else:
             self.set_logged_out()
 
-    @pyqtSlot()
-    def _on_sync_started(self) -> None:
+    @pyqtSlot(datetime)
+    def _on_sync_started(self, timestamp: datetime) -> None:
         try:
             self.update_authentication_state(self.controller.is_authenticated)
             if self.text_edit.hasFocus():

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3481,7 +3481,6 @@ class SourceConversationWrapper(QWidget):
     per-source resources.
     """
 
-    deleting_account = False
     deleting_conversation = False
 
     def __init__(self, source: Source, controller: Controller) -> None:
@@ -3555,7 +3554,6 @@ class SourceConversationWrapper(QWidget):
 
     def start_account_deletion(self) -> None:
         self.reply_box.setProperty("class", "deleting")
-        self.deleting_account = True
         self.reply_box.text_edit.setText("")
         self.start_deletion()
 
@@ -3585,7 +3583,6 @@ class SourceConversationWrapper(QWidget):
         self.end_deletion()
 
     def end_account_deletion(self) -> None:
-        self.deleting_account = False
         self.end_deletion()
 
     def end_deletion(self) -> None:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -607,25 +607,32 @@ class MainView(QWidget):
 
     def show_sources(self, sources: List[Source]) -> None:
         """
-        Update the left hand sources list in the UI with the passed in list of
-        sources.
+        Update the sources list in the GUI with the supplied list of sources.
         """
-        if sources:
+        # If no sources are supplied, display the EmptyConversationView with the no-sources message.
+        #
+        # If there are sources but no source is selected in the GUI, display the
+        # EmptyConversationView with the no-source-selected messaging.
+        #
+        # Otherwise, hide the EmptyConversationView.
+        if not sources:
+            self.empty_conversation_view.show_no_sources_message()
+            self.empty_conversation_view.show()
+        elif not self.source_list.get_selected_source():
             self.empty_conversation_view.show_no_source_selected_message()
             self.empty_conversation_view.show()
         else:
-            self.empty_conversation_view.show_no_sources_message()
-            self.empty_conversation_view.show()
+            self.empty_conversation_view.hide()
 
-        if self.source_list.source_items:
-            # The source list already contains sources.
+        # If the source list in the GUI is empty, then we will run the optimized intial update.
+        # Otherwise, do a regular source list update.
+        if not self.source_list.source_items:
+            self.source_list.initial_update(sources)
+        else:
             deleted_sources = self.source_list.update(sources)
             for source_uuid in deleted_sources:
                 # Then call the function to remove the wrapper and its children.
                 self.delete_conversation(source_uuid)
-        else:
-            # We have an empty source list, so do an initial update.
-            self.source_list.initial_update(sources)
 
     def on_source_changed(self) -> None:
         """

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -670,22 +670,15 @@ class MainView(QWidget):
             logger.debug(e)
 
     def refresh_source_conversations(self) -> None:
-        deleting_conversations = [
-            c for c in self.source_conversations.values() if c.deleting_conversation
-        ]
-        for conversation_wrapper in deleting_conversations:
-            conversation_wrapper.end_conversation_deletion()
-
-        source = self.source_list.get_selected_source()
-        if not source:
-            return
-
-        self.on_source_changed()
-        conversation_wrapper = self.source_conversations[source.uuid]
-        source_widget = self.source_list.get_source_widget(source.uuid)
-        if source_widget:
-            source_widget.deletion_indicator.stop()
+        """
+        Refresh the selected source conversation.
+        """
         try:
+            source = self.source_list.get_selected_source()
+            if not source:
+                return
+            self.controller.session.refresh(source)
+            conversation_wrapper = self.source_conversations[source.uuid]
             conversation_wrapper.conversation_view.update_conversation(source.collection)
         except sqlalchemy.exc.InvalidRequestError as e:
             logger.debug("Error refreshing source conversations: %s", e)

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -291,6 +291,15 @@ class Controller(QObject):
     source_deletion_failed = pyqtSignal(str)
 
     """
+    This signal indicates that a deletion attempt was successful at the server.
+
+    Emits:
+        str: the source UUID
+        datetime: the timestamp for when the deletion succeeded
+    """
+    conversation_deletion_successful = pyqtSignal(str, datetime)
+
+    """
     This signal lets the queue manager know to add the job to the appropriate
     network queue.
 
@@ -1005,8 +1014,12 @@ class Controller(QObject):
             self.gui.update_error_status(_("The file download failed. Please try again."))
 
     def on_delete_conversation_success(self, uuid: str) -> None:
+        """
+        If the source collection has been successfully scheduled for deletion on the server, emit a
+        signal and sync.
+        """
         logger.info("Conversation %s successfully deleted at server", uuid)
-        self.api_sync.sync()
+        self.conversation_deletion_successful.emit(uuid, datetime.utcnow())
 
     def on_delete_conversation_failure(self, e: Exception) -> None:
         if isinstance(e, DeleteConversationJobException):

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -16,12 +16,12 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-import datetime
 import functools
 import inspect
 import logging
 import os
 import uuid
+from datetime import datetime
 from gettext import gettext as _
 from typing import Dict, List, Type, Union  # noqa: F401
 
@@ -138,8 +138,11 @@ class Controller(QObject):
 
     """
     This signal indicates when a sync has started.
+
+    Emits:
+        datetime: the time that the sync started
     """
-    sync_started = pyqtSignal()
+    sync_started = pyqtSignal(datetime)
 
     """
     This signal indicates when a sync has successfully completed.
@@ -592,7 +595,7 @@ class Controller(QObject):
             return None
 
     def on_sync_started(self) -> None:
-        self.sync_started.emit()
+        self.sync_started.emit(datetime.utcnow())
 
     def on_sync_success(self) -> None:
         """
@@ -1079,7 +1082,7 @@ class Controller(QObject):
         )
         draft_reply = db.DraftReply(
             uuid=reply_uuid,
-            timestamp=datetime.datetime.utcnow(),
+            timestamp=datetime.utcnow(),
             source_id=source.id,
             journalist_id=self.authenticated_user.id,
             file_counter=source.interaction_count,

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -136,10 +136,18 @@ class Controller(QObject):
     application, this is the controller.
     """
 
-    sync_events = pyqtSignal(str)
+    """
+    This signal indicates when a sync has started.
+    """
+    sync_started = pyqtSignal()
 
     """
-    A signal that emits a signal when the authentication state changes.
+    This signal indicates when a sync has successfully completed.
+    """
+    sync_succeeded = pyqtSignal()
+
+    """
+    This signal indicates when the authentication state changes.
 
     Emits:
         bool: is_authenticated
@@ -584,7 +592,7 @@ class Controller(QObject):
             return None
 
     def on_sync_started(self) -> None:
-        self.sync_events.emit("syncing")
+        self.sync_started.emit()
 
     def on_sync_success(self) -> None:
         """
@@ -608,7 +616,7 @@ class Controller(QObject):
         self.gui.refresh_current_source_conversation()
         self.download_new_messages()
         self.download_new_replies()
-        self.sync_events.emit("synced")
+        self.sync_succeeded.emit()
 
         if (
             self.authenticated_user

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -4584,7 +4584,9 @@ def test_ConversationView_on_reply_sent_with_deleted_source(mocker):
 
     cv.on_reply_sent(source.uuid, "mock", "mock")
 
-    debug_logger.assert_any_call("Error in ConversationView.on_reply_sent: %s", ire)
+    debug_logger.assert_any_call(
+        f"Could not Update deletion markers in the ConversationView: {ire}"
+    )
 
 
 def test_ConversationView_add_reply_from_reply_box(mocker, session, session_maker, homedir):
@@ -5644,6 +5646,7 @@ def test_update_conversation_content_updates(mocker, session):
     session.commit()
 
     cv = ConversationView(source, mock_controller)
+    cv.update_deletion_markers = mocker.MagicMock()
     cv.current_messages = {}
 
     cv.scroll.conversation_layout.removeWidget = mocker.MagicMock()
@@ -5742,6 +5745,8 @@ def test_update_conversation_updates_sender_when_sender_changes(
     controller = logic.Controller("http://localhost", mocker.MagicMock(), session_maker, homedir)
     controller.update_authenticated_user = mocker.MagicMock()
     cv = ConversationView(source, controller)
+    cv.update_deletion_markers = mocker.MagicMock()
+
     cv.update_conversation(cv.source.collection)
 
     reply.journalist.firstname = "abc"

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -558,7 +558,17 @@ def test_MainView_show_sources_with_none_selected(mocker):
     Ensure the sources list is passed to the source list widget to be updated.
     """
     mv = MainView(None)
-    mv.source_list = mocker.MagicMock()
+
+    # Set up SourceList so that SourceList.get_selected_source() returns a source
+    mv.source_list = SourceList()
+    source_widget = SourceWidget(
+        mocker.MagicMock(), factory.Source(uuid="stub_uuid"), mocker.MagicMock(), mocker.MagicMock()
+    )
+    source_item = SourceListWidgetItem(mv.source_list)
+    mv.source_list.setItemWidget(source_item, source_widget)
+    mv.source_list.source_items["stub_uuid"] = source_item
+    mocker.patch.object(mv.source_list, "update")
+
     mv.empty_conversation_view = mocker.MagicMock()
 
     mv.show_sources([1, 2, 3])

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -275,7 +275,7 @@ def test_SyncIcon__on_sync_started(mocker):
     """
     sync_icon = SyncIcon()
 
-    sync_icon._on_sync_started()
+    sync_icon._on_sync_started(mocker.MagicMock())
 
     file_path = sync_icon.sync_animation.fileName()
     filename = file_path[file_path.rfind("/") + 1 :]
@@ -5056,14 +5056,14 @@ def test_ReplyBoxWidget_test_refocus_after_sync(mocker):
     rb.text_edit.hasFocus = mocker.MagicMock(return_value=True)
     rb.text_edit.setFocus = mocker.MagicMock()
 
-    rb._on_sync_started()
+    rb._on_sync_started(mocker.MagicMock())
     assert rb.refocus_after_sync is True
 
     rb._on_sync_succeeded()
     rb.text_edit.setFocus.assert_called_once_with()
 
     rb.text_edit.hasFocus.return_value = False
-    rb._on_sync_started()
+    rb._on_sync_started(mocker.MagicMock())
     assert rb.refocus_after_sync is False
 
 
@@ -5079,7 +5079,7 @@ def test_ReplyBoxWidget_on_sync_source_deleted(mocker, source):
 
     uas = mocker.patch.object(ReplyBoxWidget, "update_authentication_state")
     uas.side_effect = pretend_source_was_deleted
-    rb._on_sync_started()
+    rb._on_sync_started(mocker.MagicMock())
     rb._on_sync_succeeded()
 
     exception_str = str(sqlalchemy.orm.exc.ObjectDeletedError(attributes.instance_state(s), None))

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -883,16 +883,14 @@ def test_MainView_refresh_source_conversations(homedir, mocker, qtbot, session_m
     assert not scw1.conversation_deletion_indicator.isHidden()
     assert not sw1.deletion_indicator.isHidden()
 
+    # ensure that a refresh does not hide the deletion animation since the success or failure
+    # signals should be the only way to stop/hide the animation
     mv.refresh_source_conversations()
+    assert not scw1.conversation_deletion_indicator.isHidden()
 
-    assert scw1.conversation_deletion_indicator.isHidden()
-
-    # refresh with source1 selected while its account is being deleted
     scw1.on_source_deleted(source1.uuid)
     assert not scw1.deletion_indicator.isHidden()
     assert scw1.conversation_deletion_indicator.isHidden()
-
-    mv.refresh_source_conversations()
 
 
 def test_MainView_refresh_source_conversations_with_deleted(

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -407,11 +407,11 @@ def test_Controller_on_sync_started(mocker, homedir):
 
     co.on_sync_started()
 
-    sync_events = mocker.patch.object(co, "sync_events")
+    sync_started = mocker.patch.object(co, "sync_started")
 
     co.on_sync_started()
 
-    sync_events.emit.assert_called_once_with("syncing")
+    sync_started.emit.assert_called_once()
 
 
 def test_Controller_on_sync_failure(homedir, config, mocker, session_maker):


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/1285

This is in draft mode to get feedback early while I work on adding an alembic migration test and confirm fix.

# Test Plan

https://github.com/freedomofpress/securedrop-client/issues/1285 is fixed

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [x] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed
