### PR TITLE
Add menu bar for actions discoverability

### DIFF
--- a/securedrop_client/gui/__init__.py
+++ b/securedrop_client/gui/__init__.py
@@ -23,6 +23,7 @@ from PyQt5.QtWidgets import QHBoxLayout, QLabel, QPushButton, QWidget
 
 # Allow the buttons to be imported directly.
 from securedrop_client.gui.buttons import SDPushButton  # noqa: F401
+from securedrop_client.gui.menu_bar import SDMenuBar  # noqa: F401
 from securedrop_client.resources import load_icon, load_svg
 
 

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -240,6 +240,7 @@ class Window(QMainWindow):
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
         """Ensure the menu bar receives the event that will open it initially."""
-        if event.key() == Qt.Key_Alt:
-            self.menuBar().keyPressEvent(event)
+        menu_bar = self.menuBar()
+        if event.key() == menu_bar.toggle_key():
+            menu_bar.keyPressEvent(event)
         return super().keyPressEvent(event)

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -24,11 +24,20 @@ from gettext import gettext as _
 from typing import List, Optional
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QGuiApplication, QIcon, QKeySequence
-from PyQt5.QtWidgets import QAction, QApplication, QHBoxLayout, QMainWindow, QVBoxLayout, QWidget
+from PyQt5.QtGui import QGuiApplication, QIcon, QKeyEvent, QKeySequence
+from PyQt5.QtWidgets import (
+    QAction,
+    QApplication,
+    QHBoxLayout,
+    QMainWindow,
+    QMenu,
+    QVBoxLayout,
+    QWidget,
+)
 
 from securedrop_client import __version__
 from securedrop_client.db import Source, User
+from securedrop_client.gui import SDMenuBar
 from securedrop_client.gui.login_dialog import LoginDialog
 from securedrop_client.gui.widgets import LeftPane, MainView, TopPane
 from securedrop_client.logic import Controller
@@ -91,11 +100,18 @@ class Window(QMainWindow):
         self.login_dialog: Optional[LoginDialog] = None
 
         # Actions
-        quit = QAction(_("Quit"), self)
+        quit = QAction(_("&Quit"), self)
         quit.setIcon(QIcon.fromTheme("application-exit"))
         quit.setShortcut(QKeySequence.Quit)
         quit.triggered.connect(self.close)
         self.addAction(quit)
+
+        # Menu Bar
+        menuBar = SDMenuBar(self)
+        menu = QMenu(_("&SecureDrop"), menuBar)
+        menu.addAction(quit)
+        menuBar.addMenu(menu)
+        self.setMenuBar(menuBar)
 
     def setup(self, controller: Controller) -> None:
         """
@@ -221,3 +237,9 @@ class Window(QMainWindow):
         """
         cb = QApplication.clipboard()
         cb.clear()
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        """Ensure the menu bar receives the event that will open it initially."""
+        if event.key() == Qt.Key_Alt:
+            self.menuBar().keyPressEvent(event)
+        return super().keyPressEvent(event)

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -238,9 +238,9 @@ class Window(QMainWindow):
         cb = QApplication.clipboard()
         cb.clear()
 
-    def keyPressEvent(self, event: QKeyEvent) -> None:
+    def keyReleaseEvent(self, event: QKeyEvent) -> None:
         """Ensure the menu bar receives the event that will open it initially."""
         menu_bar = self.menuBar()
         if event.key() == menu_bar.toggle_key():
-            menu_bar.keyPressEvent(event)
-        return super().keyPressEvent(event)
+            menu_bar.keyReleaseEvent(event)
+        return super().keyReleaseEvent(event)

--- a/securedrop_client/gui/menu_bar.py
+++ b/securedrop_client/gui/menu_bar.py
@@ -34,6 +34,9 @@ from PyQt5.QtWidgets import QMenuBar, QWidget
 class SDMenuBar(QMenuBar):
     """A menu bar that hides itself automatically when out of focus."""
 
+    KeyToggle = Qt.Key_Alt
+    KeyClose = Qt.Key_Escape
+
     def __init__(self, parent: QWidget) -> None:
         super().__init__(parent)
         self.hide()
@@ -46,7 +49,7 @@ class SDMenuBar(QMenuBar):
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
         """Show the menu bar and grab focus when Alt is pressed. Close it on Alt or Escape."""
-        if event.key() == Qt.Key_Alt:
+        if event.key() == self.KeyToggle:
             if self.isVisible():
                 self.hide()
                 self.clearFocus()
@@ -55,8 +58,12 @@ class SDMenuBar(QMenuBar):
                 self.show()
                 self.setFocus()
                 return None
-        if event.key() == Qt.Key_Escape:
+        if event.key() == self.KeyClose:
             self.hide()
             self.clearFocus()
             return None
         return super().keyPressEvent(event)
+
+    def toggle_key(self) -> int:
+        """The key value that toggles the menu bar visibility."""
+        return self.KeyToggle

--- a/securedrop_client/gui/menu_bar.py
+++ b/securedrop_client/gui/menu_bar.py
@@ -37,7 +37,7 @@ class SDMenuBar(QMenuBar):
     KeyToggle = Qt.Key_Alt
     KeyClose = Qt.Key_Escape
 
-    def __init__(self, parent: QWidget) -> None:
+    def __init__(self, parent: QWidget = None) -> None:
         super().__init__(parent)
         self.hide()
 
@@ -58,7 +58,7 @@ class SDMenuBar(QMenuBar):
                 self.show()
                 self.setFocus()
                 return None
-        if event.key() == self.KeyClose:
+        if event.key() == self.KeyClose:  # pragma: no cover
             self.hide()
             self.clearFocus()
             return None

--- a/securedrop_client/gui/menu_bar.py
+++ b/securedrop_client/gui/menu_bar.py
@@ -47,7 +47,7 @@ class SDMenuBar(QMenuBar):
             self.hide()
         return super().focusOutEvent(event)
 
-    def keyPressEvent(self, event: QKeyEvent) -> None:
+    def keyReleaseEvent(self, event: QKeyEvent) -> None:
         """Show the menu bar and grab focus when Alt is pressed. Close it on Alt or Escape."""
         if event.key() == self.KeyToggle:
             if self.isVisible():
@@ -62,7 +62,7 @@ class SDMenuBar(QMenuBar):
             self.hide()
             self.clearFocus()
             return None
-        return super().keyPressEvent(event)
+        return super().keyReleaseEvent(event)
 
     def toggle_key(self) -> int:
         """The key value that toggles the menu bar visibility."""

--- a/securedrop_client/gui/menu_bar.py
+++ b/securedrop_client/gui/menu_bar.py
@@ -1,0 +1,62 @@
+"""
+SecureDrop Menu Bar
+
+A menu bar inspired by the behavior of the menu bar of Firefox.
+It is designed to be unobstrusive, but remains conformant with
+the Freedesktop and Qubes OS conventions for increased accessibility.
+
+This menu bar shoudl allow journalists to:
+
+- Discover all the actions available to them at any given time
+- Trigger any available action via their keyboard, or any input method
+  capable of emulating key events.
+
+Copyright (C) 2021  The Freedom of the Press Foundation.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QFocusEvent, QKeyEvent
+from PyQt5.QtWidgets import QMenuBar, QWidget
+
+
+class SDMenuBar(QMenuBar):
+    """A menu bar that hides itself automatically when out of focus."""
+
+    def __init__(self, parent: QWidget) -> None:
+        super().__init__(parent)
+        self.hide()
+
+    def focusOutEvent(self, event: QFocusEvent) -> bool:
+        """Hide the menu bar unless the focus went to a menu."""
+        if event.reason() != Qt.PopupFocusReason:
+            self.hide()
+        return super().focusOutEvent(event)
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        """Show the menu bar and grab focus when Alt is pressed. Close it on Alt or Escape."""
+        if event.key() == Qt.Key_Alt:
+            if self.isVisible():
+                self.hide()
+                self.clearFocus()
+                return None
+            else:
+                self.show()
+                self.setFocus()
+                return None
+        if event.key() == Qt.Key_Escape:
+            self.hide()
+            self.clearFocus()
+            return None
+        return super().keyPressEvent(event)

--- a/tests/gui/helpers.py
+++ b/tests/gui/helpers.py
@@ -1,0 +1,9 @@
+from PyQt5.QtCore import Qt
+from PyQt5.QtTest import QTest
+from PyQt5.QtWidgets import QWidget
+
+
+def press_alt_key(receiver: QWidget) -> None:
+    """Emit a KeyPressEvent with an 'Alt' key."""
+    # I couln't find a way to send "Alt" without sending another key as well.
+    QTest.keyClicks(receiver, " ", Qt.AltModifier)

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -3,10 +3,9 @@ Check the core Window UI class works as expected.
 """
 import unittest
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtTest import QTest
 from PyQt5.QtWidgets import QApplication, QHBoxLayout
 
+import tests.gui.helpers as helpers
 from securedrop_client.gui.main import Window
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_icon
@@ -24,8 +23,7 @@ class WindowTest(unittest.TestCase):
 
     def test_displays_a_menu_bar_when_toggle_key_is_pressed(self):
         menubar = self.window.menuBar()
-        # I couln't find a way to send "Alt" without sending another key as well.
-        QTest.keyClicks(self.window, " ", Qt.AltModifier)
+        helpers.press_alt_key(self.window)
         assert menubar.isVisibleTo(self.window)
 
 

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -1,6 +1,10 @@
 """
 Check the core Window UI class works as expected.
 """
+import unittest
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtTest import QTest
 from PyQt5.QtWidgets import QApplication, QHBoxLayout
 
 from securedrop_client.gui.main import Window
@@ -8,6 +12,21 @@ from securedrop_client.logic import Controller
 from securedrop_client.resources import load_icon
 
 app = QApplication([])
+
+
+class WindowTest(unittest.TestCase):
+    def setUp(self):
+        self.window = Window()
+
+    def test_does_not_display_a_menu_bar_by_default(self):
+        menubar = self.window.menuBar()
+        assert not menubar.isVisibleTo(self.window)
+
+    def test_displays_a_menu_bar_when_toggle_key_is_pressed(self):
+        menubar = self.window.menuBar()
+        # I couln't find a way to send "Alt" without sending another key as well.
+        QTest.keyClicks(self.window, " ", Qt.AltModifier)
+        assert menubar.isVisibleTo(self.window)
 
 
 def test_init(mocker):

--- a/tests/gui/test_menu_bar.py
+++ b/tests/gui/test_menu_bar.py
@@ -5,6 +5,7 @@ from PyQt5.QtGui import QFocusEvent
 from PyQt5.QtTest import QTest
 from PyQt5.QtWidgets import QApplication, QWidget
 
+import tests.gui.helpers as helpers
 from securedrop_client.gui import SDMenuBar
 
 app = QApplication([])
@@ -29,14 +30,12 @@ class SDMenuBarTest(unittest.TestCase):
         assert self.menubar.toggle_key() == Qt.Key_Alt
 
     def test_becomes_visible_when_toggle_key_is_pressed(self):
-        # I couln't find a way to send "Alt" without sending another key as well.
-        QTest.keyClicks(self.menubar, " ", Qt.AltModifier)
+        helpers.press_alt_key(self.menubar)
         assert self.menubar.isVisible()
 
     def test_when_visible_becomes_hidden_when_toggle_key_is_pressed(self):
         self.menubar.show()
-        # I couln't find a way to send "Alt" without sending another key as well.
-        QTest.keyClicks(self.menubar, " ", Qt.AltModifier)
+        helpers.press_alt_key(self.menubar)
         assert self.menubar.isHidden()
 
     @unittest.skip("I couldn't find how to emulate an Escape key event.")

--- a/tests/gui/test_menu_bar.py
+++ b/tests/gui/test_menu_bar.py
@@ -1,0 +1,58 @@
+import unittest
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QFocusEvent
+from PyQt5.QtTest import QTest
+from PyQt5.QtWidgets import QApplication, QWidget
+
+from securedrop_client.gui import SDMenuBar
+
+app = QApplication([])
+
+
+class SDMenuBarTest(unittest.TestCase):
+    def setUp(self):
+        self.menubar = SDMenuBar()
+
+    def test_sets_parent(self):
+        parent = QWidget()
+        menubar = SDMenuBar(parent)
+        assert menubar.parent() == parent
+
+    def test_has_no_parent_by_default(self):
+        assert self.menubar.parent() is None
+
+    def test_is_hidden_by_default(self):
+        assert self.menubar.isHidden()
+
+    def test_exposes_its_toggle_key(self):
+        assert self.menubar.toggle_key() == Qt.Key_Alt
+
+    def test_becomes_visible_when_toggle_key_is_pressed(self):
+        # I couln't find a way to send "Alt" without sending another key as well.
+        QTest.keyClicks(self.menubar, " ", Qt.AltModifier)
+        assert self.menubar.isVisible()
+
+    def test_when_visible_becomes_hidden_when_toggle_key_is_pressed(self):
+        self.menubar.show()
+        # I couln't find a way to send "Alt" without sending another key as well.
+        QTest.keyClicks(self.menubar, " ", Qt.AltModifier)
+        assert self.menubar.isHidden()
+
+    @unittest.skip("I couldn't find how to emulate an Escape key event.")
+    def test_becomes_hidden_when_close_key_is_pressed(self):
+        self.menubar.show()
+        QTest.keyClicks(self.menubar, " ")
+        assert self.menubar.isHidden()
+
+    def test_hides_automatically_when_loosing_focus(self):
+        self.menubar.show()
+        self.menubar.setFocus(True)
+        self.menubar.focusOutEvent(QFocusEvent(QFocusEvent.FocusOut))
+        assert self.menubar.isHidden()
+
+    def test_does_not_hide_automatically_when_loosing_focus_because_menu_was_open(self):
+        self.menubar.show()
+        self.menubar.setFocus(True)
+        self.menubar.focusOutEvent(QFocusEvent(QFocusEvent.FocusOut, Qt.PopupFocusReason))
+        assert self.menubar.isVisible()


### PR DESCRIPTION
# Description

This gives the journalists the _option_ to perform actions via a standard menu bar. For visual backward-compatibility, the menu bar behaves similarly to the menu bar in Firefox: it is hidden by default, and can be toggled using the <kbd>Alt</kbd> key.

<details><summary>Implementation details</summary>
 Why the <kbd>Alt</kbd> key specifically? Because it's already the one that enables menu accelerators -those underlined letters in the menus, so it's the one people looking for them are likely to reach to. I think Firefox made a reasonable trade-off with that auto-hiding menu.
</details> 

As a journalist, when I look at the application window, I want to be able to:

- Learn somehow that <kbd>Ctrl+Q</kbd> is the shortcut to quit (guessing is nice, but knowing is better)
- Be able to see what actions I can perform at any given time (even though for now it's only "quit")
- Be able to perform those action using my keyboard, or whatever keyboard-emulation tool I use on my day to day in Qubes OS (accessible + familiar)

This is a common feature in Qubes OS applications, which provides an accessible interface at a low cost.

:information_source: **Note**: As usual, I've written a lot of details in the commit messages.

# Why now?

I'm working on #1340, and realized that I was struggling to action the existing tests for the different dialogs. On the other hand, the dialogs are currently created on the fly, and attached to the main window via a global variable, which doesn't make testing easier.

As I was following through and thinking that the dialogs should be owned by the main window and merely triggered/displayed via a menu/button/whatever nested user action, I realized that I didn't have any hand place where giving visibility to any actions I'd create or surface.

Besides enabling accessibility improvements for journalists, introducing this menu bar now gives us (and firstly me :P) support to reason about what user actions are available and how they should trickle down to the button that will trigger them.

# Side benefits

- The tests offer a proof-of-concept of testing `QWidget`s without relying on mocks (which are risky, particularly when the object under test is being mocked).
- We've got a place where laying out the actions available to the journalists at any given time. :crystal_ball: I predict that going forward that will help us reason about the reach of each action, and come up with a more systematic separation of responsibilities among our Qt widgets and Python classes. 

# Test Plan

- [ ] Open the Client in offline mode
- [ ] Confirm that no menu bar is visible
- [ ] Press <kbd>Alt</kbd> and confirm a menu bar appears
- [ ] Press `S` (the underlined menu accelerator) to confirm that the menu bar has focus
- [ ] Press <kbd>Escape</kbd> and confirm the menu bar is hidden
- [ ] Press <kbd>Alt</kbd> again, then click anywhere (in the app) outside of the menu bar, confirm that the menu bar is hidden
- [ ] Press <kbd>Alt</kbd> once more, <kbd>TAB</kbd> out of the menu bar and confirm it is hidden
- [ ] Press <kbd>Alt</kbd> once more, then `S`, then `Q` to quit the application
- [ ] For bonus points :star2:, compare it to other applications and comment if it doesn't follow the same patterns : )

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
