### PR TITLE
Refactor LoginOfflineButton as QPushButton

### DIFF
--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -21,6 +21,8 @@ from typing import Union
 from PyQt5.QtCore import QSize, Qt
 from PyQt5.QtWidgets import QHBoxLayout, QLabel, QPushButton, QWidget
 
+# Allow the buttons to be imported directly.
+from securedrop_client.gui.buttons import SDPushButton  # noqa: F401
 from securedrop_client.resources import load_icon, load_svg
 
 

--- a/securedrop_client/gui/buttons.py
+++ b/securedrop_client/gui/buttons.py
@@ -1,0 +1,48 @@
+"""
+SecureDrop Buttons
+
+These buttons are styled for the SecureDrop Client. If you feel like a button
+requires special styling, adding it here is likely a good call.
+
+All buttons in this file must inherit from QAbstractButton,
+so that they implement the accessibility features provided by Qt.
+
+Please be as specific as possible when inheriting from Qt buttons.
+For example, SDPushButton inherits from QPushButton in order to
+take advantage of as many Qt-maintained features as possible.
+
+Copyright (C) 2021  The Freedom of the Press Foundation.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+from typing import NewType
+
+from PyQt5.QtWidgets import QPushButton
+
+from securedrop_client.resources import load_css
+
+
+class SDPushButton(QPushButton):
+    """A QPushButton that follows SecureDrop guidelines."""
+
+    Alignment = NewType("Alignment", str)
+    AlignLeft = Alignment("left-aligned")
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setStyleSheet(load_css("button.css"))
+
+    def setAlignment(self, align: Alignment) -> None:
+        """Visually align a button that doesn't have a visible outline."""
+        self.setProperty("class", f"button text {align}")

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -79,7 +79,13 @@ from securedrop_client.db import (
     User,
 )
 from securedrop_client.export import ExportError, ExportStatus
-from securedrop_client.gui import SecureQLabel, SvgLabel, SvgPushButton, SvgToggleButton
+from securedrop_client.gui import (
+    SDPushButton,
+    SecureQLabel,
+    SvgLabel,
+    SvgPushButton,
+    SvgToggleButton,
+)
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_css, load_icon, load_image, load_movie
 from securedrop_client.storage import source_exists
@@ -1576,26 +1582,13 @@ class StarToggleButton(SvgToggleButton):
             self.pending_count = self.pending_count - 1
 
 
-class LoginOfflineLink(QLabel):
-    """
-    A button that logs the user in in offline mode.
-    """
-
-    clicked = pyqtSignal()
+class LoginOfflineLink(SDPushButton):
+    """A button that logs the user in, in offline mode."""
 
     def __init__(self) -> None:
-        # Add svg images to button
         super().__init__()
-
-        # Set css id
-        self.setObjectName("LoginOfflineLink")
-
-        self.setFixedSize(QSize(120, 22))
-
         self.setText(_("USE OFFLINE"))
-
-    def mouseReleaseEvent(self, event: QMouseEvent) -> None:
-        self.clicked.emit()
+        self.setAlignment(SDPushButton.AlignLeft)
 
 
 class SignInButton(QPushButton):

--- a/securedrop_client/resources/css/button.css
+++ b/securedrop_client/resources/css/button.css
@@ -1,0 +1,17 @@
+.button {
+	color: #ffffff;
+	font-family: "Montserrat";
+	font-weight: 500;
+	font-size: 13px;
+	padding: 11px 18px;
+}
+
+.text {
+	border: none;
+	background-color: none;
+	text-decoration: underline;
+}
+
+.left-aligned {
+	margin: 0 0 0 -18px;
+}

--- a/securedrop_client/resources/css/sdclient.css
+++ b/securedrop_client/resources/css/sdclient.css
@@ -29,12 +29,6 @@ QWidget {
     color: #9fddff;
 }
 
-#LoginOfflineLink {
-    border: none;
-    color: #fff;
-    text-decoration: underline;
-}
-
 #SignInButton {
     border: none;
     background-color: #05edfe;

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -34,7 +34,6 @@ from securedrop_client.gui.widgets import (
     LoginButton,
     LoginDialog,
     LoginErrorBar,
-    LoginOfflineLink,
     MainView,
     MessageWidget,
     PasswordEdit,
@@ -2745,18 +2744,6 @@ def test_LoginErrorBar_clear_message(mocker):
 
     error_bar.error_status_bar.setText.assert_called_with("")
     error_bar.hide.assert_called_with()
-
-
-def test_LoginOfflineLink(mocker):
-    """
-    Assert that the clicked signal is emitted on mouse release event.
-    """
-    offline_link = LoginOfflineLink()
-    offline_link.clicked = mocker.MagicMock()
-
-    offline_link.mouseReleaseEvent(None)
-
-    offline_link.clicked.emit.assert_called_with()
 
 
 def test_LoginDialog_closeEvent_does_not_exit_when_main_window_is_visible(mocker):

--- a/tests/integration/test_styles_sdclient.py
+++ b/tests/integration/test_styles_sdclient.py
@@ -19,7 +19,6 @@ def test_class_name_matches_css_object_name(mocker, main_window):
     assert "LoginDialog" in app_version_label.objectName()
     login_offline_link = login_dialog.offline_mode
     assert "LoginOfflineLink" == login_offline_link.__class__.__name__
-    assert "LoginOfflineLink" == login_offline_link.objectName()
     login_button = login_dialog.submit
     assert "SignInButton" == login_button.__class__.__name__
     assert "SignInButton" in login_button.objectName()


### PR DESCRIPTION
**Why now / motivation**: The UI code can be made simpler to work with by embracing the ways and features of the Qt framework. For example: the 90% of the accessibility of the app should come for free from using Qt in the ways it's intended to. (Like 90% of a website accessibility comes from the use of _semantic HTML markup_.) Because of that, following the thread of accessibility issues is a good way to identify and apply bite-sized refactoring to our widgets, and improve the maintainability of the code as well as the user experience.
The less time we need to spend thinking about _how_ the UI code works/fails, the more we can dedicate to _what_ our users need. The framework's job is precisely to help us with that, and I think investing into aligning the existing code to the framework ways before the team grows can yield good return on investment.

---

## Overview

This refactoring enures that `LoginOfflineLink` inherits from `QPushButton`. That will make the interface more consistent from the point of view of the operating system tools (e.g. accessibility tools). We'll build on that in the future. **Concretely, this means that this PR enables journalists to action the `USE OFFLINE` button with their keyboard.**

Addresses https://github.com/freedomofpress/securedrop-client/issues/274

## Implementation

Introduces a new class `SDPushButton` that hold the styles of the button. That class will be extended to support the various button types that the SecureDrop Client requires.

Over time, building up a library of widgets is expected to make it easier to ensure that the user experience is consistent, but also make it easier to improve the behavior of UI elements across the board. Finally, I expect that progressively building a library of components will guide the collaboration between designers and engineers by surfacing gaps in communication or functionality (e.g. what should the focus states look like?)

As we go, the design constants (tokens) can be organized further. I did what I think makes sense for the usage that is currently given to `SDPushButton`, but YMMV! Please comment if you feel we should do more, or less! :slightly_smiling_face: 

## Test plan

- Check that names make sense to you:
  - [ ] Namespaces (modules)
  - [ ] Classes
- Run the Client and:
  - [ ] Confirm that the login prompt looks the same as it used to
  - [ ] Confirm that the `USE OFFLINE` button is still functional as it used to be
  - [ ] Confim that the `USE OFFLINE` button can be focused and pressed using the keyboard (typically <kbd>TAB</kbd>, then <kbd>Space</kbd>)

## References

- Material Guidelines: https://material.io/components/buttons
- [SecureDrop Client Color definitions (Figma)](https://www.figma.com/file/gMltGAq8YhrjhpLHyr7PpyqR/FPF-Peeps-Colors?node-id=24%3A2)
