### PR TITLE
Make RunnableQueue process any QueueJob instead of just ApiJob

### DIFF
--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -163,8 +163,9 @@ class RunnableQueue(QObject):
                 return
 
             try:
-                session = self.session_maker()
-                self.current_job._do_call_api(self.api_client, session)
+                if isinstance(self.current_job, ApiJob):
+                    session = self.session_maker()
+                    self.current_job._do_call_api(self.api_client, session)
             except ApiInaccessibleError as e:
                 logger.debug("{}: {}".format(type(e).__name__, e))
                 self.api_client = None


### PR DESCRIPTION
# Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/1444

This is a draft reply until https://github.com/freedomofpress/securedrop-client/pull/1434 is merged, which will create a conflict.

# Test Plan

Since this is a refactor-only, perform regression testing around the queue: 
* Cause a network outage to enqueue a `PauseQueueJob` and confirm that the behavior is the same as on `main`
* Send a reply
* Download a file
* Logout and log in again

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed
