### PR TITLE
Re-associate draft replies with "deleted" user account

### DIFF
--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -3,6 +3,7 @@ import os
 from enum import Enum
 from pathlib import Path
 from typing import Any, List, Union  # noqa: F401
+from uuid import uuid4
 
 from sqlalchemy import (
     Boolean,
@@ -571,6 +572,11 @@ class User(Base):
             return self.lastname[0:2].lower()
         else:
             return self.username[0:2].lower()  # username must be at least 3 characters
+
+
+class DeletedUser(User):
+    def __init__(self) -> None:
+        super().__init__(uuid=str(uuid4()), username="deleted")
 
 
 class SeenFile(Base):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2034,11 +2034,14 @@ class ReplyWidget(SpeechBubble):
         """
         When the user logs in or updates user info, update the reply badge.
         """
-        if user.uuid == self.sender.uuid:
-            self.sender_is_current_user = True
-            self.sender = user
-            self.sender_icon.setToolTip(self.sender.fullname)
-            self._update_styles()
+        try:
+            if self.sender and self.sender.uuid == user.uuid:
+                self.sender_is_current_user = True
+                self.sender = user
+                self.sender_icon.setToolTip(self.sender.fullname)
+                self._update_styles()
+        except sqlalchemy.orm.exc.ObjectDeletedError:
+            logger.debug("The sender was deleted.")
 
     @pyqtSlot(str, str, str)
     def _on_reply_success(self, source_uuid: str, uuid: str, content: str) -> None:

--- a/tests/api_jobs/test_sync.py
+++ b/tests/api_jobs/test_sync.py
@@ -161,6 +161,71 @@ def test_MetadataSyncJob_reassociates_draftreplies_to_existing_account_before_de
     assert draftreply.journalist_id == reserved_deleted_user.id
 
 
+def test_MetadataSyncJob_reassociates_draftreplies_to_new_local_account_before_deleting_user(
+    mocker, homedir, session
+):
+    """
+    Ensure that any draft replies, sent by a user that is about to be deleted, are re-associated
+    to a new "deleted" user account that only exists locally.
+
+    This test is to ensure that we support an edge case that can occur on a pre-2.2.0 server
+    (before the server added support for creating an actual deleted user account).
+    """
+    user_to_delete_with_drafts = factory.User()
+    session.add(user_to_delete_with_drafts)
+    session.commit()
+
+    draftreply = factory.DraftReply(journalist_id=user_to_delete_with_drafts.id)
+    session.add(draftreply)
+    # Set up get_users so that `user_to_delete_with_drafts` will be deleted
+    api_client = mocker.patch("securedrop_client.logic.sdclientapi.API")
+    api_client.get_users = mocker.MagicMock(return_value=[])
+
+    job = MetadataSyncJob(homedir)
+    job.call_api(api_client, session)
+
+    # Ensure the account was deleted
+    deleted_user = session.query(User).filter_by(uuid=user_to_delete_with_drafts.uuid).one_or_none()
+    assert not deleted_user
+    # Ensure the "deleted" user account exists
+    reserved_deleted_user = session.query(User).filter_by(username="deleted").one_or_none()
+    assert reserved_deleted_user
+    # Ensure draft replies are reassociated
+    assert draftreply.journalist_id == reserved_deleted_user.id
+
+
+def test_MetadataSyncJob_replaces_reserved_deleted_user_account(mocker, homedir, session):
+    """
+    Ensure that we delete the local "deleted" user account if it is being replaced by a new account
+    from the server and that any draft replies are re-associated appropriately.
+
+    This test is to ensure that we support an edge case that can occur on a pre-2.2.0 server
+    (before the server added support for creating an actual deleted user account).
+    """
+    local_reserved_deleted_user = factory.User(username="deleted")
+    session.add(local_reserved_deleted_user)
+    session.commit()
+    draftreply = factory.DraftReply(journalist_id=local_reserved_deleted_user.id)
+    session.add(draftreply)
+    session.commit()
+
+    remote_reserved_deleted_user = factory.RemoteUser(username="deleted")
+    # Set up get_users so that `user_to_delete_with_drafts` will be deleted and
+    # `remote_reserved_deleted_user` will replace `local_reserved_deleted_user`
+    api_client = mocker.patch("securedrop_client.logic.sdclientapi.API")
+    api_client.get_users = mocker.MagicMock(return_value=[remote_reserved_deleted_user])
+
+    job = MetadataSyncJob(homedir)
+    job.call_api(api_client, session)
+
+    # Ensure `remote_reserved_deleted_user` replaced `local_reserved_deleted_user` and that the
+    # draft reply was reassociated to the new "deleted" user account.
+    reserved_deleted_user = session.query(User).filter_by(username="deleted").one_or_none()
+    assert reserved_deleted_user
+    assert reserved_deleted_user.uuid == remote_reserved_deleted_user.uuid
+    assert draftreply.journalist_id == reserved_deleted_user.id
+
+
 def test_MetadataSyncJob_success(mocker, homedir, session, session_maker):
     job = MetadataSyncJob(homedir)
 

--- a/tests/api_jobs/test_sync.py
+++ b/tests/api_jobs/test_sync.py
@@ -67,6 +67,100 @@ def test_MetadataSyncJob_deletes_user(mocker, homedir, session, session_maker):
     assert not local_user
 
 
+def test_MetadataSyncJob_does_not_delete_reserved_deleted_user(mocker, homedir, session):
+    """
+    Ensure that we do not delete the local "deleted" user account unless a "deleted" user account
+    exists on the server that we can replace it with.
+
+    This test is to ensure that we support an edge case that can occur on a pre-2.2.0 server
+    (before the server added support for creating an actual deleted user account).
+    """
+    api_client = mocker.patch("securedrop_client.logic.sdclientapi.API")
+    api_client.get_users = mocker.MagicMock(return_value=[])
+
+    reserved_deleted_user = factory.User(username="deleted")
+    session.add(reserved_deleted_user)
+
+    job = MetadataSyncJob(homedir)
+    job.call_api(api_client, session)
+
+    assert session.query(User).filter_by(username="deleted").one_or_none()
+
+
+def test_MetadataSyncJob_reassociates_draftreplies_to_new_account_before_deleting_user(
+    mocker, homedir, session
+):
+    """
+    Ensure that any draft replies sent by a user that is about to be deleted are re-associated
+    to a new "deleted" user account that exists on the server.
+    """
+    user_to_delete_with_drafts = factory.User()
+    session.add(user_to_delete_with_drafts)
+    session.commit()
+    draftreply = factory.DraftReply(journalist_id=user_to_delete_with_drafts.id)
+    session.add(draftreply)
+    session.commit()
+
+    remote_reserved_deleted_user = factory.RemoteUser(username="deleted")
+    # Set up get_users so that `user_to_delete_with_drafts` will be deleted and
+    # `remote_reserved_deleted_user` will be created since it exists on the server
+    api_client = mocker.patch("securedrop_client.logic.sdclientapi.API")
+    api_client.get_users = mocker.MagicMock(return_value=[remote_reserved_deleted_user])
+
+    job = MetadataSyncJob(homedir)
+    job.call_api(api_client, session)
+
+    # Ensure the account was deleted
+    deleted_user = session.query(User).filter_by(uuid=user_to_delete_with_drafts.uuid).one_or_none()
+    assert not deleted_user
+    # Ensure the "deleted" user account that exists on the server was created locally
+    reserved_deleted_user = session.query(User).filter_by(username="deleted").one_or_none()
+    assert reserved_deleted_user
+    assert reserved_deleted_user.uuid == remote_reserved_deleted_user.uuid
+    # Ensure draft replies are reassociated
+    assert draftreply.journalist_id == reserved_deleted_user.id
+
+
+def test_MetadataSyncJob_reassociates_draftreplies_to_existing_account_before_deleting_user(
+    mocker, homedir, session
+):
+    """
+    Ensure that any draft replies sent by a user that is about to be deleted are re-associated
+    to an existing "deleted" user account.
+    """
+    user_to_delete_with_drafts = factory.User()
+    session.add(user_to_delete_with_drafts)
+    session.commit()
+    draftreply = factory.DraftReply(journalist_id=user_to_delete_with_drafts.id)
+    session.add(draftreply)
+    session.commit()
+
+    local_reserved_deleted_user = factory.User(username="deleted")
+    session.add(local_reserved_deleted_user)
+    session.commit()
+
+    remote_reserved_deleted_user = factory.RemoteUser(
+        username="deleted", uuid=local_reserved_deleted_user.uuid
+    )
+    # Set up get_users so that `user_to_delete_with_drafts` will be deleted and
+    # `remote_reserved_deleted_user` will replace `local_reserved_deleted_user`
+    api_client = mocker.patch("securedrop_client.logic.sdclientapi.API")
+    api_client.get_users = mocker.MagicMock(return_value=[remote_reserved_deleted_user])
+
+    job = MetadataSyncJob(homedir)
+    job.call_api(api_client, session)
+
+    # Ensure the account was deleted
+    deleted_user = session.query(User).filter_by(uuid=user_to_delete_with_drafts.uuid).one_or_none()
+    assert not deleted_user
+    # Ensure the "deleted" user account still exists
+    reserved_deleted_user = session.query(User).filter_by(username="deleted").one_or_none()
+    assert reserved_deleted_user
+    assert reserved_deleted_user.uuid == local_reserved_deleted_user.uuid
+    # Ensure draft replies are reassociated
+    assert draftreply.journalist_id == reserved_deleted_user.id
+
+
 def test_MetadataSyncJob_success(mocker, homedir, session, session_maker):
     job = MetadataSyncJob(homedir)
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -562,11 +562,6 @@ def test_update_replies_deletes_files_associated_with_the_reply(homedir, mocker)
     abs_local_filename = add_test_file_to_temp_dir(source_directory, local_filename_when_decrypted)
     local_replies = [local_reply]
 
-    # There needs to be a corresponding local_source.
-    local_source = mocker.MagicMock()
-    local_source.uuid = "test-source-uuid"
-    local_source.id = 666
-    mock_session.query().filter_by.return_value = [local_source]
     update_replies(remote_replies, local_replies, mock_session, homedir)
 
     # Ensure the file associated with the reply are deleted on disk.


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/1414
Fixes https://github.com/freedomofpress/securedrop-client/issues/1416
Fixes https://github.com/freedomofpress/securedrop-client/issues/1411

This PR fixes all the issues above by ensuring that a pending or failed reply (aka "draft reply", because it exists in the `draftreplies` table) cannot have a null sender. One of the issues that came up during our testing was that we were allowing null `journalist_id` in the `draftreplies` table. Once the data was in this state, there would be issues whenever the client would have to update badges (on authentication change, when a user's name changed, and when badge needed to be updated to show the "deleted" sparkles icon).

# Test Plan

In case you are a QA tester, ensure that your local database is cleaned up from running QA tests during previous release candidate testing by deleting all draft replies in the `draftreplies` table where `journalist_id` is null. 

Follow STR in https://github.com/freedomofpress/securedrop-client/issues/1414:
- [ ] Confirm that you can no longer repro the issue

Follow STR in https://github.com/freedomofpress/securedrop-client/issues/1416
- [ ] Confirm that you can no longer repro the issue

Follow STR in https://github.com/freedomofpress/securedrop-client/issues/1411
- [ ] Confirm that you can no longer repro the issue

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
