### PR TITLE
tests localization and documents preflight check

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -27,5 +27,6 @@ SecureDrop maintainers and testers: As you QA this release, please report back y
 - [ ] Build production package in standard [build environment](https://github.com/freedomofpress/securedrop-debian-packaging/wiki/FAQ#how-do-i-create-a-local-environment-suitable-for-building-packages)
 - [ ] Sign production package
 - [ ] Perform final pre-flight testing using apt-qa.freedom.press
+  - [ ] **Localization:** In a dispVM, change your locale (e.g.: `export LANG=es_ES.utf-8; dpkg-reconfigure locales`), run the Client, and confirm that the application is translated.
 - [ ] Publish production package
 - [ ] Publicize release via support channels

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,27 @@ TIME_FILE_DOWNLOAD = 5000
 
 
 @pytest.fixture(scope="function")
+def lang(request):
+    """
+    Setup:  Override $LANG as parameterized and configure locale accordingly.
+
+    Teardown:  Restore original $LANG and locale configuration.
+
+    Must be used with "indirect" to wrap setup and teardown at runtime.
+    """
+    lang = request.param
+
+    LANG = os.environ.get("LANG", "")
+    os.environ["LANG"] = lang
+    configure_locale_and_language()
+
+    yield lang
+
+    os.environ["LANG"] = LANG
+    configure_locale_and_language()
+
+
+@pytest.fixture(scope="function")
 def modal_dialog(mocker, homedir):
     mocker.patch("PyQt5.QtWidgets.QApplication.activeWindow", return_value=QMainWindow())
 

--- a/tests/gui/auth/test_dialog.py
+++ b/tests/gui/auth/test_dialog.py
@@ -1,14 +1,13 @@
-import os
-
+import pytest
 from PyQt5.QtWidgets import QApplication
 
-from securedrop_client.app import configure_locale_and_language
 from securedrop_client.gui.auth import LoginDialog
 
 app = QApplication([])
 
 
-def test_LoginDialog_translated():
+@pytest.mark.parametrize("lang", ["es"], indirect=True)
+def test_LoginDialog_translated(lang):
     """
     The LoginDialog is translated when a valid $LANG is set.
 
@@ -17,34 +16,19 @@ def test_LoginDialog_translated():
     constants or even read (via polib) from the gettext catalogs under
     "securedrop_client/locale/", but the complication (never mind the extra
     dependency) doesn't seem worthwhile for a few tests.
-
-    Note that we reset $LANG to its original value so that other string-based
-    tests don't fail under translation.  This could be factored out into a
-    fixture for easier reuse.
     """
-    LANG = os.environ.get("LANG", "")
-
-    os.environ["LANG"] = "es"
-    configure_locale_and_language()
     ld = LoginDialog(None)
     assert ld.username_label.text() == "Nombre de Usuario"  # expected translation
 
-    os.environ["LANG"] = LANG
 
-
-def test_LoginDialog_not_translated_with_invalid_lang():
+@pytest.mark.parametrize("lang", ["foo"], indirect=True)
+def test_LoginDialog_not_translated_with_invalid_lang(lang):
     """
     The LoginDialog falls back to source (English) strings when an invalid $LANG
     is set.  See test_LoginDialog_translated() above for commentary.
     """
-    LANG = os.environ.get("LANG", "")
-
-    os.environ["LANG"] = "foo"  # no such locale!
-    configure_locale_and_language()
     ld = LoginDialog(None)
     assert ld.username_label.text() == "Username"  # expected source string
-
-    os.environ["LANG"] = LANG
 
 
 def test_LoginDialog_setup(mocker, i18n):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -30,6 +30,19 @@ def test_application_sets_en_as_default_language_code(mocker):
     assert language_code == "en"
 
 
+def test_application_uses_set_locale(mocker):
+    """
+    The application respects the locale set in the environment's $LANG.
+    """
+    LANG = os.environ.get("LANG", "")
+
+    os.environ["LANG"] = "es"
+    language_code = configure_locale_and_language()
+    assert language_code == "es"
+
+    os.environ["LANG"] = LANG
+
+
 def test_excepthook(mocker):
     """
     Ensure the custom excepthook logs the error and calls sys.exit.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -30,17 +30,13 @@ def test_application_sets_en_as_default_language_code(mocker):
     assert language_code == "en"
 
 
-def test_application_uses_set_locale(mocker):
+@pytest.mark.parametrize("lang", ["es"], indirect=True)
+def test_application_uses_set_locale(mocker, lang):
     """
     The application respects the locale set in the environment's $LANG.
     """
-    LANG = os.environ.get("LANG", "")
-
-    os.environ["LANG"] = "es"
-    language_code = configure_locale_and_language()
-    assert language_code == "es"
-
-    os.environ["LANG"] = LANG
+    language_code = os.environ["LANG"]
+    assert language_code == lang
 
 
 def test_excepthook(mocker):


### PR DESCRIPTION
# Description

Closes #1398 by:

1. testing that the Client appears translated when run under a (translated) valid `$LANG`; and
2. adding a manual check for (1) in preflight testing.

# Test Plan

- [ ] CI passes, especially including the tests added here.
- [ ] The preflight check suggested in the release template is reasonable (and this is a reasonable place for it).

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
