### PR TITLE
Refactor extract SignInButton to 'gui.auth.sign_in' namespace

### DIFF
--- a/securedrop_client/gui/auth/__init__.py
+++ b/securedrop_client/gui/auth/__init__.py
@@ -1,0 +1,20 @@
+"""
+Widgets related to authentication.
+
+Copyright (C) 2018  The Freedom of the Press Foundation.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+# Import classes here to make possible to import them from securedrop_client.gui.auth
+from securedrop_client.gui.auth.sign_in import SignInButton  # noqa: F401

--- a/securedrop_client/gui/auth/sign_in/__init__.py
+++ b/securedrop_client/gui/auth/sign_in/__init__.py
@@ -1,0 +1,20 @@
+"""
+Widgets related to the activity of signing in.
+
+Copyright (C) 2018  The Freedom of the Press Foundation.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+# Import classes here to make possible to import them from securedrop_client.gui.auth.sign_in
+from securedrop_client.gui.auth.sign_in.button import SignInButton  # noqa: F401

--- a/securedrop_client/gui/auth/sign_in/button.py
+++ b/securedrop_client/gui/auth/sign_in/button.py
@@ -1,0 +1,50 @@
+"""
+Contains the main widgets used by the client to display things in the UI.
+
+Copyright (C) 2018  The Freedom of the Press Foundation.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+from gettext import gettext as _
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QColor, QCursor
+from PyQt5.QtWidgets import QGraphicsDropShadowEffect, QPushButton
+
+
+class SignInButton(QPushButton):
+    """
+    A button that logs the user into application when clicked.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setText(_("SIGN IN"))
+
+        # Set css id
+        self.setObjectName("SignInButton")
+
+        self.setFixedHeight(40)
+        self.setFixedWidth(140)
+
+        # Set cursor.
+        self.setCursor(QCursor(Qt.PointingHandCursor))
+
+        # Set drop shadow effect
+        effect = QGraphicsDropShadowEffect(self)
+        effect.setOffset(0, 1)
+        effect.setBlurRadius(8)
+        effect.setColor(QColor("#aa000000"))
+        self.setGraphicsEffect(effect)
+        self.update()

--- a/securedrop_client/gui/login_dialog.py
+++ b/securedrop_client/gui/login_dialog.py
@@ -35,8 +35,9 @@ from PyQt5.QtWidgets import (
 )
 
 from securedrop_client import __version__ as sd_version
+from securedrop_client.gui.auth import SignInButton
 from securedrop_client.gui.base import PasswordEdit
-from securedrop_client.gui.widgets import LoginErrorBar, LoginOfflineLink, SignInButton
+from securedrop_client.gui.widgets import LoginErrorBar, LoginOfflineLink
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_image
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1637,33 +1637,6 @@ class LoginOfflineLink(SDPushButton):
         self.setAlignment(SDPushButton.AlignLeft)
 
 
-class SignInButton(QPushButton):
-    """
-    A button that logs the user into application when clicked.
-    """
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.setText(_("SIGN IN"))
-
-        # Set css id
-        self.setObjectName("SignInButton")
-
-        self.setFixedHeight(40)
-        self.setFixedWidth(140)
-
-        # Set cursor.
-        self.setCursor(QCursor(Qt.PointingHandCursor))
-
-        # Set drop shadow effect
-        effect = QGraphicsDropShadowEffect(self)
-        effect.setOffset(0, 1)
-        effect.setBlurRadius(8)
-        effect.setColor(QColor("#aa000000"))
-        self.setGraphicsEffect(effect)
-        self.update()
-
-
 class LoginErrorBar(QWidget):
     """
     A bar widget for displaying messages about login errors to the user.


### PR DESCRIPTION
# Description

This is the fourth step to be split out of #1369.
It moves the `SignInButton` definition to its own file/module. Eventually, the `LoginDialog` will be part o the `auth` package too,.

This step is necessary to prevent a circular dependency when extracting the `LoginDialog` out of `widgets.py`.

# Test Plan

- [ ] Confirm that the "Sign In' button in the login dialog behavior and appearance haven't changed
- [ ] Confirm that the `SignInButton` definition is unchanged
- [ ] Confirm that the `SignInButton` didn't have any individual unit test
- [ ] Confirm that CI is green

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
