### PR TITLE
Fix remove inaccurate message when source is selected

### DIFF
--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -160,6 +160,10 @@ class Window(QMainWindow):
         """
         self.main_view.show_sources(sources)
 
+        selected_source = self.main_view.source_list.get_selected_source()
+        if selected_source:
+            self.main_view.empty_conversation_view.hide()
+
     def show_last_sync(self, updated_on):  # type: ignore [no-untyped-def]
         """
         Display a message indicating the time of last sync with the server.


### PR DESCRIPTION
# Description

Fixes #1290

# Test Plan

- [ ] Verify that you can reproduce #1290 from the `main` branch
- [ ] Confirm that the "Select a source..." message isn't present anymore when following the same steps in this branch

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
