### PR TITLE
minor fix in show_login

### DIFF
--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -131,8 +131,8 @@ class Window(QMainWindow):
         # Always display the login dialog centered in the screen.
         screen_size = QGuiApplication.primaryScreen().availableGeometry()
         login_dialog_size = self.login_dialog.geometry()
-        x_center = (screen_size.width() - login_dialog_size.width()) / 2
-        y_center = (screen_size.height() - login_dialog_size.height()) / 2
+        x_center = int((screen_size.width() - login_dialog_size.width()) / 2)
+        y_center = int((screen_size.height() - login_dialog_size.height()) / 2)
         self.login_dialog.move(x_center, y_center)
         self.login_dialog.setup(self.controller)
         self.login_dialog.reset()


### PR DESCRIPTION
# Description

QWidget.move requires either a QPoint or (int, int) as arguments instead of (float, float)

# Test Plan


# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [X] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [X] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [X] No database schema changes are needed
