### PR TITLE
Document need for Python 3.7 and make `make venv` more flexible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 .PHONY: all
 all: help
 
+# Default to plain "python3"
+PYTHON ?= python3
+
 .PHONY: venv-debian
 venv-debian: hooks ## Provision a Python 3 virtualenv for development on a prod-like system that has installed dependencies specified in https://github.com/freedomofpress/securedrop-debian-packaging/blob/main/securedrop-client/debian/control
-	python3 -m venv .venv-debian --system-site-packages
+	$(PYTHON) -m venv .venv-debian --system-site-packages
 	.venv-debian/bin/pip install --upgrade pip wheel
 	.venv-debian/bin/pip install --require-hashes -r "requirements/dev-requirements-debian.txt"
 	@echo "#################"
@@ -13,7 +16,7 @@ venv-debian: hooks ## Provision a Python 3 virtualenv for development on a prod-
 
 .PHONY: venv
 venv: hooks ## Provision a Python 3 virtualenv for development on Linux
-	python3 -m venv .venv
+	$(PYTHON) -m venv .venv
 	.venv/bin/pip install --upgrade pip wheel
 	.venv/bin/pip install --require-hashes -r "requirements/dev-requirements.txt"
 	@echo "#################"
@@ -21,7 +24,7 @@ venv: hooks ## Provision a Python 3 virtualenv for development on Linux
 
 .PHONY: venv-mac
 venv-mac: hooks ## Provision a Python 3 virtualenv for development on macOS
-	python3 -m venv .venv
+	$(PYTHON) -m venv .venv
 	.venv/bin/pip install --upgrade pip wheel
 	.venv/bin/pip install --require-hashes -r "requirements/dev-mac-requirements.txt"
 	@echo "#################"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ make venv
 source .venv/bin/activate
 ```
 
+   * You will need Python 3.7 to run the client. If it's not the default `python3` on your installation, you can use `PYTHON=python3.7 make venv` to explicitly use a `python3.7` binary.
    * `make venv` will also run `make hooks`, which will configure Git to use the hooks found in `.githooks/` to check certain code-quality standards on new commits in this repository.  These checks are also enforced in CI.
 
 4. Run SecureDrop Client


### PR DESCRIPTION
# Description

To be able to install the dependencies you need Python 3.7 installed.
For newer Fedora/Debian versions where `python3` points at a different
version, a variable can be set to use a different binary:
 `PYTHON=python3.7 make venv`

This is also documented in the README.

Fixes #1399.

# Test Plan

* Run `make venv`, observe it still runs `python3 -m venv ...`.
* Then try `PYTHON=python3.7 make venv`, observe it now runs `python3.7 -m venv ...`

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [x] No update to the AppArmor profile is required for these changes

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [x] No database schema changes are needed
