### PR TITLE
Fix AppArmor rules for Qubes 4.1; update dispVM syntax

### DIFF
--- a/files/usr.bin.securedrop-client
+++ b/files/usr.bin.securedrop-client
@@ -33,6 +33,7 @@
   /usr/bin/cat mrix,
   /usr/bin/chmod mrix,
   /usr/bin/dash ix,
+  /usr/bin/expr ix,
   /usr/bin/mkdir mrix,
   /usr/bin/qrexec-client-vm mrix,
   /usr/bin/qubes-gpg-client mrix,

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -926,7 +926,7 @@ class Controller(QObject):
             return
 
         command = "qvm-open-in-vm"
-        args = ["--view-only", "$dispvm:sd-viewer", file.location(self.data_dir)]
+        args = ["--view-only", "@dispvm:sd-viewer", file.location(self.data_dir)]
         process = QProcess(self)
         process.start(command, args)
 


### PR DESCRIPTION
# Description

1. Adds `/usr/bin/expr` to the AppArmor profile for `securedrop-client` because it is now called by `qvm-open-in-vm` (see https://github.com/QubesOS/qubes-core-agent-linux/blame/master/qubes-rpc/qvm-open-in-vm).  This causes attempts to open files in disposable VMs to fail. See https://github.com/freedomofpress/securedrop-workstation/issues/766#issuecomment-1115730873 for details. 
2. Uses `@` instead of `$` syntax for `qvm-open-in-vm` call per https://github.com/QubesOS/qubes-secpack/blob/master/QSBs/qsb-038-2018.txt

Resolves https://github.com/freedomofpress/securedrop-workstation/issues/766

# Test Plan

For all test cases:
- Build a package based on this branch and install it in `sd-small-buster-template` (this is necessary because the AppArmor change is installed in `/etc/apparmor.d` in the template); then restart the TemplateVM and the AppVM to pick up the changes
- Ensure that downloadable files are present on the server

### Test case 1: No breakage on Qubes 4.0

1. Run the client you installed via the custom package
2. Download a file
- [ ] Observe that you are able to open files in disposable VMs by clicking on them in SecureDrop Client
- [ ] Observe no AppArmor-related messages in `/var/log/syslog` on `sd-app`
 
### Test case 2: Fixes regression on Qubes 4.1 with Qubes 4.1 packages in AppmVM

1. Ensure your `sd-small-buster-template` uses the Qubes 4.1 packages. On my system, `/etc/apt/sources.list.d/qubes-r4.list` contains only the following uncommented line:

```
deb [arch=amd64] https://deb.qubes-os.org/r4.1/vm buster main
```

2. After changing it,  run `sudo apt update` and `sudo apt dist-upgrade` on `sd-small-buster-template` to switch to 4.1 packages, and restart `sd-small-buster-template` and `sd-app`. 
2. Run the client you installed via the custom package
3. Download a file
- [ ] Confirm that your copy of `qvm-open-in-vm` in `/usr/bin/qvm-open-in-vm` on `sd-app` calls out to `expr` as you see here: https://github.com/QubesOS/qubes-core-agent-linux/blob/3a5afc2525d5e01122e28aeb6f9192ea28751537/qubes-rpc/qvm-open-in-vm#L67
- [ ] Observe that you are able to open files in disposable VMs by clicking on them in SecureDrop Client
- [ ] Observe no AppArmor-related messages in `/var/log/syslog` on `sd-app`
