### PR TITLE
Refactor extract PasswordEdit to 'gui.base' namespace

### DIFF
--- a/securedrop_client/gui/base/__init__.py
+++ b/securedrop_client/gui/base/__init__.py
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 # Import classes here to make possible to import them from securedrop_client.gui.base
 from securedrop_client.gui.base.buttons import SDPushButton  # noqa: F401
+from securedrop_client.gui.base.inputs import PasswordEdit  # noqa: F401
 from securedrop_client.gui.base.misc import (  # noqa: F401
     SecureQLabel,
     SvgLabel,

--- a/securedrop_client/gui/base/inputs.py
+++ b/securedrop_client/gui/base/inputs.py
@@ -1,0 +1,49 @@
+"""
+A passphrase input that allows to show and hide it.
+
+Copyright (C) 2018  The Freedom of the Press Foundation.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+from PyQt5.QtWidgets import QDialog, QLineEdit
+
+from securedrop_client.resources import load_icon
+
+
+class PasswordEdit(QLineEdit):
+    """
+    A LineEdit with icons to show/hide password entries
+    """
+
+    def __init__(self, parent: QDialog) -> None:
+        self.parent = parent
+        super().__init__(self.parent)
+
+        self.visibleIcon = load_icon("eye_visible.svg")
+        self.hiddenIcon = load_icon("eye_hidden.svg")
+
+        self.setEchoMode(QLineEdit.Password)
+        self.togglepasswordAction = self.addAction(self.hiddenIcon, QLineEdit.TrailingPosition)
+        self.togglepasswordAction.triggered.connect(self.on_toggle_password_Action)
+        self.password_shown = False
+
+    def on_toggle_password_Action(self) -> None:
+        if not self.password_shown:
+            self.setEchoMode(QLineEdit.Normal)
+            self.password_shown = True
+            self.togglepasswordAction.setIcon(self.visibleIcon)
+        else:
+            self.setEchoMode(QLineEdit.Password)
+            self.password_shown = False
+            self.togglepasswordAction.setIcon(self.hiddenIcon)

--- a/securedrop_client/gui/login_dialog.py
+++ b/securedrop_client/gui/login_dialog.py
@@ -35,12 +35,8 @@ from PyQt5.QtWidgets import (
 )
 
 from securedrop_client import __version__ as sd_version
-from securedrop_client.gui.widgets import (
-    LoginErrorBar,
-    LoginOfflineLink,
-    PasswordEdit,
-    SignInButton,
-)
+from securedrop_client.gui.base import PasswordEdit
+from securedrop_client.gui.widgets import LoginErrorBar, LoginOfflineLink, SignInButton
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_image
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -77,6 +77,7 @@ from securedrop_client.db import (
 )
 from securedrop_client.export import ExportError, ExportStatus
 from securedrop_client.gui.base import (
+    PasswordEdit,
     SDPushButton,
     SecureQLabel,
     SvgLabel,
@@ -1713,34 +1714,6 @@ class LoginErrorBar(QWidget):
     def clear_message(self) -> None:
         self.error_status_bar.setText("")
         self.hide()
-
-
-class PasswordEdit(QLineEdit):
-    """
-    A LineEdit with icons to show/hide password entries
-    """
-
-    def __init__(self, parent: QDialog) -> None:
-        self.parent = parent
-        super().__init__(self.parent)
-
-        self.visibleIcon = load_icon("eye_visible.svg")
-        self.hiddenIcon = load_icon("eye_hidden.svg")
-
-        self.setEchoMode(QLineEdit.Password)
-        self.togglepasswordAction = self.addAction(self.hiddenIcon, QLineEdit.TrailingPosition)
-        self.togglepasswordAction.triggered.connect(self.on_toggle_password_Action)
-        self.password_shown = False
-
-    def on_toggle_password_Action(self) -> None:
-        if not self.password_shown:
-            self.setEchoMode(QLineEdit.Normal)
-            self.password_shown = True
-            self.togglepasswordAction.setIcon(self.visibleIcon)
-        else:
-            self.setEchoMode(QLineEdit.Password)
-            self.password_shown = False
-            self.togglepasswordAction.setIcon(self.hiddenIcon)
 
 
 class SenderIcon(QWidget):

--- a/tests/gui/base/test_inputs.py
+++ b/tests/gui/base/test_inputs.py
@@ -1,0 +1,14 @@
+from PyQt5.QtWidgets import QApplication, QLineEdit
+
+from securedrop_client.gui.base import PasswordEdit
+
+app = QApplication([])
+
+
+def test_PasswordEdit(mocker):
+    passwordline = PasswordEdit(None)
+    passwordline.togglepasswordAction.trigger()
+
+    assert passwordline.echoMode() == QLineEdit.Normal
+    passwordline.togglepasswordAction.trigger()
+    assert passwordline.echoMode() == QLineEdit.Password

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -14,7 +14,7 @@ import sqlalchemy.orm.exc
 from PyQt5.QtCore import QEvent, QSize, Qt
 from PyQt5.QtGui import QFocusEvent, QKeyEvent, QMovie, QResizeEvent
 from PyQt5.QtTest import QTest
-from PyQt5.QtWidgets import QApplication, QLineEdit, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QApplication, QVBoxLayout, QWidget
 from sqlalchemy.orm import attributes, scoped_session, sessionmaker
 
 from securedrop_client import db, logic, storage
@@ -36,7 +36,6 @@ from securedrop_client.gui.widgets import (
     LoginErrorBar,
     MainView,
     MessageWidget,
-    PasswordEdit,
     PrintDialog,
     ReplyBoxWidget,
     ReplyTextEdit,
@@ -5064,15 +5063,6 @@ def test_DeleteSourceAction_init(mocker):
     mock_controller = mocker.MagicMock()
     mock_source = mocker.MagicMock()
     DeleteSourceAction(mock_source, None, mock_controller)
-
-
-def test_PasswordEdit(mocker):
-    passwordline = PasswordEdit(None)
-    passwordline.togglepasswordAction.trigger()
-
-    assert passwordline.echoMode() == QLineEdit.Normal
-    passwordline.togglepasswordAction.trigger()
-    assert passwordline.echoMode() == QLineEdit.Password
 
 
 def test_DeleteSourceAction_trigger(mocker):


### PR DESCRIPTION
# Description

This is the third step to be split out of #1369.
It moves the `PasswordEdit` definition to its own file/module. Eventually, more form inputs could be extracted there, but for now there is only this one.

This step is necessary to prevent a circular dependency when extracting the `LoginDialog` out of `widgets.py`.

# Test Plan

- [ ] Confirm that the passphrase input in the login dialog behavior and appearance haven't changed
- [ ] Confirm that the `PasswordEdit` definition is unchanged
- [ ] Confirm that the `PasswordEdit` test is unchaged and passes
- [ ] Confirm that CI is green

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
