### PR TITLE
Unbreak export on Qubes OS R4.1

### DIFF
--- a/securedrop_client/export.py
+++ b/securedrop_client/export.py
@@ -113,7 +113,16 @@ class Export(QObject):
             # Python's implementation of subprocess, see
             # https://docs.python.org/3/library/subprocess.html#security-considerations
             output = subprocess.check_output(
-                [quote("qvm-open-in-vm"), quote("sd-devices"), quote(archive_path), "--view-only"],
+                [
+                    quote("qrexec-client-vm"),
+                    quote("--"),
+                    quote("sd-devices"),
+                    quote("qubes.OpenInVM"),
+                    quote("/usr/lib/qubes/qopen-in-vm"),
+                    quote("--view-only"),
+                    quote("--"),
+                    quote(archive_path),
+                ],
                 stderr=subprocess.STDOUT,
             )
             return output.decode("utf-8").strip()

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -410,5 +410,15 @@ def test__export_archive_with_evil_command(mocker):
     export._export_archive("somefile; rm -rf ~")
 
     check_output.assert_called_once_with(
-        ["qvm-open-in-vm", "sd-devices", "'somefile; rm -rf ~'", "--view-only"], stderr=-2
+        [
+            "qrexec-client-vm",
+            "--",
+            "sd-devices",
+            "qubes.OpenInVM",
+            "/usr/lib/qubes/qopen-in-vm",
+            "--view-only",
+            "--",
+            "'somefile; rm -rf ~'",
+        ],
+        stderr=-2,
     )


### PR DESCRIPTION
# Description

On templates using R4.1 tools, `qvm-open-in-vm` redirects stdout/stderr to `/dev/null`, so instead we call `qrexec-client-vm` directly

Fixes https://github.com/freedomofpress/securedrop-workstation/issues/775

# Test Plan

**In Qubes 4.0**:
- [ ] Exporting a file from the client is successful

**In Qubes 4.1**, using our VM templates with Qubes R4.1 repositories (i.e. bullseye, buster with manual upgrade, or after in-place upgrade to 4.1):
- [ ] Exporting a file from the client is successful

# Checklist

 - [x] I have tested these changes in the appropriate Qubes environment
 - [x] No update to the AppArmor profile is required for these changes
 - [x] No database schema changes are needed
