### PR TITLE
Delete source files and records locally as soon as server confirms deletion

### DIFF
--- a/alembic/versions/9ba8d7524871_add_deletedsource_table.py
+++ b/alembic/versions/9ba8d7524871_add_deletedsource_table.py
@@ -1,0 +1,32 @@
+"""add deletedsource table
+
+Revision ID: 9ba8d7524871
+Revises: eff1387cfd0b
+Create Date: 2022-03-15 12:25:59.145300
+
+"""
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9ba8d7524871"
+down_revision = "eff1387cfd0b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # ### Add DeletedSource table ###
+    op.create_table(
+        "deletedsource",
+        sa.Column("uuid", sa.String(length=36), nullable=False),
+        sa.PrimaryKeyConstraint("uuid", name=op.f("pk_deletedsource")),
+    )
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    # ### Remove DeletedSource table ###
+    op.drop_table("deletedsource")
+    # ### end Alembic commands ###

--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -130,6 +130,26 @@ class DeletedConversation(Base):
         super().__init__(**kwargs)
 
 
+class DeletedSource(Base):
+    """
+    Table that temporarily stores UUIDs of sources whose accounts are deleted
+    locally, to prevent them from being re-added to the Sources table
+    during a 'stale sync' (network race condition).
+    """
+
+    __tablename__ = "deletedsource"
+
+    uuid = Column(String(36), primary_key=True, nullable=False)
+
+    def __repr__(self):
+        return "DeletedSource ({})".format(self.uuid)
+
+    def __init__(self, **kwargs: Any) -> None:
+        if "uuid" not in kwargs:
+            raise TypeError("Keyword argument 'uuid' is required")
+        super().__init__(**kwargs)
+
+
 class Message(Base):
 
     __tablename__ = "messages"

--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -141,7 +141,7 @@ class DeletedSource(Base):
 
     uuid = Column(String(36), primary_key=True, nullable=False)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "DeletedSource ({})".format(self.uuid)
 
     def __init__(self, **kwargs: Any) -> None:

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -1045,10 +1045,11 @@ class Controller(QObject):
 
     def on_delete_source_success(self, source_uuid: str) -> None:
         """
-        Rely on sync to delete the source locally so we know for sure it was deleted
+        Delete source locally once it has been scheduled for deletion at server, and
+        emit a signal.
         """
-        logger.info("Source %s successfully deleted at server", source_uuid)
-        self.api_sync.sync()
+        logger.info("Source %s successfully scheduled for deletion at server", source_uuid)
+        storage.delete_local_source_by_uuid(self.session, source_uuid, self.data_dir)
 
     def on_delete_source_failure(self, e: Exception) -> None:
         if isinstance(e, DeleteSourceJobException):

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -230,7 +230,8 @@ def _cleanup_flagged_locally_deleted(
     session: Session, deleted_conversations: List[DeletedConversation]
 ) -> None:
     """
-    Helper function that removes a list of DeletedConversation items from local database.
+    Helper function that removes a list of DeletedConversation and DeletedSource
+    items from local database.
     """
     for item in deleted_conversations:
         logger.debug(

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -238,7 +238,7 @@ def update_local_storage(
 
 def _get_flagged_locally_deleted(
     session: Session,
-) -> (List[DeletedConversation], List[DeletedSource]):
+) -> Tuple[List[DeletedConversation], List[DeletedSource]]:
     """
     Helper function that returns two lists of source UUIDs, corresponding to
     locally-deleted conversations and sources, respsectively.

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -5050,7 +5050,7 @@ def test_ReplyBoxWidget_enable_after_source_gets_key(mocker, session, session_ma
     source_with_key = factory.RemoteSource(uuid=source.uuid)
 
     # passing 'None' for skip_uuid, test that separately
-    storage.update_sources([source_with_key], [source], None, session, homedir)
+    storage.update_sources([source_with_key], [source], [], [], session, homedir)
 
     # ... simulate the ReplyBoxWidget receiving the sync success signal
     rbw._on_sync_succeeded()

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1924,9 +1924,9 @@ def test_Controller_on_message_downloaded_decryption_failure(mocker, homedir, se
     message_download_failed.emit.assert_called_with(message.source.uuid, message.uuid, str(message))
 
 
-def test_Controller_on_delete_source_success(mocker, homedir):
+def test_Controller_on_delete_source_success(mocker, homedir, session_maker):
     """
-    Test that on a successful deletion does not delete the source locally (regression).
+    Test that on a successful deletion callback, controller deletes the source from local storage.
     """
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
     co.source_deleted = mocker.MagicMock()
@@ -1934,7 +1934,7 @@ def test_Controller_on_delete_source_success(mocker, homedir):
 
     co.on_delete_source_success("uuid")
 
-    storage.delete_local_source_by_uuid.assert_not_called()
+    storage.delete_local_source_by_uuid.assert_called_once_with(co.session, "uuid", co.data_dir)
 
 
 def test_Controller_on_delete_source_failure(homedir, config, mocker, session_maker):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,7 @@ import pytest
 
 from securedrop_client.db import (
     DeletedConversation,
+    DeletedSource,
     DownloadError,
     DownloadErrorCodes,
     DraftReply,
@@ -378,3 +379,11 @@ def test_deletedconversation_creation(session):
 
     dc = DeletedConversation(uuid="test-uuid")
     assert str(dc) == "DeletedConversation (source {})".format(dc.uuid)
+
+
+def test_deletedsource_creation(session):
+    with pytest.raises(TypeError):
+        DeletedSource()  # must initialize with a UUID
+
+    ds = DeletedSource(uuid="test-uuid")
+    assert str(ds) == "DeletedSource ({})".format(ds.uuid)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -65,6 +65,23 @@ def test_ApiSync_stop_calls_quit(mocker, session_maker, homedir):
     api_sync.sync_thread.quit.assert_called_once_with()
 
 
+def test_ApiSync_sync_starts_now(mocker, session_maker, homedir):
+    """
+    Ensure ApiSync sync() starts immediate single-shot sync
+    QTimer.singleShot(1, self.api_sync_bg_task.sync)
+    """
+    api_sync = ApiSync(mocker.MagicMock(), session_maker, mocker.MagicMock(), homedir)
+
+    mock_qtimer = mocker.MagicMock()
+    mocker.patch("securedrop_client.sync.QTimer", mock_qtimer)
+    mock_singleshot_method = mocker.MagicMock()
+    mock_qtimer.singleShot = mock_singleshot_method
+
+    api_sync.sync()
+
+    mock_singleshot_method.assert_called_once_with(1, api_sync.api_sync_bg_task.sync)
+
+
 def test_ApiSyncBackgroundTask_sync(mocker, session_maker, homedir):
     """
     Ensure sync enqueues a MetadataSyncJob and calls it's parent's processing function


### PR DESCRIPTION
# Description

Fixes #1344.

# Test Plan
- Setup: ensure your instance has a number (> 5) of sources with files, messages, and replies. For at least one source, save their codename. 

**Migration**
- [ ] test migration path with existing db
 
**Test local deletion: happy path**
- Choose a source in the client and download files/attachments for them. 
- Inspect Sources table and note their id
- Select "Delete Source"
- [ ] Source is deleted from database and source documents are deleted from relevant `data` directory
- [ ] Source cannot log in from Tor browser

**Test local deletion right after conversation deletion**
- Choose a source in the client and download files/attachments for them. 
- Inspect Sources table and note their id
- Select "Delete files and messages"
- Quickly select "Delete source" (inside same sync period)
- [ ] Observe source is deleted from database and source documents are deleted

**Test local deletion: network failure**
- Choose a source in the client and download files/attachments for them.
- Inspect Sources table and note their id 
- Select "Delete Source", then once GUI animation completes, quickly kill network connection (`sudo service tor stop` in sd-whonix, or set netvm to None)
- [ ] Observe source record is deleted from database (query via ID) and source documents are deleted 

**Regression testing: remote deletion**
- Open the client and observe a source in client conversation view. Download files and messages for the source. 
- Delete the source via Journalist Interface/Tor Browser
- Wait for sync
- [ ] Source is not present in the client conversation view and source files are removed from `data` directory.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment (**and I would also appreciate more testing on Qubes**)
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [x] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed
