### PR TITLE
If user has manually unlocked USB drive, don't re-prompt for pasphrase

### DIFF
--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -3814,7 +3814,9 @@ def test_ExportDialog__on_preflight_success_drive_unlocked(mocker, export_dialog
     # Call with the signal that is emitted when a drive is already unlocked
     export_dialog._on_preflight_success(status=ExportStatus.USB_ENCRYPTED_UNLOCKED.value)
 
-    export_dialog.continue_button.clicked.connect.assert_called_once_with(export_dialog._export_file)
+    export_dialog.continue_button.clicked.connect.assert_called_once_with(
+        export_dialog._export_file
+    )
 
 
 def test_ExportDialog__on_preflight_success_drive_unlocked_continue_enabled(mocker, export_dialog):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -3805,6 +3805,30 @@ def test_ExportDialog__on_preflight_success_when_continue_enabled(mocker, export
     export_dialog._show_passphrase_request_message.assert_called_once_with()
 
 
+def test_ExportDialog__on_preflight_success_drive_unlocked(mocker, export_dialog):
+    export_dialog._show_passphrase_request_message = mocker.MagicMock()
+    export_dialog.continue_button = mocker.MagicMock()
+    mocker.patch.object(export_dialog.continue_button, "isEnabled", return_value=False)
+    export_dialog.continue_button.clicked = mocker.MagicMock()
+
+    # Call with the signal that is emitted when a drive is already unlocked
+    export_dialog._on_preflight_success(status=ExportStatus.USB_ENCRYPTED_UNLOCKED.value)
+
+    export_dialog.continue_button.clicked.connect.assert_called_once_with(export_dialog._export_file)
+
+
+def test_ExportDialog__on_preflight_success_drive_unlocked_continue_enabled(mocker, export_dialog):
+    export_dialog._show_passphrase_request_message = mocker.MagicMock()
+    export_dialog.continue_button.setEnabled(True)
+    mock_export_file = mocker.patch.object(export_dialog, "_export_file")
+
+    # Call with the signal that is emitted when a drive is already unlocked
+    export_dialog._on_preflight_success(status=ExportStatus.USB_ENCRYPTED_UNLOCKED.value)
+
+    export_dialog._show_passphrase_request_message.assert_not_called()
+    mock_export_file.assert_called_once_with()
+
+
 def test_ExportDialog__on_preflight_success_enabled_after_preflight_success(mocker, export_dialog):
     assert not export_dialog.continue_button.isEnabled()
     export_dialog._on_preflight_success()


### PR DESCRIPTION
# Description

If a user has unlocked their Export device (i.e. via the commandline or by opening Nautilus in `sd-devices` and inputting the passphrase), recognize that the drive is unlocked and don't ask again for passphrase before exporting documents.

Returns a status code from the disk checks run in `sd-export` (This will also enable us to incorporate other response/status codes, for example to distinguish between LUKS and Veracrypt devices, in future).

**Note** Changes must be tested with corresponding changes in `sd-export` and released together.

Fixes https://github.com/freedomofpress/securedrop-export/issues/40 (Together with corresponding sd-export PR)
Towards https://github.com/freedomofpress/securedrop-workstation/issues/265

# Test Plan
TK

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment (**and I would also like a reviewer to test on Qubes**)
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
