### PR TITLE
Add locally-deleted Source to DeletedSource table

### DIFF
--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -74,13 +74,16 @@ def get_local_sources(session: Session) -> List[Source]:
 
 def delete_local_source_by_uuid(session: Session, uuid: str, data_dir: str) -> None:
     """
-    Delete the source with the referenced UUID.
+    Delete the source with the referenced UUID and add the source to the
+    DeletedSource table.
+    This method is used only during local delete actions.
     """
     source = session.query(Source).filter_by(uuid=uuid).one_or_none()
     if source:
         logger.debug("Delete source {} from local database.".format(uuid))
         delete_source_collection(source.journalist_filename, data_dir)
         session.delete(source)
+        session.add(DeletedSource(uuid=uuid))
         session.commit()
 
 


### PR DESCRIPTION
# Description

Fixes #1472
Towards #1465

# Test Plan
- Set up a staging environment with n > 10 sources. Since this is a race condition, you may have to test a lot of sources to create this behaviour.
- Wait for at least one sync, to ensure client and server are in same state.
- Start deleting sources via the client. The goal is to locally-delete a source right before a sync is applied (syncs are every 15 seconds).
- [ ] Ensure deleted source is not visible again in the conversation view. 
- [ ] Follow rest of 0.7.0 Release ticket's test plan for testing local source deletion.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment (**QAers: please also test in Qubes on Prod or Staging setup. The issue will not be visible enough using a dev setup**)
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
