### PR TITLE
Add user guide link

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -197,12 +197,16 @@ class LeftPane(QWidget):
         self.branding_barre.setPixmap(load_image("left_pane.svg"))
         self.user_profile = UserProfile()
 
+        # Add user guide links in left pane.
+        self.user_guide_label = UserGuideLabel()
+
         # Hide user profile widget until user logs in
         self.user_profile.hide()
 
         # Add widgets to layout
         layout.addWidget(self.user_profile)
         layout.addWidget(self.branding_barre)
+        layout.addWidget(self.user_guide_label)
 
     def setup(self, window, controller: Controller) -> None:  # type: ignore [no-untyped-def]
         self.user_profile.setup(window, controller)
@@ -375,6 +379,31 @@ class ErrorStatusBar(QWidget):
         """
         self.status_bar.clearMessage()
         self._hide()
+
+
+class UserGuideLabel(QLabel):
+    """ A widget that contains the user guide for journalists.
+    This opens in a Tor disposable VM.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        # Set css id
+        self.setObjectName("UserGuideLink")
+
+        self.setFixedSize(QSize(120, 22))
+        self.setAlignment(Qt.AlignCenter)
+
+        self.setOpenExternalLinks(True)
+
+        linkTemplate = "<a href={0}>{1}<a/>"
+        self.setText(
+            linkTemplate.format(
+                "https://workstation.securedrop.org/en/stable/journalist/introduction.html",
+                "User Guide",
+            )
+        )
 
 
 class UserProfile(QLabel):


### PR DESCRIPTION
This is a draft PR towards #1169 to get early feedback while I continue working on this. As of now the user guide gets opened in default browser, and I am working on making it open in disposable Tor VM. However, I am having a hard time figuring how we should go about doing it, any resources related to that would be of great help. Other than that appropriate CSS also needs to be added for the user guide link. 

Closes #1169 

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [x] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [x] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
