### PR TITLE
Add bug, feature, release templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Create a report to help us improve the SecureDrop Client
+
+---
+
+## Description
+
+A short summary of the issue.
+
+## Steps to Reproduce
+
+Please specify your environment if that is necessary to reproduce the bug (if in
+doubt, include it).
+
+## Expected Behavior
+
+
+## Actual Behavior
+
+Please provide screenshots where appropriate.
+
+## Comments
+
+Suggestions to fix, any other relevant information.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+## Description
+
+A short summary of the idea.
+
+## How will this impact [SecureDrop users](https://github.com/freedomofpress/securedrop-ux/wiki/Users)?
+<!-- How do you feel this change might impact SecureDrop's usability, accessibility, or usefulness—and specifically, for which users? Has anecdotal feedback from users influenced this change? Does evidence exist from user research to support this idea? Could design or user research efforts be helpful to support a change? -->
+
+## How would this affect SecureDrop's [threat model](https://docs.securedrop.org/en/stable/threat_model/threat_model.html)?
+<!-- Would this change create new risks for sources, journalists, or administrators? Would it mitigate existing risks? -->
+
+## User Stories
+<!-- “As a [role], I want to [task], so that [reason].” -->
+
+If appropriate

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,6 +14,4 @@ A short summary of the idea.
 <!-- Would this change create new risks for sources, journalists, or administrators? Would it mitigate existing risks? -->
 
 ## User Stories
-<!-- “As a [role], I want to [task], so that [reason].” -->
-
-If appropriate
+<!-- If appropriate, add one or more relevant user stories in this format: “As a [role], I want to [task], so that [reason].” -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,7 +10,7 @@ A short summary of the idea.
 ## How will this impact [SecureDrop users](https://github.com/freedomofpress/securedrop-ux/wiki/Users)?
 <!-- How do you feel this change might impact SecureDrop's usability, accessibility, or usefulness—and specifically, for which users? Has anecdotal feedback from users influenced this change? Does evidence exist from user research to support this idea? Could design or user research efforts be helpful to support a change? -->
 
-## How would this affect SecureDrop's [threat model](https://docs.securedrop.org/en/stable/threat_model/threat_model.html)?
+## How would this affect the SecureDrop Workstation [threat model](https://github.com/freedomofpress/securedrop-workstation/#threat-model)?
 <!-- Would this change create new risks for sources, journalists, or administrators? Would it mitigate existing risks? -->
 
 ## User Stories

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,0 +1,30 @@
+---
+name: Release
+about: Create a tracking ticket for a SecureDrop Client release
+
+---
+
+This issue tracks the SecureDrop Client release [version]. It will be organized by:
+
+- Release Manager:
+- Deputy Release Manager:
+
+This release includes the following changes:
+- [high level summary of changes]
+
+SecureDrop maintainers and testers: As you QA this release, please report back your testing results as comments on this ticket. File GitHub issues for any problems found, tag them "QA: Release", and associate them with the release milestone for tracking (or ask a maintainer to do so).
+
+## Test plan
+
+[Once completed, insert or link to test plan here, can be left out until then]
+
+## Release tasks
+
+- [ ] Update changelog
+- [ ] Create test plan
+- [ ] Refresh nightlies
+- [ ] Begin formal QA using nightlies; refresh nightlies as needed
+- [ ] Build production package in standard [build environment](https://github.com/freedomofpress/securedrop-debian-packaging/wiki/FAQ#how-do-i-create-a-local-environment-suitable-for-building-packages)
+- [ ] Sign production package
+- [ ] Perform final pre-flight testing using apt-qa.freedom.press
+- [ ] Publish production package

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -28,3 +28,4 @@ SecureDrop maintainers and testers: As you QA this release, please report back y
 - [ ] Sign production package
 - [ ] Perform final pre-flight testing using apt-qa.freedom.press
 - [ ] Publish production package
+- [ ] Publicize release via support channels


### PR DESCRIPTION
Adds bug and issue templates with language largely taken from the SecureDrop server repo. I've incorporated @ninavizz's proposed changes in https://github.com/freedomofpress/securedrop/pull/6175 with some modifications; if you review this PR, please also review Nina's, so we can keep language in sync between the two.

The release template is new. It should resemble previous release tickets like #1275, with two notable differences:
- I've added placeholders for RM and Deputy RM roles
- I've added a pre-flight testing step using apt-qa.

This assumes that we'll want to continue to do most QA using nightlies (which does have the benefit of high developer agility -- we can build those quickly and on-demand without worrying about RC increments) while getting important pre-release confidence in our build results. Happy to describe a different process, e.g., if we want to instead use the release branch/RC builds model for the next release.