### PR TITLE
fix: clear `RunnableQueue`s on `ApiJobQueue.stop()`

### DIFF
--- a/securedrop_client/api_jobs/base.py
+++ b/securedrop_client/api_jobs/base.py
@@ -41,6 +41,10 @@ class QueueJob(QObject):
         return self.order_number < other.order_number
 
 
+class ClearQueueJob(QueueJob):
+    pass
+
+
 class PauseQueueJob(QueueJob):
     def __init__(self) -> None:
         super().__init__()

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -12,6 +12,7 @@ from securedrop_client.api_jobs.base import (
     DEFAULT_NUM_ATTEMPTS,
     ApiInaccessibleError,
     ApiJob,
+    ClearQueueJob,
     PauseQueueJob,
 )
 from securedrop_client.api_jobs.downloads import (
@@ -52,6 +53,7 @@ class RunnableQueue(QObject):
 
     # These are the priorities for processing jobs. Lower numbers corresponds to a higher priority.
     JOB_PRIORITIES = {
+        ClearQueueJob: 0,  # Must preempt all other jobs
         PauseQueueJob: 11,
         FileDownloadJob: 13,  # File downloads processed in separate queue
         DeleteSourceJob: 14,
@@ -63,7 +65,7 @@ class RunnableQueue(QObject):
         SeenJob: 18,
     }
 
-    # Signal that is emitted when processing is stopped and enqueued jobs are cleared
+    # Signal that is emitted when processing is stopped and queued jobs are cleared
     cleared = pyqtSignal()
 
     # Signal that is emitted when processing is paused
@@ -148,6 +150,9 @@ class RunnableQueue(QObject):
         """
         Process the next job in the queue.
 
+        If the job is a ClearQueueJob, call _clear() and return from the processing loop so that
+        the processing thread can quit.
+
         If the job is a PauseQueueJob, emit the paused signal and return from the processing loop so
         that no more jobs are processed until the queue resumes.
 
@@ -168,7 +173,13 @@ class RunnableQueue(QObject):
                 self.condition_add_or_remove_job.wait_for(lambda: not self.queue.empty())
                 priority, self.current_job = self.queue.get(block=False)
 
-            if isinstance(self.current_job, PauseQueueJob):
+            if isinstance(self.current_job, ClearQueueJob):
+                with self.condition_add_or_remove_job:
+                    self.current_job = None
+                self._clear()
+                return
+
+            if isinstance(self.current_job, PauseQueueJob):  # type: ignore
                 self.paused.emit()
                 with self.condition_add_or_remove_job:
                     self.current_job = None
@@ -209,6 +220,9 @@ class ApiJobQueue(QObject):
     from the Controller.
     """
 
+    # Signal that is emitted after a queue is cleared.
+    cleared = pyqtSignal()
+
     # Signal that is emitted after a queue is paused.
     paused = pyqtSignal()
 
@@ -230,6 +244,9 @@ class ApiJobQueue(QObject):
         self.main_queue.paused.connect(self.on_main_queue_paused)
         self.download_file_queue.paused.connect(self.on_file_download_queue_paused)
 
+        self.main_queue.cleared.connect(self.on_main_queue_cleared)
+        self.download_file_queue.cleared.connect(self.on_file_download_queue_cleared)
+
     def start(self, api_client: API) -> None:
         """
         Start the queues whenever a new api token is provided.
@@ -247,15 +264,19 @@ class ApiJobQueue(QObject):
 
     def stop(self) -> None:
         """
-        Stop the queues.
+        Inject a ClearQueueJob into each queue and quit its processing thread.  To keep this
+        method non-blocking, we do NOT wait() for the thread to return, which will happen only
+        when RunnableQueue.process() reaches the ClearQueueJob and returns from its loop.
         """
         if self.main_thread.isRunning():
+            self.main_queue.add_job(ClearQueueJob())
             self.main_thread.quit()
-            logger.debug("Stopped main queue")
+            logger.debug("Asked main queue thread to quit")
 
         if self.download_file_thread.isRunning():
+            self.download_file_queue.add_job(ClearQueueJob())
             self.download_file_thread.quit()
-            logger.debug("Stopped file download queue")
+            logger.debug("Asked file-download queue thread to quit")
 
     @pyqtSlot()
     def on_main_queue_paused(self) -> None:
@@ -272,6 +293,22 @@ class ApiJobQueue(QObject):
         """
         logger.debug("Paused file download queue")
         self.paused.emit()
+
+    @pyqtSlot()
+    def on_main_queue_cleared(self) -> None:
+        """
+        Emit the "cleared" signal when the main RunnableQueue is cleared.
+        """
+        logger.debug("Cleared main queue")
+        self.cleared.emit()
+
+    @pyqtSlot()
+    def on_file_download_queue_cleared(self) -> None:
+        """
+        Emit the "cleared" signal when the file-download RunnableQueue is cleared.
+        """
+        logger.debug("Cleared file download queue")
+        self.cleared.emit()
 
     def resume_queues(self) -> None:
         """

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -63,7 +63,10 @@ class RunnableQueue(QObject):
         SeenJob: 18,
     }
 
-    # Signal that is emitted when processing stops
+    # Signal that is emitted when processing is stopped and enqueued jobs are cleared
+    cleared = pyqtSignal()
+
+    # Signal that is emitted when processing is paused
     paused = pyqtSignal()
 
     # Signal that is emitted to resume processing jobs
@@ -96,6 +99,16 @@ class RunnableQueue(QObject):
             logger.debug("Duplicate job {}, skipping".format(job))
             return True
         return False
+
+    def _clear(self) -> None:
+        """
+        Reinstantiate the PriorityQueue, rather than trying to clear it via undocumented methods.[1]
+
+        [1]: https://stackoverflow.com/a/38560911
+        """
+        with self.condition_add_or_remove_job:
+            self.queue = PriorityQueue()
+        self.cleared.emit()
 
     def add_job(self, job: ApiJob) -> None:
         """

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -237,6 +237,22 @@ def test_RunnableQueue_does_not_run_jobs_when_not_authed(mocker):
     assert queue.api_client is None
 
 
+def test_RunnableQueue_clear(mocker):
+    """
+    After RunnableQueue.clear(), the underlying PriorityQueue is empty.
+    """
+    api_client = mocker.MagicMock()
+    session_maker = mocker.MagicMock(return_value=mocker.MagicMock())
+    queue = RunnableQueue(api_client, session_maker)
+
+    job = SendReplyJob("mock", "mock", "mock", "mock")
+    queue.add_job(job)
+    assert queue.queue.qsize() == 1
+
+    queue._clear()
+    assert queue.queue.empty()
+
+
 def test_ApiJobQueue_enqueue_when_queues_are_running(mocker):
     mock_client = mocker.MagicMock()
     mock_session_maker = mocker.MagicMock()


### PR DESCRIPTION
# Description

Fixes #1420 by:

1. defining a highest-priority (0) `ClearQueueJob`; and
2. enqueuing a `ClearQueueJob` in `ApiJobQueue.stop()`; thereby
3. clearing the `ApiJobQueue`'s `RunnableQueue`s and stopping their processing threads non-blocking, without `QThread.wait()`ing for them to return. 

# Test Plan

1. [ ] Follow #1420's steps to reproduce on `main` and confirm the actual versus expected behavior.
2. [ ] Follow #1420's steps to reproduce on `1420-stale-jobs` and observe the expected behavior.
    - [ ] While the `SendReplyJob` is timing out, the GUI does not freeze.

# Checklist

## After merge

- [ ] Update ["How Queue Processing Works"](https://github.com/freedomofpress/securedrop-client/wiki/Architecture#how-queue-processing-works)
- [ ] Update ["Network Testing" QA stories](https://github.com/freedomofpress/securedrop-client/wiki/QA#network-testing)

## Before merge

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - I need help writing a database migration
 - [x] No database schema changes are needed
