### PR TITLE
Refactor move user actions to 'gui.actions' namespace

### DIFF
--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -1,0 +1,116 @@
+"""
+The actions available to the journalist.
+
+Over time, this module could become the interface between
+the GUI and the controller.
+
+Copyright (C) 2021 The Freedom of the Press Foundation.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+from gettext import gettext as _
+from typing import Optional
+
+from PyQt5.QtCore import Qt, pyqtSlot
+from PyQt5.QtWidgets import QAction, QMenu
+
+from securedrop_client import state
+from securedrop_client.db import Source
+from securedrop_client.gui.conversation import DeleteConversationDialog
+from securedrop_client.gui.source import DeleteSourceDialog
+from securedrop_client.logic import Controller
+
+
+class DownloadConversation(QAction):
+    """Download all files and messages of the currently selected conversation."""
+
+    def __init__(
+        self, parent: QMenu, controller: Controller, app_state: Optional[state.State] = None
+    ) -> None:
+        self._controller = controller
+        self._state = app_state
+        self._text = _("All Files")
+        super().__init__(self._text, parent)
+        self.setShortcut(Qt.CTRL + Qt.Key_D)
+        self.triggered.connect(self.on_triggered)
+        self.setShortcutVisibleInContextMenu(True)
+
+        self._connect_enabled_to_conversation_changes()
+        self._set_enabled_initial_value()
+
+    @pyqtSlot()
+    def on_triggered(self) -> None:
+        if self._state is not None:
+            id = self._state.selected_conversation
+            if id is None:
+                return
+            self._controller.download_conversation(id)
+
+    def _connect_enabled_to_conversation_changes(self) -> None:
+        if self._state is not None:
+            self._state.selected_conversation_files_changed.connect(
+                self._on_selected_conversation_files_changed
+            )
+
+    @pyqtSlot()
+    def _on_selected_conversation_files_changed(self) -> None:
+        if self._state is None:
+            return
+        if self._state.selected_conversation_has_downloadable_files:
+            self.setEnabled(True)
+        else:
+            self.setEnabled(False)
+
+    def _set_enabled_initial_value(self) -> None:
+        self._on_selected_conversation_files_changed()
+
+
+class DeleteSourceAction(QAction):
+    """Use this action to delete the source record."""
+
+    def __init__(self, source: Source, parent: QMenu, controller: Controller) -> None:
+        self.source = source
+        self.controller = controller
+        self.text = _("Entire source account")
+
+        super().__init__(self.text, parent)
+
+        self.confirmation_dialog = DeleteSourceDialog(self.source, self.controller)
+        self.triggered.connect(self.trigger)
+
+    def trigger(self) -> None:
+        if self.controller.api is None:
+            self.controller.on_action_requiring_login()
+        else:
+            self.confirmation_dialog.exec()
+
+
+class DeleteConversationAction(QAction):
+    """Use this action to delete a source's submissions and replies."""
+
+    def __init__(self, source: Source, parent: QMenu, controller: Controller) -> None:
+        self.source = source
+        self.controller = controller
+        self.text = _("Files and messages")
+
+        super().__init__(self.text, parent)
+
+        self.confirmation_dialog = DeleteConversationDialog(self.source, self.controller)
+        self.triggered.connect(self.trigger)
+
+    def trigger(self) -> None:
+        if self.controller.api is None:
+            self.controller.on_action_requiring_login()
+        else:
+            self.confirmation_dialog.exec()

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -3,21 +3,6 @@ The actions available to the journalist.
 
 Over time, this module could become the interface between
 the GUI and the controller.
-
-Copyright (C) 2021 The Freedom of the Press Foundation.
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as published
-by the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
-
-You should have received a copy of the GNU Affero General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from gettext import gettext as _
 from typing import Optional

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3680,7 +3680,7 @@ class DownloadConversation(QAction):
 class DeleteSourceAction(QAction):
     """Use this action to delete the source record."""
 
-    def __init__(self, source: Source, parent: SourceMenu, controller: Controller) -> None:
+    def __init__(self, source: Source, parent: QMenu, controller: Controller) -> None:
         self.source = source
         self.controller = controller
         self.text = _("Entire source account")
@@ -3700,7 +3700,7 @@ class DeleteSourceAction(QAction):
 class DeleteConversationAction(QAction):
     """Use this action to delete a source's submissions and replies."""
 
-    def __init__(self, source: Source, parent: SourceMenu, controller: Controller) -> None:
+    def __init__(self, source: Source, parent: QMenu, controller: Controller) -> None:
         self.source = source
         self.controller = controller
         self.text = _("Files and messages")

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -71,6 +71,11 @@ from securedrop_client.db import (
     User,
 )
 from securedrop_client.export import ExportError, ExportStatus
+from securedrop_client.gui.actions import (
+    DeleteConversationAction,
+    DeleteSourceAction,
+    DownloadConversation,
+)
 from securedrop_client.gui.base import (
     ModalDialog,
     PasswordEdit,
@@ -79,8 +84,6 @@ from securedrop_client.gui.base import (
     SvgPushButton,
     SvgToggleButton,
 )
-from securedrop_client.gui.conversation import DeleteConversationDialog
-from securedrop_client.gui.source import DeleteSourceDialog
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_css, load_icon, load_image, load_movie
 from securedrop_client.storage import source_exists
@@ -3631,90 +3634,6 @@ class SourceMenu(QMenu):
 
         self.addAction(DeleteConversationAction(self.source, self, self.controller))
         self.addAction(DeleteSourceAction(self.source, self, self.controller))
-
-
-class DownloadConversation(QAction):
-    """Download all files and messages of the currently selected conversation."""
-
-    def __init__(
-        self, parent: QMenu, controller: Controller, app_state: Optional[state.State] = None
-    ) -> None:
-        self._controller = controller
-        self._state = app_state
-        self._text = _("All Files")
-        super().__init__(self._text, parent)
-        self.setShortcut(Qt.CTRL + Qt.Key_D)
-        self.triggered.connect(self.on_triggered)
-        self.setShortcutVisibleInContextMenu(True)
-
-        self._connect_enabled_to_conversation_changes()
-        self._set_enabled_initial_value()
-
-    @pyqtSlot()
-    def on_triggered(self) -> None:
-        if self._state is not None:
-            id = self._state.selected_conversation
-            if id is None:
-                return
-            self._controller.download_conversation(id)
-
-    def _connect_enabled_to_conversation_changes(self) -> None:
-        if self._state is not None:
-            self._state.selected_conversation_files_changed.connect(
-                self._on_selected_conversation_files_changed
-            )
-
-    @pyqtSlot()
-    def _on_selected_conversation_files_changed(self) -> None:
-        if self._state is None:
-            return
-        if self._state.selected_conversation_has_downloadable_files:
-            self.setEnabled(True)
-        else:
-            self.setEnabled(False)
-
-    def _set_enabled_initial_value(self) -> None:
-        self._on_selected_conversation_files_changed()
-
-
-class DeleteSourceAction(QAction):
-    """Use this action to delete the source record."""
-
-    def __init__(self, source: Source, parent: QMenu, controller: Controller) -> None:
-        self.source = source
-        self.controller = controller
-        self.text = _("Entire source account")
-
-        super().__init__(self.text, parent)
-
-        self.confirmation_dialog = DeleteSourceDialog(self.source, self.controller)
-        self.triggered.connect(self.trigger)
-
-    def trigger(self) -> None:
-        if self.controller.api is None:
-            self.controller.on_action_requiring_login()
-        else:
-            self.confirmation_dialog.exec()
-
-
-class DeleteConversationAction(QAction):
-    """Use this action to delete a source's submissions and replies."""
-
-    def __init__(self, source: Source, parent: QMenu, controller: Controller) -> None:
-        self.source = source
-        self.controller = controller
-        self.text = _("Files and messages")
-
-        super().__init__(self.text, parent)
-
-        self.confirmation_dialog = DeleteConversationDialog(self.source, self.controller)
-        self.triggered.connect(self.trigger)
-
-    def trigger(self) -> None:
-        if self.controller.api is None:
-            self.controller.on_action_requiring_login()
-        else:
-            self.confirmation_dialog.exec()
 
 
 class SourceMenuButton(QToolButton):

--- a/securedrop_client/locale/messages.pot
+++ b/securedrop_client/locale/messages.pot
@@ -59,6 +59,15 @@ msgstr ""
 msgid "Failed to delete source at server"
 msgstr ""
 
+msgid "All Files"
+msgstr ""
+
+msgid "Entire source account"
+msgstr ""
+
+msgid "Files and messages"
+msgstr ""
+
 msgid "SecureDrop Client {}"
 msgstr ""
 
@@ -227,15 +236,6 @@ msgid " to compose or send a reply"
 msgstr ""
 
 msgid "DELETE"
-msgstr ""
-
-msgid "All Files"
-msgstr ""
-
-msgid "Entire source account"
-msgstr ""
-
-msgid "Files and messages"
 msgstr ""
 
 msgid "Username"

--- a/tests/gui/test_actions.py
+++ b/tests/gui/test_actions.py
@@ -1,0 +1,190 @@
+import unittest
+from unittest import mock
+
+from PyQt5.QtWidgets import QApplication, QMenu
+
+from securedrop_client import state
+from securedrop_client.gui.actions import (
+    DeleteConversationAction,
+    DeleteSourceAction,
+    DownloadConversation,
+)
+from securedrop_client.gui.source import DeleteSourceDialog
+
+app = QApplication([])
+
+
+def test_DeleteSourceAction_init(mocker):
+    mock_controller = mocker.MagicMock()
+    mock_source = mocker.MagicMock()
+    DeleteSourceAction(mock_source, None, mock_controller)
+
+
+def test_DeleteSourceAction_trigger(mocker):
+    mock_controller = mocker.MagicMock()
+    mock_source = mocker.MagicMock()
+    mock_delete_source_dialog_instance = mocker.MagicMock(DeleteSourceDialog)
+    mock_delete_source_dialog = mocker.MagicMock()
+    mock_delete_source_dialog.return_value = mock_delete_source_dialog_instance
+
+    mocker.patch("securedrop_client.gui.actions.DeleteSourceDialog", mock_delete_source_dialog)
+    delete_source_action = DeleteSourceAction(mock_source, None, mock_controller)
+    delete_source_action.trigger()
+    mock_delete_source_dialog_instance.exec.assert_called_once()
+
+
+def test_DeleteConversationAction_trigger(mocker):
+    mock_controller = mocker.MagicMock()
+    mock_source = mocker.MagicMock()
+    mock_delete_conversation_dialog_instance = mocker.MagicMock(DeleteSourceDialog)
+    mock_delete_conversation_dialog = mocker.MagicMock()
+    mock_delete_conversation_dialog.return_value = mock_delete_conversation_dialog_instance
+
+    mocker.patch(
+        "securedrop_client.gui.actions.DeleteConversationDialog", mock_delete_conversation_dialog
+    )
+    delete_conversation_action = DeleteConversationAction(mock_source, None, mock_controller)
+    delete_conversation_action.trigger()
+    mock_delete_conversation_dialog_instance.exec.assert_called_once()
+
+
+def test_DeleteConversationAction_trigger_when_user_is_loggedout(mocker):
+    mock_controller = mocker.MagicMock()
+    mock_controller.api = None
+    mock_source = mocker.MagicMock()
+    mock_delete_conversation_dialog_instance = mocker.MagicMock(DeleteSourceDialog)
+    mock_delete_conversation_dialog = mocker.MagicMock()
+    mock_delete_conversation_dialog.return_value = mock_delete_conversation_dialog_instance
+
+    mocker.patch(
+        "securedrop_client.gui.conversation.DeleteConversationDialog",
+        mock_delete_conversation_dialog,
+    )
+    delete_conversation_action = DeleteConversationAction(mock_source, None, mock_controller)
+    delete_conversation_action.trigger()
+    mock_delete_conversation_dialog_instance.exec.assert_not_called()
+
+
+def test_DeleteSourceAction_requires_an_authenticated_journalist(mocker):
+    mock_controller = mocker.MagicMock()
+    mock_controller.api = None  # no aouthenticated journalist
+    mock_source = mocker.MagicMock()
+    mock_delete_source_dialog_instance = mocker.MagicMock(DeleteSourceDialog)
+    mock_delete_source_dialog = mocker.MagicMock()
+    mock_delete_source_dialog.return_value = mock_delete_source_dialog_instance
+
+    mocker.patch("securedrop_client.gui.actions.DeleteSourceDialog", mock_delete_source_dialog)
+    delete_source_action = DeleteSourceAction(mock_source, None, mock_controller)
+    delete_source_action.trigger()
+    assert not mock_delete_source_dialog_instance.exec.called
+    mock_controller.on_action_requiring_login.assert_called_once()
+
+
+class TestDownloadConversation(unittest.TestCase):
+    def test_trigger(self):
+        menu = QMenu()
+        controller = mock.MagicMock()
+        app_state = state.State()
+        action = DownloadConversation(menu, controller, app_state)
+
+        conversation_id = state.ConversationId("some_conversation")
+        app_state.selected_conversation = conversation_id
+
+        action.trigger()
+
+        controller.download_conversation.assert_called_once_with(conversation_id)
+
+    def test_trigger_downloads_nothing_if_no_conversation_is_selected(self):
+        menu = QMenu()
+        controller = mock.MagicMock()
+        app_state = state.State()
+        action = DownloadConversation(menu, controller, app_state)
+
+        action.trigger()
+        assert controller.download_conversation.not_called
+
+    def test_gets_disabled_when_no_files_to_download_remain(self):
+        menu = QMenu()
+        controller = mock.MagicMock()
+        app_state = state.State()
+        action = DownloadConversation(menu, controller, app_state)
+
+        conversation_id = state.ConversationId(3)
+        app_state.selected_conversation = conversation_id
+
+        app_state.add_file(conversation_id, 5)
+        app_state.file(5).is_downloaded = True
+
+        action.setEnabled(True)  # only for extra contrast
+        app_state.selected_conversation_files_changed.emit()
+        assert not action.isEnabled()
+
+    def test_gets_enabled_when_files_are_available_to_download(self):
+        menu = QMenu()
+        controller = mock.MagicMock()
+        app_state = state.State()
+        action = DownloadConversation(menu, controller, app_state)
+
+        conversation_id = state.ConversationId(3)
+        app_state.selected_conversation = conversation_id
+
+        app_state.add_file(conversation_id, 5)
+        app_state.file(5).is_downloaded = False
+
+        action.setEnabled(False)  # only for extra contrast
+        app_state.selected_conversation_files_changed.emit()
+        assert action.isEnabled()
+
+    def test_gets_initially_disabled_when_file_information_is_available(self):
+        menu = QMenu()
+        controller = mock.MagicMock()
+        app_state = state.State()
+
+        conversation_id = state.ConversationId(3)
+        app_state.selected_conversation = conversation_id
+        app_state.add_file(conversation_id, 5)
+        app_state.file(5).is_downloaded = True
+
+        action = DownloadConversation(menu, controller, app_state)
+
+        assert not action.isEnabled()
+
+    def test_gets_initially_enabled_when_file_information_is_available(self):
+        menu = QMenu()
+        controller = mock.MagicMock()
+        app_state = state.State()
+
+        conversation_id = state.ConversationId(3)
+        app_state.selected_conversation = conversation_id
+        app_state.add_file(conversation_id, 5)
+        app_state.file(5).is_downloaded = False
+
+        action = DownloadConversation(menu, controller, app_state)
+
+        assert action.isEnabled()
+
+    def test_does_not_require_state_to_be_defined(self):
+        menu = QMenu()
+        controller = mock.MagicMock()
+        action = DownloadConversation(menu, controller, app_state=None)
+
+        action.setEnabled(False)
+        assert not action.isEnabled()
+
+        action.setEnabled(True)
+        assert action.isEnabled()
+
+    def test_on_selected_conversation_files_changed_handles_missing_state_gracefully(
+        self,
+    ):
+        menu = QMenu()
+        controller = mock.MagicMock()
+        action = DownloadConversation(menu, controller, None)
+
+        action.setEnabled(True)
+        action._on_selected_conversation_files_changed()
+        assert action.isEnabled()
+
+        action.setEnabled(False)
+        action._on_selected_conversation_files_changed()
+        assert not action.isEnabled()

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -20,13 +20,15 @@ from sqlalchemy.orm import attributes, scoped_session, sessionmaker
 
 from securedrop_client import db, logic, state, storage
 from securedrop_client.export import ExportError, ExportStatus
+from securedrop_client.gui.actions import (
+    DeleteConversationAction,
+    DeleteSourceAction,
+    DownloadConversation,
+)
 from securedrop_client.gui.source import DeleteSourceDialog
 from securedrop_client.gui.widgets import (
     ActivityStatusBar,
     ConversationView,
-    DeleteConversationAction,
-    DeleteSourceAction,
-    DownloadConversation,
     EmptyConversationView,
     ErrorStatusBar,
     ExportDialog,
@@ -4749,7 +4751,7 @@ def test_DeleteSourceAction_trigger(mocker):
     mock_delete_source_dialog = mocker.MagicMock()
     mock_delete_source_dialog.return_value = mock_delete_source_dialog_instance
 
-    mocker.patch("securedrop_client.gui.widgets.DeleteSourceDialog", mock_delete_source_dialog)
+    mocker.patch("securedrop_client.gui.actions.DeleteSourceDialog", mock_delete_source_dialog)
     delete_source_action = DeleteSourceAction(mock_source, None, mock_controller)
     delete_source_action.trigger()
     mock_delete_source_dialog_instance.exec.assert_called_once()
@@ -4763,7 +4765,7 @@ def test_DeleteSourceAction_requires_an_authenticated_journalist(mocker):
     mock_delete_source_dialog = mocker.MagicMock()
     mock_delete_source_dialog.return_value = mock_delete_source_dialog_instance
 
-    mocker.patch("securedrop_client.gui.widgets.DeleteSourceDialog", mock_delete_source_dialog)
+    mocker.patch("securedrop_client.gui.actions.DeleteSourceDialog", mock_delete_source_dialog)
     delete_source_action = DeleteSourceAction(mock_source, None, mock_controller)
     delete_source_action.trigger()
     assert not mock_delete_source_dialog_instance.exec.called
@@ -4778,7 +4780,7 @@ def test_DeleteConversationAction_trigger(mocker):
     mock_delete_conversation_dialog.return_value = mock_delete_conversation_dialog_instance
 
     mocker.patch(
-        "securedrop_client.gui.widgets.DeleteConversationDialog", mock_delete_conversation_dialog
+        "securedrop_client.gui.actions.DeleteConversationDialog", mock_delete_conversation_dialog
     )
     delete_conversation_action = DeleteConversationAction(mock_source, None, mock_controller)
     delete_conversation_action.trigger()
@@ -4794,7 +4796,8 @@ def test_DeleteConversationAction_trigger_when_user_is_loggedout(mocker):
     mock_delete_conversation_dialog.return_value = mock_delete_conversation_dialog_instance
 
     mocker.patch(
-        "securedrop_client.gui.widgets.DeleteConversationDialog", mock_delete_conversation_dialog
+        "securedrop_client.gui.conversation.DeleteConversationDialog",
+        mock_delete_conversation_dialog,
     )
     delete_conversation_action = DeleteConversationAction(mock_source, None, mock_controller)
     delete_conversation_action.trigger()
@@ -4809,7 +4812,7 @@ def test_DeleteSource_from_source_menu_when_user_is_loggedout(mocker):
     mock_delete_source_dialog = mocker.MagicMock()
     mock_delete_source_dialog.return_value = mock_delete_source_dialog_instance
 
-    mocker.patch("securedrop_client.gui.widgets.DeleteSourceDialog", mock_delete_source_dialog)
+    mocker.patch("securedrop_client.gui.source.DeleteSourceDialog", mock_delete_source_dialog)
     source_menu = SourceMenu(mock_source, mock_controller, None)
     source_menu.actions()[2].trigger()
     mock_delete_source_dialog_instance.exec.assert_not_called()


### PR DESCRIPTION
# Description

:crystal_ball: **Review recommendations**: I split the changes in three commits, so that tests can be run (unchanged) after the class as been moved, then can be run again (without changes to the non-test code) after they are moved. :slightly_smiling_face: 

This is the 12th step to be split out of #1369.
It moves the `DeleteSourceAction` and `DeleteConversationAction` definition to their own file/module. That module is at the top level at the moment because most actions benefit from being available at the "main widows" level when used with keyboard shortcuts (the widget needs to be in focus for the shortcut to be available, the main window is always in focus). Adding shortcuts for actions is discussed in https://github.com/freedomofpress/securedrop-client/issues/1358

Once we have clarity about which shortcuts we'll add or not add, the actions can be brought down the widget tree when appropriate.

# Test Plan

- [x] Confirm that that sources can be deleted as usual
- [x] Confirm that that conversations can be deleted as usual
- [x] Confirm that the `DeleteSourceAction` definition is not changed significantly (beyond resolving the circular dependency)
- [x] Confirm that the `DeleteSourceAction` tests are not changed significantly (beyond resolving the circular dependency)
- [x] Confirm that the `DeleteConversationAction` definition is not changed significantly (beyond resolving the circular dependency)
- [x] Confirm that the `DeleteConversationAction` tests are not changed significantly (beyond resolving the circular dependency)
- [x] Confirm that the `DownloadConversation` action definition is not changed significantly
- [x] Confirm that the `DownloadConversation` action tests are not changed significantly
- [x] Confirm that the translatable strings haven't changed
- [x] Confirm that CI is green

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
