### PR TITLE
Fix 1404

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -639,16 +639,21 @@ class Controller(QObject):
         self.download_new_replies()
         self.sync_succeeded.emit()
 
-        if (
-            self.authenticated_user
-            and self.api
-            and (
-                self.authenticated_user.username != self.api.username
-                or self.authenticated_user.firstname != self.api.first_name
-                or self.authenticated_user.lastname != self.api.last_name
-            )
-        ):
-            self.update_authenticated_user.emit(self.authenticated_user)
+        try:
+            if (
+                self.authenticated_user
+                and self.api
+                and (
+                    self.authenticated_user.username != self.api.username
+                    or self.authenticated_user.firstname != self.api.first_name
+                    or self.authenticated_user.lastname != self.api.last_name
+                )
+            ):
+                self.update_authenticated_user.emit(self.authenticated_user)
+        except sqlalchemy.orm.exc.ObjectDeletedError:
+            self.invalidate_token()
+            self.logout()
+            self.gui.show_login(error=_("Your session expired. Please log in again."))
 
         self.resume_queues()
 

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -651,9 +651,7 @@ class Controller(QObject):
             ):
                 self.update_authenticated_user.emit(self.authenticated_user)
         except sqlalchemy.orm.exc.ObjectDeletedError:
-            self.invalidate_token()
-            self.logout()
-            self.gui.show_login(error=_("Your session expired. Please log in again."))
+            self._close_client_session()
 
         self.resume_queues()
 
@@ -670,13 +668,16 @@ class Controller(QObject):
             if not self.is_authenticated or not self.api:
                 return
 
-            self.invalidate_token()
-            self.logout()
-            self.gui.show_login(error=_("Your session expired. Please log in again."))
+            self._close_client_session()
         elif isinstance(result, (RequestTimeoutError, ServerConnectionError)):
             self.gui.update_error_status(
                 _("The SecureDrop server cannot be reached. Trying to reconnect..."), duration=0
             )
+
+    def _close_client_session(self) -> None:
+        self.invalidate_token()
+        self.logout()
+        self.gui.show_login(error=_("Your session expired. Please log in again."))
 
     def show_last_sync(self) -> None:
         """

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -552,6 +552,21 @@ def test_Controller_on_sync_success_when_current_user_deleted(mocker, homedir):
     co.gui.logout.assert_called_once_with()
 
 
+def test_Controller__close_client_session(mocker, homedir):
+    co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir)
+    co.authenticated_user = factory.User(username="foo")
+    co.api = "not None"
+    co.gui = mocker.MagicMock()
+
+    co._close_client_session()
+
+    assert co.authenticated_user is None
+    assert co.api is None
+    assert co.is_authenticated is False
+    co.gui.logout.assert_called_once_with()
+    co.gui.show_login.assert_called_once_with(error="Your session expired. Please log in again.")
+
+
 def test_Controller_on_sync_success_username_change(homedir, session, config, mocker):
     """
     If there's a result to syncing, then update local storage.


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/1404

The fix is a minimal fix to address an issue with the rc1 package that is currently undergoing QA.

@gonzalo-bulnes would you please confirm the test plan below?

# Test Plan

- Follow original STR in issue
   - [ ] Confirm that the bug is fixed using dev server
   - [ ] Confirm new behavior logs user out when they have been deleted
- Follow [staging STR](https://github.com/freedomofpress/securedrop-client/issues/1404#issuecomment-1027584013) in issue
   * I was unable to create an STR that causes the client to crash on staging
   - [ ] Confirm new behavior logs user out when they have been deleted

This is currently high priority because we are going to pull this fix into `securedrop-client-0.6.0-rc2` during the current QA period.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [x] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
