### PR TITLE
Upload test coverage report to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,8 @@ jobs:
       - checkout
       - run: sudo apt-get install -y sqlite3 libqt5x11extras5
       - *run_tests
+      - store_test_results:
+          path: test-results
       - *run_lint
       - *check_python_dependencies_for_vulns
 

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ wheels/
 *.egg
 MANIFEST
 
+# ignore the test-results directory which is used to share logs and test files.
+test-results
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ test: ## Run the application tests in parallel (for rapid development)
 
 .PHONY: test-random
 test-random: ## Run the application tests in random order
-	@TEST_CMD="python -m pytest -v --random-order-bucket=global --ignore=$(FTESTS) --ignore=$(ITESTS) $(TESTOPTS) $(TESTS)" ; \
+	@TEST_CMD="python -m pytest -v --junitxml=test-results/junit.xml --random-order-bucket=global --ignore=$(FTESTS) --ignore=$(ITESTS) $(TESTOPTS) $(TESTS)" ; \
 		if command -v xvfb-run > /dev/null; then \
 		xvfb-run -a $$TEST_CMD ; else \
 		$$TEST_CMD ; fi


### PR DESCRIPTION
# Description
With this PR we upload test results to CircleCI, thus providing an easy to read UI for tests.

Since, `store_test_results` only supports a single `junit.xml` file, but we run pytest in three places (`test-random`, `test-integration` and `test-functional`) which would consequently create three xml files: I added reporting only for `test-random` because that gives us the most coverage. Is that a good idea?

Closes #1284 

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
