### PR TITLE
When all submissions are deleted for a source, delete the enclosing directory

### DIFF
--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -488,7 +488,12 @@ def __update_submissions(
 
     # The uuids remaining in local_uuids do not exist on the remote server, so
     # delete the related records.
+    # We will also collect the journalist desginations of deleted submissions to
+    # check if we have left empty directories behind after deletion.
+    deleted_submission_directory_names = set()
     for deleted_submission in local_submissions_by_uuid.values():
+
+        deleted_submission_directory_names.add(deleted_submission.source.journalist_filename)
 
         # The local method could have deleted these files and submissions already
         try:
@@ -501,6 +506,15 @@ def __update_submissions(
                 "it was already deleted locally."
             )
     session.commit()
+
+    # Check if we left any empty directories when deleting file submissions
+    if model.__name__ == File.__name__:
+        for directory_name in deleted_submission_directory_names:
+            try:
+                logger.debug("Cleanup {} if empty".format(os.path.join(data_dir, directory_name)))
+                _cleanup_directory_if_empty(os.path.join(data_dir, directory_name))
+            except FileNotFoundError:
+                logger.error("Could not check {}".format(directory_name))
 
 
 def add_seen_file_records(file_id: int, journalist_uuids: List[str], session: Session) -> None:
@@ -938,6 +952,24 @@ def delete_single_submission_or_reply_on_disk(
             shutil.rmtree(os.path.dirname(obj_db.location(data_dir)))
         except FileNotFoundError:
             pass
+
+
+def _cleanup_directory_if_empty(target_dir: str) -> None:
+    """
+    If a directory is empty, remove it. Used after sync to ensure that an empty
+    directory is not left behind after files and messages are deleted.
+    """
+
+    try:
+        if os.path.isdir(target_dir):
+            if not next(os.scandir(target_dir), None):
+                # It's an empty directory; remove it
+                logger.debug("Remove empty directory {}".format(target_dir))
+                shutil.rmtree(target_dir)
+        else:
+            logger.error("Error: method called on missing or malformed directory")
+    except FileNotFoundError as e:
+        logger.error("Could not clean up directory: {}".format(e))
 
 
 def delete_local_conversation_by_source_uuid(session: Session, uuid: str, data_dir: str) -> None:

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -513,7 +513,7 @@ def __update_submissions(
             try:
                 logger.debug("Cleanup {} if empty".format(os.path.join(data_dir, directory_name)))
                 _cleanup_directory_if_empty(os.path.join(data_dir, directory_name))
-            except FileNotFoundError:
+            except OSError:
                 logger.error("Could not check {}".format(directory_name))
 
 


### PR DESCRIPTION
# Description

Fixes #1474

# Test Plan
- [ ] Run through STR in the linked issue and confirm safe deletion behaviour on sync (deletion of files and messages via JI) and deletion behaviour via local deletion produce the same results--the enclosing directory is removed when empty
- Choose a source with multiple file submissions. Download only one file via the client, and delete only that one submission via the JI, leaving the others intact but not yet downloaded.
- [ ] The enclosing directory is removed
- [ ] The enclosing directory is recreated when another submission is downloaded

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
