### PR TITLE
add dev reminder to activate venv and update docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ venv: ## Provision a Python 3 virtualenv for development
 	python3 -m venv .venv
 	.venv/bin/pip install --upgrade pip wheel
 	.venv/bin/pip install --require-hashes -r "requirements/dev-requirements.txt"
+	@echo "#################"
+	@echo "Make sure to run: source .venv/bin/activate"
 
 SEMGREP_FLAGS := --exclude "tests/" --error --strict --verbose
 

--- a/README.md
+++ b/README.md
@@ -100,9 +100,8 @@ See [SecureDrop docs](https://docs.securedrop.org/en/latest/development/setup_de
 ```
 git clone git@github.com:freedomofpress/securedrop-client.git
 cd securedrop-client
-virtualenv --python=python3.7 .venv
+make venv
 source .venv/bin/activate
-pip install --require-hashes -r requirements/dev-requirements.txt
 ```
 
 4. Run SecureDrop Client


### PR DESCRIPTION
# Description

No longer tell developers to use `virtualenv` in the docs, and add a reminder to activate the virtual environment after running `make venv`. /cc @zenmonkeykstop 

# Test Plan

Confirm no errors when using `make venv`.