### PR TITLE
avoids kicking off translation updates at development runtime

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -57,5 +57,4 @@ fi
 
 wait
 
-make compile-translation-catalogs
 python -m securedrop_client --sdc-home "$SDC_HOME" --no-proxy "$qubes_flag" "$@"


### PR DESCRIPTION
# Description

Fixes #1322 by removing the invocation of the `compile-translation-catalogs` Make target that makes loadable `.mo` files available to the Client at development runtime (`run.sh`).

As a side effect, no `.mo` files will be compiled at runtime, and the Client will fall back to the English source strings as if untranslated, regardless of locale, until a revised version of this translation worfklow is restored in #1317.

# Test Plan

1. Follow the steps to reproduce in #1322.
2. [ ] Confirm that `git status` lists no `.po[t]` files with changes not staged for commit. 

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - I have tested these changes in the appropriate Qubes environment
 - I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - I need help writing a database migration
 - [x] No database schema changes are needed
