### PR TITLE
update gui immediately after deletion

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -1050,6 +1050,7 @@ class Controller(QObject):
         """
         logger.info("Source %s successfully scheduled for deletion at server", source_uuid)
         storage.delete_local_source_by_uuid(self.session, source_uuid, self.data_dir)
+        self.update_sources()
 
     def on_delete_source_failure(self, e: Exception) -> None:
         if isinstance(e, DeleteSourceJobException):


### PR DESCRIPTION
# Description

Followup for https://github.com/freedomofpress/securedrop-client/issues/1344

# Test Plan

- [ ] Confirm that the client gui is removes the source immediately after it has been deleted locally
- Note that https://github.com/freedomofpress/securedrop-client/pull/1458 ensures that a stale sync will not add the source back, so there is no longer a need to keep track of timestamps in the gui. Either tomorrow or in a follow PR, after our scheduled release, we can remove this stale code. 
- [ ] Interrupt the deletion job before it is processed by removing network access and confirm expected behavior (the GUI remains in pending state until it succeeds or fails)
- [ ] Interrupt the deletion job right after it is successfully sent to the server by removing network access and confirm expected behavior (the GUI remains in pending state until it succeeds or fails)

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
