### PR TITLE
Refactor extract LoginOfflineLink to 'gui.auth.use_offline' namespace

### DIFF
--- a/securedrop_client/gui/auth/use_offline/__init__.py
+++ b/securedrop_client/gui/auth/use_offline/__init__.py
@@ -1,5 +1,5 @@
 """
-Widgets related to authentication.
+Widgets related to the activity of using the application offline.
 
 Copyright (C) 2021  The Freedom of the Press Foundation.
 
@@ -16,6 +16,5 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-# Import classes here to make possible to import them from securedrop_client.gui.auth
-from securedrop_client.gui.auth.sign_in import LoginErrorBar, SignInButton  # noqa: F401
-from securedrop_client.gui.auth.use_offline import LoginOfflineLink  # noqa: F401
+# Import classes here to make possible to import them from securedrop_client.gui.auth.use_offline
+from securedrop_client.gui.auth.use_offline.button import LoginOfflineLink  # noqa: F401

--- a/securedrop_client/gui/auth/use_offline/button.py
+++ b/securedrop_client/gui/auth/use_offline/button.py
@@ -1,0 +1,12 @@
+from gettext import gettext as _
+
+from securedrop_client.gui.base import SDPushButton
+
+
+class LoginOfflineLink(SDPushButton):
+    """A button that logs the user in, in offline mode."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setText(_("USE OFFLINE"))
+        self.setAlignment(SDPushButton.AlignLeft)

--- a/securedrop_client/gui/login_dialog.py
+++ b/securedrop_client/gui/login_dialog.py
@@ -35,9 +35,8 @@ from PyQt5.QtWidgets import (
 )
 
 from securedrop_client import __version__ as sd_version
-from securedrop_client.gui.auth import LoginErrorBar, SignInButton
+from securedrop_client.gui.auth import LoginErrorBar, LoginOfflineLink, SignInButton
 from securedrop_client.gui.base import PasswordEdit
-from securedrop_client.gui.widgets import LoginOfflineLink
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_image
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -78,7 +78,6 @@ from securedrop_client.db import (
 from securedrop_client.export import ExportError, ExportStatus
 from securedrop_client.gui.base import (
     PasswordEdit,
-    SDPushButton,
     SecureQLabel,
     SvgLabel,
     SvgPushButton,
@@ -1626,15 +1625,6 @@ class StarToggleButton(SvgToggleButton):
         """
         if self.source_uuid == source_uuid:
             self.pending_count = self.pending_count - 1
-
-
-class LoginOfflineLink(SDPushButton):
-    """A button that logs the user in, in offline mode."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.setText(_("USE OFFLINE"))
-        self.setAlignment(SDPushButton.AlignLeft)
 
 
 class SenderIcon(QWidget):

--- a/securedrop_client/locale/messages.pot
+++ b/securedrop_client/locale/messages.pot
@@ -143,9 +143,6 @@ msgstr ""
 msgid "— All files and messages deleted for this source —"
 msgstr ""
 
-msgid "USE OFFLINE"
-msgstr ""
-
 msgid "Failed to send"
 msgstr ""
 
@@ -311,5 +308,8 @@ msgid "Entire source account"
 msgstr ""
 
 msgid "Files and messages"
+msgstr ""
+
+msgid "USE OFFLINE"
 msgstr ""
 


### PR DESCRIPTION
# Description

This is the 6th step to be split out of #1369.
It moves the `LoginOfflineLink` definition to its own file/module. Eventually, the `LoginDialog` will be part o the `auth` package too,.

This step is necessary to prevent a circular dependency when extracting the `LoginDialog` out of `widgets.py`.

# Test Plan

- [ ] Confirm that the "Use Offline" (in the login dialog) behavior and appearance haven't changed
- [ ] Confirm that the `LoginOfflineLink` definition is unchanged
- [ ] Confirm that the `LoginOfflineLink` didn't have any unit test
- [ ] Confirm that CI is green

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
