### PR TITLE
Disable download when conversation was deleted

### DIFF
--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -5,15 +5,13 @@ Over time, this module could become the interface between
 the GUI and the controller.
 """
 from gettext import gettext as _
-from typing import Optional
+from typing import Callable, Optional
 
 from PyQt5.QtCore import Qt, pyqtSlot
-from PyQt5.QtWidgets import QAction, QMenu
+from PyQt5.QtWidgets import QAction, QDialog, QMenu
 
 from securedrop_client import state
 from securedrop_client.db import Source
-from securedrop_client.gui.conversation import DeleteConversationDialog
-from securedrop_client.gui.source import DeleteSourceDialog
 from securedrop_client.logic import Controller
 
 
@@ -64,38 +62,56 @@ class DownloadConversation(QAction):
 class DeleteSourceAction(QAction):
     """Use this action to delete the source record."""
 
-    def __init__(self, source: Source, parent: QMenu, controller: Controller) -> None:
+    def __init__(
+        self,
+        source: Source,
+        parent: QMenu,
+        controller: Controller,
+        confirmation_dialog: Callable[[Source], QDialog],
+    ) -> None:
         self.source = source
         self.controller = controller
         self.text = _("Entire source account")
 
         super().__init__(self.text, parent)
 
-        self.confirmation_dialog = DeleteSourceDialog(self.source, self.controller)
+        self._confirmation_dialog = confirmation_dialog(self.source)
+        self._confirmation_dialog.accepted.connect(
+            lambda: self.controller.delete_source(self.source)
+        )
         self.triggered.connect(self.trigger)
 
     def trigger(self) -> None:
         if self.controller.api is None:
             self.controller.on_action_requiring_login()
         else:
-            self.confirmation_dialog.exec()
+            self._confirmation_dialog.exec()
 
 
 class DeleteConversationAction(QAction):
     """Use this action to delete a source's submissions and replies."""
 
-    def __init__(self, source: Source, parent: QMenu, controller: Controller) -> None:
+    def __init__(
+        self,
+        source: Source,
+        parent: QMenu,
+        controller: Controller,
+        confirmation_dialog: Callable[[Source], QDialog],
+    ) -> None:
         self.source = source
         self.controller = controller
         self.text = _("Files and messages")
 
         super().__init__(self.text, parent)
 
-        self.confirmation_dialog = DeleteConversationDialog(self.source, self.controller)
+        self._confirmation_dialog = confirmation_dialog(self.source)
+        self._confirmation_dialog.accepted.connect(
+            lambda: self.controller.delete_conversation(self.source)
+        )
         self.triggered.connect(self.trigger)
 
     def trigger(self) -> None:
         if self.controller.api is None:
             self.controller.on_action_requiring_login()
         else:
-            self.confirmation_dialog.exec()
+            self._confirmation_dialog.exec()

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -34,11 +34,14 @@ class DownloadConversation(QAction):
 
     @pyqtSlot()
     def on_triggered(self) -> None:
-        if self._state is not None:
-            id = self._state.selected_conversation
-            if id is None:
-                return
-            self._controller.download_conversation(id)
+        if self._controller.api is None:
+            self._controller.on_action_requiring_login()
+        else:
+            if self._state is not None:
+                id = self._state.selected_conversation
+                if id is None:
+                    return
+                self._controller.download_conversation(id)
 
     def _connect_enabled_to_conversation_changes(self) -> None:
         if self._state is not None:

--- a/securedrop_client/gui/base/dialogs.py
+++ b/securedrop_client/gui/base/dialogs.py
@@ -132,7 +132,6 @@ class ModalDialog(QDialog):
 
         self.cancel_button = QPushButton(_("CANCEL"))
         self.cancel_button.setStyleSheet(self.BUTTON_CSS)
-        self.cancel_button.clicked.connect(self.close)
 
         self.continue_button = QPushButton(_("CONTINUE"))
         self.continue_button.setStyleSheet(self.BUTTON_CSS)
@@ -152,8 +151,11 @@ class ModalDialog(QDialog):
             self.cancel_button.setObjectName("ModalDialog_cancel_button")
             self.continue_button.setObjectName("ModalDialog_primary_button")
 
-        button_box.addButton(self.cancel_button, QDialogButtonBox.ActionRole)
-        button_box.addButton(self.continue_button, QDialogButtonBox.ActionRole)
+        button_box.addButton(self.cancel_button, QDialogButtonBox.RejectRole)
+        button_box.addButton(self.continue_button, QDialogButtonBox.AcceptRole)
+
+        button_box.rejected.connect(self.reject)
+        button_box.accepted.connect(self.accept)
 
         self.confirmation_label = QLabel()
         self.confirmation_label.setObjectName("ModalDialogConfirmation")
@@ -215,3 +217,7 @@ class ModalDialog(QDialog):
         self.header_icon.setVisible(True)
         self.header_spinner_label.setVisible(False)
         self.header_animation.stop()
+
+    def text(self) -> str:
+        """A text-only representation of the dialog."""
+        return self.body.text()

--- a/securedrop_client/gui/conversation/delete/dialog.py
+++ b/securedrop_client/gui/conversation/delete/dialog.py
@@ -86,3 +86,8 @@ class DeleteConversationDialog(ModalDialog):
             replies_to_delete=replies_to_delete,
             source=source,
         )
+
+    def exec(self) -> None:
+        # Refresh counters
+        self.body.setText(self.make_body_text())
+        super().exec()

--- a/securedrop_client/gui/conversation/delete/dialog.py
+++ b/securedrop_client/gui/conversation/delete/dialog.py
@@ -19,11 +19,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from gettext import gettext as _
 from gettext import ngettext
 
-from PyQt5.QtCore import pyqtSlot
-
 from securedrop_client.db import File, Message, Reply, Source
 from securedrop_client.gui.base import ModalDialog
-from securedrop_client.logic import Controller
 
 
 class DeleteConversationDialog(ModalDialog):
@@ -31,16 +28,14 @@ class DeleteConversationDialog(ModalDialog):
     Shown to confirm deletion of all content in a source conversation.
     """
 
-    def __init__(self, source: Source, controller: Controller) -> None:
+    def __init__(self, source: Source) -> None:
         super().__init__(show_header=False, dangerous=False)
 
         self.source = source
-        self.controller = controller
 
         self.body.setText(self.make_body_text())
 
         self.continue_button.setText(_("YES, DELETE FILES AND MESSAGES"))
-        self.continue_button.clicked.connect(self.delete_conversation)
         self.continue_button.setFocus()
 
         self.adjustSize()
@@ -91,13 +86,3 @@ class DeleteConversationDialog(ModalDialog):
             replies_to_delete=replies_to_delete,
             source=source,
         )
-
-    def exec(self) -> None:
-        # Refresh counters
-        self.body.setText(self.make_body_text())
-        super().exec()
-
-    @pyqtSlot()
-    def delete_conversation(self) -> None:
-        self.controller.delete_conversation(self.source)
-        self.close()

--- a/securedrop_client/gui/source/delete/dialog.py
+++ b/securedrop_client/gui/source/delete/dialog.py
@@ -18,29 +18,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 from gettext import gettext as _
 
-from PyQt5.QtCore import pyqtSlot
-
 from securedrop_client.db import Source
 from securedrop_client.gui.base import ModalDialog
-from securedrop_client.logic import Controller
 
 
 class DeleteSourceDialog(ModalDialog):
     """Used to confirm deletion of source accounts."""
 
-    def __init__(self, source: Source, controller: Controller) -> None:
+    def __init__(self, source: Source) -> None:
         super().__init__(show_header=False, dangerous=True)
 
         self.source = source
-        self.controller = controller
 
         self.body.setText(self.make_body_text())
-
         self.continue_button.setText(_("YES, DELETE ENTIRE SOURCE ACCOUNT"))
-        self.continue_button.clicked.connect(self.delete_source)
-
+        self.cancel_button.setDefault(True)
+        self.cancel_button.setFocus()
         self.confirmation_label.setText(_("Are you sure this is what you want?"))
-
         self.adjustSize()
 
     def make_body_text(self) -> str:
@@ -66,8 +60,3 @@ class DeleteSourceDialog(ModalDialog):
         return "".join(message_tuple).format(
             source="<b>{}</b>".format(self.source.journalist_designation)
         )
-
-    @pyqtSlot()
-    def delete_source(self) -> None:
-        self.controller.delete_source(self.source)
-        self.close()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -84,6 +84,8 @@ from securedrop_client.gui.base import (
     SvgPushButton,
     SvgToggleButton,
 )
+from securedrop_client.gui.conversation import DeleteConversationDialog
+from securedrop_client.gui.source import DeleteSourceDialog
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_css, load_icon, load_image, load_movie
 from securedrop_client.storage import source_exists
@@ -3632,8 +3634,10 @@ class SourceMenu(QMenu):
         delete_section = self.addSection(_("DELETE"))
         delete_section.setFont(separator_font)
 
-        self.addAction(DeleteConversationAction(self.source, self, self.controller))
-        self.addAction(DeleteSourceAction(self.source, self, self.controller))
+        self.addAction(
+            DeleteConversationAction(self.source, self, self.controller, DeleteConversationDialog)
+        )
+        self.addAction(DeleteSourceAction(self.source, self, self.controller, DeleteSourceDialog))
 
 
 class SourceMenuButton(QToolButton):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3635,7 +3635,9 @@ class SourceMenu(QMenu):
         delete_section.setFont(separator_font)
 
         self.addAction(
-            DeleteConversationAction(self.source, self, self.controller, DeleteConversationDialog)
+            DeleteConversationAction(
+                self.source, self, self.controller, DeleteConversationDialog, app_state
+            )
         )
         self.addAction(DeleteSourceAction(self.source, self, self.controller, DeleteSourceDialog))
 

--- a/securedrop_client/state/state.py
+++ b/securedrop_client/state/state.py
@@ -59,6 +59,11 @@ class State(QObject):
             if cid == self._selected_conversation:
                 self.selected_conversation_files_changed.emit()
 
+    def remove_conversation_files(self, id: ConversationId) -> None:
+        self._conversation_files[id] = []
+        if id == self._selected_conversation:
+            self.selected_conversation_files_changed.emit()
+
     def conversation_files(self, id: ConversationId) -> List[File]:
         default: List[File] = []
         return self._conversation_files.get(id, default)

--- a/tests/gui/conversation/delete/test_dialog.py
+++ b/tests/gui/conversation/delete/test_dialog.py
@@ -1,5 +1,6 @@
 import unittest
 
+from PyQt5.QtCore import QTimer
 from PyQt5.QtWidgets import QApplication
 
 from securedrop_client.gui.conversation.delete import DeleteConversationDialog as Dialog
@@ -19,14 +20,14 @@ class DeleteConversationDialogTest(unittest.TestCase):
         assert "0 messages" in self.dialog.text()
         assert "0 replies" in self.dialog.text()
 
-    @unittest.skip("Not yet implemented")
     def test_displays_updated_source_information_when_shown(self):
         for i in range(2):
             factory.Reply(source=self._source)
         for i in range(3):
             factory.Message(source=self._source)
 
-        self.dialog.open()
+        QTimer.singleShot(300, self.dialog.close)
+        self.dialog.exec()
 
         assert "3 messages" in self.dialog.text()
         assert "2 replies" in self.dialog.text()

--- a/tests/gui/source/delete/test_dialog.py
+++ b/tests/gui/source/delete/test_dialog.py
@@ -1,72 +1,26 @@
-from gettext import gettext as _
+import unittest
 
 from PyQt5.QtWidgets import QApplication
 
-from securedrop_client.gui.source import DeleteSourceDialog
+from securedrop_client.gui.source.delete import DeleteSourceDialog as Dialog
 from tests import factory
 
 app = QApplication([])
 
 
-def test_DeleteSourceDialog_init(mocker, source):
-    mock_controller = mocker.MagicMock()
-    DeleteSourceDialog(source["source"], mock_controller)
+class DeleteSourceDialogTest(unittest.TestCase):
+    def setUp(self):
+        self._source = factory.Source()
+        factory.File(source=self._source)
+        self.dialog = Dialog(self._source)
 
+    def test_default_button_is_safer_choice(self):
+        # This test does rely on an implementation detail (the buttons)
+        # but I couldn't find a way to test this properly using key events.
+        assert not self.dialog.continue_button.isDefault()
+        assert self.dialog.cancel_button.isDefault()
 
-def test_DeleteSourceDialog_cancel(mocker, source):
-    source = source["source"]  # to get the Source object
-
-    mock_controller = mocker.MagicMock()
-    delete_source_dialog = DeleteSourceDialog(source, mock_controller)
-    delete_source_dialog.cancel_button.click()
-    mock_controller.delete_source.assert_not_called()
-
-
-def test_DeleteSourceDialog_continue(mocker, source, session):
-    source = source["source"]  # to get the Source object
-
-    mock_controller = mocker.MagicMock()
-    delete_source_dialog = DeleteSourceDialog(source, mock_controller)
-    delete_source_dialog.continue_button.click()
-    mock_controller.delete_source.assert_called_once_with(source)
-
-
-def test_DeleteSourceDialog_make_body_text(mocker, source, session):
-    source = source["source"]  # to get the Source object
-    file_ = factory.File(source=source)
-    session.add(file_)
-    message = factory.Message(source=source)
-    session.add(message)
-    message = factory.Message(source=source)
-    session.add(message)
-    reply = factory.Reply(source=source)
-    session.add(reply)
-    session.commit()
-
-    mock_controller = mocker.MagicMock()
-
-    delete_source_message_box = DeleteSourceDialog(source, mock_controller)
-
-    message = delete_source_message_box.make_body_text()
-
-    expected_message = "".join(
-        (
-            "<style>",
-            "p {{white-space: nowrap;}}",
-            "</style>",
-            "<p><b>",
-            _("When the entire account for a source is deleted:"),
-            "</b></p>",
-            "<p><b>\u2219</b>&nbsp;",
-            _("The source will not be able to log in with their codename again."),
-            "</p>",
-            "<p><b>\u2219</b>&nbsp;",
-            _("Your organization will not be able to send them replies."),
-            "</p>",
-            "<p><b>\u2219</b>&nbsp;",
-            _("All files and messages from that source will also be destroyed."),
-            "</p>",
-            "<p>&nbsp;</p>",
-        )
-    ).format(source=source.journalist_designation)
-    assert message == expected_message
+    def test_displays_important_information_when_shown(self):
+        assert "not be able to send them replies" in self.dialog.text()
+        assert "source will not be able to log in" in self.dialog.text()
+        assert "files and messages from that source will also be destroyed" in self.dialog.text()

--- a/tests/gui/test_actions.py
+++ b/tests/gui/test_actions.py
@@ -53,8 +53,7 @@ class DeleteConversationActionTest(unittest.TestCase):
         assert not self._controller.delete_conversation.called
 
     def test_requires_authenticated_journalist(self):
-        controller = mock.MagicMock()
-        controller.api = None  # no authenticated user
+        controller = mock.MagicMock(Controller, api=None)  # no authenticated user
         self.action.controller = controller
 
         confirmation_dialog = mock.MagicMock()
@@ -100,8 +99,7 @@ class DeleteSourceActionTest(unittest.TestCase):
         assert not self._controller.delete_source.called
 
     def test_requires_authenticated_journalist(self):
-        controller = mock.MagicMock()
-        controller.api = None  # no authenticated user
+        controller = mock.MagicMock(Controller, api=None)  # no authenticated user
         self.action.controller = controller
 
         confirmation_dialog = mock.MagicMock()
@@ -117,7 +115,7 @@ class DeleteSourceActionTest(unittest.TestCase):
 class TestDownloadConversation(unittest.TestCase):
     def test_trigger(self):
         menu = QMenu()
-        controller = mock.MagicMock()
+        controller = MagicMock(Controller, api=True)
         app_state = state.State()
         action = DownloadConversation(menu, controller, app_state)
 
@@ -128,9 +126,23 @@ class TestDownloadConversation(unittest.TestCase):
 
         controller.download_conversation.assert_called_once_with(conversation_id)
 
+    def test_requires_authenticated_journalist(self):
+        menu = QMenu()
+        controller = mock.MagicMock(Controller, api=None)  # no authenticated user
+        app_state = state.State()
+        action = DownloadConversation(menu, controller, app_state)
+
+        conversation_id = state.ConversationId("some_conversation")
+        app_state.selected_conversation = conversation_id
+
+        action.trigger()
+
+        assert not controller.download_conversation.called
+        controller.on_action_requiring_login.assert_called_once()
+
     def test_trigger_downloads_nothing_if_no_conversation_is_selected(self):
         menu = QMenu()
-        controller = mock.MagicMock()
+        controller = MagicMock(Controller, api=True)
         app_state = state.State()
         action = DownloadConversation(menu, controller, app_state)
 
@@ -139,7 +151,7 @@ class TestDownloadConversation(unittest.TestCase):
 
     def test_gets_disabled_when_no_files_to_download_remain(self):
         menu = QMenu()
-        controller = mock.MagicMock()
+        controller = MagicMock(Controller, api=True)
         app_state = state.State()
         action = DownloadConversation(menu, controller, app_state)
 
@@ -155,7 +167,7 @@ class TestDownloadConversation(unittest.TestCase):
 
     def test_gets_enabled_when_files_are_available_to_download(self):
         menu = QMenu()
-        controller = mock.MagicMock()
+        controller = MagicMock(Controller, api=True)
         app_state = state.State()
         action = DownloadConversation(menu, controller, app_state)
 
@@ -171,7 +183,7 @@ class TestDownloadConversation(unittest.TestCase):
 
     def test_gets_initially_disabled_when_file_information_is_available(self):
         menu = QMenu()
-        controller = mock.MagicMock()
+        controller = MagicMock(Controller, api=True)
         app_state = state.State()
 
         conversation_id = state.ConversationId(3)
@@ -185,7 +197,7 @@ class TestDownloadConversation(unittest.TestCase):
 
     def test_gets_initially_enabled_when_file_information_is_available(self):
         menu = QMenu()
-        controller = mock.MagicMock()
+        controller = MagicMock(Controller, api=True)
         app_state = state.State()
 
         conversation_id = state.ConversationId(3)
@@ -199,7 +211,7 @@ class TestDownloadConversation(unittest.TestCase):
 
     def test_does_not_require_state_to_be_defined(self):
         menu = QMenu()
-        controller = mock.MagicMock()
+        controller = MagicMock(Controller, api=True)
         action = DownloadConversation(menu, controller, app_state=None)
 
         action.setEnabled(False)
@@ -212,7 +224,7 @@ class TestDownloadConversation(unittest.TestCase):
         self,
     ):
         menu = QMenu()
-        controller = mock.MagicMock()
+        controller = MagicMock(Controller, api=True)
         action = DownloadConversation(menu, controller, None)
 
         action.setEnabled(True)

--- a/tests/gui/test_actions.py
+++ b/tests/gui/test_actions.py
@@ -18,7 +18,8 @@ app = QApplication([])
 def test_DeleteSourceAction_init(mocker):
     mock_controller = mocker.MagicMock()
     mock_source = mocker.MagicMock()
-    DeleteSourceAction(mock_source, None, mock_controller)
+    mock_delete_source_dialog = mocker.MagicMock()
+    DeleteSourceAction(mock_source, None, mock_controller, mock_delete_source_dialog)
 
 
 def test_DeleteSourceAction_trigger(mocker):
@@ -28,8 +29,9 @@ def test_DeleteSourceAction_trigger(mocker):
     mock_delete_source_dialog = mocker.MagicMock()
     mock_delete_source_dialog.return_value = mock_delete_source_dialog_instance
 
-    mocker.patch("securedrop_client.gui.actions.DeleteSourceDialog", mock_delete_source_dialog)
-    delete_source_action = DeleteSourceAction(mock_source, None, mock_controller)
+    delete_source_action = DeleteSourceAction(
+        mock_source, None, mock_controller, mock_delete_source_dialog
+    )
     delete_source_action.trigger()
     mock_delete_source_dialog_instance.exec.assert_called_once()
 
@@ -41,10 +43,9 @@ def test_DeleteConversationAction_trigger(mocker):
     mock_delete_conversation_dialog = mocker.MagicMock()
     mock_delete_conversation_dialog.return_value = mock_delete_conversation_dialog_instance
 
-    mocker.patch(
-        "securedrop_client.gui.actions.DeleteConversationDialog", mock_delete_conversation_dialog
+    delete_conversation_action = DeleteConversationAction(
+        mock_source, None, mock_controller, mock_delete_conversation_dialog
     )
-    delete_conversation_action = DeleteConversationAction(mock_source, None, mock_controller)
     delete_conversation_action.trigger()
     mock_delete_conversation_dialog_instance.exec.assert_called_once()
 
@@ -57,11 +58,9 @@ def test_DeleteConversationAction_trigger_when_user_is_loggedout(mocker):
     mock_delete_conversation_dialog = mocker.MagicMock()
     mock_delete_conversation_dialog.return_value = mock_delete_conversation_dialog_instance
 
-    mocker.patch(
-        "securedrop_client.gui.conversation.DeleteConversationDialog",
-        mock_delete_conversation_dialog,
+    delete_conversation_action = DeleteConversationAction(
+        mock_source, None, mock_controller, mock_delete_conversation_dialog
     )
-    delete_conversation_action = DeleteConversationAction(mock_source, None, mock_controller)
     delete_conversation_action.trigger()
     mock_delete_conversation_dialog_instance.exec.assert_not_called()
 
@@ -74,8 +73,9 @@ def test_DeleteSourceAction_requires_an_authenticated_journalist(mocker):
     mock_delete_source_dialog = mocker.MagicMock()
     mock_delete_source_dialog.return_value = mock_delete_source_dialog_instance
 
-    mocker.patch("securedrop_client.gui.actions.DeleteSourceDialog", mock_delete_source_dialog)
-    delete_source_action = DeleteSourceAction(mock_source, None, mock_controller)
+    delete_source_action = DeleteSourceAction(
+        mock_source, None, mock_controller, mock_delete_source_dialog
+    )
     delete_source_action.trigger()
     assert not mock_delete_source_dialog_instance.exec.called
     mock_controller.on_action_requiring_login.assert_called_once()

--- a/tests/gui/test_actions.py
+++ b/tests/gui/test_actions.py
@@ -34,9 +34,7 @@ class DeleteConversationActionTest(unittest.TestCase):
 
     def test_deletes_conversation_when_dialog_accepted(self):
         # Accept the confimation dialog from a separate thread.
-        timer = QTimer()
-        timer.start(10)
-        timer.timeout.connect(lambda: self._dialog.accept())
+        QTimer.singleShot(10, self._dialog.accept)
 
         self.action.trigger()
 
@@ -44,9 +42,7 @@ class DeleteConversationActionTest(unittest.TestCase):
 
     def test_does_not_delete_conversation_when_dialog_rejected(self):
         # Reject the confimation dialog from a separate thread.
-        timer = QTimer()
-        timer.start(10)
-        timer.timeout.connect(lambda: self._dialog.reject())
+        QTimer.singleShot(10, self._dialog.reject)
 
         self.action.trigger()
 
@@ -80,9 +76,7 @@ class DeleteSourceActionTest(unittest.TestCase):
 
     def test_deletes_source_when_dialog_accepted(self):
         # Accept the confimation dialog from a separate thread.
-        timer = QTimer()
-        timer.start(10)
-        timer.timeout.connect(lambda: self._dialog.accept())
+        QTimer.singleShot(10, self._dialog.accept)
 
         self.action.trigger()
 
@@ -90,9 +84,7 @@ class DeleteSourceActionTest(unittest.TestCase):
 
     def test_does_not_delete_source_when_dialog_rejected(self):
         # Reject the confimation dialog from a separate thread.
-        timer = QTimer()
-        timer.start(10)
-        timer.timeout.connect(lambda: self._dialog.reject())
+        QTimer.singleShot(10, self._dialog.reject)
 
         self.action.trigger()
 

--- a/tests/gui/test_actions.py
+++ b/tests/gui/test_actions.py
@@ -9,6 +9,7 @@ from securedrop_client.gui.actions import (
     DeleteSourceAction,
     DownloadConversation,
 )
+from securedrop_client.gui.conversation import DeleteConversationDialog
 from securedrop_client.gui.source import DeleteSourceDialog
 
 app = QApplication([])
@@ -36,7 +37,7 @@ def test_DeleteSourceAction_trigger(mocker):
 def test_DeleteConversationAction_trigger(mocker):
     mock_controller = mocker.MagicMock()
     mock_source = mocker.MagicMock()
-    mock_delete_conversation_dialog_instance = mocker.MagicMock(DeleteSourceDialog)
+    mock_delete_conversation_dialog_instance = mocker.MagicMock(DeleteConversationDialog)
     mock_delete_conversation_dialog = mocker.MagicMock()
     mock_delete_conversation_dialog.return_value = mock_delete_conversation_dialog_instance
 
@@ -52,7 +53,7 @@ def test_DeleteConversationAction_trigger_when_user_is_loggedout(mocker):
     mock_controller = mocker.MagicMock()
     mock_controller.api = None
     mock_source = mocker.MagicMock()
-    mock_delete_conversation_dialog_instance = mocker.MagicMock(DeleteSourceDialog)
+    mock_delete_conversation_dialog_instance = mocker.MagicMock(DeleteConversationDialog)
     mock_delete_conversation_dialog = mocker.MagicMock()
     mock_delete_conversation_dialog.return_value = mock_delete_conversation_dialog_instance
 

--- a/tests/gui/test_actions.py
+++ b/tests/gui/test_actions.py
@@ -1,16 +1,20 @@
 import unittest
 from unittest import mock
+from unittest.mock import MagicMock
 
-from PyQt5.QtWidgets import QApplication, QMenu
+from PyQt5.QtCore import QTimer
+from PyQt5.QtWidgets import QApplication, QDialog, QMenu
 
 from securedrop_client import state
+from securedrop_client.db import Source
 from securedrop_client.gui.actions import (
     DeleteConversationAction,
     DeleteSourceAction,
     DownloadConversation,
 )
-from securedrop_client.gui.conversation import DeleteConversationDialog
 from securedrop_client.gui.source import DeleteSourceDialog
+from securedrop_client.logic import Controller
+from tests import factory
 
 app = QApplication([])
 
@@ -36,35 +40,6 @@ def test_DeleteSourceAction_trigger(mocker):
     mock_delete_source_dialog_instance.exec.assert_called_once()
 
 
-def test_DeleteConversationAction_trigger(mocker):
-    mock_controller = mocker.MagicMock()
-    mock_source = mocker.MagicMock()
-    mock_delete_conversation_dialog_instance = mocker.MagicMock(DeleteConversationDialog)
-    mock_delete_conversation_dialog = mocker.MagicMock()
-    mock_delete_conversation_dialog.return_value = mock_delete_conversation_dialog_instance
-
-    delete_conversation_action = DeleteConversationAction(
-        mock_source, None, mock_controller, mock_delete_conversation_dialog
-    )
-    delete_conversation_action.trigger()
-    mock_delete_conversation_dialog_instance.exec.assert_called_once()
-
-
-def test_DeleteConversationAction_trigger_when_user_is_loggedout(mocker):
-    mock_controller = mocker.MagicMock()
-    mock_controller.api = None
-    mock_source = mocker.MagicMock()
-    mock_delete_conversation_dialog_instance = mocker.MagicMock(DeleteConversationDialog)
-    mock_delete_conversation_dialog = mocker.MagicMock()
-    mock_delete_conversation_dialog.return_value = mock_delete_conversation_dialog_instance
-
-    delete_conversation_action = DeleteConversationAction(
-        mock_source, None, mock_controller, mock_delete_conversation_dialog
-    )
-    delete_conversation_action.trigger()
-    mock_delete_conversation_dialog_instance.exec.assert_not_called()
-
-
 def test_DeleteSourceAction_requires_an_authenticated_journalist(mocker):
     mock_controller = mocker.MagicMock()
     mock_controller.api = None  # no aouthenticated journalist
@@ -79,6 +54,55 @@ def test_DeleteSourceAction_requires_an_authenticated_journalist(mocker):
     delete_source_action.trigger()
     assert not mock_delete_source_dialog_instance.exec.called
     mock_controller.on_action_requiring_login.assert_called_once()
+
+
+class DeleteConversationActionTest(unittest.TestCase):
+    def setUp(self):
+        self._source = factory.Source()
+        _menu = QMenu()
+        self._controller = MagicMock(Controller, api=True)
+        self._dialog = QDialog()
+
+        def _dialog_constructor(source: Source) -> QDialog:
+            return self._dialog
+
+        self.action = DeleteConversationAction(
+            self._source, _menu, self._controller, _dialog_constructor
+        )
+
+    def test_deletes_conversation_when_dialog_accepted(self):
+        # Accept the confimation dialog from a separate thread.
+        timer = QTimer()
+        timer.start(10)
+        timer.timeout.connect(lambda: self._dialog.accept())
+
+        self.action.trigger()
+
+        self._controller.delete_conversation.assert_called_once_with(self._source)
+
+    def test_does_not_delete_conversation_when_dialog_rejected(self):
+        # Reject the confimation dialog from a separate thread.
+        timer = QTimer()
+        timer.start(10)
+        timer.timeout.connect(lambda: self._dialog.reject())
+
+        self.action.trigger()
+
+        assert not self._controller.delete_conversation.called
+
+    def test_requires_authenticated_journalist(self):
+        controller = mock.MagicMock()
+        controller.api = None  # no authenticated user
+        self.action.controller = controller
+
+        confirmation_dialog = mock.MagicMock()
+        self.action._confirmation_dialog = confirmation_dialog
+
+        self.action.trigger()
+
+        assert not confirmation_dialog.exec.called
+        assert not controller.delete_conversation.called
+        controller.on_action_requiring_login.assert_called_once()
 
 
 class TestDownloadConversation(unittest.TestCase):

--- a/tests/state/test_state.py
+++ b/tests/state/test_state.py
@@ -43,6 +43,17 @@ class TestState(unittest.TestCase):
         self.state.add_file(5, 7)
         assert len(self.state.conversation_files(5)) == 2
 
+    def test_remove_conversation_files_removes_all_conversation_files(self):
+        self.state.add_file(7, 3)
+        self.state.add_file(7, 1)
+        assert len(self.state.conversation_files(7)) == 2
+        self.state.remove_conversation_files(7)
+        assert len(self.state.conversation_files(7)) == 0
+
+    def test_remove_conversation_files_handles_missing_files_gracefully(self):
+        self.state.remove_conversation_files(8)
+        assert len(self.state.conversation_files(8)) == 0
+
     def test_conversation_files_is_empty_by_default(self):
         assert len(self.state.conversation_files(2)) == 0
 
@@ -93,6 +104,14 @@ class TestState(unittest.TestCase):
         # when a file is added to the selected conversation
         self.state.add_file(1, "some_file_id")
         assert len(signal_emissions) == 3
+
+        # NOT when files are removed from a conversation that's not the selected one
+        self.state.remove_conversation_files("some_conversation_id")
+        assert len(signal_emissions) == 3  # the signal wasn't emited again
+
+        # when the selected conversation files are removed
+        self.state.remove_conversation_files(1)
+        assert len(signal_emissions) == 4
 
     def test_selected_conversation_has_downloadable_files_false_by_default(self):
         assert not self.state.selected_conversation_has_downloadable_files


### PR DESCRIPTION
# Description

:crystal_ball: **Reviewers** (@creviera): This PR builds on #1447, please wait until that one is merged to rebase then review. Only two commits will remain :slightly_smiling_face: (In the meantime you can look at the last two commits to get an idea of the changes involved.)

Fixes #1442 

# Test Plan

Ensure that the steps to reproduce defined in #1442 are handled:

- Select a source with files that have not yet been downloaded
- Delete the source conversation
- Select the source menu
- [ ] Confirm that the "Download All Files" action is disabled

# Comments

This PR gives `DeleteConversationAction` access to the application state, which means we can now expand `state.State` to contain information about messages and use it to enable/disable the action dynamically. It's out of scope, but I thought it was worth mentioning.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
