### PR TITLE
Refactor simplify buttons creation in Login Dialog

### DIFF
--- a/securedrop_client/gui/login_dialog.py
+++ b/securedrop_client/gui/login_dialog.py
@@ -107,10 +107,9 @@ class LoginDialog(QDialog):
         buttons_layout = QHBoxLayout()
         buttons.setLayout(buttons_layout)
         buttons_layout.setContentsMargins(0, 20, 0, 0)
-        self.submit = SignInButton(self)
-        self.submit.setDefault(True)
+        self.submit = SignInButton()
         self.submit.clicked.connect(self.validate)
-        self.offline_mode = LoginOfflineLink(self)
+        self.offline_mode = LoginOfflineLink()
         buttons_layout.addWidget(self.offline_mode)
         buttons_layout.addStretch()
         buttons_layout.addWidget(self.submit)
@@ -136,6 +135,8 @@ class LoginDialog(QDialog):
         layout.addWidget(form)
         layout.addStretch()
         layout.addWidget(application_version)
+
+        self.submit.setDefault(True)
 
     def setup(self, controller: Controller) -> None:
         self.controller = controller

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1581,8 +1581,8 @@ class StarToggleButton(SvgToggleButton):
 class LoginOfflineLink(SDPushButton):
     """A button that logs the user in, in offline mode."""
 
-    def __init__(self, parent: QWidget = None) -> None:
-        super().__init__(parent)
+    def __init__(self) -> None:
+        super().__init__()
         self.setText(_("USE OFFLINE"))
         self.setAlignment(SDPushButton.AlignLeft)
 
@@ -1592,8 +1592,8 @@ class SignInButton(QPushButton):
     A button that logs the user into application when clicked.
     """
 
-    def __init__(self, parent: QWidget = None) -> None:
-        super().__init__(parent)
+    def __init__(self) -> None:
+        super().__init__()
         self.setText(_("SIGN IN"))
 
         # Set css id


### PR DESCRIPTION
# Description

This is a pure refactoring (no user-facing effects). It is a follow up on https://github.com/freedomofpress/securedrop-client/pull/1339#discussion_r751674758.

Details in the commit message :slightly_smiling_face: 

# Test Plan

Regression testing on #1339:

1. Launch the SecureDrop Client
2. In the login dialog, fill in the credentials
3. Press <kbd>Enter</kbd>
- [ ] Confirm that the login form is submitted

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
