### PR TITLE
Allow users to quit the application using their keyboard

### DIFF
--- a/securedrop_client/gui/login_dialog.py
+++ b/securedrop_client/gui/login_dialog.py
@@ -125,13 +125,9 @@ class LoginDialog(QDialog):
         form_layout.addWidget(buttons)
 
         # Create widget to display application name and version
-        application_version = QWidget()
-        application_version_layout = QHBoxLayout()
-        application_version.setLayout(application_version_layout)
-        application_version_label = QLabel(_("SecureDrop Client v{}").format(sd_version))
-        application_version_label.setAlignment(Qt.AlignHCenter)
-        application_version_label.setObjectName("LoginDialog_app_version_label")
-        application_version_layout.addWidget(application_version_label)
+        application_version = QLabel(_("SecureDrop Client v{}").format(sd_version))
+        application_version.setAlignment(Qt.AlignHCenter)
+        application_version.setObjectName("LoginDialog_app_version_label")
 
         # Add widgets
         layout.addWidget(self.error_bar)

--- a/securedrop_client/gui/login_dialog.py
+++ b/securedrop_client/gui/login_dialog.py
@@ -1,0 +1,244 @@
+# coding: utf-8
+
+"""
+A dialog that allows users to sign in, or use the application offline.
+
+Copyright (C) 2021  The Freedom of the Press Foundation.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+import logging
+import sys
+from gettext import gettext as _
+
+from PyQt5.QtCore import QSize, Qt
+from PyQt5.QtGui import QBrush, QCloseEvent, QKeyEvent, QPalette
+from PyQt5.QtWidgets import (
+    QDialog,
+    QGraphicsOpacityEffect,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+from securedrop_client import __version__ as sd_version
+from securedrop_client.gui.widgets import (
+    LoginErrorBar,
+    LoginOfflineLink,
+    PasswordEdit,
+    SignInButton,
+)
+from securedrop_client.logic import Controller
+from securedrop_client.resources import load_image
+
+logger = logging.getLogger(__name__)
+
+
+class LoginDialog(QDialog):
+    """
+    A dialog to display the login form.
+    """
+
+    MIN_PASSWORD_LEN = 14  # Journalist.MIN_PASSWORD_LEN on server
+    MAX_PASSWORD_LEN = 128  # Journalist.MAX_PASSWORD_LEN on server
+    MIN_JOURNALIST_USERNAME = 3  # Journalist.MIN_USERNAME_LEN on server
+
+    def __init__(self, parent: QWidget) -> None:
+        self.parent = parent
+        super().__init__(self.parent)
+
+        # Set modal
+        self.setModal(True)
+
+        # Set layout
+        layout = QVBoxLayout(self)
+        self.setLayout(layout)
+
+        # Set margins and spacing
+        layout.setContentsMargins(0, 274, 0, 20)
+        layout.setSpacing(0)
+
+        # Set background
+        self.setAutoFillBackground(True)
+        palette = QPalette()
+        palette.setBrush(QPalette.Background, QBrush(load_image("login_bg.svg")))
+        self.setPalette(palette)
+        self.setFixedSize(QSize(596, 671))  # Set to size provided in the login_bg.svg file
+        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+
+        # Create error bar
+        self.error_bar = LoginErrorBar()
+
+        # Create form widget
+        form = QWidget()
+
+        form.setObjectName("LoginDialog_form")
+
+        form_layout = QVBoxLayout()
+        form.setLayout(form_layout)
+
+        form_layout.setContentsMargins(80, 0, 80, 0)
+        form_layout.setSpacing(8)
+
+        self.username_label = QLabel(_("Username"))
+        self.username_field = QLineEdit()
+
+        self.password_label = QLabel(_("Passphrase"))
+        self.password_field = PasswordEdit(self)
+
+        self.tfa_label = QLabel(_("Two-Factor Code"))
+        self.tfa_field = QLineEdit()
+
+        self.opacity_effect = QGraphicsOpacityEffect()
+
+        buttons = QWidget()
+        buttons_layout = QHBoxLayout()
+        buttons.setLayout(buttons_layout)
+        buttons_layout.setContentsMargins(0, 20, 0, 0)
+        self.submit = SignInButton()
+        self.submit.clicked.connect(self.validate)
+        self.offline_mode = LoginOfflineLink()
+        buttons_layout.addWidget(self.offline_mode)
+        buttons_layout.addStretch()
+        buttons_layout.addWidget(self.submit)
+
+        form_layout.addWidget(self.username_label)
+        form_layout.addWidget(self.username_field)
+        form_layout.addWidget(QWidget(self))
+        form_layout.addWidget(self.password_label)
+        form_layout.addWidget(self.password_field)
+        form_layout.addWidget(QWidget(self))
+        form_layout.addWidget(self.tfa_label)
+        form_layout.addWidget(self.tfa_field)
+        form_layout.addWidget(buttons)
+
+        # Create widget to display application name and version
+        application_version = QWidget()
+        application_version_layout = QHBoxLayout()
+        application_version.setLayout(application_version_layout)
+        application_version_label = QLabel(_("SecureDrop Client v{}").format(sd_version))
+        application_version_label.setAlignment(Qt.AlignHCenter)
+        application_version_label.setObjectName("LoginDialog_app_version_label")
+        application_version_layout.addWidget(application_version_label)
+
+        # Add widgets
+        layout.addWidget(self.error_bar)
+        layout.addStretch()
+        layout.addWidget(form)
+        layout.addStretch()
+        layout.addWidget(application_version)
+
+    def closeEvent(self, event: QCloseEvent) -> None:
+        """
+        Only exit the application when the main window is not visible.
+        """
+        if not self.parent.isVisible():
+            sys.exit(0)
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        """
+        Cutomize keyboard behavior in the login dialog.
+
+        - [Esc] should not close the dialog
+        - [Enter] or [Return] should attempt to submit the form
+        """
+        if event.key() == Qt.Key_Escape:
+            event.ignore()
+
+        if event.key() == Qt.Key_Enter or event.key() == Qt.Key_Return:
+            self.validate()
+
+    def setup(self, controller: Controller) -> None:
+        self.controller = controller
+        self.offline_mode.clicked.connect(self.controller.login_offline_mode)
+
+    def reset(self) -> None:
+        """
+        Resets the login form to the default state.
+        """
+        self.username_field.setText("")
+        self.username_field.setFocus()
+        self.password_field.setText("")
+        self.tfa_field.setText("")
+        self.setDisabled(False)
+        self.error_bar.clear_message()
+
+    def error(self, message: str) -> None:
+        """
+        Ensures the passed in message is displayed as an error message.
+        """
+        self.setDisabled(False)
+        self.submit.setText(_("SIGN IN"))
+        self.error_bar.set_message(message)
+
+        self.opacity_effect.setOpacity(1)
+        self.offline_mode.setGraphicsEffect(self.opacity_effect)
+
+    def validate(self) -> None:
+        """
+        Validate the user input -- we expect values for:
+
+        * username (free text)
+        * password (free text)
+        * TFA token (numerals)
+        """
+        self.setDisabled(True)
+        username = self.username_field.text()
+        password = self.password_field.text()
+        tfa_token = self.tfa_field.text().replace(" ", "")
+        if username and password and tfa_token:
+            # Validate username
+            if len(username) < self.MIN_JOURNALIST_USERNAME:
+                self.setDisabled(False)
+                self.error(
+                    _("That username won't work.\n" "It should be at least 3 characters long.")
+                )
+                return
+
+            # Validate password
+            if len(password) < self.MIN_PASSWORD_LEN or len(password) > self.MAX_PASSWORD_LEN:
+                self.setDisabled(False)
+                self.error(
+                    _(
+                        "That passphrase won't work.\n"
+                        "It should be between 14 and 128 characters long."
+                    )
+                )
+                return
+
+            # Validate 2FA token
+            try:
+                int(tfa_token)
+            except ValueError:
+                self.setDisabled(False)
+                self.error(
+                    _("That two-factor code won't work.\n" "It should only contain numerals.")
+                )
+                return
+            self.submit.setText(_("SIGNING IN"))
+
+            # Changing the opacity of the link to .4 alpha of its' 100% value when authenticated
+            self.opacity_effect.setOpacity(0.4)
+            self.offline_mode.setGraphicsEffect(self.opacity_effect)
+
+            # If authentication is successful, clear error messages displayed priorly
+            self.error_bar.clear_message()
+
+            self.controller.login(username, password, tfa_token)
+        else:
+            self.setDisabled(False)
+            self.error(_("Please enter a username, passphrase and " "two-factor code."))

--- a/securedrop_client/gui/login_dialog.py
+++ b/securedrop_client/gui/login_dialog.py
@@ -19,11 +19,10 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import logging
-import sys
 from gettext import gettext as _
 
 from PyQt5.QtCore import QSize, Qt
-from PyQt5.QtGui import QBrush, QCloseEvent, QKeyEvent, QPalette
+from PyQt5.QtGui import QBrush, QKeyEvent, QPalette
 from PyQt5.QtWidgets import (
     QDialog,
     QGraphicsOpacityEffect,
@@ -58,8 +57,7 @@ class LoginDialog(QDialog):
     MIN_JOURNALIST_USERNAME = 3  # Journalist.MIN_USERNAME_LEN on server
 
     def __init__(self, parent: QWidget) -> None:
-        self.parent = parent
-        super().__init__(self.parent)
+        super().__init__(parent)
 
         # Set modal
         self.setModal(True)
@@ -141,13 +139,6 @@ class LoginDialog(QDialog):
         layout.addWidget(form)
         layout.addStretch()
         layout.addWidget(application_version)
-
-    def closeEvent(self, event: QCloseEvent) -> None:
-        """
-        Only exit the application when the main window is not visible.
-        """
-        if not self.parent.isVisible():
-            sys.exit(0)
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
         """

--- a/securedrop_client/gui/login_dialog.py
+++ b/securedrop_client/gui/login_dialog.py
@@ -22,7 +22,7 @@ import logging
 from gettext import gettext as _
 
 from PyQt5.QtCore import QSize, Qt
-from PyQt5.QtGui import QBrush, QKeyEvent, QPalette
+from PyQt5.QtGui import QBrush, QPalette
 from PyQt5.QtWidgets import (
     QDialog,
     QGraphicsOpacityEffect,
@@ -108,6 +108,7 @@ class LoginDialog(QDialog):
         buttons.setLayout(buttons_layout)
         buttons_layout.setContentsMargins(0, 20, 0, 0)
         self.submit = SignInButton()
+        self.submit.setDefault(True)
         self.submit.clicked.connect(self.validate)
         self.offline_mode = LoginOfflineLink()
         buttons_layout.addWidget(self.offline_mode)
@@ -135,19 +136,6 @@ class LoginDialog(QDialog):
         layout.addWidget(form)
         layout.addStretch()
         layout.addWidget(application_version)
-
-    def keyPressEvent(self, event: QKeyEvent) -> None:
-        """
-        Cutomize keyboard behavior in the login dialog.
-
-        - [Esc] should not close the dialog
-        - [Enter] or [Return] should attempt to submit the form
-        """
-        if event.key() == Qt.Key_Escape:
-            event.ignore()
-
-        if event.key() == Qt.Key_Enter or event.key() == Qt.Key_Return:
-            self.validate()
 
     def setup(self, controller: Controller) -> None:
         self.controller = controller

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -24,8 +24,8 @@ from gettext import gettext as _
 from typing import List, Optional
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QGuiApplication
-from PyQt5.QtWidgets import QApplication, QHBoxLayout, QMainWindow, QVBoxLayout, QWidget
+from PyQt5.QtGui import QGuiApplication, QIcon, QKeySequence
+from PyQt5.QtWidgets import QAction, QApplication, QHBoxLayout, QMainWindow, QVBoxLayout, QWidget
 
 from securedrop_client import __version__
 from securedrop_client.db import Source, User
@@ -89,6 +89,13 @@ class Window(QMainWindow):
 
         # Dialogs
         self.login_dialog: Optional[LoginDialog] = None
+
+        # Actions
+        quit = QAction(_("Quit"), self)
+        quit.setIcon(QIcon.fromTheme("application-exit"))
+        quit.setShortcut(QKeySequence.Quit)
+        quit.triggered.connect(self.close)
+        self.addAction(quit)
 
     def setup(self, controller: Controller) -> None:
         """

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -29,7 +29,8 @@ from PyQt5.QtWidgets import QApplication, QHBoxLayout, QMainWindow, QVBoxLayout,
 
 from securedrop_client import __version__
 from securedrop_client.db import Source, User
-from securedrop_client.gui.widgets import LeftPane, LoginDialog, MainView, TopPane
+from securedrop_client.gui.login_dialog import LoginDialog
+from securedrop_client.gui.widgets import LeftPane, MainView, TopPane
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_css, load_font, load_icon
 

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import logging
 from gettext import gettext as _
-from typing import List, Optional  # noqa: F401
+from typing import List, Optional
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QGuiApplication

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -14,7 +14,7 @@ import sqlalchemy.orm.exc
 from PyQt5.QtCore import QEvent, QSize, Qt
 from PyQt5.QtGui import QFocusEvent, QKeyEvent, QMovie, QResizeEvent
 from PyQt5.QtTest import QTest
-from PyQt5.QtWidgets import QApplication, QLineEdit, QMainWindow, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QApplication, QLineEdit, QVBoxLayout, QWidget
 from sqlalchemy.orm import attributes, scoped_session, sessionmaker
 
 from securedrop_client import db, logic, storage
@@ -2709,21 +2709,6 @@ def test_LoginDialog_submitKeyPressEvent(mocker, qt_key):
     ld.validate.assert_called_once_with()
 
 
-def test_LoginDialog_closeEvent_exits(mocker):
-    """
-    If the main window is not visible, then exit the application when the LoginDialog receives a
-    close event.
-    """
-    mw = QMainWindow()
-    ld = LoginDialog(mw)
-    sys_exit_fn = mocker.patch("securedrop_client.gui.widgets.sys.exit")
-    mw.hide()
-
-    ld.closeEvent(event="mock")
-
-    sys_exit_fn.assert_called_once_with(0)
-
-
 def test_LoginErrorBar_set_message(mocker):
     error_bar = LoginErrorBar()
     error_bar.error_status_bar = mocker.MagicMock()
@@ -2744,21 +2729,6 @@ def test_LoginErrorBar_clear_message(mocker):
 
     error_bar.error_status_bar.setText.assert_called_with("")
     error_bar.hide.assert_called_with()
-
-
-def test_LoginDialog_closeEvent_does_not_exit_when_main_window_is_visible(mocker):
-    """
-    If the main window is visible, then to not exit the application when the LoginDialog receives a
-    close event.
-    """
-    mw = QMainWindow()
-    ld = LoginDialog(mw)
-    sys_exit_fn = mocker.patch("securedrop_client.gui.widgets.sys.exit")
-    mw.show()
-
-    ld.closeEvent(event="mock")
-
-    assert sys_exit_fn.called is False
 
 
 def test_SpeechBubble_init(mocker):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import attributes, scoped_session, sessionmaker
 
 from securedrop_client import db, logic, storage
 from securedrop_client.export import ExportError, ExportStatus
+from securedrop_client.gui.login_dialog import LoginDialog
 from securedrop_client.gui.widgets import (
     ActivityStatusBar,
     ConversationView,
@@ -32,7 +33,6 @@ from securedrop_client.gui.widgets import (
     FileWidget,
     LeftPane,
     LoginButton,
-    LoginDialog,
     LoginErrorBar,
     MainView,
     MessageWidget,

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -2679,36 +2679,6 @@ def test_LoginDialog_validate_input_ok(mocker):
     mock_controller.login.assert_called_once_with("foo", "nicelongpassword", "123456")
 
 
-def test_LoginDialog_escapeKeyPressEvent(mocker):
-    """
-    Ensure we don't hide the login dialog when Esc key is pressed.
-    """
-    ld = LoginDialog(None)
-    event = mocker.MagicMock()
-    event.key = mocker.MagicMock(return_value=Qt.Key_Escape)
-
-    ld.keyPressEvent(event)
-
-    event.ignore.assert_called_once_with()
-
-
-@pytest.mark.parametrize("qt_key", [Qt.Key_Enter, Qt.Key_Return])
-def test_LoginDialog_submitKeyPressEvent(mocker, qt_key):
-    """
-    Ensure we submit the form when the user presses [Enter] or [Return]
-    """
-
-    ld = LoginDialog(None)
-    event = mocker.MagicMock()
-    event.key = mocker.MagicMock(return_value=qt_key)
-
-    ld.validate = mocker.MagicMock()
-
-    ld.keyPressEvent(event)
-
-    ld.validate.assert_called_once_with()
-
-
 def test_LoginErrorBar_set_message(mocker):
     error_bar = LoginErrorBar()
     error_bar.error_status_bar = mocker.MagicMock()

--- a/tests/integration/test_styles_sdclient.py
+++ b/tests/integration/test_styles_sdclient.py
@@ -15,7 +15,7 @@ def test_class_name_matches_css_object_name(mocker, main_window):
     assert "LoginDialog" == login_dialog.__class__.__name__
     form = login_dialog.layout().itemAt(2).widget()
     assert "LoginDialog" in form.objectName()
-    app_version_label = login_dialog.layout().itemAt(4).widget().layout().itemAt(0).widget()
+    app_version_label = login_dialog.layout().itemAt(4).widget()
     assert "LoginDialog" in app_version_label.objectName()
     login_offline_link = login_dialog.offline_mode
     assert "LoginOfflineLink" == login_offline_link.__class__.__name__
@@ -161,7 +161,7 @@ def test_styles_for_login_dialog(mocker, main_window):
     for c in form_children_qlineedit:
         assert 30 == c.height()  # 30px + 0px margin
         assert (0, 0, 0, 0) == c.getContentsMargins()
-    app_version_label = login_dialog.layout().itemAt(4).widget().layout().itemAt(0).widget()
+    app_version_label = login_dialog.layout().itemAt(4).widget()
     assert "#9fddff" == app_version_label.palette().color(QPalette.Foreground).name()
 
     login_offline_link = login_dialog.offline_mode


### PR DESCRIPTION
# Overview

Fixes #35

:warning: This PR introduces a new translatable string (`"Quit"`), and instructions will need to be given to the translators. Specifically, the string is not currently visible (there is no menu bar), but would be read out as an available action (to quit the application).

## Implementation details

I extracted the `LoginDialog` class to it own file.
I'm introducing the Quit _user action_ as a `QAction` in a move to embrace Qt's framework because I'm convinced that will help us reason about the app.

# Test Plan

## Signed in scenario

- [ ] Start the SecureDrop Client and sign in
- [ ] Press <kbd>Ctrl</kbd>+<kbd>Q</kbd> and confirm the application quit

## Offline scenario

- [ ] Start the SecureDrop Client and "use offline"
- [ ] Press <kbd>Ctrl</kbd>+<kbd>Q</kbd> and confirm the application quit

## Change of mind scenario

- [ ] Start the SecureDrop Client
- [ ] Press <kbd>Escape</kbd> and confirm the application quit

## Sanity-check scenario

- [ ] Start the SecureDrop Client and "use offline" (similarly, you could sign in, then sign out)
- [ ] Press the "Sign in" button, you'll see the signin dialog
- [ ] Press <kbd>Escape</kbd> and confirm the dialog gets closed and the main window gains focus (the application **hasn't** quit)

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
