### PR TITLE
guard against a reply being sent to a source that was just deleted

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -1114,9 +1114,14 @@ class Controller(QObject):
             logger.error("Sender of reply {} has been deleted".format(reply_uuid))
             return
 
+        source = self.session.query(db.Source).filter_by(uuid=source_uuid).one_or_none()
+        if not source:
+            logger.error("Cannot send a reply to a source account that has been deleted")
+            self.update_sources()  # Refresh source list to remove deleted source widget
+            return
+
         # Before we send the reply, add the draft to the database with a PENDING
         # reply send status.
-        source = self.session.query(db.Source).filter_by(uuid=source_uuid).one()
         reply_status = (
             self.session.query(db.ReplySendStatus)
             .filter_by(name=db.ReplySendStatusCodes.PENDING.value)


### PR DESCRIPTION
# Description

I still need to see if I can create an STR, but I ran into an issue at some point while stress testing deletion and saw that we were not handling a NoResultFound db error here.

Opening up a draft PR in the meantime, in case this comes up during QA testing for the client release, and to get @rocodes's attention on this early since I'll be out for the rest of the week.

I also made this change last week, so it's not super fresh and may need a little rework.

# Test Plan

...

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed
