### PR TITLE
Fix reply ordering and update source and reply attributes after safe delete

### DIFF
--- a/securedrop_client/api_jobs/uploads.py
+++ b/securedrop_client/api_jobs/uploads.py
@@ -93,20 +93,21 @@ class SendReplyJob(SingleObjectApiJob):
             # Update following draft replies for the same source to reflect the new reply count
             draft_file_counter = draft_reply_db_object.file_counter
             draft_timestamp = draft_reply_db_object.timestamp
+
             update_draft_replies(
                 session,
                 source.id,
                 draft_timestamp,
                 draft_file_counter,
                 new_file_counter,
-                commit=False,
             )
 
             # Add reply to replies table and increase the source interaction count by 1 and delete
             # the draft reply.
             session.add(reply_db_object)
-            source.interaction_count += 1
+            source.interaction_count = source.interaction_count + 1
             session.add(source)
+
             session.delete(draft_reply_db_object)
             session.commit()
 

--- a/securedrop_client/api_jobs/uploads.py
+++ b/securedrop_client/api_jobs/uploads.py
@@ -100,6 +100,7 @@ class SendReplyJob(SingleObjectApiJob):
                 draft_timestamp,
                 draft_file_counter,
                 new_file_counter,
+                commit=False,
             )
 
             # Add reply to replies table and increase the source interaction count by 1 and delete

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3151,6 +3151,7 @@ class ConversationView(QWidget):
         self.reply_flag = True
         if source_uuid == self.source.uuid:
             try:
+                self.controller.session.refresh(self.source)
                 self.update_conversation(self.source.collection)
             except sqlalchemy.exc.InvalidRequestError as e:
                 logger.debug(e)

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -276,24 +276,30 @@ def update_sources(
     for source in remote_sources:
         if source.uuid in local_sources_by_uuid:
 
-            # If source UUID has been flagged as having been locally updated, wait
-            # til next sync to update it. The list of skip_uuids is managed by the
-            # parent method and purged after each sync.
+            # Update an existing record.
+            logger.debug("Update source {}".format(source.uuid))
+            local_source = local_sources_by_uuid[source.uuid]
+
+            lazy_setattr(local_source, "journalist_designation", source.journalist_designation)
+            lazy_setattr(local_source, "is_flagged", source.is_flagged)
+            lazy_setattr(local_source, "interaction_count", source.interaction_count)
+            lazy_setattr(local_source, "is_starred", source.is_starred)
+            lazy_setattr(local_source, "last_updated", parse(source.last_updated))
+            lazy_setattr(local_source, "public_key", source.key["public"])
+            lazy_setattr(local_source, "fingerprint", source.key["fingerprint"])
+
+            # If source files and messages have been locally-deleted, set the document count
+            # to 0. Otherwise, populate with document count.
             if skip_uuids_deleted_conversation and source.uuid in skip_uuids_deleted_conversation:
-                logger.debug("Skip source update for {} (this sync only)".format(source.uuid))
+                logger.debug(
+                    "Local deletion: override document_count for {} (this sync only)".format(
+                        source.uuid
+                    )
+                )
+                lazy_setattr(local_source, "document_count", 0)
 
             else:
-                # Update an existing record.
-                logger.debug("Update source {}".format(source.uuid))
-                local_source = local_sources_by_uuid[source.uuid]
-                lazy_setattr(local_source, "journalist_designation", source.journalist_designation)
-                lazy_setattr(local_source, "is_flagged", source.is_flagged)
-                lazy_setattr(local_source, "interaction_count", source.interaction_count)
                 lazy_setattr(local_source, "document_count", source.number_of_documents)
-                lazy_setattr(local_source, "is_starred", source.is_starred)
-                lazy_setattr(local_source, "last_updated", parse(source.last_updated))
-                lazy_setattr(local_source, "public_key", source.key["public"])
-                lazy_setattr(local_source, "fingerprint", source.key["fingerprint"])
 
             # Removing the UUID from local_sources_by_uuid ensures
             # this record won't be deleted at the end of this
@@ -384,7 +390,7 @@ def __update_submissions(
 
     for submission in remote_submissions:
         local_submission = local_submissions_by_uuid.get(submission.uuid)
-        if local_submission and submission.source_uuid not in skip_uuids_deleted_conversation:
+        if local_submission:
             lazy_setattr(local_submission, "size", submission.size)
             lazy_setattr(local_submission, "is_read", submission.is_read)
             lazy_setattr(local_submission, "download_url", submission.download_url)
@@ -550,7 +556,7 @@ def update_replies(
             user_cache[reply.journalist_uuid] = user
 
         local_reply = local_replies_by_uuid.get(reply.uuid)
-        if local_reply and reply.source_uuid not in skip_uuids_deleted_conversation:
+        if local_reply:
             lazy_setattr(local_reply, "journalist_id", user.id)
             lazy_setattr(local_reply, "size", reply.size)
             lazy_setattr(local_reply, "filename", reply.filename)
@@ -559,12 +565,11 @@ def update_replies(
 
             del local_replies_by_uuid[reply.uuid]
             logger.debug("Updated reply {}".format(reply.uuid))
-        elif local_reply and reply.source_uuid in skip_uuids_deleted_conversation:
+        elif reply.source_uuid in skip_uuids_deleted_conversation:
             logger.debug(
-                "Reply {} found for locally-modified source {}, "
-                "skipping update (for one sync)".format(reply.uuid, reply.source_uuid)
+                "Conversation deleted locally; skip remote reply {} "
+                "for source {} for one sync".format(reply.uuid, reply.source_uuid)
             )
-            del local_replies_by_uuid[reply.uuid]
         else:
             # A new reply to be added to the database.
             source = source_cache.get(reply.source_uuid)
@@ -703,7 +708,7 @@ def update_draft_replies(
             and_(
                 DraftReply.source_id == source_id,
                 DraftReply.timestamp > timestamp,
-                DraftReply.file_counter == old_file_counter,
+                DraftReply.file_counter <= old_file_counter,
             )
         )
         .all()
@@ -927,7 +932,6 @@ def _delete_source_collection_from_db(session: Session, source: Source) -> None:
     # Add source UUID to deletedconversation table, but only if we actually made
     # local database modifications
     if is_local_db_modified:
-        session.begin_nested()
         flagged_conversation = DeletedConversation(uuid=source.uuid)
         try:
             if not session.query(DeletedConversation).filter_by(uuid=source.uuid).one_or_none():
@@ -937,7 +941,14 @@ def _delete_source_collection_from_db(session: Session, source: Source) -> None:
             logger.error("Could not add source {} to deletedconversation table".format(source.uuid))
             session.rollback()
 
-    session.commit()
+    try:
+        session.commit()
+    except SQLAlchemyError:
+        logger.error(
+            "Could not locally delete conversation for source {}"
+            "(collection will be deleted by sync)".format(source.uuid)
+        )
+        session.rollback()
 
 
 def source_exists(session: Session, source_uuid: str) -> bool:

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -937,16 +937,17 @@ def _delete_source_collection_from_db(session: Session, source: Source) -> None:
             if not session.query(DeletedConversation).filter_by(uuid=source.uuid).one_or_none():
                 logger.debug("Add source {} to deletedconversation table".format(source.uuid))
                 session.add(flagged_conversation)
-        except SQLAlchemyError:
-            logger.error("Could not add source {} to deletedconversation table".format(source.uuid))
+        except SQLAlchemyError as e:
+            logger.error(
+                "Could not add source {} to deletedconversation table: {}".format(source.uuid, e)
+            )
             session.rollback()
 
     try:
         session.commit()
-    except SQLAlchemyError:
+    except SQLAlchemyError as e:
         logger.error(
-            "Could not locally delete conversation for source {}"
-            "(collection will be deleted by sync)".format(source.uuid)
+            "Could not locally delete conversation for source {}: {}".format(source.uuid, e)
         )
         session.rollback()
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,6 +11,7 @@ from securedrop_client.db import (
     Message,
     Reply,
     ReplySendStatus,
+    ReplySendStatusCodes,
     User,
 )
 from tests import factory
@@ -144,6 +145,25 @@ def test_string_representation_of_draft_reply():
     draft_reply.__str__()
     draft_reply.content = "hello"
     draft_reply.__str__()
+
+
+def test_reply_pending_status():
+    source = factory.Source()
+    journo = User(username="dellsberg")
+    failed_send_status = factory.ReplySendStatus(name=ReplySendStatusCodes.FAILED.value)
+    pending_send_status = factory.ReplySendStatus(name=ReplySendStatusCodes.PENDING.value)
+
+    draft_reply_pending = DraftReply(
+        source=source, journalist=journo, uuid="example", send_status=pending_send_status
+    )
+    draft_reply_failed = DraftReply(
+        source=source, journalist=journo, uuid="example2", send_status=failed_send_status
+    )
+    draft_reply_none = DraftReply(source=source, journalist=journo, uuid="example3")
+
+    assert draft_reply_pending.is_pending
+    assert not draft_reply_failed.is_pending
+    assert not draft_reply_none.is_pending
 
 
 def test_string_representation_of_send_reply_status():


### PR DESCRIPTION
# Description

Fixes #1445 
Fixes #1450

# Test Plan

- [ ] Perform STR in #1445, confirm fix 
- [ ] Perform STR in #1450, confirm fix 
- Perform regression testing as indicated in #1432 and ensure no regression (i.e. deleted messages are not re-downloaded during stale sync, and deletion via the JI still works)

**Test with larger number of sources/database writes:** 
- Log into the client wait for sync. Ssh into your server, and using our QA script (loaddata), add a large number of sources to the sever (n>50). While client is syncing, begin to safe-delete some local conversations. 
- [ ] ensure new sources are still added to the client
- [ ] inspect the logs and ensure no database lock-up errors are present
- [ ] safe-delete and reply after safe delete work as expected   

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment (**but I would also like a reviewer to test in Qubes**)
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
