### PR TITLE
Set opacity of offline mode link to .4 alpha when active.

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -49,6 +49,7 @@ from PyQt5.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QGraphicsDropShadowEffect,
+    QGraphicsOpacityEffect,
     QGridLayout,
     QHBoxLayout,
     QLabel,
@@ -1758,6 +1759,8 @@ class LoginDialog(QDialog):
         self.tfa_label = QLabel(_("Two-Factor Code"))
         self.tfa_field = QLineEdit()
 
+        self.opacity_effect = QGraphicsOpacityEffect()
+
         buttons = QWidget()
         buttons_layout = QHBoxLayout()
         buttons.setLayout(buttons_layout)
@@ -1838,6 +1841,9 @@ class LoginDialog(QDialog):
         self.submit.setText(_("SIGN IN"))
         self.error_bar.set_message(message)
 
+        self.opacity_effect.setOpacity(1)
+        self.offline_mode.setGraphicsEffect(self.opacity_effect)
+
     def validate(self) -> None:
         """
         Validate the user input -- we expect values for:
@@ -1880,6 +1886,11 @@ class LoginDialog(QDialog):
                 )
                 return
             self.submit.setText(_("SIGNING IN"))
+
+            # Changing the opacity of the link to .4 alpha of its' 100% value when authenticated
+            self.opacity_effect.setOpacity(0.4)
+            self.offline_mode.setGraphicsEffect(self.opacity_effect)
+
             self.controller.login(username, password, tfa_token)
         else:
             self.setDisabled(False)


### PR DESCRIPTION
closes #1245

# Description
The Offline Mode link's opacity is set to 0.4 alpha in the scenario where user's login process is successful. For this, the QGraphicsOpacityEffect class has been imported, providing access to the opacity effect. In cases where the user authentication fails and an error message is displayed, the opacity is reset to its' default state.


# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [x] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
