### PR TITLE
Add download conversation

### DIFF
--- a/securedrop_client/api_jobs/sync.py
+++ b/securedrop_client/api_jobs/sync.py
@@ -5,6 +5,7 @@ from sdclientapi import API
 from sdclientapi import User as SDKUser
 from sqlalchemy.orm.session import Session
 
+from securedrop_client import state
 from securedrop_client.api_jobs.base import ApiJob
 from securedrop_client.db import DeletedUser, DraftReply, User
 from securedrop_client.storage import get_remote_data, update_local_storage
@@ -19,9 +20,10 @@ class MetadataSyncJob(ApiJob):
 
     NUMBER_OF_TIMES_TO_RETRY_AN_API_CALL = 2
 
-    def __init__(self, data_dir: str) -> None:
+    def __init__(self, data_dir: str, app_state: Optional[state.State] = None) -> None:
         super().__init__(remaining_attempts=self.NUMBER_OF_TIMES_TO_RETRY_AN_API_CALL)
         self.data_dir = data_dir
+        self._state = app_state
 
     def call_api(self, api_client: API, session: Session) -> Any:
         """
@@ -43,6 +45,8 @@ class MetadataSyncJob(ApiJob):
         MetadataSyncJob._update_users(session, users)
         sources, submissions, replies = get_remote_data(api_client)
         update_local_storage(session, sources, submissions, replies, self.data_dir)
+        if self._state is not None:
+            _update_state(self._state, submissions)
 
     def _update_users(session: Session, remote_users: List[SDKUser]) -> None:
         """
@@ -122,3 +126,14 @@ class MetadataSyncJob(ApiJob):
             logger.debug(f"Deleting account for user with uuid='{uuid}'")
 
         session.commit()
+
+
+def _update_state(
+    app_state: state.State,
+    submissions: List,
+) -> None:
+    for submission in submissions:
+        if submission.is_file():
+            app_state.add_file(
+                state.ConversationId(submission.source_uuid), state.FileId(submission.uuid)
+            )

--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -34,6 +34,7 @@ from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtWidgets import QApplication, QMessageBox
 
 from securedrop_client import __version__, state
+from securedrop_client.database import Database
 from securedrop_client.db import make_session_maker
 from securedrop_client.gui.main import Window
 from securedrop_client.logic import Controller
@@ -215,7 +216,9 @@ def start_app(args, qt_args) -> NoReturn:  # type: ignore [no-untyped-def]
 
     session_maker = make_session_maker(args.sdc_home)
 
-    app_state = state.State()
+    session = session_maker()
+    database = Database(session)
+    app_state = state.State(database)
     gui = Window(app_state)
 
     controller = Controller(

--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -33,7 +33,7 @@ from typing import NewType, NoReturn
 from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtWidgets import QApplication, QMessageBox
 
-from securedrop_client import __version__
+from securedrop_client import __version__, state
 from securedrop_client.db import make_session_maker
 from securedrop_client.gui.main import Window
 from securedrop_client.logic import Controller
@@ -215,13 +215,15 @@ def start_app(args, qt_args) -> NoReturn:  # type: ignore [no-untyped-def]
 
     session_maker = make_session_maker(args.sdc_home)
 
-    gui = Window()
+    app_state = state.State()
+    gui = Window(app_state)
 
     controller = Controller(
         "http://localhost:8081/",
         gui,
         session_maker,
         args.sdc_home,
+        app_state,
         not args.no_proxy,
         not args.no_qubes,
     )

--- a/securedrop_client/database.py
+++ b/securedrop_client/database.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright © 2022 The Freedom of the Press Foundation.
+from typing import List
+
+from sqlalchemy.orm.session import Session
+
+from securedrop_client.db import File
+from securedrop_client.storage import get_local_files
+
+
+class Database:
+    """Provide an interface to the database while abstracting session details."""
+
+    def __init__(self, session: Session):
+        super().__init__()
+        self.session = session
+
+    def get_files(self) -> List[File]:
+        return get_local_files(self.session)

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -27,7 +27,7 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QGuiApplication, QIcon, QKeySequence
 from PyQt5.QtWidgets import QAction, QApplication, QHBoxLayout, QMainWindow, QVBoxLayout, QWidget
 
-from securedrop_client import __version__
+from securedrop_client import __version__, state
 from securedrop_client.db import Source, User
 from securedrop_client.gui.auth import LoginDialog
 from securedrop_client.gui.widgets import LeftPane, MainView, TopPane
@@ -45,7 +45,7 @@ class Window(QMainWindow):
 
     icon = "icon.png"
 
-    def __init__(self) -> None:
+    def __init__(self, app_state: Optional[state.State] = None) -> None:
         """
         Create the default start state. The window contains a root widget into
         which is placed:
@@ -73,7 +73,7 @@ class Window(QMainWindow):
         layout.setSpacing(0)
         self.main_pane.setLayout(layout)
         self.left_pane = LeftPane()
-        self.main_view = MainView(self.main_pane)
+        self.main_view = MainView(self.main_pane, app_state)
         layout.addWidget(self.left_pane)
         layout.addWidget(self.main_view)
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3646,10 +3646,8 @@ class DownloadConversation(QAction):
         self.triggered.connect(self.on_triggered)
         self.setShortcutVisibleInContextMenu(True)
 
-        if self._state is not None:
-            self._state.selected_conversation_files_changed.connect(
-                self._on_selected_conversation_files_changed
-            )
+        self._connect_enabled_to_conversation_changes()
+        self._set_enabled_initial_value()
 
     @pyqtSlot()
     def on_triggered(self) -> None:
@@ -3659,6 +3657,12 @@ class DownloadConversation(QAction):
                 return
             self._controller.download_conversation(id)
 
+    def _connect_enabled_to_conversation_changes(self) -> None:
+        if self._state is not None:
+            self._state.selected_conversation_files_changed.connect(
+                self._on_selected_conversation_files_changed
+            )
+
     @pyqtSlot()
     def _on_selected_conversation_files_changed(self) -> None:
         if self._state is None:
@@ -3667,6 +3671,9 @@ class DownloadConversation(QAction):
             self.setEnabled(True)
         else:
             self.setEnabled(False)
+
+    def _set_enabled_initial_value(self) -> None:
+        self._on_selected_conversation_files_changed()
 
 
 class DeleteSourceAction(QAction):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -88,6 +88,9 @@ from securedrop_client.utils import humanize_filesize
 logger = logging.getLogger(__name__)
 
 
+MINIMUM_ANIMATION_DURATION_IN_MILLISECONDS = 300
+
+
 class TopPane(QWidget):
     """
     Top pane of the app window.
@@ -2253,13 +2256,17 @@ class FileWidget(QWidget):
     def _on_file_downloaded(self, source_uuid: str, file_uuid: str, filename: str) -> None:
         if file_uuid == self.uuid:
             self.downloading = False
-            QTimer.singleShot(300, self.stop_button_animation)
+            QTimer.singleShot(
+                MINIMUM_ANIMATION_DURATION_IN_MILLISECONDS, self.stop_button_animation
+            )
 
     @pyqtSlot(str, str, str)
     def _on_file_missing(self, source_uuid: str, file_uuid: str, filename: str) -> None:
         if file_uuid == self.uuid:
             self.downloading = False
-            QTimer.singleShot(300, self.stop_button_animation)
+            QTimer.singleShot(
+                MINIMUM_ANIMATION_DURATION_IN_MILLISECONDS, self.stop_button_animation
+            )
 
     @pyqtSlot()
     def _on_export_clicked(self) -> None:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -90,6 +90,7 @@ logger = logging.getLogger(__name__)
 
 
 MINIMUM_ANIMATION_DURATION_IN_MILLISECONDS = 300
+NO_DELAY = 1
 
 
 class TopPane(QWidget):
@@ -2097,6 +2098,7 @@ class FileWidget(QWidget):
         self,
         file_uuid: str,
         controller: Controller,
+        file_download_started: pyqtBoundSignal,
         file_ready_signal: pyqtBoundSignal,
         file_missing: pyqtBoundSignal,
         index: int,
@@ -2202,6 +2204,7 @@ class FileWidget(QWidget):
         layout.addWidget(self.file_size)
 
         # Connect signals to slots
+        file_download_started.connect(self._on_file_download_started, type=Qt.QueuedConnection)
         file_ready_signal.connect(self._on_file_downloaded, type=Qt.QueuedConnection)
         file_missing.connect(self._on_file_missing, type=Qt.QueuedConnection)
 
@@ -2275,6 +2278,12 @@ class FileWidget(QWidget):
         if self.file_name.is_elided():
             self.horizontal_line.hide()
             self.spacer.show()
+
+    @pyqtSlot(state.FileId)
+    def _on_file_download_started(self, id: state.FileId) -> None:
+        if str(id) == self.uuid:
+            self.downloading = True
+            QTimer.singleShot(NO_DELAY, self.start_button_animation)
 
     @pyqtSlot(str, str, str)
     def _on_file_downloaded(self, source_uuid: str, file_uuid: str, filename: str) -> None:
@@ -3063,6 +3072,7 @@ class ConversationView(QWidget):
         conversation_item = FileWidget(
             file.uuid,
             self.controller,
+            self.controller.file_download_started,
             self.controller.file_ready,
             self.controller.file_missing,
             index,

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3610,6 +3610,29 @@ class SourceMenu(QMenu):
         self.addAction(DeleteSourceAction(self.source, self, self.controller))
 
 
+class DownloadConversation(QAction):
+    """Download all files and messages of the currently selected conversation."""
+
+    def __init__(
+        self, parent: QMenu, controller: Controller, app_state: Optional[state.State] = None
+    ) -> None:
+        self._controller = controller
+        self._state = app_state
+        self._text = _("All Files")
+        super().__init__(self._text, parent)
+        self.setShortcut(Qt.CTRL + Qt.Key_D)
+        self.triggered.connect(self.on_triggered)
+        self.setShortcutVisibleInContextMenu(True)
+
+    @pyqtSlot()
+    def on_triggered(self) -> None:
+        if self._state is not None:
+            id = self._state.selected_conversation
+            if id is None:
+                return
+            self._controller.download_conversation(id)
+
+
 class DeleteSourceAction(QAction):
     """Use this action to delete the source record."""
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3646,6 +3646,11 @@ class DownloadConversation(QAction):
         self.triggered.connect(self.on_triggered)
         self.setShortcutVisibleInContextMenu(True)
 
+        if self._state is not None:
+            self._state.selected_conversation_files_changed.connect(
+                self._on_selected_conversation_files_changed
+            )
+
     @pyqtSlot()
     def on_triggered(self) -> None:
         if self._state is not None:
@@ -3653,6 +3658,15 @@ class DownloadConversation(QAction):
             if id is None:
                 return
             self._controller.download_conversation(id)
+
+    @pyqtSlot()
+    def _on_selected_conversation_files_changed(self) -> None:
+        if self._state is None:
+            return
+        if self._state.selected_conversation_has_downloadable_files:
+            self.setEnabled(True)
+        else:
+            self.setEnabled(False)
 
 
 class DeleteSourceAction(QAction):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -60,6 +60,7 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
+from securedrop_client import state
 from securedrop_client.db import (
     DraftReply,
     File,
@@ -566,8 +567,10 @@ class MainView(QWidget):
     and main context view).
     """
 
-    def __init__(self, parent: QObject) -> None:
+    def __init__(self, parent: QObject, app_state: Optional[state.State] = None) -> None:
         super().__init__(parent)
+
+        self._state = app_state
 
         # Set id and styles
         self.setObjectName("MainView")

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -667,13 +667,16 @@ class MainView(QWidget):
                 conversation_wrapper = self.source_conversations[source.uuid]
                 conversation_wrapper.conversation_view.update_conversation(source.collection)
             else:
-                conversation_wrapper = SourceConversationWrapper(source, self.controller)
+                conversation_wrapper = SourceConversationWrapper(
+                    source, self.controller, self._state
+                )
                 self.source_conversations[source.uuid] = conversation_wrapper
 
             self.set_conversation(conversation_wrapper)
             logger.debug(
                 "Set conversation to the selected source with uuid: {}".format(source.uuid)
             )
+
         except sqlalchemy.exc.InvalidRequestError as e:
             logger.debug(e)
 
@@ -3151,7 +3154,9 @@ class SourceConversationWrapper(QWidget):
 
     deleting_conversation = False
 
-    def __init__(self, source: Source, controller: Controller) -> None:
+    def __init__(
+        self, source: Source, controller: Controller, app_state: Optional[state.State] = None
+    ) -> None:
         super().__init__()
 
         self.setObjectName("SourceConversationWrapper")
@@ -3175,7 +3180,7 @@ class SourceConversationWrapper(QWidget):
         layout.setSpacing(0)
 
         # Create widgets
-        self.conversation_title_bar = SourceProfileShortWidget(source, controller)
+        self.conversation_title_bar = SourceProfileShortWidget(source, controller, app_state)
         self.conversation_view = ConversationView(source, controller)
         self.reply_box = ReplyBoxWidget(source, controller)
         self.deletion_indicator = SourceDeletionIndicator()
@@ -3593,7 +3598,9 @@ class SourceMenu(QMenu):
 
     SOURCE_MENU_CSS = load_css("source_menu.css")
 
-    def __init__(self, source: Source, controller: Controller) -> None:
+    def __init__(
+        self, source: Source, controller: Controller, app_state: Optional[state.State]
+    ) -> None:
         super().__init__()
         self.source = source
         self.controller = controller
@@ -3602,6 +3609,11 @@ class SourceMenu(QMenu):
         separator_font = QFont()
         separator_font.setLetterSpacing(QFont.AbsoluteSpacing, 2)
         separator_font.setBold(True)
+
+        download_section = self.addSection(_("DOWNLOAD"))
+        download_section.setFont(separator_font)
+
+        self.addAction(DownloadConversation(self, self.controller, app_state))
 
         delete_section = self.addSection(_("DELETE"))
         delete_section.setFont(separator_font)
@@ -3679,7 +3691,9 @@ class SourceMenuButton(QToolButton):
     This button is responsible for launching the source menu on click.
     """
 
-    def __init__(self, source: Source, controller: Controller) -> None:
+    def __init__(
+        self, source: Source, controller: Controller, app_state: Optional[state.State]
+    ) -> None:
         super().__init__()
         self.controller = controller
         self.source = source
@@ -3689,7 +3703,7 @@ class SourceMenuButton(QToolButton):
         self.setIcon(load_icon("ellipsis.svg"))
         self.setIconSize(QSize(22, 33))  # Make it taller than the svg viewBox to increase hitbox
 
-        self.menu = SourceMenu(self.source, self.controller)
+        self.menu = SourceMenu(self.source, self.controller, app_state)
         self.setMenu(self.menu)
 
         self.setPopupMode(QToolButton.InstantPopup)
@@ -3729,7 +3743,9 @@ class SourceProfileShortWidget(QWidget):
     MARGIN_RIGHT = 17
     VERTICAL_MARGIN = 14
 
-    def __init__(self, source: Source, controller: Controller) -> None:
+    def __init__(
+        self, source: Source, controller: Controller, app_state: Optional[state.State]
+    ) -> None:
         super().__init__()
 
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
@@ -3751,7 +3767,7 @@ class SourceProfileShortWidget(QWidget):
         )
         title = TitleLabel(self.source.journalist_designation)
         self.updated = LastUpdatedLabel(_(arrow.get(self.source.last_updated).format("MMM D")))
-        menu = SourceMenuButton(self.source, self.controller)
+        menu = SourceMenuButton(self.source, self.controller, app_state)
         header_layout.addWidget(title, alignment=Qt.AlignLeft)
         header_layout.addStretch()
         header_layout.addWidget(self.updated, alignment=Qt.AlignRight)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3622,6 +3622,7 @@ class SourceMenu(QMenu):
 
         download_section = self.addSection(_("DOWNLOAD"))
         download_section.setFont(separator_font)
+        download_section.setObjectName("first_section")
 
         self.addAction(DownloadConversation(self, self.controller, app_state))
 

--- a/securedrop_client/locale/messages.pot
+++ b/securedrop_client/locale/messages.pot
@@ -229,6 +229,9 @@ msgstr ""
 msgid "DELETE"
 msgstr ""
 
+msgid "All Files"
+msgstr ""
+
 msgid "Entire source account"
 msgstr ""
 

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -223,6 +223,8 @@ class Controller(QObject):
     """
     message_download_failed = pyqtSignal(str, str, str)
 
+    file_download_started = pyqtSignal(state.FileId)
+
     """
     This signal indicates that a file has been successfully downloaded.
 
@@ -1087,6 +1089,17 @@ class Controller(QObject):
 
         self.add_job.emit(job)
         self.conversation_deleted.emit(source.uuid)
+
+    @login_required
+    def download_conversation(self, id: state.ConversationId) -> None:
+        files = self._state.conversation_files(id)
+        for file in files:
+            if not file.is_downloaded:
+                job = FileDownloadJob(str(file.id), self.data_dir, self.gpg)
+                job.success_signal.connect(self.on_file_download_success, type=Qt.QueuedConnection)
+                job.failure_signal.connect(self.on_file_download_failure, type=Qt.QueuedConnection)
+                self.add_job.emit(job)
+                self.file_download_started.emit(file.id)
 
     @login_required
     def send_reply(self, source_uuid: str, reply_uuid: str, message: str) -> None:

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -1004,6 +1004,7 @@ class Controller(QObject):
         file_obj = storage.get_file(self.session, uuid)
         file_obj.download_error = None
         storage.update_file_size(uuid, self.data_dir, self.session)
+        self._state.record_file_download(state.FileId(uuid))
 
         self.file_ready.emit(file_obj.source.uuid, uuid, file_obj.filename)
 

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -32,7 +32,7 @@ from PyQt5.QtCore import QObject, QProcess, Qt, QThread, QTimer, pyqtSignal
 from sdclientapi import AuthError, RequestTimeoutError, ServerConnectionError
 from sqlalchemy.orm.session import sessionmaker
 
-from securedrop_client import db, storage
+from securedrop_client import db, state, storage
 from securedrop_client.api_jobs.base import ApiInaccessibleError
 from securedrop_client.api_jobs.downloads import (
     DownloadChecksumMismatchException,
@@ -314,6 +314,7 @@ class Controller(QObject):
         gui,
         session_maker: sessionmaker,
         home: str,
+        state: state.State,
         proxy: bool = True,
         qubes: bool = True,
     ) -> None:
@@ -324,6 +325,8 @@ class Controller(QObject):
         """
         check_dir_permissions(home)
         super().__init__()
+
+        self._state = state
 
         # Controller is unauthenticated by default
         self.__is_authenticated = False
@@ -370,7 +373,7 @@ class Controller(QObject):
         self.data_dir = os.path.join(self.home, "data")
 
         # Background sync to keep client up-to-date with server changes
-        self.api_sync = ApiSync(self.api, self.session_maker, self.gpg, self.data_dir)
+        self.api_sync = ApiSync(self.api, self.session_maker, self.gpg, self.data_dir, state)
         self.api_sync.sync_started.connect(self.on_sync_started, type=Qt.QueuedConnection)
         self.api_sync.sync_success.connect(self.on_sync_success, type=Qt.QueuedConnection)
         self.api_sync.sync_failure.connect(self.on_sync_failure, type=Qt.QueuedConnection)

--- a/securedrop_client/resources/css/source_menu.css
+++ b/securedrop_client/resources/css/source_menu.css
@@ -1,18 +1,22 @@
 QMenu {
     font-family: 'Source Sans Pro';
-    padding: 1em 0.5em;
+    padding: 0.5em 0;
     font-size: 16px;
 }
 
 QMenu::separator {
-    padding: 1em 0.25em;
+    margin: 1.0em 1.75em 0.5em 1.675em;
+    height: 1em;
     font-weight: 900;
     color: #b8c0de;
 }
 
+QMenu::separator#first_section {
+    margin-top: 0.5em;
+}
+
 QMenu::item {
-    padding: 0.25em 1em 0.25em 1.25em;
-    margin: 0.25em 0 0 0;
+    padding: 0.5em 2em;
 }
 
 QMenu::item:selected {

--- a/securedrop_client/state/__init__.py
+++ b/securedrop_client/state/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright © 2022 The Freedom of the Press Foundation.
+"""
+The internal state of the SecureDrop Client.
+"""
+# Import classes here to make possible to import them from securedrop_client.state
+from .domain import ConversationId, File, FileId, SourceId  # noqa: F401
+from .state import State  # noqa: F401

--- a/securedrop_client/state/domain.py
+++ b/securedrop_client/state/domain.py
@@ -23,11 +23,11 @@ class FileId(str):
 
 class File:
     def __init__(self, id: FileId) -> None:
-        self._id: str = id
+        self._id: FileId = id
         self._is_downloaded: bool = False
 
     @property
-    def id(self) -> str:
+    def id(self) -> FileId:
         """A unique identifier file set by the server (opaque string)."""
         return self._id
 

--- a/securedrop_client/state/domain.py
+++ b/securedrop_client/state/domain.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright © 2022 The Freedom of the Press Foundation.
+"""
+The types relevant to the internal state of the SecureDrop Client.
+"""
+from typing import NewType
+
+
+class SourceId(str):
+    """Identifies a source."""
+
+    pass
+
+
+ConversationId = NewType("ConversationId", str)
+
+
+class FileId(str):
+    """Identifies a file."""
+
+    pass
+
+
+class File:
+    def __init__(self, id: FileId) -> None:
+        self._id: str = id
+        self._is_downloaded: bool = False
+
+    @property
+    def id(self) -> str:
+        """A unique identifier file set by the server (opaque string)."""
+        return self._id
+
+    @property
+    def is_downloaded(self) -> bool:
+        """Whether the file is available locally."""
+        return self._is_downloaded
+
+    @is_downloaded.setter
+    def is_downloaded(self, value: bool) -> None:
+        self._is_downloaded = value

--- a/securedrop_client/state/state.py
+++ b/securedrop_client/state/state.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright © 2022 The Freedom of the Press Foundation.
+"""
+Stores and provides read/write access to the internal state of the SecureDrop Client.
+
+Note: the Graphical User Interface MUST NOT write state, except in QActions.
+"""
+from typing import Dict, List, Optional
+
+from .domain import ConversationId, File, FileId
+
+
+class State:
+    """Stores and provides read/write access to the internal state of the SecureDrop Client.
+
+    Note: the Graphical User Interface SHOULD NOT write state, except in QActions.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._files: Dict[FileId, File] = {}
+        self._conversation_files: Dict[ConversationId, List[File]] = {}
+        self._selected_conversation: Optional[ConversationId] = None
+
+    def add_file(self, cid: ConversationId, fid: FileId) -> None:
+        file = File(fid)  # store references to the same object
+        if fid not in self._files.keys():
+            self._files[fid] = file
+
+        if cid not in self._conversation_files.keys():
+            self._conversation_files[cid] = [file]
+        else:
+            file_is_known = False
+            for known_file in self._conversation_files[cid]:
+                if fid == known_file.id:
+                    file_is_known = True
+            if not file_is_known:
+                self._conversation_files[cid].append(file)
+
+    def conversation_files(self, id: ConversationId) -> List[File]:
+        default: List[File] = []
+        return self._conversation_files.get(id, default)
+
+    def record_file_download(self, id: FileId) -> None:
+        if id not in self._files.keys():
+            pass
+        else:
+            self._files[id].is_downloaded = True
+
+    @property
+    def selected_conversation(self) -> Optional[ConversationId]:
+        """The identifier of the currently selected conversation, or None"""
+        return self._selected_conversation
+
+    @selected_conversation.setter
+    def selected_conversation(self, id: Optional[ConversationId]) -> None:
+        self._selected_conversation = id

--- a/securedrop_client/state/state.py
+++ b/securedrop_client/state/state.py
@@ -41,6 +41,9 @@ class State:
         default: List[File] = []
         return self._conversation_files.get(id, default)
 
+    def file(self, id: FileId) -> Optional[File]:
+        return self._files.get(id, None)
+
     def record_file_download(self, id: FileId) -> None:
         if id not in self._files.keys():
             pass

--- a/securedrop_client/state/state.py
+++ b/securedrop_client/state/state.py
@@ -7,10 +7,12 @@ Note: the Graphical User Interface MUST NOT write state, except in QActions.
 """
 from typing import Dict, List, Optional
 
-from .domain import ConversationId, File, FileId
+from PyQt5.QtCore import QObject, pyqtSlot
+
+from .domain import ConversationId, File, FileId, SourceId
 
 
-class State:
+class State(QObject):
     """Stores and provides read/write access to the internal state of the SecureDrop Client.
 
     Note: the Graphical User Interface SHOULD NOT write state, except in QActions.
@@ -58,3 +60,11 @@ class State:
     @selected_conversation.setter
     def selected_conversation(self, id: Optional[ConversationId]) -> None:
         self._selected_conversation = id
+
+    @pyqtSlot(SourceId)
+    def set_selected_conversation_for_source(self, source_id: SourceId) -> None:
+        self.selected_conversation = ConversationId(str(source_id))
+
+    @pyqtSlot()
+    def clear_selected_conversation(self) -> None:
+        self.selected_conversation = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QMainWindow
 
+from securedrop_client import state
 from securedrop_client.app import configure_locale_and_language
 from securedrop_client.config import Config
 from securedrop_client.db import (
@@ -148,10 +149,11 @@ def functional_test_app_started_context(homedir, reply_status_codes, session, co
     used to for tests that need to start from the login dialog before the main application window
     is visible.
     """
-    gui = Window()
+    app_state = state.State()
+    gui = Window(app_state)
     create_gpg_test_context(homedir)  # Configure test keys
     session_maker = make_session_maker(homedir)  # Configure and create the database
-    controller = Controller(HOSTNAME, gui, session_maker, homedir, False, False)
+    controller = Controller(HOSTNAME, gui, session_maker, homedir, app_state, False, False)
     gui.setup(controller)  # Connect the gui to the controller
 
     def login_dialog_is_visible():

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -5,6 +5,7 @@ import unittest
 
 from PyQt5.QtWidgets import QApplication, QHBoxLayout
 
+from securedrop_client import state
 from securedrop_client.gui.main import Window
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_icon
@@ -37,11 +38,12 @@ def test_init(mocker):
     mocker.patch("securedrop_client.gui.main.Window.setStyleSheet")
     load_css = mocker.patch("securedrop_client.gui.main.load_css")
 
-    w = Window()
+    app_state = state.State()
+    w = Window(app_state)
 
     mock_li.assert_called_once_with(w.icon)
     mock_lp.assert_called_once_with()
-    mock_mv.assert_called_once_with(w.main_pane)
+    mock_mv.assert_called_once_with(w.main_pane, app_state)
     assert mock_lo().addWidget.call_count == 2
     load_css.assert_called_once_with("sdclient.css")
 
@@ -56,7 +58,7 @@ def test_setup(mocker, homedir, session_maker):
     w.top_pane = mocker.MagicMock()
     w.left_pane = mocker.MagicMock()
     w.main_view = mocker.MagicMock()
-    controller = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir)
+    controller = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
 
     w.setup(controller)
 
@@ -69,7 +71,7 @@ def test_setup(mocker, homedir, session_maker):
 
 def test_show_main_window(mocker, homedir, session_maker):
     w = Window()
-    controller = Controller("http://localhost", w, session_maker, homedir)
+    controller = Controller("http://localhost", w, session_maker, homedir, None)
     w.setup(controller)
     w.show = mocker.MagicMock()
     w.showMaximized = mocker.MagicMock()
@@ -100,7 +102,7 @@ def test_show_main_window_when_already_showing(mocker, homedir, session_maker):
     Ensure we don't maximize the main window if it's already showing.
     """
     w = Window()
-    controller = Controller("http://localhost", w, session_maker, homedir)
+    controller = Controller("http://localhost", w, session_maker, homedir, None)
     w.setup(controller)
     w.show = mocker.MagicMock()
     w.showMaximized = mocker.MagicMock()
@@ -129,7 +131,7 @@ def test_show_main_window_when_already_showing(mocker, homedir, session_maker):
 
 def test_show_main_window_without_username(mocker, homedir, session_maker):
     w = Window()
-    controller = Controller("http://localhost", w, session_maker, homedir)
+    controller = Controller("http://localhost", w, session_maker, homedir, None)
     w.setup(controller)
     w.show = mocker.MagicMock()
     w.showMaximized = mocker.MagicMock()
@@ -156,7 +158,7 @@ def test_show_main_window_without_username(mocker, homedir, session_maker):
 
 def test_show_main_window_without_username_when_already_showing(mocker, homedir, session_maker):
     w = Window()
-    controller = Controller("http://localhost", w, session_maker, homedir)
+    controller = Controller("http://localhost", w, session_maker, homedir, None)
     w.setup(controller)
     w.show = mocker.MagicMock()
     w.showMaximized = mocker.MagicMock()

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -13,10 +13,10 @@ import sqlalchemy.orm.exc
 from PyQt5.QtCore import QEvent, QSize, Qt
 from PyQt5.QtGui import QFocusEvent, QMovie, QResizeEvent
 from PyQt5.QtTest import QTest
-from PyQt5.QtWidgets import QApplication, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QApplication, QMenu, QVBoxLayout, QWidget
 from sqlalchemy.orm import attributes, scoped_session, sessionmaker
 
-from securedrop_client import db, logic, storage
+from securedrop_client import db, logic, state, storage
 from securedrop_client.export import ExportError, ExportStatus
 from securedrop_client.gui.source import DeleteSourceDialog
 from securedrop_client.gui.widgets import (
@@ -24,6 +24,7 @@ from securedrop_client.gui.widgets import (
     ConversationView,
     DeleteConversationAction,
     DeleteSourceAction,
+    DownloadConversation,
     EmptyConversationView,
     ErrorStatusBar,
     ExportDialog,
@@ -4621,6 +4622,31 @@ def test_DeleteSourceAction_trigger(mocker):
     delete_source_action = DeleteSourceAction(mock_source, None, mock_controller)
     delete_source_action.trigger()
     mock_delete_source_dialog_instance.exec.assert_called_once()
+
+
+def test_DownloadConversation_trigger(mocker):
+    menu = QMenu()
+    controller = mocker.MagicMock()
+    app_state = state.State()
+
+    conversation_id = state.ConversationId("some_conversation")
+    app_state.selected_conversation = conversation_id
+
+    action = DownloadConversation(menu, controller, app_state)
+    action.trigger()
+
+    controller.download_conversation.assert_called_once_with(conversation_id)
+
+
+def test_DownloadConversation_trigger_downloads_nothing_if_no_conversation_is_selected(mocker):
+    menu = QMenu()
+    controller = mocker.MagicMock()
+    app_state = state.State()
+
+    action = DownloadConversation(menu, controller, app_state)
+    action.trigger()
+
+    assert controller.download_conversation.not_called
 
 
 def test_DeleteConversationAction_trigger(mocker):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -817,7 +817,7 @@ def test_MainView_refresh_source_conversations(homedir, mocker, qtbot, session_m
     mv = MainView(None)
 
     mock_gui = mocker.MagicMock()
-    controller = logic.Controller("http://localhost", mock_gui, session_maker, homedir)
+    controller = logic.Controller("http://localhost", mock_gui, session_maker, homedir, None)
     controller.api = mocker.MagicMock()
 
     mv.setup(controller)
@@ -894,7 +894,7 @@ def test_MainView_refresh_source_conversations_with_deleted(
     mv = MainView(None)
 
     mock_gui = mocker.MagicMock()
-    controller = logic.Controller("http://localhost", mock_gui, session_maker, homedir)
+    controller = logic.Controller("http://localhost", mock_gui, session_maker, homedir, None)
     controller.api = mocker.MagicMock()
 
     debug_logger = mocker.patch("securedrop_client.gui.widgets.logger.debug")
@@ -1041,7 +1041,7 @@ def test_SourceList_update_when_source_deleted(mocker, session, session_maker, h
     ongoing sync will handle the deletion of the source's widgets.
     """
     mock_gui = mocker.MagicMock()
-    controller = logic.Controller("http://localhost", mock_gui, session_maker, homedir)
+    controller = logic.Controller("http://localhost", mock_gui, session_maker, homedir, None)
 
     # create the source in another session
     source = factory.Source()
@@ -1896,7 +1896,7 @@ def test_SourceWidget_set_snippet_draft_only(mocker, session_maker, session, hom
     Snippets/previews do not include draft messages.
     """
     mock_gui = mocker.MagicMock()
-    controller = logic.Controller("http://localhost", mock_gui, session_maker, homedir)
+    controller = logic.Controller("http://localhost", mock_gui, session_maker, homedir, None)
     source = factory.Source(document_count=1)
     mark_seen_signal = mocker.MagicMock()
     f = factory.File(source=source)
@@ -1916,7 +1916,7 @@ def test_SourceWidget_set_snippet(mocker, session_maker, session, homedir):
     Snippets are set as expected.
     """
     mock_gui = mocker.MagicMock()
-    controller = logic.Controller("http://localhost", mock_gui, session_maker, homedir)
+    controller = logic.Controller("http://localhost", mock_gui, session_maker, homedir, None)
     source = factory.Source(document_count=1)
     mark_seen_signal = mocker.MagicMock()
     f = factory.File(source=source)
@@ -2941,7 +2941,7 @@ def test_ReplyWidget__on_update_authenticated_user(mocker):
 def test_ReplyWidget__on_update_authenticated_user_updates_sender_when_changed(mocker, homedir):
     authenticated_user = factory.User()
     co = mocker.MagicMock(authenticated_user=authenticated_user)
-    co = logic.Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir)
+    co = logic.Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
     user = factory.User(uuid="abc123", username="foo")
     co.authenticated_user = user
     co.session.refresh = mocker.MagicMock()
@@ -3333,7 +3333,7 @@ def test_FileWidget_on_file_missing_show_download_button_when_uuid_matches(
     session.commit()
 
     mock_gui = mocker.MagicMock()
-    controller = logic.Controller("http://localhost", mock_gui, session_maker, homedir)
+    controller = logic.Controller("http://localhost", mock_gui, session_maker, homedir, None)
 
     fw = FileWidget(file.uuid, controller, controller.file_ready, controller.file_missing, 0, 123)
     fw._on_file_missing(file.source.uuid, file.uuid, str(file))
@@ -3471,7 +3471,7 @@ def test_FileWidget_update_file_size_with_deleted_file(
     mocker, homedir, config, session_maker, source
 ):
     mock_gui = mocker.MagicMock()
-    controller = logic.Controller("http://localhost", mock_gui, session_maker, homedir)
+    controller = logic.Controller("http://localhost", mock_gui, session_maker, homedir, None)
 
     file = factory.File(source=source["source"], is_downloaded=True)
     controller.session.add(file)
@@ -4343,7 +4343,9 @@ def test_ConversationView_add_message(mocker, session, session_maker, homedir):
     """
     Adding a message results in a new MessageWidget added to the layout.
     """
-    controller = logic.Controller("http://localhost", mocker.MagicMock(), session_maker, homedir)
+    controller = logic.Controller(
+        "http://localhost", mocker.MagicMock(), session_maker, homedir, None
+    )
     controller.authenticated_user = factory.User()
     source = factory.Source()
     message = factory.Message(source=source, content=">^..^<")
@@ -4369,7 +4371,9 @@ def test_ConversationView_add_message_no_content(mocker, session, session_maker,
     checks that if a `Message` has `content = None` that a helpful message is displayed as would
     be the case if download/decryption never occurred or failed.
     """
-    controller = logic.Controller("http://localhost", mocker.MagicMock(), session_maker, homedir)
+    controller = logic.Controller(
+        "http://localhost", mocker.MagicMock(), session_maker, homedir, None
+    )
     controller.authenticated_user = factory.User()
     source = factory.Source()
     message = factory.Message(source=source, is_decrypted=False, content=None)
@@ -4446,7 +4450,9 @@ def test_ConversationView_add_reply(mocker, homedir, session, session_maker):
     """
     Adding a reply from a source results in a new ReplyWidget added to the layout.
     """
-    controller = logic.Controller("http://localhost", mocker.MagicMock(), session_maker, homedir)
+    controller = logic.Controller(
+        "http://localhost", mocker.MagicMock(), session_maker, homedir, None
+    )
     controller.authenticated_user = factory.User()
     source = factory.Source()
     sender = factory.User()
@@ -4479,7 +4485,9 @@ def test_ConversationView_add_reply_no_content(mocker, homedir, session_maker, s
     checks that if a `Reply` has `content = None` that a helpful message is displayed as would
     be the case if download/decryption never occurred or failed.
     """
-    controller = logic.Controller("http://localhost", mocker.MagicMock(), session_maker, homedir)
+    controller = logic.Controller(
+        "http://localhost", mocker.MagicMock(), session_maker, homedir, None
+    )
     controller.authenticated_user = factory.User()
     source = factory.Source()
     sender = factory.User()
@@ -4513,7 +4521,9 @@ def test_ConversationView_add_reply_that_has_current_user_as_sender(
     Adding a reply from a source results in a new ReplyWidget added to the layout.
     """
     authenticated_user = factory.User()
-    controller = logic.Controller("http://localhost", mocker.MagicMock(), session_maker, homedir)
+    controller = logic.Controller(
+        "http://localhost", mocker.MagicMock(), session_maker, homedir, None
+    )
     controller.authenticated_user = authenticated_user
     source = factory.Source()
     reply = factory.Reply(uuid="abc123", source=source, content=">^..^<")
@@ -4943,7 +4953,7 @@ def test_ReplyBoxWidget_enable_after_source_gets_key(mocker, session, session_ma
 
     mocker.patch("sdclientapi.API")
     mock_gui = mocker.MagicMock()
-    controller = logic.Controller("http://localhost", mock_gui, session_maker, homedir)
+    controller = logic.Controller("http://localhost", mock_gui, session_maker, homedir, None)
     controller.is_authenticated = True
 
     # create source without key or fingerprint
@@ -5403,7 +5413,9 @@ def test_update_conversation_updates_sender(mocker, homedir, session_maker, sess
     session.add(reply.journalist)
     session.add(reply)
     session.commit()
-    controller = logic.Controller("http://localhost", mocker.MagicMock(), session_maker, homedir)
+    controller = logic.Controller(
+        "http://localhost", mocker.MagicMock(), session_maker, homedir, None
+    )
     controller.authenticated_user = factory.User()
     controller.update_authenticated_user = mocker.MagicMock()
     cv = ConversationView(source, controller)
@@ -5427,7 +5439,9 @@ def test_update_conversation_calls_updates_sender_for_authenticated_user(
     session.add(reply.journalist)
     session.add(reply)
     session.commit()
-    controller = logic.Controller("http://localhost", mocker.MagicMock(), session_maker, homedir)
+    controller = logic.Controller(
+        "http://localhost", mocker.MagicMock(), session_maker, homedir, None
+    )
     controller.authenticated_user = reply.journalist
     controller.update_authenticated_user = mocker.MagicMock()
     cv = ConversationView(source, controller)
@@ -5451,7 +5465,9 @@ def test_update_conversation_updates_sender_when_sender_changes(
     session.add(reply.journalist)
     session.add(reply)
     session.commit()
-    controller = logic.Controller("http://localhost", mocker.MagicMock(), session_maker, homedir)
+    controller = logic.Controller(
+        "http://localhost", mocker.MagicMock(), session_maker, homedir, None
+    )
     controller.update_authenticated_user = mocker.MagicMock()
     cv = ConversationView(source, controller)
     cv.update_deletion_markers = mocker.MagicMock()
@@ -5486,7 +5502,9 @@ def test_update_conversation_shows_marker_when_all_items_deleted(
     source.interaction_count = 5
     session.add(source)
     session.commit()
-    controller = logic.Controller("http://localhost", mocker.MagicMock(), session_maker, homedir)
+    controller = logic.Controller(
+        "http://localhost", mocker.MagicMock(), session_maker, homedir, None
+    )
     controller.update_authenticated_user = mocker.MagicMock()
     cv = ConversationView(source, controller)
     cv.update_conversation(cv.source.collection)

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -5801,7 +5801,35 @@ class TestDownloadConversation(unittest.TestCase):
         app_state.selected_conversation_files_changed.emit()
         assert action.isEnabled()
 
-    def test_does_not_require_state_to_be_defined_defined(self):
+    def test_gets_initially_disabled_when_file_information_is_available(self):
+        menu = QMenu()
+        controller = mock.MagicMock()
+        app_state = state.State()
+
+        conversation_id = state.ConversationId(3)
+        app_state.selected_conversation = conversation_id
+        app_state.add_file(conversation_id, 5)
+        app_state.file(5).is_downloaded = True
+
+        action = DownloadConversation(menu, controller, app_state)
+
+        assert not action.isEnabled()
+
+    def test_gets_initially_enabled_when_file_information_is_available(self):
+        menu = QMenu()
+        controller = mock.MagicMock()
+        app_state = state.State()
+
+        conversation_id = state.ConversationId(3)
+        app_state.selected_conversation = conversation_id
+        app_state.add_file(conversation_id, 5)
+        app_state.file(5).is_downloaded = False
+
+        action = DownloadConversation(menu, controller, app_state)
+
+        assert action.isEnabled()
+
+    def test_does_not_require_state_to_be_defined(self):
         menu = QMenu()
         controller = mock.MagicMock()
         action = DownloadConversation(menu, controller, app_state=None)

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -3013,7 +3013,9 @@ def test_FileWidget_init_file_not_downloaded(mocker, source, session):
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
 
-    fw = FileWidget("mock", controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        "mock", controller, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), 0, 123
+    )
 
     assert fw.controller == controller
     assert fw.file.is_downloaded is False
@@ -3036,7 +3038,9 @@ def test_FileWidget_init_file_downloaded(mocker, source, session):
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
 
-    fw = FileWidget("mock", controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        "mock", controller, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), 0, 123
+    )
 
     assert fw.controller == controller
     assert fw.file.is_downloaded is True
@@ -3058,7 +3062,15 @@ def test_FileWidget_adjust_width(mocker):
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
 
-    fw = FileWidget("abc123-ima-uuid", controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        "abc123-ima-uuid",
+        controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
 
     fw.adjust_width(fw.MIN_CONTAINER_WIDTH - 1)
     assert fw.width() == fw.MIN_WIDTH
@@ -3079,7 +3091,15 @@ def test_FileWidget__set_file_state_under_mouse(mocker, source, session):
     mock_get_file = mocker.MagicMock(return_value=file_)
     mock_controller = mocker.MagicMock(get_file=mock_get_file)
 
-    fw = FileWidget(file_.uuid, mock_controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        file_.uuid,
+        mock_controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
     fw.download_button.underMouse = mocker.MagicMock(return_value=True)
     fw.download_button.setIcon = mocker.MagicMock()
     mock_load = mocker.MagicMock()
@@ -3101,7 +3121,15 @@ def test_FileWidget_event_handler_left_click(mocker, session, source):
     test_event = QEvent(QEvent.MouseButtonPress)
     test_event.button = mocker.MagicMock(return_value=Qt.LeftButton)
 
-    fw = FileWidget(file_.uuid, mock_controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        file_.uuid,
+        mock_controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
     fw._on_left_click = mocker.MagicMock()
 
     fw.eventFilter(fw, test_event)
@@ -3120,7 +3148,15 @@ def test_FileWidget_event_handler_hover(mocker, session, source):
     mock_get_file = mocker.MagicMock(return_value=file_)
     mock_controller = mocker.MagicMock(get_file=mock_get_file)
 
-    fw = FileWidget(file_.uuid, mock_controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        file_.uuid,
+        mock_controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
     fw.download_button = mocker.MagicMock()
 
     # Hover enter
@@ -3147,7 +3183,15 @@ def test_FileWidget_on_left_click_download(mocker, session, source):
     mock_get_file = mocker.MagicMock(return_value=file_)
     mock_controller = mocker.MagicMock(get_file=mock_get_file)
 
-    fw = FileWidget(file_.uuid, mock_controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        file_.uuid,
+        mock_controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
     fw.download_button = mocker.MagicMock()
     mock_get_file.assert_called_once_with(file_.uuid)
     mock_get_file.reset_mock()
@@ -3169,7 +3213,15 @@ def test_FileWidget_on_left_click_downloading_in_progress(mocker, session, sourc
     mock_get_file = mocker.MagicMock(return_value=file_)
     mock_controller = mocker.MagicMock(get_file=mock_get_file)
 
-    fw = FileWidget(file_.uuid, mock_controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        file_.uuid,
+        mock_controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
     fw.downloading = True
     fw.download_button = mocker.MagicMock()
     mock_get_file.assert_called_once_with(file_.uuid)
@@ -3189,7 +3241,15 @@ def test_FileWidget_start_button_animation(mocker, session, source):
     session.commit()
     mock_get_file = mocker.MagicMock(return_value=file_)
     mock_controller = mocker.MagicMock(get_file=mock_get_file)
-    fw = FileWidget(file_.uuid, mock_controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        file_.uuid,
+        mock_controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
     fw.download_button = mocker.MagicMock()
     fw.start_button_animation()
     # Check indicators of activity have been updated.
@@ -3207,7 +3267,15 @@ def test_FileWidget_on_left_click_open(mocker, session, source):
     mock_get_file = mocker.MagicMock(return_value=file_)
     mock_controller = mocker.MagicMock(get_file=mock_get_file)
 
-    fw = FileWidget(file_.uuid, mock_controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        file_.uuid,
+        mock_controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
     fw._on_left_click()
     fw.controller.on_file_open.assert_called_once_with(file_)
 
@@ -3224,7 +3292,15 @@ def test_FileWidget_set_button_animation_frame(mocker, session, source):
     mock_get_file = mocker.MagicMock(return_value=file_)
     mock_controller = mocker.MagicMock(get_file=mock_get_file)
 
-    fw = FileWidget(file_.uuid, mock_controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        file_.uuid,
+        mock_controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
     fw.download_button = mocker.MagicMock()
     fw.set_button_animation_frame(1)
     assert fw.download_button.setIcon.call_count == 1
@@ -3239,7 +3315,9 @@ def test_FileWidget_update(mocker, session, source):
     session.commit()
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
-    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), 0, 123
+    )
 
     fw.update()
 
@@ -3259,7 +3337,9 @@ def test_FileWidget_on_file_download_updates_items_when_uuid_matches(mocker, sou
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
 
-    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), 0, 123
+    )
     fw.update = mocker.MagicMock()
 
     fw._on_file_downloaded(file.source.uuid, file.uuid, str(file))
@@ -3270,6 +3350,31 @@ def test_FileWidget_on_file_download_updates_items_when_uuid_matches(mocker, sou
     assert not fw.print_button.isHidden()
     assert fw.no_file_name.isHidden()
     assert not fw.file_name.isHidden()
+
+
+def test_FileWidget_on_file_download_started_updates_items_when_uuid_matches(
+    mocker, source, session
+):
+    """
+    The _on_download_started method should update the FileWidget
+    """
+    file = factory.File(source=source["source"])
+    session.add(file)
+    session.commit()
+
+    get_file = mocker.MagicMock(return_value=file)
+    controller = mocker.MagicMock(get_file=get_file)
+
+    fw = FileWidget(
+        file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), 0, 123
+    )
+    fw.update = mocker.MagicMock()
+
+    assert not fw.downloading
+
+    fw._on_file_download_started(file.uuid)
+
+    assert fw.downloading
 
 
 def test_FileWidget_filename_truncation(mocker, source, session):
@@ -3286,7 +3391,9 @@ def test_FileWidget_filename_truncation(mocker, source, session):
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
 
-    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), 0, 123
+    )
     fw.update = mocker.MagicMock()
 
     fw._on_file_downloaded(file.source.uuid, file.uuid, str(file))
@@ -3308,7 +3415,9 @@ def test_FileWidget_on_file_download_updates_items_when_uuid_does_not_match(
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
 
-    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), 0, 123
+    )
     fw.clear = mocker.MagicMock()
     fw.update = mocker.MagicMock()
 
@@ -3336,7 +3445,15 @@ def test_FileWidget_on_file_missing_show_download_button_when_uuid_matches(
     mock_gui = mocker.MagicMock()
     controller = logic.Controller("http://localhost", mock_gui, session_maker, homedir, None)
 
-    fw = FileWidget(file.uuid, controller, controller.file_ready, controller.file_missing, 0, 123)
+    fw = FileWidget(
+        file.uuid,
+        controller,
+        controller.file_download_started,
+        controller.file_ready,
+        controller.file_missing,
+        0,
+        123,
+    )
     fw._on_file_missing(file.source.uuid, file.uuid, str(file))
 
     # this is necessary for the timer that stops the download
@@ -3365,7 +3482,9 @@ def test_FileWidget_on_file_missing_does_not_show_download_button_when_uuid_does
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
 
-    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), 0, 123
+    )
     fw.download_button.show = mocker.MagicMock()
 
     fw._on_file_missing("not a matching source uuid", "not a matching file uuid", "mock filename")
@@ -3384,7 +3503,9 @@ def test_FileWidget__on_export_clicked(mocker, session, source):
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
 
-    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), 0, 123
+    )
     fw.update = mocker.MagicMock()
     mocker.patch("PyQt5.QtWidgets.QDialog.exec")
     controller.run_export_preflight_checks = mocker.MagicMock()
@@ -3407,7 +3528,9 @@ def test_FileWidget__on_export_clicked_missing_file(mocker, session, source):
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
 
-    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), 0, 123
+    )
     fw.update = mocker.MagicMock()
     mocker.patch("PyQt5.QtWidgets.QDialog.exec")
     controller.run_export_preflight_checks = mocker.MagicMock()
@@ -3431,7 +3554,9 @@ def test_FileWidget__on_print_clicked(mocker, session, source):
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
 
-    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), 0, 123
+    )
     fw.update = mocker.MagicMock()
     mocker.patch("PyQt5.QtWidgets.QDialog.exec")
     controller.print_file = mocker.MagicMock()
@@ -3455,7 +3580,9 @@ def test_FileWidget__on_print_clicked_missing_file(mocker, session, source):
     get_file = mocker.MagicMock(return_value=file)
     controller = mocker.MagicMock(get_file=get_file)
 
-    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), 0, 123
+    )
     fw.update = mocker.MagicMock()
     mocker.patch("PyQt5.QtWidgets.QDialog.exec")
     controller.print_file = mocker.MagicMock()
@@ -3478,7 +3605,9 @@ def test_FileWidget_update_file_size_with_deleted_file(
     controller.session.add(file)
     controller.session.commit()
 
-    fw = FileWidget(file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), 0, 123)
+    fw = FileWidget(
+        file.uuid, controller, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), 0, 123
+    )
 
     mocker.patch("securedrop_client.gui.widgets.humanize_filesize", side_effect=Exception("boom!"))
     fw.update_file_size()

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -4018,7 +4018,7 @@ def test_SourceConversationWrapper_on_conversation_updated(mocker, qtbot):
     controller = mocker.MagicMock(get_file=get_file)
     source = factory.Source()
 
-    scw = SourceConversationWrapper(source, controller)
+    scw = SourceConversationWrapper(source, controller, None)
     scw.conversation_title_bar.updated.setText("CANARY")
 
     scw.conversation_view.add_file(file=file_, index=1)
@@ -4038,7 +4038,7 @@ def test_SourceConversationWrapper_on_source_deleted(mocker):
     mv.source_list.get_selected_source = mocker.MagicMock(return_value=source)
     mv.controller = mocker.MagicMock(is_authenticated=True)
     mv.show()
-    scw = SourceConversationWrapper(source, mv.controller)
+    scw = SourceConversationWrapper(source, mv.controller, None)
     mocker.patch("securedrop_client.gui.widgets.SourceConversationWrapper", return_value=scw)
     mv.on_source_changed()
     scw.on_source_deleted("123")
@@ -4094,7 +4094,7 @@ def test_SourceConversationWrapper_on_conversation_deleted(mocker):
     mv.source_list.get_selected_source = mocker.MagicMock(return_value=source)
     mv.controller = mocker.MagicMock(is_authenticated=True)
     mv.show()
-    scw = SourceConversationWrapper(source, mv.controller)
+    scw = SourceConversationWrapper(source, mv.controller, None)
     mocker.patch("securedrop_client.gui.widgets.SourceConversationWrapper", return_value=scw)
     mv.on_source_changed()
 
@@ -4624,6 +4624,21 @@ def test_DeleteSourceAction_trigger(mocker):
     mock_delete_source_dialog_instance.exec.assert_called_once()
 
 
+def test_DeleteSourceAction_requires_an_authenticated_journalist(mocker):
+    mock_controller = mocker.MagicMock()
+    mock_controller.api = None  # no aouthenticated journalist
+    mock_source = mocker.MagicMock()
+    mock_delete_source_dialog_instance = mocker.MagicMock(DeleteSourceDialog)
+    mock_delete_source_dialog = mocker.MagicMock()
+    mock_delete_source_dialog.return_value = mock_delete_source_dialog_instance
+
+    mocker.patch("securedrop_client.gui.widgets.DeleteSourceDialog", mock_delete_source_dialog)
+    delete_source_action = DeleteSourceAction(mock_source, None, mock_controller)
+    delete_source_action.trigger()
+    assert not mock_delete_source_dialog_instance.exec.called
+    mock_controller.on_action_requiring_login.assert_called_once()
+
+
 def test_DownloadConversation_trigger(mocker):
     menu = QMenu()
     controller = mocker.MagicMock()
@@ -4689,7 +4704,7 @@ def test_DeleteSource_from_source_menu_when_user_is_loggedout(mocker):
     mock_delete_source_dialog.return_value = mock_delete_source_dialog_instance
 
     mocker.patch("securedrop_client.gui.widgets.DeleteSourceDialog", mock_delete_source_dialog)
-    source_menu = SourceMenu(mock_source, mock_controller)
+    source_menu = SourceMenu(mock_source, mock_controller, None)
     source_menu.actions()[2].trigger()
     mock_delete_source_dialog_instance.exec.assert_not_called()
 
@@ -4742,7 +4757,7 @@ def test_ReplyBoxWidget_send_reply(mocker):
     controller = mocker.MagicMock()
     mocker.patch("securedrop_client.gui.widgets.SourceProfileShortWidget")
     mocker.patch("securedrop_client.gui.widgets.QVBoxLayout.addWidget")
-    scw = SourceConversationWrapper(source, controller)
+    scw = SourceConversationWrapper(source, controller, None)
     on_reply_sent_fn = mocker.MagicMock()
     scw.conversation_view.on_reply_sent = on_reply_sent_fn
     scw.reply_box.reply_sent = mocker.MagicMock()
@@ -5547,7 +5562,7 @@ def test_SourceProfileShortWidget_update_timestamp(mocker):
     mock_source = mocker.MagicMock()
     mock_source.last_updated = datetime.now()
     mock_source.journalist_designation = "wimple horse knackered unittest"
-    spsw = SourceProfileShortWidget(mock_source, mock_controller)
+    spsw = SourceProfileShortWidget(mock_source, mock_controller, None)
     spsw.updated = mocker.MagicMock()
     spsw.update_timestamp()
     spsw.updated.setText.assert_called_once_with(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,7 +14,7 @@ def main_window(mocker, homedir):
     gui = Window()
     app.setActiveWindow(gui)
     gui.show()
-    controller = Controller("http://localhost", gui, mocker.MagicMock(), homedir, proxy=False)
+    controller = Controller("http://localhost", gui, mocker.MagicMock(), homedir, None, proxy=False)
     controller.authenticated_user = factory.User()
     controller.qubes = False
     gui.setup(controller)
@@ -54,7 +54,7 @@ def main_window_no_key(mocker, homedir):
     gui = Window()
     app.setActiveWindow(gui)
     gui.show()
-    controller = Controller("http://localhost", gui, mocker.MagicMock(), homedir, proxy=False)
+    controller = Controller("http://localhost", gui, mocker.MagicMock(), homedir, None, proxy=False)
     controller.authenticated_user = factory.User()
     controller.qubes = False
     gui.setup(controller)
@@ -92,7 +92,7 @@ def modal_dialog(mocker, homedir):
     app = QApplication([])
     gui = Window()
     gui.show()
-    controller = Controller("http://localhost", gui, mocker.MagicMock(), homedir, proxy=False)
+    controller = Controller("http://localhost", gui, mocker.MagicMock(), homedir, None, proxy=False)
     controller.authenticated_user = factory.User()
     controller.qubes = False
     gui.setup(controller)
@@ -111,7 +111,7 @@ def print_dialog(mocker, homedir):
     app = QApplication([])
     gui = Window()
     gui.show()
-    controller = Controller("http://localhost", gui, mocker.MagicMock(), homedir, proxy=False)
+    controller = Controller("http://localhost", gui, mocker.MagicMock(), homedir, None, proxy=False)
     controller.authenticated_user = factory.User()
     controller.qubes = False
     gui.setup(controller)
@@ -130,7 +130,7 @@ def export_dialog(mocker, homedir):
     app = QApplication([])
     gui = Window()
     gui.show()
-    controller = Controller("http://localhost", gui, mocker.MagicMock(), homedir, proxy=False)
+    controller = Controller("http://localhost", gui, mocker.MagicMock(), homedir, None, proxy=False)
     controller.authenticated_user = factory.User()
     controller.qubes = False
     gui.setup(controller)

--- a/tests/state/test_domain.py
+++ b/tests/state/test_domain.py
@@ -1,0 +1,13 @@
+import unittest
+
+from securedrop_client import state as local
+
+
+class TestFile(unittest.TestCase):
+    def test_files_can_be_downloaded(self):
+        file = local.File("some opaque identifier")
+        assert file.id == local.FileId("some opaque identifier")
+        assert not file.is_downloaded
+
+        file.is_downloaded = True
+        assert file.is_downloaded

--- a/tests/state/test_state.py
+++ b/tests/state/test_state.py
@@ -1,0 +1,58 @@
+import unittest
+
+from securedrop_client import state
+
+
+class TestState(unittest.TestCase):
+    def setUp(self):
+        self.state = state.State()
+
+    def test_selected_conversation_is_unset_by_default(self):
+        assert self.state.selected_conversation is None
+
+    def test_selected_conversation_can_be_updated(self):
+        self.state.selected_conversation = "0"
+        assert self.state.selected_conversation == "0"
+
+        # File identifiers can be of any shape.
+        self.state.selected_conversation = 1
+        assert self.state.selected_conversation == 1
+
+    def test_add_file_does_not_duplicate_information(self):
+        self.state.add_file(5, 1)
+        self.state.add_file(5, 7)
+        assert len(self.state.conversation_files(5)) == 2
+        self.state.add_file(5, 7)
+        assert len(self.state.conversation_files(5)) == 2
+
+    def test_conversation_files_is_empty_by_default(self):
+        assert len(self.state.conversation_files(2)) == 0
+
+    def test_conversation_files_returns_the_conversation_files(self):
+        self.state.add_file(4, 1)
+        self.state.add_file(4, 7)
+        self.state.add_file(4, 3)
+        assert len(self.state.conversation_files(4)) == 3
+
+        self.state.add_file(4, 8)
+        assert len(self.state.conversation_files(4)) == 4
+
+    def test_records_downloads(self):
+        some_file_id = state.FileId("X")
+        another_file_id = state.FileId("Y")
+        self.state.add_file("4", some_file_id)
+        self.state.add_file("4", another_file_id)
+        files = self.state.conversation_files("4")
+        assert len(files) == 2
+        assert not files[0].is_downloaded
+        assert not files[1].is_downloaded
+
+        self.state.record_file_download(some_file_id)
+        assert len(files) == 2
+        assert files[0].is_downloaded
+        assert not files[1].is_downloaded
+
+    def test_record_downloads_ignores_missing_files(self):
+        missing_file_id = state.FileId("missing")
+        self.state.record_file_download(missing_file_id)
+        assert True

--- a/tests/state/test_state.py
+++ b/tests/state/test_state.py
@@ -18,6 +18,14 @@ class TestState(unittest.TestCase):
         self.state.selected_conversation = 1
         assert self.state.selected_conversation == 1
 
+    def test_selected_conversation_can_be_set_from_an_optional_source_id_and_cleared(self):
+        source_id = state.SourceId("some_id")
+        self.state.set_selected_conversation_for_source(source_id)
+        assert self.state.selected_conversation == state.ConversationId("some_id")
+
+        self.state.clear_selected_conversation()
+        assert self.state.selected_conversation is None
+
     def test_add_file_does_not_duplicate_information(self):
         self.state.add_file(5, 1)
         self.state.add_file(5, 7)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,6 +8,7 @@ import sys
 import pytest
 from PyQt5.QtWidgets import QApplication
 
+from securedrop_client import state
 from securedrop_client.app import (
     DEFAULT_SDC_HOME,
     ENCODING,
@@ -138,6 +139,8 @@ def test_start_app(homedir, mocker):
     mock_qt_args = mocker.MagicMock()
     mock_args.sdc_home = str(homedir)
     mock_args.proxy = False
+    app_state = state.State()
+    mocker.patch("securedrop_client.state.State", return_value=app_state)
 
     mocker.patch("securedrop_client.app.configure_logging")
     mock_app = mocker.patch("securedrop_client.app.QApplication")
@@ -151,9 +154,15 @@ def test_start_app(homedir, mocker):
     start_app(mock_args, mock_qt_args)
 
     mock_app.assert_called_once_with(mock_qt_args)
-    mock_win.assert_called_once_with()
+    mock_win.assert_called_once_with(app_state)
     mock_controller.assert_called_once_with(
-        "http://localhost:8081/", mock_win(), mock_session_maker, homedir, False, False
+        "http://localhost:8081/",
+        mock_win(),
+        mock_session_maker,
+        homedir,
+        app_state,
+        False,
+        False,
     )
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -252,6 +252,7 @@ def test_signal_interception(mocker, homedir):
     mocker.patch("securedrop_client.app.prevent_second_instance")
     mocker.patch("sys.exit")
     mocker.patch("securedrop_client.db.make_session_maker")
+    mocker.patch("securedrop_client.app.Database")
     mocker.patch("securedrop_client.app.init")
     mocker.patch("securedrop_client.logic.Controller.setup")
     mocker.patch("securedrop_client.logic.GpgHelper")

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1275,6 +1275,35 @@ def test_Controller_on_file_downloaded_success(homedir, config, mocker, session_
     mock_file_ready.emit.assert_called_once_with("a_uuid", "file_uuid", "foo.txt")
 
 
+def test_Controller_on_file_downloaded_success_updates_application_state(
+    homedir, config, mocker, session_maker
+):
+    """
+    Using the `config` fixture to ensure the config is written to disk.
+    """
+    mock_gui = mocker.MagicMock()
+    app_state = state.State()
+
+    co = Controller("http://localhost", mock_gui, session_maker, homedir, app_state)
+    co.session = mocker.MagicMock()
+
+    mock_storage = mocker.MagicMock()
+    mock_file = mocker.MagicMock()
+    mock_file.filename = "foo.txt"
+    mock_file.source.uuid = "a_uuid"
+    mock_storage.get_file.return_value = mock_file
+    mocker.patch("securedrop_client.logic.storage", mock_storage)
+
+    app_state.add_file("a_uuid", state.FileId("file_uuid"))
+
+    assert app_state.file(state.FileId("file_uuid"))
+    assert not app_state.file(state.FileId("file_uuid")).is_downloaded
+
+    co.on_file_download_success("file_uuid")
+
+    assert app_state.file(state.FileId("file_uuid")).is_downloaded
+
+
 def test_Controller_on_file_downloaded_api_failure(homedir, config, mocker, session_maker):
     """
     Using the `config` fixture to ensure the config is written to disk.

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -13,6 +13,7 @@ import arrow
 import pytest
 import sqlalchemy.orm.exc
 from PyQt5.QtCore import Qt
+from PyQt5.QtTest import QSignalSpy
 from sdclientapi import AuthError, RequestTimeoutError, ServerConnectionError
 from sqlalchemy.orm import attributes
 
@@ -1176,6 +1177,101 @@ def test_create_client_dir_permissions(tmpdir, mocker, session_maker):
     # check that both mocks were called to ensure they aren't "dead code"
     assert mock_open.called
     assert mock_json.called
+
+
+def test_Controller_download_conversation(homedir, config, session, mocker, session_maker):
+
+    app_state = state.State()
+    gui = mocker.MagicMock()
+    co = Controller("http://localhost", gui, session_maker, homedir, app_state)
+    co.api = "journalist is authenticated"
+
+    add_job_emissions = QSignalSpy(co.add_job)
+    file_download_started_emissions = QSignalSpy(co.file_download_started)
+
+    job_success_signal = mocker.MagicMock()
+    job_failure_signal = mocker.MagicMock()
+    job = mocker.MagicMock(success_signal=job_success_signal, failure_signal=job_failure_signal)
+    file_download_job_constructor = mocker.patch(
+        "securedrop_client.logic.FileDownloadJob", return_value=job
+    )
+
+    conversation_id = state.ConversationId("some_conversation")
+    unrelated_conversation_id = state.ConversationId("unrelated_conversation")
+    some_file_id = state.FileId("some_file")
+    another_file_id = state.FileId("another_file")
+    unrelated_file_id = state.FileId("unrelated_file")
+
+    app_state.add_file(conversation_id, some_file_id)
+    app_state.add_file(conversation_id, another_file_id)
+    app_state.add_file(unrelated_conversation_id, unrelated_file_id)
+
+    co.download_conversation(conversation_id)
+
+    expected = [
+        call(some_file_id, co.data_dir, co.gpg),
+        call(another_file_id, co.data_dir, co.gpg),
+    ]
+    assert file_download_job_constructor.mock_calls == expected
+
+    assert len(add_job_emissions) == 2
+    assert add_job_emissions[0] == [job]
+    assert add_job_emissions[1] == [job]
+    expected = [
+        call(co.on_file_download_success, type=Qt.QueuedConnection),
+        call(co.on_file_download_success, type=Qt.QueuedConnection),
+    ]
+    assert job_success_signal.connect.mock_calls == expected
+    expected = [
+        call(co.on_file_download_failure, type=Qt.QueuedConnection),
+        call(co.on_file_download_failure, type=Qt.QueuedConnection),
+    ]
+    assert job_failure_signal.connect.mock_calls == expected
+
+    assert len(file_download_started_emissions) == 2
+    assert file_download_started_emissions[0] == [some_file_id]
+    assert file_download_started_emissions[1] == [another_file_id]
+
+
+def test_Controller_download_conversation_requires_authenticated_journalist(
+    homedir, config, session, mocker, session_maker
+):
+    app_state = state.State()
+    gui = mocker.MagicMock()
+    co = Controller("http://localhost", gui, session_maker, homedir, app_state)
+    co.api = None  # journalist is not authenticated
+
+    co.add_job = mocker.MagicMock()
+    co.add_job.emit = mocker.MagicMock()
+    co.file_download_started = mocker.MagicMock()
+    co.file_download_started.emit = mocker.MagicMock()
+    co.on_action_requiring_login = mocker.MagicMock()
+
+    job_success_signal = mocker.MagicMock()
+    job_failure_signal = mocker.MagicMock()
+    job = mocker.MagicMock(success_signal=job_success_signal, failure_signal=job_failure_signal)
+    file_download_job_constructor = mocker.patch(
+        "securedrop_client.logic.FileDownloadJob", return_value=job
+    )
+
+    conversation_id = state.ConversationId("some_conversation")
+    unrelated_conversation_id = state.ConversationId("unrelated_conversation")
+    some_file_id = state.FileId("some_file")
+    another_file_id = state.FileId("another_file")
+    unrelated_file_id = state.FileId("unrelated_file")
+
+    app_state.add_file(conversation_id, some_file_id)
+    app_state.add_file(conversation_id, another_file_id)
+    app_state.add_file(unrelated_conversation_id, unrelated_file_id)
+
+    co.download_conversation(conversation_id)
+
+    assert not file_download_job_constructor.called
+    assert not co.add_job.emit.called
+    assert not job_success_signal.connect.called
+    assert not job_failure_signal.connect.called
+    assert not co.file_download_started.emit.called
+    assert co.on_action_requiring_login.called
 
 
 def test_Controller_on_file_download_Submission(homedir, config, session, mocker, session_maker):


### PR DESCRIPTION
> :crystal_ball: **Reviewers!** The commits are built individually and are meant to do one thing at a time. ~~I left a couple of quirks when splitting them, that you'll likely notice if you review commit by commit, but~~ I think it's ~~still~~ worth [reviewing commit by commit] if the overall diff feels a bit overwhelming. :slightly_smiling_face: 
>
> Once we're there, I'll rebase the branch one more time so that it's fully up to date before merging, just let me know.

# Description 

Closes https://github.com/freedomofpress/securedrop-client/issues/1354

Please refer to the issue for context.

**Summary**:
- This PR enables a journalist to download all the files of the currently visible conversation at once, via the conversation menu (a.k.a "source menu", a.k.a "kebab menu") or a keyboard shortcut (`Ctrl+D`).
- From that single user action, the files are downloaded one by one, the oldest file first. Progress is visible to the journalist in the same way as for individual downloads: files currently being downloaded display a spinning icon, and two "export" and "print" buttons replace that icon once the download is ready.
- If a conversation has no files or all its files have already been downloaded (whether individually or all at once), the menu action is disabled. (That's also true to the keyboard shortcut.)

_This feature is a prerequisite to introducing the possibility of _exporting_ a entire conversation at once._
:pear: @creviera

# Implementation Decisions

1. The state of the files is tracked in Python, in a new structure called `state.State`.
2. The state refers to files, source and conversations using identifiers that treat the server-generated identifiers as _opaque strings_. As far as the client state is concerned, it doesn't matter that files are identified by a UUID, a number, or something else as long as the identifiers are unique.
2. GUI elements interact with that new `state.State` structure exclusively: both the _controller_ and the _database_ are abstracted away from the GUI. (Scope: only for this feature. We can propagate the pattern later if we like.)
3. The GUI subscribes to changes of the state via Qt signals.
4. A limited number of GUI elements update the state via Qt slots.
5. Part of the state is persisted to the _database_ so that it remains available across reboots. That state was already being persisted, and this PR doesn't change that (out of scope). That state is loaded when the application starts, and it is currently the only interaction of `state.State` with the database. (A `database.Database` object was introduced for clarity of the API and ease of testing.)
6. The downloading of the files is performed using the same _job_ queue, and the same _job_ types as individual downloads. The only addition is making sure the state gets notice when downloads succeed.
7. The action is called "All Files" within a "Download" menu section (see #1354)

<details><summary>Reference diagram</summary>
<pre><code>
           Sync --updates ---\
                (ongoing)    |
                             v
GUI  --communicates with--> State --abstracts--> Controller ------manages--> Queue of API Jobs --downloads from--> SDK | Server
                             |                        |
                      reads from                 persists state to*
                   (intialization)                    |
                              \---> Database  <------/
 
(*) State will do it in the future, but that change is out of scope for this PR.
</code></pre></details>

<details><summary>Reference screenshots</summary>
This is what things should look like. (These were taken in a development environment, the original mockups are in #1354).
<img title="menu item enabled" src="https://user-images.githubusercontent.com/1619067/151924005-2cd2fe7a-2dd7-4ce2-8d2b-71c25d0c3fb9.png"/>
<img title="menu item selected" src="https://user-images.githubusercontent.com/1619067/151924007-20883ab6-0d4d-4822-8a1c-a5ce9f2163d8.png"/>
<img title="menu item disabled" src="https://user-images.githubusercontent.com/1619067/151924008-20ca006b-8227-48f6-963f-7e8435381edd.png"/>
</details>

# Test Plan

**Note**: Thorough the test plan, please try to activate the "All Files" action menu by clicking on it, but also using the <kbd>Ctlr</kbd>+<kbd>D</kbd> shortcut.
**Note on Qubes OS**: Performing the testing in at least one Workstation is necessary, because some of the UI may behave differently on Qubes OS (e.g. the conversation menu will be framed by the label color of the `sd-app` _qube_.)

It's a fairly long test plan, here we go!

- Make sure your server is up to date (see [SecureDrop 2.1.0](https://github.com/freedomofpress/securedrop/tree/2.1.0))
- Start the server, start the client, select a source.
- [ ] Confirm that the conversation and its files are shown as usual.
- [ ] Confirm that the "conversation menu" (a.k.a "source menu", a.k.a "kebab menu") contains a sub-section "Download" and an action "All Files".
- [ ] Confirm that the "All Files" action is enabled for conversations that have at least one file that hasn't been downloaded before.
- [ ] Confirm that the files can be downloaded individually (by activating their "Download" buttons) as usual.
- [ ] Confirm that downloading all the files of a conversation one by one (by activating their "Download" buttons) causes the "All Files" action to be disabled.
- [ ] Confirm that activating the "All Files" menu action causes all the not-already-downloaded files of the conversation to start downloading.
- [ ] Confirm that when downloading all files, the oldest are downloaded first.
- [ ] Confirm that once all files are downloaded, the "All Files" action is disabled.
- For later, leave some conversation with a few files to download, one file to download, no files to download, mixing those you download individually and those you download all at once.
- Stop the client.

Take a breath!

----


- Start the client.
- [ ] Confirm that the "All Files" action is disabled for conversations that have no files to download, and enabled for all the other. (Independently of the fact that the files were or not downloaded individually or via "All Files").
- [ ] Confirm that everything in the steps above is still true.

Next comes testing the sync.

----

- Stop the server (or somehow disconnect the client, this could be done emulating a network issue)
- Wait until the client displays the banner that indicates that the connection to the server was lost.
- Upload new files for existing sources. (Ideally upload file to some sources that already have files to download and other that don't have any yet, so that you can confirm later that the action was enabled as expected.)
- Create new sources, upload files from some sources, and leave other conversations without files
- Start the server (or somehow fix the network issue)
- [ ] Confirm that the banner is cleared as usual when the client is automatically sync'd
- [ ] Confirm that the new sources are loaded
- [ ] Confirm that the "All Files" action is enabled for the conversations of the new sources with files
- [ ] Confirm that the "All Files" action is disabled for the conversations of the new sources with no files
- [ ] Confirm that the new files are visible for the previously existing sources
- [ ] Confirm that the "All Files" action is enabled for the conversations that were added files
- [ ] Confirm that the "All Files" action is disabled for the conversations that didn't have files and weren't added files

Take a breath again : )

----

- Start downloading "All Files"
- Disconnect the server while the files are downloading (ideally, some were downloaded, others not yet)
- [ ] Confirm that the client behaves as usual with respect of failed download tasks. (@creviera I need your help to detail this step!)
- Stop the client

Remain some steps specific to using the keyboard shortcut.

----

- Start the client, do not select any source.
- [ ] Confirm that pressing <kbd>Ctlr</kbd>+<kbd>D</kbd> ("the shorcut") does not trigger any download (even when all conversation have files that could be downloaded)
- Select a source
- [ ] Confirm that pressing "the shortcut" causes all files to be downloaded for the conversation that's visible.
- [ ] Confirm that the "All Files" action in the conversation menu is disabled once all files were downloaded using the shortcut.
- Select a different source
- [ ] Confirm that the shortcut only causes files to be downloaded for the currently selected conversation
 
Thanks for sticking through! Last but not least, please let me know of any scenarios you'd test that I didn't think of : ) :star:
Bonus points for getting the client into an inconsistent state! :star2:

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] ~~These changes should not need testing in Qubes~~

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
