### PR TITLE
Fix missing bottom margin in conversation

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3022,6 +3022,7 @@ class DeleteConversationDialog(ModalDialog):
 
 class ConversationScrollArea(QScrollArea):
 
+    MARGIN_BOTTOM = 28
     MARGIN_LEFT = 38
     MARGIN_RIGHT = 20
 
@@ -3041,7 +3042,9 @@ class ConversationScrollArea(QScrollArea):
         conversation.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.conversation_layout = QVBoxLayout()
         conversation.setLayout(self.conversation_layout)
-        self.conversation_layout.setContentsMargins(self.MARGIN_LEFT, 0, self.MARGIN_RIGHT, 0)
+        self.conversation_layout.setContentsMargins(
+            self.MARGIN_LEFT, 0, self.MARGIN_RIGHT, self.MARGIN_BOTTOM
+        )
         self.conversation_layout.setSpacing(0)
 
         # `conversation` is a child of this scroll area


### PR DESCRIPTION
# Description

Ensures that the last message of a conversation is never too close to the reply box.

:pear: @creviera 

Fixes @ninavizz's unhappiness.

# Test Plan

- [ ] Verify that the minimum padding below the last message is the same as the padding above the first message in any given conversation.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
