### PR TITLE
Refactor move DeleteConversationDialog to 'gui.conversation' namespace

### DIFF
--- a/securedrop_client/gui/conversation/__init__.py
+++ b/securedrop_client/gui/conversation/__init__.py
@@ -1,0 +1,20 @@
+"""
+A conversation between a source and one or more journalists.
+
+Copyright (C) 2021  The Freedom of the Press Foundation.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+# Import classes here to make possible to import them from securedrop_client.gui.conversation
+from securedrop_client.gui.conversation.delete import DeleteConversationDialog  # noqa: F401

--- a/securedrop_client/gui/conversation/delete/__init__.py
+++ b/securedrop_client/gui/conversation/delete/__init__.py
@@ -1,0 +1,20 @@
+"""
+Everything necessary for a journalist to delete a conversation.
+
+Copyright (C) 2021  The Freedom of the Press Foundation.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+# Import classes here to make possible to import them from securedrop_client.gui.conversation.delete
+from securedrop_client.gui.conversation.delete.dialog import DeleteConversationDialog  # noqa: F401

--- a/securedrop_client/gui/conversation/delete/dialog.py
+++ b/securedrop_client/gui/conversation/delete/dialog.py
@@ -1,0 +1,103 @@
+"""
+Conversation deletion dialog.
+
+Copyright (C) 2021  The Freedom of the Press Foundation.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+from gettext import gettext as _
+from gettext import ngettext
+
+from PyQt5.QtCore import pyqtSlot
+
+from securedrop_client.db import File, Message, Reply, Source
+from securedrop_client.gui.base import ModalDialog
+from securedrop_client.logic import Controller
+
+
+class DeleteConversationDialog(ModalDialog):
+    """
+    Shown to confirm deletion of all content in a source conversation.
+    """
+
+    def __init__(self, source: Source, controller: Controller) -> None:
+        super().__init__(show_header=False, dangerous=False)
+
+        self.source = source
+        self.controller = controller
+
+        self.body.setText(self.make_body_text())
+
+        self.continue_button.setText(_("YES, DELETE FILES AND MESSAGES"))
+        self.continue_button.clicked.connect(self.delete_conversation)
+        self.continue_button.setFocus()
+
+        self.adjustSize()
+
+    def make_body_text(self) -> str:
+        files = 0
+        messages = 0
+        replies = 0
+        for submission in self.source.collection:
+            if isinstance(submission, Message):
+                messages += 1
+            if isinstance(submission, Reply):
+                replies += 1
+            elif isinstance(submission, File):
+                files += 1
+
+        message_tuple = (
+            "<style>li {{line-height: 150%;}}</li></style>",
+            "<p>",
+            _(
+                "You would like to delete {files_to_delete}, {replies_to_delete}, "
+                "{messages_to_delete} from the source account for {source}?"
+            ),
+            "</p>",
+            "<p>",
+            _(
+                "Preserving the account will retain its metadata, and the ability for {source} "
+                "to log in to your SecureDrop again."
+            ),
+            "</p>",
+        )
+
+        files_to_delete = ngettext("one file", "{file_count} files", files).format(file_count=files)
+
+        replies_to_delete = ngettext("one reply", "{reply_count} replies", replies).format(
+            reply_count=replies
+        )
+
+        messages_to_delete = ngettext("one message", "{message_count} messages", messages).format(
+            message_count=messages
+        )
+
+        source = "<b>{}</b>".format(self.source.journalist_designation)
+
+        return "".join(message_tuple).format(
+            files_to_delete=files_to_delete,
+            messages_to_delete=messages_to_delete,
+            replies_to_delete=replies_to_delete,
+            source=source,
+        )
+
+    def exec(self) -> None:
+        # Refresh counters
+        self.body.setText(self.make_body_text())
+        super().exec()
+
+    @pyqtSlot()
+    def delete_conversation(self) -> None:
+        self.controller.delete_conversation(self.source)
+        self.close()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -20,7 +20,6 @@ import html
 import logging
 from datetime import datetime
 from gettext import gettext as _
-from gettext import ngettext
 from typing import Dict, List, Optional, Union  # noqa: F401
 from uuid import uuid4
 
@@ -79,6 +78,7 @@ from securedrop_client.gui.base import (
     SvgPushButton,
     SvgToggleButton,
 )
+from securedrop_client.gui.conversation import DeleteConversationDialog
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_css, load_icon, load_image, load_movie
 from securedrop_client.storage import source_exists
@@ -2819,83 +2819,6 @@ class DeleteSourceDialog(ModalDialog):
     @pyqtSlot()
     def delete_source(self) -> None:
         self.controller.delete_source(self.source)
-        self.close()
-
-
-class DeleteConversationDialog(ModalDialog):
-    """
-    Shown to confirm deletion of all content in a source conversation.
-    """
-
-    def __init__(self, source: Source, controller: Controller) -> None:
-        super().__init__(show_header=False, dangerous=False)
-
-        self.source = source
-        self.controller = controller
-
-        self.body.setText(self.make_body_text())
-
-        self.continue_button.setText(_("YES, DELETE FILES AND MESSAGES"))
-        self.continue_button.clicked.connect(self.delete_conversation)
-        self.continue_button.setFocus()
-
-        self.adjustSize()
-
-    def make_body_text(self) -> str:
-        files = 0
-        messages = 0
-        replies = 0
-        for submission in self.source.collection:
-            if isinstance(submission, Message):
-                messages += 1
-            if isinstance(submission, Reply):
-                replies += 1
-            elif isinstance(submission, File):
-                files += 1
-
-        message_tuple = (
-            "<style>li {{line-height: 150%;}}</li></style>",
-            "<p>",
-            _(
-                "You would like to delete {files_to_delete}, {replies_to_delete}, "
-                "{messages_to_delete} from the source account for {source}?"
-            ),
-            "</p>",
-            "<p>",
-            _(
-                "Preserving the account will retain its metadata, and the ability for {source} "
-                "to log in to your SecureDrop again."
-            ),
-            "</p>",
-        )
-
-        files_to_delete = ngettext("one file", "{file_count} files", files).format(file_count=files)
-
-        replies_to_delete = ngettext("one reply", "{reply_count} replies", replies).format(
-            reply_count=replies
-        )
-
-        messages_to_delete = ngettext("one message", "{message_count} messages", messages).format(
-            message_count=messages
-        )
-
-        source = "<b>{}</b>".format(self.source.journalist_designation)
-
-        return "".join(message_tuple).format(
-            files_to_delete=files_to_delete,
-            messages_to_delete=messages_to_delete,
-            replies_to_delete=replies_to_delete,
-            source=source,
-        )
-
-    def exec(self) -> None:
-        # Refresh counters
-        self.body.setText(self.make_body_text())
-        super().exec()
-
-    @pyqtSlot()
-    def delete_conversation(self) -> None:
-        self.controller.delete_conversation(self.source)
         self.close()
 
 

--- a/securedrop_client/locale/messages.pot
+++ b/securedrop_client/locale/messages.pot
@@ -221,30 +221,6 @@ msgstr ""
 msgid "All files and messages from that source will also be destroyed."
 msgstr ""
 
-msgid "YES, DELETE FILES AND MESSAGES"
-msgstr ""
-
-msgid "You would like to delete {files_to_delete}, {replies_to_delete}, {messages_to_delete} from the source account for {source}?"
-msgstr ""
-
-msgid "Preserving the account will retain its metadata, and the ability for {source} to log in to your SecureDrop again."
-msgstr ""
-
-msgid "one file"
-msgid_plural "{file_count} files"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "one reply"
-msgid_plural "{reply_count} replies"
-msgstr[0] ""
-msgstr[1] ""
-
-msgid "one message"
-msgid_plural "{message_count} messages"
-msgstr[0] ""
-msgstr[1] ""
-
 msgid "Earlier files and messages deleted."
 msgstr ""
 
@@ -312,4 +288,28 @@ msgstr ""
 
 msgid "CANCEL"
 msgstr ""
+
+msgid "YES, DELETE FILES AND MESSAGES"
+msgstr ""
+
+msgid "You would like to delete {files_to_delete}, {replies_to_delete}, {messages_to_delete} from the source account for {source}?"
+msgstr ""
+
+msgid "Preserving the account will retain its metadata, and the ability for {source} to log in to your SecureDrop again."
+msgstr ""
+
+msgid "one file"
+msgid_plural "{file_count} files"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "one reply"
+msgid_plural "{reply_count} replies"
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "one message"
+msgid_plural "{message_count} messages"
+msgstr[0] ""
+msgstr[1] ""
 

--- a/tests/gui/conversation/delete/test_dialog.py
+++ b/tests/gui/conversation/delete/test_dialog.py
@@ -1,0 +1,29 @@
+from PyQt5.QtWidgets import QApplication
+
+from securedrop_client.gui.conversation import DeleteConversationDialog
+
+app = QApplication([])
+
+
+def test_DeleteConversationDialog_continue(mocker, source, session):
+    source = source["source"]  # to get the Source object
+
+    mock_controller = mocker.MagicMock()
+    dialog = DeleteConversationDialog(source, mock_controller)
+    dialog.continue_button.click()
+    mock_controller.delete_conversation.assert_called_once_with(source)
+
+
+def test_DeleteConversationDialog_exec(mocker, source, session):
+    """
+    Test that the dialog body is updated every time it is opened, to ensure
+    that the file, message and reply counters are up-to-date.
+    """
+    source = source["source"]  # to get the Source object
+
+    mock_controller = mocker.MagicMock()
+    dialog = DeleteConversationDialog(source, mock_controller)
+    mocker.patch.object(dialog.body, "setText")
+    mocker.patch("securedrop_client.gui.widgets.ModalDialog.exec")
+    dialog.exec()
+    dialog.body.setText.assert_called_once()

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -22,7 +22,6 @@ from securedrop_client.gui.widgets import (
     ActivityStatusBar,
     ConversationView,
     DeleteConversationAction,
-    DeleteConversationDialog,
     DeleteSourceAction,
     DeleteSourceDialog,
     EmptyConversationView,
@@ -4828,30 +4827,6 @@ def test_ConversationView_add_not_downloaded_file(mocker, homedir, source, sessi
 
     file_widget = cv.scroll.conversation_layout.itemAt(1).widget()
     assert isinstance(file_widget, FileWidget)
-
-
-def test_DeleteConversationDialog_continue(mocker, source, session):
-    source = source["source"]  # to get the Source object
-
-    mock_controller = mocker.MagicMock()
-    dialog = DeleteConversationDialog(source, mock_controller)
-    dialog.continue_button.click()
-    mock_controller.delete_conversation.assert_called_once_with(source)
-
-
-def test_DeleteConversationDialog_exec(mocker, source, session):
-    """
-    Test that the dialog body is updated every time it is opened, to ensure
-    that the file, message and reply counters are up-to-date.
-    """
-    source = source["source"]  # to get the Source object
-
-    mock_controller = mocker.MagicMock()
-    dialog = DeleteConversationDialog(source, mock_controller)
-    mocker.patch.object(dialog.body, "setText")
-    mocker.patch("securedrop_client.gui.widgets.ModalDialog.exec")
-    dialog.exec()
-    dialog.body.setText.assert_called_once()
 
 
 def test_DeleteSourceDialog_init(mocker, source):


### PR DESCRIPTION
# Description

:crystal_ball: **Review recommendations**: I split the changes in two commits, so that tests can be run (unchanged) after the class as been moved, then can be run again (without changes to the non-test code) after they are moved. :slightly_smiling_face: 

This is the 10th step to be split out of #1369.
It moves the `DeleteConversationDialog` definition to its own file/module.

# Test Plan

- [ ] Confirm that the `DeleteConversationDialog` dialog behavior and appearance hasn't changed
- [ ] Confirm that the `DeleteConversationDialog` definition is not changed
- [ ] Confirm that the `DeleteConversationDialog` unit tests haven't changed
- [ ] Confirm that the translatable strings haven't changed
- [ ] Confirm that CI is green

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
