### PR TITLE
Tooltip to reply badges1168

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2001,7 +2001,7 @@ class ReplyWidget(SpeechBubble):
         self.sender_icon.is_current_user = self._sender_is_current_user
         if self._sender:
             self.sender_icon.initials = self._sender.initials
-
+            self.sender_icon.setToolTip(self._sender.fullname)
         self._update_styles()
 
     @property
@@ -2025,6 +2025,7 @@ class ReplyWidget(SpeechBubble):
 
         if self._sender:
             self.sender_icon.initials = self._sender.initials
+            self.sender_icon.setToolTip(self._sender.fullname)
 
     @pyqtSlot(bool)
     def _on_authentication_changed(self, authenticated: bool) -> None:
@@ -2043,6 +2044,7 @@ class ReplyWidget(SpeechBubble):
         if user.uuid == self.sender.uuid:
             self.sender_is_current_user = True
             self.sender = user
+            self.sender_icon.setToolTip(self.sender.fullname)
             self._update_styles()
 
     @pyqtSlot(str, str, str)

--- a/securedrop_client/resources/css/sender_icon.css
+++ b/securedrop_client/resources/css/sender_icon.css
@@ -57,3 +57,17 @@
     font-size: 23px;
     color: #fff;
 }
+
+#SenderIcon QToolTip {
+    border: none;
+    padding: 5px;
+    background-color: #ffffff;
+    font-family: 'Source Sans Pro';
+}
+
+#SenderIcon_current_user QToolTip {
+    border: none;
+    padding: 5px;
+    background-color: #ffffff;
+    font-family: 'Source Sans Pro';
+}


### PR DESCRIPTION
# Description
Adding a PyQt tool-tip to reply badges, displaying: first name/last name (or both, if provided), or username in the scenario that the full name has not been specified. A simple change in the tool-tip's display has also been added to the `sender_icon.css` file.

Fixes #1168 

# Test Plan

1. Login as journalist via client. Ensure that the tool-tip displays the default username of the reply badges.
2. Configure the first name and last name in the web-based administration interface. Check that the tool-tip displays user's full name. 
3. Test scenarios in which the user has set only one credential (either first or last name) and ensure that the tool-tip displays either of them.
4. Login as dellsberg via client. Repeat steps 1 to 4.
5. Update journalist's credentials through the web-based administration interface while being logged in as dellsberg. Ensure that the tool-tip displays the updated credentials.
5. Create a new user via the web-based administration interface. Login through client. Repeat steps 1 to 5 while staying logged as the new user.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [x] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
