### PR TITLE
fix apparmor rules for qubes 4.1 by using updated dispVM syntax

### DIFF
--- a/files/usr.bin.securedrop-client
+++ b/files/usr.bin.securedrop-client
@@ -33,6 +33,7 @@
   /usr/bin/cat mrix,
   /usr/bin/chmod mrix,
   /usr/bin/dash ix,
+  /usr/bin/expr ix,
   /usr/bin/mkdir mrix,
   /usr/bin/qrexec-client-vm mrix,
   /usr/bin/qubes-gpg-client mrix,

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -926,7 +926,7 @@ class Controller(QObject):
             return
 
         command = "qvm-open-in-vm"
-        args = ["--view-only", "$dispvm:sd-viewer", file.location(self.data_dir)]
+        args = ["--view-only", "@dispvm:sd-viewer", file.location(self.data_dir)]
         process = QProcess(self)
         process.start(command, args)
 


### PR DESCRIPTION
See https://github.com/freedomofpress/securedrop-client/pull/1488