### PR TITLE
Refactor extract LoginErrorBar to 'gui.auth.sign_in' namespace

### DIFF
--- a/securedrop_client/gui/auth/__init__.py
+++ b/securedrop_client/gui/auth/__init__.py
@@ -17,4 +17,4 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 # Import classes here to make possible to import them from securedrop_client.gui.auth
-from securedrop_client.gui.auth.sign_in import SignInButton  # noqa: F401
+from securedrop_client.gui.auth.sign_in import LoginErrorBar, SignInButton  # noqa: F401

--- a/securedrop_client/gui/auth/sign_in/__init__.py
+++ b/securedrop_client/gui/auth/sign_in/__init__.py
@@ -18,3 +18,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 # Import classes here to make possible to import them from securedrop_client.gui.auth.sign_in
 from securedrop_client.gui.auth.sign_in.button import SignInButton  # noqa: F401
+from securedrop_client.gui.auth.sign_in.error_bar import LoginErrorBar  # noqa: F401

--- a/securedrop_client/gui/auth/sign_in/error_bar.css
+++ b/securedrop_client/gui/auth/sign_in/error_bar.css
@@ -1,0 +1,18 @@
+QWidget {
+    font-family: 'Source Sans Pro';
+}
+
+#LoginErrorBar QWidget {
+    background-color: #ce0083;
+}
+
+#LoginErrorBar_icon {
+    color: #fff;
+}
+
+#LoginErrorBar_status_bar {
+    font-family: 'Montserrat';
+    font-weight: 500;
+    font-size: 12px;
+    color: #fff;
+}

--- a/securedrop_client/gui/auth/sign_in/error_bar.py
+++ b/securedrop_client/gui/auth/sign_in/error_bar.py
@@ -1,0 +1,74 @@
+"""
+A widget that displays error messages.
+
+Copyright (C) 2021  The Freedom of the Press Foundation.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+from PyQt5.QtCore import QSize
+from PyQt5.QtWidgets import QHBoxLayout, QWidget
+
+from securedrop_client.gui.base import SecureQLabel, SvgLabel
+
+
+class LoginErrorBar(QWidget):
+    """
+    A bar widget for displaying messages about login errors to the user.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        self.setObjectName("LoginErrorBar")
+
+        # Set layout
+        layout = QHBoxLayout(self)
+        self.setLayout(layout)
+
+        # Remove margins and spacing
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        # Set size policy
+        retain_space = self.sizePolicy()
+        retain_space.setRetainSizeWhenHidden(True)
+        self.setSizePolicy(retain_space)
+
+        # Error icon
+        self.error_icon = SvgLabel("error_icon_white.svg", svg_size=QSize(18, 18))
+        self.error_icon.setObjectName("LoginErrorBar_icon")
+        self.error_icon.setFixedWidth(42)
+
+        # Error status bar
+        self.error_status_bar = SecureQLabel(wordwrap=False)
+        self.error_status_bar.setObjectName("LoginErrorBar_status_bar")
+        self.setFixedHeight(42)
+
+        # Create space ths size of the error icon to keep the error message centered
+        spacer1 = QWidget()
+        spacer2 = QWidget()
+
+        # Add widgets to layout
+        layout.addWidget(spacer1)
+        layout.addWidget(self.error_icon)
+        layout.addWidget(self.error_status_bar)
+        layout.addWidget(spacer2)
+
+    def set_message(self, message: str) -> None:
+        self.show()
+        self.error_status_bar.setText(message)
+
+    def clear_message(self) -> None:
+        self.error_status_bar.setText("")
+        self.hide()

--- a/securedrop_client/gui/login_dialog.py
+++ b/securedrop_client/gui/login_dialog.py
@@ -35,9 +35,9 @@ from PyQt5.QtWidgets import (
 )
 
 from securedrop_client import __version__ as sd_version
-from securedrop_client.gui.auth import SignInButton
+from securedrop_client.gui.auth import LoginErrorBar, SignInButton
 from securedrop_client.gui.base import PasswordEdit
-from securedrop_client.gui.widgets import LoginErrorBar, LoginOfflineLink
+from securedrop_client.gui.widgets import LoginOfflineLink
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_image
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1637,58 +1637,6 @@ class LoginOfflineLink(SDPushButton):
         self.setAlignment(SDPushButton.AlignLeft)
 
 
-class LoginErrorBar(QWidget):
-    """
-    A bar widget for displaying messages about login errors to the user.
-    """
-
-    def __init__(self) -> None:
-        super().__init__()
-
-        self.setObjectName("LoginErrorBar")
-
-        # Set layout
-        layout = QHBoxLayout(self)
-        self.setLayout(layout)
-
-        # Remove margins and spacing
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(0)
-
-        # Set size policy
-        retain_space = self.sizePolicy()
-        retain_space.setRetainSizeWhenHidden(True)
-        self.setSizePolicy(retain_space)
-
-        # Error icon
-        self.error_icon = SvgLabel("error_icon_white.svg", svg_size=QSize(18, 18))
-        self.error_icon.setObjectName("LoginErrorBar_icon")
-        self.error_icon.setFixedWidth(42)
-
-        # Error status bar
-        self.error_status_bar = SecureQLabel(wordwrap=False)
-        self.error_status_bar.setObjectName("LoginErrorBar_status_bar")
-        self.setFixedHeight(42)
-
-        # Create space ths size of the error icon to keep the error message centered
-        spacer1 = QWidget()
-        spacer2 = QWidget()
-
-        # Add widgets to layout
-        layout.addWidget(spacer1)
-        layout.addWidget(self.error_icon)
-        layout.addWidget(self.error_status_bar)
-        layout.addWidget(spacer2)
-
-    def set_message(self, message: str) -> None:
-        self.show()
-        self.error_status_bar.setText(message)
-
-    def clear_message(self) -> None:
-        self.error_status_bar.setText("")
-        self.hide()
-
-
 class SenderIcon(QWidget):
     """
     Represents a reply to a source.

--- a/tests/gui/auth/sign_in/test_error_bar.py
+++ b/tests/gui/auth/sign_in/test_error_bar.py
@@ -1,0 +1,27 @@
+from PyQt5.QtWidgets import QApplication
+
+from securedrop_client.gui.auth import LoginErrorBar
+
+app = QApplication([])
+
+
+def test_LoginErrorBar_set_message(mocker):
+    error_bar = LoginErrorBar()
+    error_bar.error_status_bar = mocker.MagicMock()
+    mocker.patch.object(error_bar, "show")
+
+    error_bar.set_message("mock error")
+
+    error_bar.error_status_bar.setText.assert_called_with("mock error")
+    error_bar.show.assert_called_with()
+
+
+def test_LoginErrorBar_clear_message(mocker):
+    error_bar = LoginErrorBar()
+    error_bar.error_status_bar = mocker.MagicMock()
+    mocker.patch.object(error_bar, "hide")
+
+    error_bar.clear_message()
+
+    error_bar.error_status_bar.setText.assert_called_with("")
+    error_bar.hide.assert_called_with()

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -33,7 +33,6 @@ from securedrop_client.gui.widgets import (
     FileWidget,
     LeftPane,
     LoginButton,
-    LoginErrorBar,
     MainView,
     MessageWidget,
     PrintDialog,
@@ -2756,28 +2755,6 @@ def test_LoginDialog_validate_input_ok(mocker):
     assert ld.setDisabled.call_count == 1
     assert ld.error.call_count == 0
     mock_controller.login.assert_called_once_with("foo", "nicelongpassword", "123456")
-
-
-def test_LoginErrorBar_set_message(mocker):
-    error_bar = LoginErrorBar()
-    error_bar.error_status_bar = mocker.MagicMock()
-    mocker.patch.object(error_bar, "show")
-
-    error_bar.set_message("mock error")
-
-    error_bar.error_status_bar.setText.assert_called_with("mock error")
-    error_bar.show.assert_called_with()
-
-
-def test_LoginErrorBar_clear_message(mocker):
-    error_bar = LoginErrorBar()
-    error_bar.error_status_bar = mocker.MagicMock()
-    mocker.patch.object(error_bar, "hide")
-
-    error_bar.clear_message()
-
-    error_bar.error_status_bar.setText.assert_called_with("")
-    error_bar.hide.assert_called_with()
 
 
 def test_SpeechBubble_init(mocker):


### PR DESCRIPTION
# Description

This is the 5th step to be split out of #1369.
It moves the `LoginErrorBar` definition to its own file/module. Eventually, the `LoginDialog` will be part o the `auth` package too,.

This step is necessary to prevent a circular dependency when extracting the `LoginDialog` out of `widgets.py`.

# Test Plan

- [ ] Confirm that the error bar in the login dialog behavior and appearance haven't changed
- [ ] Confirm that the `LoginErrorBar` definition is unchanged
- [ ] Confirm that the `LoginErrorBar` tests pass
- [ ] Confirm that CI is green

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
