### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,13 @@
 
 # securedrop-client
 
-The SecureDrop Client is a desktop application for journalists to communicate with sources and work with SecureDrop submissions on the [SecureDrop Workstation](https://github.com/freedomofpress/securedrop-workstation).
+The SecureDrop Client is a desktop application for journalists to communicate with sources and work with submissions on the [SecureDrop Workstation](https://github.com/freedomofpress/securedrop-workstation).
 
 The client runs within a [Qubes OS](https://www.qubes-os.org/intro/) VM that has no direct network access and opens files within individual, non-networked, disposable VMs. API requests and responses to and from the [SecureDrop application server](https://docs.securedrop.org/en/stable/glossary.html#application-server) are sent through an intermediate VM using the [SecureDrop Proxy](https://github.com/freedomofpress/securedrop-proxy).
 
-To learn more about architecture and our rationale behind our Qubes OS approach for source communication and handling submissions, see the [SecureDrop Workstation readme](https://github.com/freedomofpress/securedrop-workstation/blob/main/README.md).
+To learn more about architecture and our rationale behind our Qubes OS approach, see the [SecureDrop Workstation readme](https://github.com/freedomofpress/securedrop-workstation/blob/main/README.md).
 
 **IMPORTANT:** This project is currently undergoing a pilot study and should not be used in production environments.
-
-# Current limitations
-
-This client is under active development and currently supports a minimal feature set. Major supported features include:
-
-- the download and decryption of files, messages, and replies (using [Qubes split-gpg](https://www.qubes-os.org/doc/split-gpg/))
-- the display of decrypted messages and replies in a new conversation view
-- the opening of all files in individual, non-networked, Qubes disposable VMs
-- replying to sources
-- deleting sources
-- exporting files to LUKS-encrypted USB drives
-- printing to supported printers
 
 ## Getting Started
 

--- a/securedrop_client/locale/messages.pot
+++ b/securedrop_client/locale/messages.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: SecureDrop Client 0.5.0\n"
+"Project-Id-Version: SecureDrop Client 0.5.1\n"
 "Report-Msgid-Bugs-To: securedrop@freedom.press\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"


### PR DESCRIPTION
# Description

Acouple minor readme changes, including no longer tracking list of supported features in the README, since this is better tracked externally, or in the workstation docs.

This also updates the `messages.pot` file after running `make extract-strings` to pick up strings, see https://github.com/freedomofpress/securedrop-client/pull/1348

# Test plan

- [ ] CI passes
- [ ] Readme changes look good