### PR TITLE
Revert source deletion changes

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -297,15 +297,6 @@ class Controller(QObject):
         str: the source UUID
         datetime: the timestamp for when the deletion succeeded
     """
-    source_deletion_successful = pyqtSignal(str, datetime)
-
-    """
-    This signal indicates that a deletion attempt was successful at the server.
-
-    Emits:
-        str: the source UUID
-        datetime: the timestamp for when the deletion succeeded
-    """
     conversation_deletion_successful = pyqtSignal(str, datetime)
 
     """
@@ -1031,7 +1022,7 @@ class Controller(QObject):
     def on_delete_conversation_success(self, uuid: str) -> None:
         """
         If the source collection has been successfully scheduled for deletion on the server, emit a
-        signal.
+        signal and sync.
         """
         logger.info("Conversation %s successfully deleted at server", uuid)
         self.conversation_deletion_successful.emit(uuid, datetime.utcnow())
@@ -1045,11 +1036,10 @@ class Controller(QObject):
 
     def on_delete_source_success(self, source_uuid: str) -> None:
         """
-        If the source has been successfully scheduled for deletion on the server, emit a
-        signal.
+        Rely on sync to delete the source locally so we know for sure it was deleted
         """
         logger.info("Source %s successfully deleted at server", source_uuid)
-        self.source_deletion_successful.emit(source_uuid, datetime.utcnow())
+        self.api_sync.sync()
 
     def on_delete_source_failure(self, e: Exception) -> None:
         if isinstance(e, DeleteSourceJobException):

--- a/securedrop_client/sync.py
+++ b/securedrop_client/sync.py
@@ -42,11 +42,17 @@ class ApiSync(QObject):
 
         self.sync_thread.started.connect(self.api_sync_bg_task.sync)
 
+        self.timer = QTimer()
+        self.timer.setInterval(self.TIME_BETWEEN_SYNCS_MS)
+        self.timer.timeout.connect(self.sync)
+
     def start(self, api_client: API) -> None:
         """
         Start metadata syncs.
         """
         self.api_client = api_client
+
+        self.timer.start()
 
         if not self.sync_thread.isRunning():
             logger.debug("Starting sync thread")
@@ -68,14 +74,18 @@ class ApiSync(QObject):
         Start another sync on success.
         """
         self.sync_success.emit()
-        QTimer.singleShot(self.TIME_BETWEEN_SYNCS_MS, self.api_sync_bg_task.sync)
 
     def on_sync_failure(self, result: Exception) -> None:
         """
         Only start another sync on failure if the reason is a timeout request.
         """
         self.sync_failure.emit(result)
-        QTimer.singleShot(self.TIME_BETWEEN_SYNCS_MS, self.api_sync_bg_task.sync)
+
+    def sync(self) -> None:
+        """
+        Start an immediate sync.
+        """
+        QTimer.singleShot(1, self.api_sync_bg_task.sync)
 
 
 class ApiSyncBackgroundTask(QObject):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -945,70 +945,6 @@ def test_MainView_set_conversation(mocker):
     mv.view_layout.addWidget.assert_called_once_with(mock_widget)
 
 
-def test_MainView__delete_source(mocker):
-    """
-    Ensure that the source and conversation provided by source uuid are deleted.
-    """
-    source = factory.Source(uuid="123")
-    conversation_wrapper = SourceConversationWrapper(source, mocker.MagicMock())
-    mv = MainView(None)
-    mv.source_conversations = {}
-    mv.source_conversations["123"] = conversation_wrapper
-    mv.source_list.controller = mocker.MagicMock()
-    mv.source_list.update([source])
-    assert len(mv.source_list.source_items) > 0
-
-    mv._delete_source("123")
-
-    assert len(mv.source_conversations) == 0
-    assert len(mv.source_list.source_items) == 0
-
-
-def test_MainView__delete_source_with_multiple_sources(mocker):
-    """
-    Ensure that the source and conversation provided by source uuid are deleted.
-    """
-    source1 = factory.Source(uuid="abc")
-    source2 = factory.Source(uuid="123")
-    mv = MainView(None)
-    mv.source_conversations = {}
-    mv.source_conversations["123"] = SourceConversationWrapper(source1, mocker.MagicMock())
-    mv.source_conversations["123"] = SourceConversationWrapper(source2, mocker.MagicMock())
-    mv.source_list.controller = mocker.MagicMock()
-    mv.source_list.update([source1, source2])
-    assert len(mv.source_list.source_items) > 0
-
-    mv._delete_source("123")
-    mv._delete_source("abc")
-
-    assert len(mv.source_conversations) == 0
-    assert len(mv.source_list.source_items) == 0
-
-
-def test_MainView__on_source_deletion_successful(mocker):
-    """
-    Ensure that the source and conversation provided by source uuid are deleted.
-    """
-    source = factory.Source(uuid="123")
-    conversation_wrapper = SourceConversationWrapper(source, mocker.MagicMock())
-    mv = MainView(None)
-    mv.source_conversations = {}
-    mv.source_conversations["123"] = conversation_wrapper
-    mv.source_list.controller = mocker.MagicMock()
-    mv.source_list.update([source])
-    assert len(mv.source_list.source_items) > 0
-
-    mv._on_source_deletion_successful("123", datetime.now())
-
-    assert len(mv.source_conversations) == 0
-    assert len(mv.source_list.source_items) == 0
-
-
-def test_MainView__on_source_deletion_handles_keyerror(mocker):
-    mv = MainView(None)
-    mv._on_source_deletion_successful("throw-keyerror", datetime.now())
-
-
 def test_EmptyConversationView_show_no_sources_message(mocker):
     ecv = EmptyConversationView()
 
@@ -2087,30 +2023,6 @@ def test_SourceWidget__on_source_deleted_wrong_uuid(mocker, session, source):
     assert not sw.preview.isHidden()
     assert sw.deletion_indicator.isHidden()
     assert not sw.timestamp.isHidden()
-
-
-def test_SourceWidget_update_and_set_snippet_ineffective_after_deletion_successful(mocker):
-    """
-    Ensure that a source widget is not updated by a stale sync if a deletion
-    request has been successfully received by the server.
-    """
-    controller = mocker.MagicMock()
-    mark_seen_signal = mocker.MagicMock()
-    sw = SourceWidget(controller, factory.Source(uuid="123"), mark_seen_signal, mocker.MagicMock())
-    sw._on_sync_started(datetime.now())
-
-    sw._on_source_deletion_successful("123", datetime.now())
-
-    sw.update_styles = mocker.MagicMock()
-    sw.set_snippet("mock_uuid", "msg_uuid", "msg_content")
-    sw.update_styles.assert_not_called()
-
-    sw.set_snippet = mocker.MagicMock()
-    sw.set_snippet_to_conversation_deleted = mocker.MagicMock()
-    sw.update()
-    sw.set_snippet.assert_not_called()
-    sw.set_snippet_to_conversation_deleted.assert_not_called()
-    sw.update_styles.assert_not_called()
 
 
 def test_SourceWidget__on_source_deletion_failed(mocker, session, source):
@@ -4174,30 +4086,6 @@ def test_SourceConversationWrapper_on_source_deleted(mocker):
     assert scw.reply_box.text_edit.document().isEmpty()
     assert scw.conversation_view.isHidden()
     assert not scw.deletion_indicator.isHidden()
-
-
-def test_SourceWidget_update_and_set_snippet_ineffective_after_deletion_started(mocker):
-    """
-    Ensure that when deletion has started that the source widget is not
-    updated when set_snippet or update are called.
-    """
-    controller = mocker.MagicMock()
-    sw = SourceWidget(
-        controller, factory.Source(uuid="123"), mocker.MagicMock(), mocker.MagicMock()
-    )
-    sw._on_source_deleted("123")  # Start source deletion
-    sw.update_styles = mocker.MagicMock()
-    sw.set_snippet_to_conversation_deleted = mocker.MagicMock()
-
-    sw.set_snippet("123", "msg_uuid", "msg_content")
-    sw.update_styles.assert_not_called()
-    sw.set_snippet_to_conversation_deleted.assert_not_called()
-
-    sw.set_snippet = mocker.MagicMock()
-    sw.update()
-    sw.update_styles.assert_not_called()
-    sw.set_snippet.assert_not_called()
-    sw.set_snippet_to_conversation_deleted.assert_not_called()
 
 
 def test_SourceConversationWrapper_on_source_deleted_wrong_uuid(mocker):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -603,21 +603,6 @@ def test_MainView_show_sources_when_sources_are_deleted(mocker):
     mv.delete_conversation.assert_called_once_with(4)
 
 
-def test_MainView_show_sources_does_not_reshow_deleted_sources(mocker):
-    """
-    Ensure that the hidden source remains hidden.
-    """
-    mv = MainView(None)
-    mv.source_list.controller = mocker.MagicMock()
-    source = factory.Source(uuid="123")
-    mv.source_list.update([factory.Source(uuid="abc"), source])
-    mv._on_source_deletion_successful("123", datetime.now())  # "delete" the source
-
-    mv.show_sources([source])
-
-    assert mv.source_list.source_items["123"].isHidden()
-
-
 def test_MainView_delete_conversation_when_conv_wrapper_exists(mocker):
     """
     Ensure SourceConversationWrapper is deleted if it exists.
@@ -960,10 +945,9 @@ def test_MainView_set_conversation(mocker):
     mv.view_layout.addWidget.assert_called_once_with(mock_widget)
 
 
-def test_MainView__hide_source(mocker):
+def test_MainView__delete_source(mocker):
     """
-    Ensure that the source and conversation provided by source uuid are hidden,
-    and then deleted later by show_sources.
+    Ensure that the source and conversation provided by source uuid are deleted.
     """
     source = factory.Source(uuid="123")
     conversation_wrapper = SourceConversationWrapper(source, mocker.MagicMock())
@@ -972,49 +956,38 @@ def test_MainView__hide_source(mocker):
     mv.source_conversations["123"] = conversation_wrapper
     mv.source_list.controller = mocker.MagicMock()
     mv.source_list.update([source])
-
-    mv._hide_source("123")
-
-    assert len(mv.source_conversations) > 0
     assert len(mv.source_list.source_items) > 0
 
-    mv.show_sources([])  # Now the server is telling us to delete the source
+    mv._delete_source("123")
 
-    # Ensure the hidden source and conversation are actually deleted
     assert len(mv.source_conversations) == 0
     assert len(mv.source_list.source_items) == 0
 
 
-def test_MainView__hide_source_with_multiple_sources(mocker):
+def test_MainView__delete_source_with_multiple_sources(mocker):
     """
-    Ensure that each source and conversation provided by source uuid are hidden,
-    and that both are deleted later by show_sources.
+    Ensure that the source and conversation provided by source uuid are deleted.
     """
     source1 = factory.Source(uuid="abc")
     source2 = factory.Source(uuid="123")
     mv = MainView(None)
     mv.source_conversations = {}
     mv.source_conversations["123"] = SourceConversationWrapper(source1, mocker.MagicMock())
-    mv.source_conversations["abc"] = SourceConversationWrapper(source2, mocker.MagicMock())
+    mv.source_conversations["123"] = SourceConversationWrapper(source2, mocker.MagicMock())
     mv.source_list.controller = mocker.MagicMock()
     mv.source_list.update([source1, source2])
+    assert len(mv.source_list.source_items) > 0
 
-    mv._hide_source("123")
-    mv._hide_source("abc")
+    mv._delete_source("123")
+    mv._delete_source("abc")
 
-    assert len(mv.source_conversations) == 2
-    assert len(mv.source_list.source_items) == 2
-
-    mv.show_sources([])  # Now the server is telling us to delete both sources
-
-    # Ensure hidden sources and conversations are actually deleted
     assert len(mv.source_conversations) == 0
     assert len(mv.source_list.source_items) == 0
 
 
 def test_MainView__on_source_deletion_successful(mocker):
     """
-    Ensure that the source and conversation provided by source uuid are hidden.
+    Ensure that the source and conversation provided by source uuid are deleted.
     """
     source = factory.Source(uuid="123")
     conversation_wrapper = SourceConversationWrapper(source, mocker.MagicMock())
@@ -1023,30 +996,15 @@ def test_MainView__on_source_deletion_successful(mocker):
     mv.source_conversations["123"] = conversation_wrapper
     mv.source_list.controller = mocker.MagicMock()
     mv.source_list.update([source])
-    mv.source_conversations["123"].setHidden(False)
+    assert len(mv.source_list.source_items) > 0
 
     mv._on_source_deletion_successful("123", datetime.now())
 
-    assert mv.source_conversations["123"].isHidden()
-    assert mv.source_list.source_items["123"].isHidden()
+    assert len(mv.source_conversations) == 0
+    assert len(mv.source_list.source_items) == 0
 
 
-def test_MainView__on_source_deletion_successful_does_not_select_next_source(mocker):
-    """
-    Ensure that no other source is selected by default after a source deletion.
-    """
-    source = factory.Source(uuid="123")
-    mv = MainView(None)
-    mv.setup(mocker.MagicMock())
-    mv.source_list.update([source])
-    mv.source_list.setCurrentItem(mv.source_list.itemAt(0, 0))  # select source
-
-    mv._on_source_deletion_successful("123", datetime.now())
-
-    assert not mv.source_list.get_selected_source()
-
-
-def test_MainView__on_source_deletion_handles_keyerror():
+def test_MainView__on_source_deletion_handles_keyerror(mocker):
     mv = MainView(None)
     mv._on_source_deletion_successful("throw-keyerror", datetime.now())
 
@@ -1085,11 +1043,6 @@ def test_SourceList_get_selected_source(mocker):
     current_source = sl.get_selected_source()
 
     assert current_source.id == sources[1].id
-
-
-def test_SourceList_delete_sources_handles_keyerror():
-    sl = SourceList()
-    sl.delete_sources([factory.Source(uuid="throw-keyerror")])
 
 
 def test_SourceList_update_adds_new_sources(mocker):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -158,14 +158,12 @@ def test_ApiSync_on_sync_failure(mocker, session_maker, homedir):
     """
     api_sync = ApiSync(mocker.MagicMock(), session_maker, mocker.MagicMock(), homedir)
     sync_failure = mocker.patch.object(api_sync, "sync_failure")
-    singleShot_fn = mocker.patch("securedrop_client.sync.QTimer.singleShot")
 
     error = Exception()
 
     api_sync.on_sync_failure(error)
 
     sync_failure.emit.assert_called_once_with(error)
-    singleShot_fn.assert_called_once_with(15000, api_sync.api_sync_bg_task.sync)
 
 
 @pytest.mark.parametrize("exception", [RequestTimeoutError, ServerConnectionError])
@@ -177,10 +175,8 @@ def test_ApiSync_on_sync_failure_because_of_timeout(mocker, session_maker, homed
     """
     api_sync = ApiSync(mocker.MagicMock(), session_maker, mocker.MagicMock(), homedir)
     sync_failure = mocker.patch.object(api_sync, "sync_failure")
-    singleShot_fn = mocker.patch("securedrop_client.sync.QTimer.singleShot")
     error = exception()
 
     api_sync.on_sync_failure(error)
 
     sync_failure.emit.assert_called_once_with(error)
-    singleShot_fn.assert_called_once_with(15000, api_sync.api_sync_bg_task.sync)


### PR DESCRIPTION
# Description

As discussed today in pre-release check-in, revert source deletion changes and defer to next release so that we can fully resolve https://github.com/freedomofpress/securedrop-client/issues/1422. This reverts https://github.com/freedomofpress/securedrop-client/pull/1386.

# Test Plan

- Ensure that the revert does not break subsequent changes
- Changes should be reviewed as part of rc4 QA

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 -  [x] **The reviewer will need to test these changes**
 
If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
