### PR TITLE
Delete conversation files and records as soon as server confirms scheduled deletion

### DIFF
--- a/alembic/versions/eff1387cfd0b_add_deletedconversation_table.py
+++ b/alembic/versions/eff1387cfd0b_add_deletedconversation_table.py
@@ -1,0 +1,34 @@
+"""add deletedconversation table
+
+Revision ID: eff1387cfd0b
+Revises: bd57477f19a2
+Create Date: 2022-02-24 13:11:22.227528
+
+"""
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "eff1387cfd0b"
+down_revision = "bd57477f19a2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add deletedconversation table to manage locally-deleted records
+    # and ensure they do not get re-downloaded to the database during
+    # a network race condition.
+    # UUID was chosen as PK to avoid storing data such as source_id that
+    # could divulge information about the source account creation timeline.
+    # Note that records in this table are purged every 15 seconds.
+    op.create_table(
+        "deletedconversation",
+        sa.Column("uuid", sa.String(length=36), nullable=False),
+        sa.PrimaryKeyConstraint("uuid", name=op.f("pk_deletedconversation")),
+    )
+
+
+def downgrade():
+    op.drop_table("deletedconversation")

--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -108,6 +108,26 @@ class Source(Base):
         return True
 
 
+class DeletedConversation(Base):
+    """
+    Table that stores only source UUIDs for conversations (files and messages) that
+    have been deleted locally, to prevent them from being re-added to the Messages and
+    Replies tables during a 'stale sync' (network race condition).
+    """
+
+    __tablename__ = "deletedconversation"
+
+    uuid = Column(String(36), primary_key=True, nullable=False)
+
+    def __repr__(self) -> str:
+        return "DeletedConversation (source {})".format(self.uuid)
+
+    def __init__(self, **kwargs: Any) -> None:
+        if "uuid" not in kwargs:
+            raise TypeError("Keyword argument 'uuid' (source UUID) required")
+        super().__init__(**kwargs)
+
+
 class Message(Base):
 
     __tablename__ = "messages"

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3116,39 +3116,16 @@ class ConversationView(QWidget):
         self.scroll.add_widget_to_conversation(index, conversation_item, Qt.AlignRight)
         self.current_messages[reply.uuid] = conversation_item
 
-    def add_reply_from_reply_box(self, uuid: str, content: str) -> None:
-        """
-        Add a reply from the reply box.
-        """
-        if not self.controller.authenticated_user:
-            logger.error("User is no longer authenticated so cannot send reply.")
-            return
-
-        index = len(self.current_messages)
-        conversation_item = ReplyWidget(
-            self.controller,
-            uuid,
-            content,
-            "PENDING",
-            self.controller.reply_ready,
-            self.controller.reply_download_failed,
-            self.controller.reply_succeeded,
-            self.controller.reply_failed,
-            index,
-            self.scroll.widget().width(),
-            self.controller.authenticated_user,
-            True,
-        )
-        self.scroll.add_widget_to_conversation(index, conversation_item, Qt.AlignRight)
-        self.current_messages[uuid] = conversation_item
-
     def on_reply_sent(self, source_uuid: str, reply_uuid: str, reply_text: str) -> None:
         """
         Add the reply text sent from ReplyBoxWidget to the conversation.
         """
         self.reply_flag = True
         if source_uuid == self.source.uuid:
-            self.add_reply_from_reply_box(reply_uuid, reply_text)
+            try:
+                self.update_conversation(self.source.collection)
+            except sqlalchemy.exc.InvalidRequestError as e:
+                logger.debug(e)
             self.update_deletion_markers()
 
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1329,11 +1329,6 @@ class SourceWidget(QWidget):
         if self.deleting or self.deleting_conversation:
             return
 
-        # If the sync started before the deletion finished, then the sync is stale and we do
-        # not want to update the source widget.
-        if self.sync_started_timestamp < self.deletion_scheduled_timestamp:
-            return
-
         # If the source collection is empty yet the interaction_count is greater than zero, then we
         # known that the conversation has been deleted.
         if not self.source.server_collection:
@@ -2944,18 +2939,15 @@ class ConversationView(QWidget):
             logger.debug(f"Could not update ConversationView: {e}")
 
     def update_deletion_markers(self) -> None:
-        try:
-            if self.source.collection:
-                self.scroll.show()
-                if self.source.collection[0].file_counter > 1:
-                    self.deleted_conversation_marker.hide()
-                    self.deleted_conversation_items_marker.show()
-            elif self.source.interaction_count > 0:
-                self.scroll.hide()
-                self.deleted_conversation_items_marker.hide()
-                self.deleted_conversation_marker.show()
-        except sqlalchemy.exc.InvalidRequestError as e:
-            logger.debug(f"Could not Update deletion markers in the ConversationView: {e}")
+        if self.source.collection:
+            self.scroll.show()
+            if self.source.collection[0].file_counter > 1:
+                self.deleted_conversation_marker.hide()
+                self.deleted_conversation_items_marker.show()
+        elif self.source.interaction_count > 0:
+            self.scroll.hide()
+            self.deleted_conversation_items_marker.hide()
+            self.deleted_conversation_marker.show()
 
     def update_conversation(self, collection: list) -> None:
         """
@@ -2976,11 +2968,6 @@ class ConversationView(QWidget):
         passed into this method in case of a mismatch between where the widget
         has been and now is in terms of its index in the conversation.
         """
-        # If the sync started before the deletion finished, then the sync is stale and we do
-        # not want to update the conversation.
-        if self.sync_started_timestamp < self.deletion_scheduled_timestamp:
-            return
-
         self.controller.session.refresh(self.source)
 
         # Keep a temporary copy of the current conversation so we can delete any
@@ -3116,7 +3103,7 @@ class ConversationView(QWidget):
         self.scroll.add_widget_to_conversation(index, conversation_item, Qt.AlignRight)
         self.current_messages[reply.uuid] = conversation_item
 
-    def on_reply_sent(self, source_uuid: str, reply_uuid: str, reply_text: str) -> None:
+    def on_reply_sent(self, source_uuid: str) -> None:
         """
         Add the reply text sent from ReplyBoxWidget to the conversation.
         """
@@ -3126,7 +3113,6 @@ class ConversationView(QWidget):
                 self.update_conversation(self.source.collection)
             except sqlalchemy.exc.InvalidRequestError as e:
                 logger.debug(e)
-            self.update_deletion_markers()
 
 
 class SourceConversationWrapper(QWidget):
@@ -3268,7 +3254,7 @@ class ReplyBoxWidget(QWidget):
     A textbox where a journalist can enter a reply.
     """
 
-    reply_sent = pyqtSignal(str, str, str)
+    reply_sent = pyqtSignal(str)
 
     def __init__(self, source: Source, controller: Controller) -> None:
         super().__init__()
@@ -3365,7 +3351,7 @@ class ReplyBoxWidget(QWidget):
             self.text_edit.setText("")
             reply_uuid = str(uuid4())
             self.controller.send_reply(self.source.uuid, reply_uuid, reply_text)
-            self.reply_sent.emit(self.source.uuid, reply_uuid, reply_text)
+            self.reply_sent.emit(self.source.uuid)
 
     @pyqtSlot(bool)
     def _on_authentication_changed(self, authenticated: bool) -> None:

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -1022,9 +1022,12 @@ class Controller(QObject):
     def on_delete_conversation_success(self, uuid: str) -> None:
         """
         If the source collection has been successfully scheduled for deletion on the server, emit a
-        signal and sync.
+        signal.
         """
-        logger.info("Conversation %s successfully deleted at server", uuid)
+        logger.info("Conversation %s successfully scheduled for deletion at server", uuid)
+
+        # Delete conversation locally to ensure that it does not remain on disk until next sync
+        storage.delete_local_conversation_by_source_uuid(self.session, uuid, self.data_dir)
         self.conversation_deletion_successful.emit(uuid, datetime.utcnow())
 
     def on_delete_conversation_failure(self, e: Exception) -> None:

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -37,6 +37,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.session import Session
 
 from securedrop_client.db import (
+    DeletedConversation,
     DeletedUser,
     DraftReply,
     File,
@@ -168,20 +169,75 @@ def update_local_storage(
     remote_messages = [x for x in remote_submissions if x.filename.endswith("msg.gpg")]
     remote_files = [x for x in remote_submissions if not x.filename.endswith("msg.gpg")]
 
+    # Get list of locally-modified conversations that have been scheduled for deletion
+    # on the server. The first sync is skipped for these conversations to avoid
+    # re-downloading deleted data.
+    skip_conversations = _get_flagged_locally_deleted(session)
+    skip_conversation_uuids = [x.uuid for x in skip_conversations]
+
     # The following update_* functions may change the database state.
     # Because of that, each get_local_* function needs to be called just before
     # its respective update_* function.
     with chronometer(logger, "update_sources"):
-        update_sources(remote_sources, get_local_sources(session), session, data_dir)
+        update_sources(
+            remote_sources, get_local_sources(session), skip_conversation_uuids, session, data_dir
+        )
 
     with chronometer(logger, "update_files"):
-        update_files(remote_files, get_local_files(session), session, data_dir)
+        update_files(
+            remote_files, get_local_files(session), skip_conversation_uuids, session, data_dir
+        )
 
     with chronometer(logger, "update_messages"):
-        update_messages(remote_messages, get_local_messages(session), session, data_dir)
+        update_messages(
+            remote_messages, get_local_messages(session), skip_conversation_uuids, session, data_dir
+        )
 
     with chronometer(logger, "update_replies"):
-        update_replies(remote_replies, get_local_replies(session), session, data_dir)
+        update_replies(
+            remote_replies, get_local_replies(session), skip_conversation_uuids, session, data_dir
+        )
+
+    # Remove source UUIDs from DeletedConversation table.
+    # A record enters this table when a user deletes data locally and the
+    # data is succesfully scheduled for deletion on the server. In order to guard
+    # against locally-deleted records being re-added to the database (even for a few seconds)
+    # during a stale sync, we flag them in this table.
+    # A stale sync is defined as a sync that began before the deletion request was
+    # received by the server, but returns after the request has been received, thus
+    # rendering some of its data stale.
+    # Assumption: There will be at most one stale sync when a record is deleted, because
+    # there is only ever one sync happening at a given time.
+    _cleanup_flagged_locally_deleted(session, skip_conversations)
+
+
+def _get_flagged_locally_deleted(session: Session) -> List[DeletedConversation]:
+    """
+    Helper function to return source UUIDs corresponding to locally-deleted conversations.
+    The first sync after a conversation is deleted locally, avoid updating the conversation,
+    to avoid possibly re-downloading stale data.
+
+    This method should be used in conjunction with `_cleanup_flagged_locally_deleted`.
+    After local sources and submissions have been updated, pass the results of this method into
+    the above cleanup function to ensure that the flagged conversations are purged from
+    the local table, and are no longer skipped on subsequent syncs.
+    """
+    return session.query(DeletedConversation).all()
+
+
+def _cleanup_flagged_locally_deleted(
+    session: Session, deleted_conversations: List[DeletedConversation]
+) -> None:
+    """
+    Helper function that removes a list of DeletedConversation items from local database.
+    """
+    for item in deleted_conversations:
+        logger.debug(
+            "Removing conversation with {} from deletedconversation "
+            "table (will not be skipped next sync)".format(item.uuid)
+        )
+        session.delete(item)
+    session.commit()
 
 
 def lazy_setattr(o: Any, a: str, v: Any) -> None:
@@ -196,37 +252,52 @@ def lazy_setattr(o: Any, a: str, v: Any) -> None:
 
 
 def update_sources(
-    remote_sources: List[SDKSource], local_sources: List[Source], session: Session, data_dir: str
+    remote_sources: List[SDKSource],
+    local_sources: List[Source],
+    skip_uuids_deleted_conversation: List[str],
+    session: Session,
+    data_dir: str,
 ) -> None:
     """
-    Given collections of remote sources, the current local sources and a
+    Given collections of remote sources, the current local sources, a list of
+    UUIDs to skip, and a
     session to the local database, ensure the state of the local database
     matches that of the remote sources:
 
     * Existing items are updated in the local database.
     * New items are created in the local database.
+    * Items that have been flagged to skip are not re-created in the local database
+      (prevent re-downloading data that has just been locally deleted)
     * Local items not returned in the remote sources are deleted from the
       local database.
     """
     local_sources_by_uuid = {s.uuid: s for s in local_sources}
     for source in remote_sources:
         if source.uuid in local_sources_by_uuid:
-            # Update an existing record.
-            local_source = local_sources_by_uuid[source.uuid]
-            lazy_setattr(local_source, "journalist_designation", source.journalist_designation)
-            lazy_setattr(local_source, "is_flagged", source.is_flagged)
-            lazy_setattr(local_source, "interaction_count", source.interaction_count)
-            lazy_setattr(local_source, "document_count", source.number_of_documents)
-            lazy_setattr(local_source, "is_starred", source.is_starred)
-            lazy_setattr(local_source, "last_updated", parse(source.last_updated))
-            lazy_setattr(local_source, "public_key", source.key["public"])
-            lazy_setattr(local_source, "fingerprint", source.key["fingerprint"])
+
+            # If source UUID has been flagged as having been locally updated, wait
+            # til next sync to update it. The list of skip_uuids is managed by the
+            # parent method and purged after each sync.
+            if skip_uuids_deleted_conversation and source.uuid in skip_uuids_deleted_conversation:
+                logger.debug("Skip source update for {} (this sync only)")
+
+            else:
+                # Update an existing record.
+                logger.debug("Update source {}".format(source.uuid))
+                local_source = local_sources_by_uuid[source.uuid]
+                lazy_setattr(local_source, "journalist_designation", source.journalist_designation)
+                lazy_setattr(local_source, "is_flagged", source.is_flagged)
+                lazy_setattr(local_source, "interaction_count", source.interaction_count)
+                lazy_setattr(local_source, "document_count", source.number_of_documents)
+                lazy_setattr(local_source, "is_starred", source.is_starred)
+                lazy_setattr(local_source, "last_updated", parse(source.last_updated))
+                lazy_setattr(local_source, "public_key", source.key["public"])
+                lazy_setattr(local_source, "fingerprint", source.key["fingerprint"])
 
             # Removing the UUID from local_sources_by_uuid ensures
             # this record won't be deleted at the end of this
             # function.
             del local_sources_by_uuid[source.uuid]
-            logger.debug("Updated source {}".format(source.uuid))
         else:
             # A new source to be added to the database.
             ns = Source(
@@ -257,25 +328,42 @@ def update_sources(
 def update_files(
     remote_submissions: List[SDKSubmission],
     local_submissions: List[File],
+    skip_uuids_deleted_conversation: List[str],
     session: Session,
     data_dir: str,
 ) -> None:
-    __update_submissions(File, remote_submissions, local_submissions, session, data_dir)
+    __update_submissions(
+        File,
+        remote_submissions,
+        local_submissions,
+        skip_uuids_deleted_conversation,
+        session,
+        data_dir,
+    )
 
 
 def update_messages(
     remote_submissions: List[SDKSubmission],
     local_submissions: List[Message],
+    skip_uuids_deleted_conversation: List[str],
     session: Session,
     data_dir: str,
 ) -> None:
-    __update_submissions(Message, remote_submissions, local_submissions, session, data_dir)
+    __update_submissions(
+        Message,
+        remote_submissions,
+        local_submissions,
+        skip_uuids_deleted_conversation,
+        session,
+        data_dir,
+    )
 
 
 def __update_submissions(
     model: Union[Type[File], Type[Message]],
     remote_submissions: List[SDKSubmission],
     local_submissions: Union[List[Message], List[File]],
+    skip_uuids_deleted_conversation: List[str],
     session: Session,
     data_dir: str,
 ) -> None:
@@ -285,14 +373,17 @@ def __update_submissions(
 
     * Existing submissions are updated in the local database.
     * New submissions have an entry created in the local database.
+        * Submissions belonging to flagged source UUIDs are skipped (this is in order to avoid
+          re-downloading locally-deleted submissions during a network race condition).
     * Local submissions not returned in the remote submissions are deleted
       from the local database.
     """
     local_submissions_by_uuid = {s.uuid: s for s in local_submissions}
     source_cache = SourceCache(session)
+
     for submission in remote_submissions:
         local_submission = local_submissions_by_uuid.get(submission.uuid)
-        if local_submission:
+        if local_submission and submission.source_uuid not in skip_uuids_deleted_conversation:
             lazy_setattr(local_submission, "size", submission.size)
             lazy_setattr(local_submission, "is_read", submission.is_read)
             lazy_setattr(local_submission, "download_url", submission.download_url)
@@ -306,6 +397,12 @@ def __update_submissions(
             # deleted at the end of this function.
             del local_submissions_by_uuid[submission.uuid]
             logger.debug(f"Updated {model.__name__} {submission.uuid}")
+        elif submission.source_uuid in skip_uuids_deleted_conversation:
+            logger.debug(
+                "Skip update for submission {} (source {}) "
+                "(this sync only)".format(submission.uuid, submission.source_uuid)
+            )
+            continue
         else:
             # A new submission to be added to the database.
             source = source_cache.get(submission.source_uuid)
@@ -329,10 +426,17 @@ def __update_submissions(
     # The uuids remaining in local_uuids do not exist on the remote server, so
     # delete the related records.
     for deleted_submission in local_submissions_by_uuid.values():
-        delete_single_submission_or_reply_on_disk(deleted_submission, data_dir)
-        session.delete(deleted_submission)
-        logger.debug(f"Deleted {model.__name__} {deleted_submission.uuid}")
 
+        # The local method could have deleted these files and submissions already
+        try:
+            delete_single_submission_or_reply_on_disk(deleted_submission, data_dir)
+            session.delete(deleted_submission)
+            logger.debug(f"Deleted {model.__name__} {deleted_submission.uuid}")
+        except NoResultFound:
+            logger.info(
+                f"Tried to delete submission {deleted_submission.uuid}, but "
+                "it was already deleted locally."
+            )
     session.commit()
 
 
@@ -403,11 +507,17 @@ def add_seen_reply_records(reply_id: int, journalist_uuids: List[str], session: 
 
 
 def update_replies(
-    remote_replies: List[SDKReply], local_replies: List[Reply], session: Session, data_dir: str
+    remote_replies: List[SDKReply],
+    local_replies: List[Reply],
+    skip_uuids_deleted_conversation: List[str],
+    session: Session,
+    data_dir: str,
 ) -> None:
     """
     * Existing replies are updated in the local database.
     * New replies have an entry created in the local database.
+        * Replies belonging to flagged source UUIDs are skipped (this is in order to avoid
+          re-downloading locally-deleted content during a network race condition).
     * Local replies not returned in the remote replies are deleted from the
       local database unless they are pending or failed.
     """
@@ -439,7 +549,7 @@ def update_replies(
             user_cache[reply.journalist_uuid] = user
 
         local_reply = local_replies_by_uuid.get(reply.uuid)
-        if local_reply:
+        if local_reply and reply.source_uuid not in skip_uuids_deleted_conversation:
             lazy_setattr(local_reply, "journalist_id", user.id)
             lazy_setattr(local_reply, "size", reply.size)
             lazy_setattr(local_reply, "filename", reply.filename)
@@ -448,6 +558,12 @@ def update_replies(
 
             del local_replies_by_uuid[reply.uuid]
             logger.debug("Updated reply {}".format(reply.uuid))
+        elif reply.source_uuid in skip_uuids_deleted_conversation:
+            logger.debug(
+                "Reply {} found for locally-modified source {}, "
+                "skipping update (for one sync)".format(reply.uuid, reply.source_uuid)
+            )
+            continue
         else:
             # A new reply to be added to the database.
             source = source_cache.get(reply.source_uuid)
@@ -490,10 +606,16 @@ def update_replies(
     # The uuids remaining in local_uuids do not exist on the remote server, so
     # delete the related records.
     for deleted_reply in local_replies_by_uuid.values():
-        delete_single_submission_or_reply_on_disk(deleted_reply, data_dir)
-        session.delete(deleted_reply)
-        logger.debug("Deleted reply {}".format(deleted_reply.uuid))
-
+        try:
+            delete_single_submission_or_reply_on_disk(deleted_reply, data_dir)
+            session.delete(deleted_reply)
+            logger.debug("Deleted reply {}".format(deleted_reply.uuid))
+        except NoResultFound:
+            logger.debug(
+                "Tried to delete submission {}, but it was already deleted locally".format(
+                    deleted_reply.uuid
+                )
+            )
     session.commit()
 
 
@@ -739,6 +861,76 @@ def delete_single_submission_or_reply_on_disk(
             shutil.rmtree(os.path.dirname(obj_db.location(data_dir)))
         except FileNotFoundError:
             pass
+
+
+def delete_local_conversation_by_source_uuid(session: Session, uuid: str, data_dir: str) -> None:
+    """
+    Delete local conversation for a source with a given UUID.
+
+    Deletes database records for files, messages, replies and drafts, as well as
+    downloaded files. Does not delete the source record.
+
+    To prevent a network race condition from re-adding deleted records to the database,
+    when a source conversation is deleted locally, the source's UUID is added to the
+    DeletedConversation table, which tracks local deletion-related database changes and
+    is purged after every sync.
+    """
+    source = session.query(Source).filter_by(uuid=uuid).one_or_none()
+    if source:
+
+        # Delete all source files on disk
+        logger.debug("Delete files on disk for source {} from local database.".format(uuid))
+        delete_source_collection(source.journalist_filename, data_dir)
+
+        # Find all associated replies and messages and delete them. Add
+        # a record to the DeletedConversation table, which flags the
+        # conversation as having been deleted locally
+        logger.debug("Delete records for source {} from local database.".format(uuid))
+        _delete_source_collection_from_db(session, source)
+
+    else:
+        logger.error("Tried to delete source {}, but UUID was not found".format(uuid))
+
+
+def _delete_source_collection_from_db(session: Session, source: Source) -> None:
+    """
+    Delete message, reply, draft, and file records belonging to a given source.
+
+    Create new DeletedConversation record to temporarily flag UUIDs of sources whose
+    conversations have been locally deleted, to prevent them from being re-added to
+    the database during a network race condition.
+
+    Source UUID is used because storing it does not expose any additional identifying
+    information about the source (compared to the source `id` field).
+    """
+
+    is_local_db_modified = False
+
+    for table in {DraftReply, File, Message, Reply}:
+        try:
+            query = session.query(table).filter_by(source_id=source.id)
+            if len(query.all()) > 0:
+                logger.debug(
+                    "Locally delete {} records associated with "
+                    "source {}".format(table.__name__, source.uuid)
+                )
+                query.delete()
+                is_local_db_modified = True
+        except NoResultFound:
+            #  Sync logic has deleted the records
+            logger.debug(
+                "Tried to locally delete {} records associated with "
+                "source {}, but none were found".format(table.__name__, source.uuid)
+            )
+
+    # Add source UUID to deletedconversation table, but only if we actually made
+    # local database modifications
+    if is_local_db_modified:
+        flagged_conversation = DeletedConversation(uuid=source.uuid)
+        logger.debug("Add source {} to deletedconversation table".format(source.uuid))
+        session.add(flagged_conversation)
+
+    session.commit()
 
 
 def source_exists(session: Session, source_uuid: str) -> bool:

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1940,41 +1940,6 @@ def test_SourceWidget_set_snippet(mocker, session_maker, session, homedir):
     sw.set_snippet(source_uuid, "mock_file_uuid", "something new")
 
 
-def test_SourceWidget_set_snippet_does_not_update_if_sync_is_stale(mocker):
-    """
-    Ensure that the snippet does not get updated when an update is based on a sync that started
-    before a deletion operation succeeded.
-    """
-    controller = mocker.MagicMock()
-    source = mocker.MagicMock()
-    source.journalist_designation = "Testy McTestface"
-    source.collection = [factory.Message(content="abc123")]
-    source.server_collection = source.collection
-    sw = SourceWidget(controller, source, mocker.MagicMock(), mocker.MagicMock())
-    sw.update()
-    assert sw.preview.text() == "abc123"
-
-    # Make the sync stale
-    sw.sync_started_timestamp = datetime.now()
-    sw.deletion_scheduled_timestamp = datetime.now()
-
-    # Set up source data so that it appears that the conversation was deleted
-    source.collection = []
-    source.interaction_count = 1
-    source.server_collection = source.collection
-
-    # Assert the preview snippet does not get updated because the sync is stale
-    sw.set_snippet(source.uuid, "mock_file_uuid")
-    assert sw.preview.text() == "abc123"
-
-    # The sync is no longer stale so the preview should show that the are no more source
-    # conversation items because they've been deleted
-    sw.deletion_scheduled_timestamp = datetime.now()
-    sw.sync_started_timestamp = datetime.now()
-    sw.set_snippet(source.uuid, "mock_file_uuid")
-    assert sw.preview.text() == "— All files and messages deleted for this source —"
-
-
 def test_SourceWidget_update_truncate_latest_msg(mocker):
     """
     If the latest message in the conversation is longer than 150 characters,
@@ -4325,22 +4290,6 @@ def test_ConversationView__on_conversation_deletion_successful_does_not_hide_dra
     assert not cv.current_messages[draft_reply.uuid].isHidden()
 
 
-def test_ConversationView_update_conversation_skips_if_sync_is_stale(mocker):
-    """
-    If the sync started before the source was scheduled for deletion, do not update the conversation
-    """
-    cv = ConversationView(factory.Source(), mocker.MagicMock())
-    cv.update_deletion_markers = mocker.MagicMock()
-    cv.sync_started_timestamp = datetime.now()
-    cv.deletion_scheduled_timestamp = datetime.now()
-    cv.update_conversation([])
-    cv.update_deletion_markers.assert_not_called()
-    # Also test that a new message will not get added if the sync is stale
-    cv.update_conversation([factory.Message()])
-    assert not cv.current_messages
-    cv.update_deletion_markers.assert_not_called()
-
-
 def test_ConversationView_update_conversation_position_follow(mocker, homedir):
     """
     Check the signal handler sets the correct value for the scrollbar to be
@@ -4451,7 +4400,7 @@ def test_ConversationView_on_reply_sent(mocker):
     cv.update_conversation = mocker.MagicMock()
 
     assert cv.reply_flag is False
-    cv.on_reply_sent(source_uuid=source.uuid, reply_uuid="abc123", reply_text="test message")
+    cv.on_reply_sent(source_uuid=source.uuid)
 
     cv.update_conversation.assert_called_with(source.collection)
     assert cv.reply_flag is True
@@ -4467,7 +4416,7 @@ def test_ConversationView_on_reply_sent_does_not_add_message_intended_for_differ
     cv = ConversationView(source, controller)
     cv.add_reply = mocker.MagicMock()
 
-    cv.on_reply_sent("different_source_id", "mock", "mock")
+    cv.on_reply_sent("different_source_id")
 
     assert not cv.add_reply.called
 
@@ -4484,18 +4433,13 @@ def test_ConversationView_on_reply_sent_with_deleted_source(mocker):
     def collection_error():
         raise sqlalchemy.exc.InvalidRequestError()
 
-    debug_logger = mocker.patch("securedrop_client.gui.widgets.logger.debug")
     mock_collection = mocker.patch(
         "securedrop_client.db.Source.collection", new_callable=PropertyMock
     )
     ire = sqlalchemy.exc.InvalidRequestError()
     mock_collection.side_effect = ire
 
-    cv.on_reply_sent(source.uuid, "mock", "mock")
-
-    debug_logger.assert_any_call(
-        f"Could not Update deletion markers in the ConversationView: {ire}"
-    )
+    cv.on_reply_sent(source.uuid)
 
 
 def test_ConversationView_add_reply(mocker, homedir, session, session_maker):
@@ -4772,7 +4716,7 @@ def test_ReplyBoxWidget_send_reply(mocker):
 
     scw.reply_box.send_reply()
 
-    scw.reply_box.reply_sent.emit.assert_called_once_with("abc123", "456xyz", "Alles für Alle")
+    scw.reply_box.reply_sent.emit.assert_called_once_with("abc123")
     scw.reply_box.text_edit.setText.assert_called_once_with("")
     controller.send_reply.assert_called_once_with("abc123", "456xyz", "Alles für Alle")
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -5070,7 +5070,9 @@ def test_ReplyBoxWidget_enable_after_source_gets_key(mocker, session, session_ma
 
     # now simulate a sync...
     source_with_key = factory.RemoteSource(uuid=source.uuid)
-    storage.update_sources([source_with_key], [source], session, homedir)
+
+    # passing 'None' for skip_uuid, test that separately
+    storage.update_sources([source_with_key], [source], None, session, homedir)
 
     # ... simulate the ReplyBoxWidget receiving the sync success signal
     rbw._on_sync_succeeded()

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1874,9 +1874,16 @@ def test_Controller_on_delete_conversation_success(mocker, homedir):
     info_logger = mocker.patch("securedrop_client.logic.logger.info")
 
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir)
+    mock_storage = mocker.MagicMock()
+    mocker.patch("securedrop_client.logic.storage", mock_storage)
+
     co.on_delete_conversation_success("uuid-blah")
+
     info_logger.assert_called_once_with(
-        "Conversation %s successfully deleted at server", "uuid-blah"
+        "Conversation %s successfully scheduled for deletion at server", "uuid-blah"
+    )
+    mock_storage.delete_local_conversation_by_source_uuid.assert_called_once_with(
+        co.session, "uuid-blah", co.data_dir
     )
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,7 @@ import datetime
 import pytest
 
 from securedrop_client.db import (
+    DeletedConversation,
     DownloadError,
     DownloadErrorCodes,
     DraftReply,
@@ -349,3 +350,11 @@ def test_reply_with_download_error(session, download_error_codes):
 
     classname = r.__class__.__name__.lower()
     assert str(r) == f"cannot decrypt {classname}"
+
+
+def test_deletedconversation_creation(session):
+    with pytest.raises(TypeError):
+        DeletedConversation()  # must initialize with a UUID
+
+    dc = DeletedConversation(uuid="test-uuid")
+    assert str(dc) == "DeletedConversation (source {})".format(dc.uuid)


### PR DESCRIPTION
# Description

Delete local files and relevant source records immediately as soon as conversation is scheduled for deletion on the server (do not wait for sync to delete).

Fixes #1429
Replaces https://github.com/freedomofpress/securedrop-client/pull/1424
Will be relevant for #1344

**High-level approach:**
- When the server has successfully scheduled files for deletion, files and records are deleted locally, and the source's UUID (not id) is inserted into a `deletedconversation` table (which is basically a flag). (We avoid storing source id and other PII/attributes.)
- For the first sync after the deletion request is made, if a source's UUID is in the `deletedconversation` table, we do not update their record. This is to avoid a situation where a stale sync re-populates source records that have been deleted (network race condition). (Note: a sync happens every 15 seconds)
- At the end of the first sync, the source's UUID is dropped from the `deletedconversation` table, and their records will be updated as normal for all subsequent syncs.
- This approach will also work for user deletion and avoiding stale syncs repopulating a deleted user's records. 

# Test Plan

**Test local deletion: happy path**
- Log into the client and select a source with replies, messages, and files. Download some files and observe them in a subdirectory of `~/.securedrop_client/data/`
- Safe-delete ("delete files and messages") for the source.
- [ ] Inspect the `~/.securedrop_client/data/` directory; the source's subdirectory should be removed and all relevant files deleted.  
- [ ] Inspect the `sources` table and note the source's id (not UUID). Query the `messages`, `replies`, `draftreplies`, and `files` tables for rows with the source `id` and ensure that no matching rows are present.

**Test local deletion with network failures**
- Log into the client and select a source with replies, messages, and files. Download some files and observe them in a subdirectory of `~/.securedrop_client/data/`
- Open the Qubes Settings -> network settings for sd-whonix, or open a terminal in sd-whonix.
- Safe-delete ("delete files and messages") for the source, then as soon as the UI confirms deletion, _quickly_ kill the network connection by setting the nevtm to `none` or issuing `sudo service tor stop` in the sd-whonix terminal.
- [ ] Inspect the `~/.securedrop_client/data/` directory; the source's subdirectory should be removed and all relevant files deleted.  
- [ ] Inspect the `sources` table and note the source's id and UUID. Query the `messages`, `replies`, `draftreplies`, and `files` tables for rows with the source `id` and ensure that no matching rows are present.
- [ ] Inspect the deletedconversation table and ensure that a row with the source `uuid` is present. 
- Re-connect the network and wait for sync.
- [ ] Again, query the `messages`, `replies`, `draftreplies`, and `files` tables for rows with the source `id` and ensure that no matching rows are present.
- [ ] Ensure the entry with source UUID has been removed from the deletedconversation table.

**Ensure no regression when deletion is done on the server**
- Download files for a source with files and messages.
- Delete the source's files and messages via the Journalist Interface.
- Wait for sync. 
- [ ] Ensure files and messages have been deleted from the client as in the steps above.

**Test upgrade of existing client**
- [ ] Ensure database upgrade works and local deletion works as above  

**(Added) No ghost replies** 
- Safe delete a conversation, then send reply A, then safe delete again.
- Send reply B
- [ ] Ensure reply A is not temporarily visible in the GUI (note: this is a GUI bug; it's not added to the database)

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [x] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed
