### PR TITLE
Fix AppArmor policy to permit execution of Python binary

### DIFF
--- a/files/usr.bin.securedrop-client
+++ b/files/usr.bin.securedrop-client
@@ -34,6 +34,7 @@
   /usr/bin/chmod mrix,
   /usr/bin/dash ix,
   /usr/bin/mkdir mrix,
+  /usr/bin/python3.7 ix,
   /usr/bin/qrexec-client-vm mrix,
   /usr/bin/qubes-gpg-client mrix,
   /usr/bin/qubes-gpg-import-key mrix,


### PR DESCRIPTION
# Description

The current prod package (0.5.0) is not runnable due to AppArmor failures when attempting to run `securedrop-client`. Instead of shipping a Python binary directly, the package symlinks to the system Python, without permitting execution of the new binary in the AppArmor profile.

This PR assumes that the behavior in 0.5.0 (use system Python) is what we want and updates the AppArmor profile accordingly.

# Test Plan

Simple route:
- Apply the diff to a broken 0.5.0 system, reload apparmor, and attempt to start `securedrop-client`

Complex route:
- Build new package with this change in place and install, confirm that it resolves
