### PR TITLE
Revert "always show selected source widget as read"

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -696,12 +696,6 @@ class MainView(QWidget):
                 return
             self.controller.session.refresh(source)
             self.controller.mark_seen(source)
-
-            # Always show the selected source widget as seen
-            source_widget = self.source_list.get_source_widget(source.uuid)
-            if source_widget and not source_widget.seen:
-                source_widget.seen = True
-
             conversation_wrapper = self.source_conversations[source.uuid]
             conversation_wrapper.conversation_view.update_conversation(source.collection)
         except sqlalchemy.exc.InvalidRequestError as e:

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -928,30 +928,6 @@ def test_MainView_refresh_source_conversations_with_deleted(
     debug_logger.assert_any_call("Error refreshing source conversations: %s", ire)
 
 
-def test_MainView_refresh_source_conversations_keeps_selected_source_as_seen(
-    mocker, session, session_maker, homedir
-):
-    mv = MainView(None)
-    controller = logic.Controller(
-        "http://localhost", mocker.MagicMock(), session_maker, homedir, None
-    )
-    controller.api = mocker.MagicMock()
-    mv.setup(controller)
-
-    source = factory.Source()
-    session.add(source)
-    mv.source_list.update([source])
-    mv.source_list.setCurrentItem(mv.source_list.itemAt(0, 0))  # select `source`
-
-    current_source_widget = mv.source_list.get_source_widget(source.uuid)
-    current_source_widget.seen = False
-    assert not current_source_widget.seen
-
-    mv.refresh_source_conversations()
-
-    assert current_source_widget.seen
-
-
 def test_MainView_set_conversation(mocker):
     """
     Ensure the passed-in widget is added to the layout of the main view holder


### PR DESCRIPTION
This reverts commit f9508edff93de0cc6cf0cc2a292006b7061e64d9.

# Description

Fixes regression described in https://github.com/freedomofpress/securedrop-client/issues/1465#issuecomment-1102964753 where an unselected source with new content shows up as read.

# Test Plan

Follow the STR described by @cfm in the regression comment here: https://github.com/freedomofpress/securedrop-client/issues/1465#issuecomment-1102964753 

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed
