### PR TITLE
always "invalidate token" when you log out

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -772,7 +772,8 @@ class Controller(QObject):
 
         if self.api is not None:
             self.call_api(self.api.logout, self.on_logout_success, self.on_logout_failure)
-            self.invalidate_token()
+
+        self.invalidate_token()
 
         failed_replies = storage.mark_all_pending_drafts_as_failed(self.session)
         for failed_reply in failed_replies:

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1055,6 +1055,7 @@ def test_Controller_logout_with_no_api(homedir, config, mocker, session_maker):
     mock_gui = mocker.MagicMock()
     co = Controller("http://localhost", mock_gui, session_maker, homedir, None)
     co.api = None
+    co.authenticated_user = factory.User()
     co.api_job_queue = mocker.MagicMock()
     co.api_job_queue.stop = mocker.MagicMock()
     co.call_api = mocker.MagicMock()

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1062,6 +1062,7 @@ def test_Controller_logout_with_no_api(homedir, config, mocker, session_maker):
 
     co.logout()
 
+    assert not co.authenticated_user
     co.call_api.assert_not_called()
     co.api_job_queue.stop.assert_called_once_with()
     co.gui.logout.assert_called_once_with()


### PR DESCRIPTION
# Description

Fixes #1453

# Test Plan

- [ ] Follow STR in issue and confirm fixed

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
