### PR TITLE
Refactor extract conversation.PrintFileDialog

### DIFF
--- a/securedrop_client/gui/conversation/__init__.py
+++ b/securedrop_client/gui/conversation/__init__.py
@@ -4,3 +4,4 @@ A conversation between a source and one or more journalists.
 # Import classes here to make possible to import them from securedrop_client.gui.conversation
 from .delete import DeleteConversationDialog  # noqa: F401
 from .export import Dialog as ExportFileDialog  # noqa: F401
+from .export import PrintDialog as PrintFileDialog  # noqa: F401

--- a/securedrop_client/gui/conversation/export/__init__.py
+++ b/securedrop_client/gui/conversation/export/__init__.py
@@ -1,1 +1,2 @@
 from .dialog import ExportDialog as Dialog  # noqa: F401
+from .print_dialog import PrintDialog  # noqa: F401

--- a/securedrop_client/gui/conversation/export/print_dialog.py
+++ b/securedrop_client/gui/conversation/export/print_dialog.py
@@ -1,0 +1,134 @@
+from gettext import gettext as _
+
+from PyQt5.QtCore import QSize, pyqtSlot
+
+from securedrop_client.export import ExportError, ExportStatus
+from securedrop_client.gui.base import ModalDialog, SecureQLabel
+from securedrop_client.logic import Controller
+
+
+class PrintDialog(ModalDialog):
+
+    FILENAME_WIDTH_PX = 260
+
+    def __init__(self, controller: Controller, file_uuid: str, file_name: str) -> None:
+        super().__init__()
+
+        self.controller = controller
+        self.file_uuid = file_uuid
+        self.file_name = SecureQLabel(
+            file_name, wordwrap=False, max_length=self.FILENAME_WIDTH_PX
+        ).text()
+        self.error_status = ""  # Hold onto the error status we receive from the Export VM
+
+        # Connect controller signals to slots
+        self.controller.export.printer_preflight_success.connect(self._on_preflight_success)
+        self.controller.export.printer_preflight_failure.connect(self._on_preflight_failure)
+
+        # Connect parent signals to slots
+        self.continue_button.setEnabled(False)
+        self.continue_button.clicked.connect(self._run_preflight)
+
+        # Dialog content
+        self.starting_header = _(
+            "Preparing to print:"
+            "<br />"
+            '<span style="font-weight:normal">{}</span>'.format(self.file_name)
+        )
+        self.ready_header = _(
+            "Ready to print:"
+            "<br />"
+            '<span style="font-weight:normal">{}</span>'.format(self.file_name)
+        )
+        self.insert_usb_header = _("Connect USB printer")
+        self.error_header = _("Printing failed")
+        self.starting_message = _(
+            "<h2>Managing printout risks</h2>"
+            "<b>QR codes and web addresses</b>"
+            "<br />"
+            "Never type in and open web addresses or scan QR codes contained in printed "
+            "documents without taking security precautions. If you are unsure how to "
+            "manage this risk, please contact your administrator."
+            "<br /><br />"
+            "<b>Printer dots</b>"
+            "<br />"
+            "Any part of a printed page may contain identifying information "
+            "invisible to the naked eye, such as printer dots. Please carefully "
+            "consider this risk when working with or publishing scanned printouts."
+        )
+        self.insert_usb_message = _("Please connect your printer to a USB port.")
+        self.generic_error_message = _("See your administrator for help.")
+
+        self._show_starting_instructions()
+        self.start_animate_header()
+        self._run_preflight()
+
+    def _show_starting_instructions(self) -> None:
+        self.header.setText(self.starting_header)
+        self.body.setText(self.starting_message)
+        self.error_details.hide()
+        self.adjustSize()
+
+    def _show_insert_usb_message(self) -> None:
+        self.continue_button.clicked.disconnect()
+        self.continue_button.clicked.connect(self._run_preflight)
+        self.header.setText(self.insert_usb_header)
+        self.body.setText(self.insert_usb_message)
+        self.error_details.hide()
+        self.adjustSize()
+
+    def _show_generic_error_message(self) -> None:
+        self.continue_button.clicked.disconnect()
+        self.continue_button.clicked.connect(self.close)
+        self.continue_button.setText(_("DONE"))
+        self.header.setText(self.error_header)
+        self.body.setText(  # nosemgrep: semgrep.untranslated-gui-string
+            "{}: {}".format(self.error_status, self.generic_error_message)
+        )
+        self.error_details.hide()
+        self.adjustSize()
+
+    @pyqtSlot()
+    def _run_preflight(self) -> None:
+        self.controller.run_printer_preflight_checks()
+
+    @pyqtSlot()
+    def _print_file(self) -> None:
+        self.controller.print_file(self.file_uuid)
+        self.close()
+
+    @pyqtSlot()
+    def _on_preflight_success(self) -> None:
+        # If the continue button is disabled then this is the result of a background preflight check
+        self.stop_animate_header()
+        self.header_icon.update_image("printer.svg", svg_size=QSize(64, 64))
+        self.header.setText(self.ready_header)
+        if not self.continue_button.isEnabled():
+            self.continue_button.clicked.disconnect()
+            self.continue_button.clicked.connect(self._print_file)
+            self.continue_button.setEnabled(True)
+            self.continue_button.setFocus()
+            return
+
+        self._print_file()
+
+    @pyqtSlot(object)
+    def _on_preflight_failure(self, error: ExportError) -> None:
+        self.stop_animate_header()
+        self.header_icon.update_image("printer.svg", svg_size=QSize(64, 64))
+        self.error_status = error.status
+        # If the continue button is disabled then this is the result of a background preflight check
+        if not self.continue_button.isEnabled():
+            self.continue_button.clicked.disconnect()
+            if error.status == ExportStatus.PRINTER_NOT_FOUND.value:
+                self.continue_button.clicked.connect(self._show_insert_usb_message)
+            else:
+                self.continue_button.clicked.connect(self._show_generic_error_message)
+
+            self.continue_button.setEnabled(True)
+            self.continue_button.setFocus()
+        else:
+            if error.status == ExportStatus.PRINTER_NOT_FOUND.value:
+                self._show_insert_usb_message()
+            else:
+                self._show_generic_error_message()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -73,7 +73,6 @@ from securedrop_client.gui.actions import (
     DeleteSourceAction,
     DownloadConversation,
 )
-from securedrop_client.gui.base import ModalDialog  # noqa: F401
 from securedrop_client.gui.base import SecureQLabel, SvgLabel, SvgPushButton, SvgToggleButton
 from securedrop_client.gui.conversation import (
     DeleteConversationDialog,

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -68,20 +68,18 @@ from securedrop_client.db import (
     Source,
     User,
 )
-from securedrop_client.export import ExportError, ExportStatus
 from securedrop_client.gui.actions import (
     DeleteConversationAction,
     DeleteSourceAction,
     DownloadConversation,
 )
-from securedrop_client.gui.base import (
-    ModalDialog,
-    SecureQLabel,
-    SvgLabel,
-    SvgPushButton,
-    SvgToggleButton,
+from securedrop_client.gui.base import ModalDialog  # noqa: F401
+from securedrop_client.gui.base import SecureQLabel, SvgLabel, SvgPushButton, SvgToggleButton
+from securedrop_client.gui.conversation import (
+    DeleteConversationDialog,
+    ExportFileDialog,
+    PrintFileDialog,
 )
-from securedrop_client.gui.conversation import DeleteConversationDialog, ExportFileDialog
 from securedrop_client.gui.source import DeleteSourceDialog
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_css, load_icon, load_image, load_movie
@@ -2411,7 +2409,7 @@ class FileWidget(QWidget):
         if not self.controller.downloaded_file_exists(self.file):
             return
 
-        dialog = PrintDialog(self.controller, self.uuid, self.file.filename)
+        dialog = PrintFileDialog(self.controller, self.uuid, self.file.filename)
         dialog.exec()
 
     def _on_left_click(self) -> None:
@@ -2459,133 +2457,6 @@ class FileWidget(QWidget):
         self.download_animation.stop()
         self.file = self.controller.get_file(self.file.uuid)
         self._set_file_state()
-
-
-class PrintDialog(ModalDialog):
-
-    FILENAME_WIDTH_PX = 260
-
-    def __init__(self, controller: Controller, file_uuid: str, file_name: str) -> None:
-        super().__init__()
-
-        self.controller = controller
-        self.file_uuid = file_uuid
-        self.file_name = SecureQLabel(
-            file_name, wordwrap=False, max_length=self.FILENAME_WIDTH_PX
-        ).text()
-        self.error_status = ""  # Hold onto the error status we receive from the Export VM
-
-        # Connect controller signals to slots
-        self.controller.export.printer_preflight_success.connect(self._on_preflight_success)
-        self.controller.export.printer_preflight_failure.connect(self._on_preflight_failure)
-
-        # Connect parent signals to slots
-        self.continue_button.setEnabled(False)
-        self.continue_button.clicked.connect(self._run_preflight)
-
-        # Dialog content
-        self.starting_header = _(
-            "Preparing to print:"
-            "<br />"
-            '<span style="font-weight:normal">{}</span>'.format(self.file_name)
-        )
-        self.ready_header = _(
-            "Ready to print:"
-            "<br />"
-            '<span style="font-weight:normal">{}</span>'.format(self.file_name)
-        )
-        self.insert_usb_header = _("Connect USB printer")
-        self.error_header = _("Printing failed")
-        self.starting_message = _(
-            "<h2>Managing printout risks</h2>"
-            "<b>QR codes and web addresses</b>"
-            "<br />"
-            "Never type in and open web addresses or scan QR codes contained in printed "
-            "documents without taking security precautions. If you are unsure how to "
-            "manage this risk, please contact your administrator."
-            "<br /><br />"
-            "<b>Printer dots</b>"
-            "<br />"
-            "Any part of a printed page may contain identifying information "
-            "invisible to the naked eye, such as printer dots. Please carefully "
-            "consider this risk when working with or publishing scanned printouts."
-        )
-        self.insert_usb_message = _("Please connect your printer to a USB port.")
-        self.generic_error_message = _("See your administrator for help.")
-
-        self._show_starting_instructions()
-        self.start_animate_header()
-        self._run_preflight()
-
-    def _show_starting_instructions(self) -> None:
-        self.header.setText(self.starting_header)
-        self.body.setText(self.starting_message)
-        self.error_details.hide()
-        self.adjustSize()
-
-    def _show_insert_usb_message(self) -> None:
-        self.continue_button.clicked.disconnect()
-        self.continue_button.clicked.connect(self._run_preflight)
-        self.header.setText(self.insert_usb_header)
-        self.body.setText(self.insert_usb_message)
-        self.error_details.hide()
-        self.adjustSize()
-
-    def _show_generic_error_message(self) -> None:
-        self.continue_button.clicked.disconnect()
-        self.continue_button.clicked.connect(self.close)
-        self.continue_button.setText(_("DONE"))
-        self.header.setText(self.error_header)
-        self.body.setText(  # nosemgrep: semgrep.untranslated-gui-string
-            "{}: {}".format(self.error_status, self.generic_error_message)
-        )
-        self.error_details.hide()
-        self.adjustSize()
-
-    @pyqtSlot()
-    def _run_preflight(self) -> None:
-        self.controller.run_printer_preflight_checks()
-
-    @pyqtSlot()
-    def _print_file(self) -> None:
-        self.controller.print_file(self.file_uuid)
-        self.close()
-
-    @pyqtSlot()
-    def _on_preflight_success(self) -> None:
-        # If the continue button is disabled then this is the result of a background preflight check
-        self.stop_animate_header()
-        self.header_icon.update_image("printer.svg", svg_size=QSize(64, 64))
-        self.header.setText(self.ready_header)
-        if not self.continue_button.isEnabled():
-            self.continue_button.clicked.disconnect()
-            self.continue_button.clicked.connect(self._print_file)
-            self.continue_button.setEnabled(True)
-            self.continue_button.setFocus()
-            return
-
-        self._print_file()
-
-    @pyqtSlot(object)
-    def _on_preflight_failure(self, error: ExportError) -> None:
-        self.stop_animate_header()
-        self.header_icon.update_image("printer.svg", svg_size=QSize(64, 64))
-        self.error_status = error.status
-        # If the continue button is disabled then this is the result of a background preflight check
-        if not self.continue_button.isEnabled():
-            self.continue_button.clicked.disconnect()
-            if error.status == ExportStatus.PRINTER_NOT_FOUND.value:
-                self.continue_button.clicked.connect(self._show_insert_usb_message)
-            else:
-                self.continue_button.clicked.connect(self._show_generic_error_message)
-
-            self.continue_button.setEnabled(True)
-            self.continue_button.setFocus()
-        else:
-            if error.status == ExportStatus.PRINTER_NOT_FOUND.value:
-                self._show_insert_usb_message()
-            else:
-                self._show_generic_error_message()
 
 
 class ConversationScrollArea(QScrollArea):

--- a/securedrop_client/locale/messages.pot
+++ b/securedrop_client/locale/messages.pot
@@ -140,30 +140,6 @@ msgstr ""
 msgid " DOWNLOADING "
 msgstr ""
 
-msgid "Preparing to print:<br /><span style=\"font-weight:normal\">{}</span>"
-msgstr ""
-
-msgid "Ready to print:<br /><span style=\"font-weight:normal\">{}</span>"
-msgstr ""
-
-msgid "Connect USB printer"
-msgstr ""
-
-msgid "Printing failed"
-msgstr ""
-
-msgid "<h2>Managing printout risks</h2><b>QR codes and web addresses</b><br />Never type in and open web addresses or scan QR codes contained in printed documents without taking security precautions. If you are unsure how to manage this risk, please contact your administrator.<br /><br /><b>Printer dots</b><br />Any part of a printed page may contain identifying information invisible to the naked eye, such as printer dots. Please carefully consider this risk when working with or publishing scanned printouts."
-msgstr ""
-
-msgid "Please connect your printer to a USB port."
-msgstr ""
-
-msgid "See your administrator for help."
-msgstr ""
-
-msgid "DONE"
-msgstr ""
-
 msgid "Earlier files and messages deleted."
 msgstr ""
 
@@ -292,6 +268,9 @@ msgstr ""
 msgid "The passphrase provided did not work. Please try again."
 msgstr ""
 
+msgid "See your administrator for help."
+msgstr ""
+
 msgid "The CONTINUE button will be disabled until the Export VM is ready"
 msgstr ""
 
@@ -299,6 +278,27 @@ msgid "Remember to be careful when working with files outside of your Workstatio
 msgstr ""
 
 msgid "SUBMIT"
+msgstr ""
+
+msgid "DONE"
+msgstr ""
+
+msgid "Preparing to print:<br /><span style=\"font-weight:normal\">{}</span>"
+msgstr ""
+
+msgid "Ready to print:<br /><span style=\"font-weight:normal\">{}</span>"
+msgstr ""
+
+msgid "Connect USB printer"
+msgstr ""
+
+msgid "Printing failed"
+msgstr ""
+
+msgid "<h2>Managing printout risks</h2><b>QR codes and web addresses</b><br />Never type in and open web addresses or scan QR codes contained in printed documents without taking security precautions. If you are unsure how to manage this risk, please contact your administrator.<br /><br /><b>Printer dots</b><br />Any part of a printed page may contain identifying information invisible to the naked eye, such as printer dots. Please carefully consider this risk when working with or publishing scanned printouts."
+msgstr ""
+
+msgid "Please connect your printer to a USB port."
 msgstr ""
 
 msgid "YES, DELETE ENTIRE SOURCE ACCOUNT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,6 @@ from securedrop_client.db import (
 )
 from securedrop_client.gui.conversation import ExportFileDialog, PrintFileDialog
 from securedrop_client.gui.main import Window
-from securedrop_client.gui.widgets import ModalDialog
 from securedrop_client.logic import Controller
 from tests import factory
 
@@ -72,15 +71,6 @@ def lang(request):
 
     os.environ["LANG"] = LANG
     configure_locale_and_language()
-
-
-@pytest.fixture(scope="function")
-def modal_dialog(mocker, homedir):
-    mocker.patch("PyQt5.QtWidgets.QApplication.activeWindow", return_value=QMainWindow())
-
-    dialog = ModalDialog()
-
-    yield dialog
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,9 +22,9 @@ from securedrop_client.db import (
     Source,
     make_session_maker,
 )
-from securedrop_client.gui.conversation import ExportFileDialog
+from securedrop_client.gui.conversation import ExportFileDialog, PrintFileDialog
 from securedrop_client.gui.main import Window
-from securedrop_client.gui.widgets import ModalDialog, PrintDialog
+from securedrop_client.gui.widgets import ModalDialog
 from securedrop_client.logic import Controller
 from tests import factory
 
@@ -92,7 +92,7 @@ def print_dialog(mocker, homedir):
     controller = mocker.MagicMock(get_file=get_file)
     controller.qubes = False
 
-    dialog = PrintDialog(controller, file.uuid, "file123.jpg")
+    dialog = PrintFileDialog(controller, file.uuid, "file123.jpg")
 
     yield dialog
 

--- a/tests/gui/base/test_dialogs.py
+++ b/tests/gui/base/test_dialogs.py
@@ -1,9 +1,20 @@
 import pytest
 from PyQt5.QtCore import QEvent, Qt
 from PyQt5.QtGui import QKeyEvent
-from PyQt5.QtWidgets import QApplication
+from PyQt5.QtWidgets import QApplication, QMainWindow
+
+from securedrop_client.gui.base import ModalDialog
 
 app = QApplication([])
+
+
+@pytest.fixture(scope="function")
+def modal_dialog(mocker, homedir):
+    mocker.patch("PyQt5.QtWidgets.QApplication.activeWindow", return_value=QMainWindow())
+
+    dialog = ModalDialog()
+
+    yield dialog
 
 
 @pytest.mark.parametrize("key", [Qt.Key_Enter, Qt.Key_Return])

--- a/tests/gui/conversation/export/test_print_dialog.py
+++ b/tests/gui/conversation/export/test_print_dialog.py
@@ -1,0 +1,215 @@
+from PyQt5.QtWidgets import QApplication
+
+from securedrop_client.export import ExportError, ExportStatus
+from securedrop_client.gui.conversation import PrintFileDialog
+
+app = QApplication([])
+
+
+def test_PrintFileDialog_init(mocker):
+    _show_starting_instructions_fn = mocker.patch(
+        "securedrop_client.gui.conversation.PrintFileDialog._show_starting_instructions"
+    )
+
+    PrintFileDialog(mocker.MagicMock(), "mock_uuid", "mock.jpg")
+
+    _show_starting_instructions_fn.assert_called_once_with()
+
+
+def test_PrintFileDialog_init_sanitizes_filename(mocker):
+    secure_qlabel = mocker.patch(
+        "securedrop_client.gui.conversation.export.print_dialog.SecureQLabel"
+    )
+    filename = '<script>alert("boom!");</script>'
+
+    PrintFileDialog(mocker.MagicMock(), "mock_uuid", filename)
+
+    secure_qlabel.call_args_list[0].assert_called_with(filename)
+
+
+def test_PrintFileDialog__show_starting_instructions(mocker, print_dialog):
+    print_dialog._show_starting_instructions()
+
+    # file123.jpg comes from the print_dialog fixture
+    assert (
+        print_dialog.header.text() == "Preparing to print:"
+        "<br />"
+        '<span style="font-weight:normal">file123.jpg</span>'
+    )
+    assert (
+        print_dialog.body.text() == "<h2>Managing printout risks</h2>"
+        "<b>QR codes and web addresses</b>"
+        "<br />"
+        "Never type in and open web addresses or scan QR codes contained in printed "
+        "documents without taking security precautions. If you are unsure how to "
+        "manage this risk, please contact your administrator."
+        "<br /><br />"
+        "<b>Printer dots</b>"
+        "<br />"
+        "Any part of a printed page may contain identifying information "
+        "invisible to the naked eye, such as printer dots. Please carefully "
+        "consider this risk when working with or publishing scanned printouts."
+    )
+    assert not print_dialog.header.isHidden()
+    assert not print_dialog.header_line.isHidden()
+    assert print_dialog.error_details.isHidden()
+    assert not print_dialog.body.isHidden()
+    assert not print_dialog.continue_button.isHidden()
+    assert not print_dialog.cancel_button.isHidden()
+
+
+def test_PrintFileDialog__show_insert_usb_message(mocker, print_dialog):
+    print_dialog._show_insert_usb_message()
+
+    assert print_dialog.header.text() == "Connect USB printer"
+    assert print_dialog.body.text() == "Please connect your printer to a USB port."
+    assert not print_dialog.header.isHidden()
+    assert not print_dialog.header_line.isHidden()
+    assert print_dialog.error_details.isHidden()
+    assert not print_dialog.body.isHidden()
+    assert not print_dialog.continue_button.isHidden()
+    assert not print_dialog.cancel_button.isHidden()
+
+
+def test_PrintFileDialog__show_generic_error_message(mocker, print_dialog):
+    print_dialog.error_status = "mock_error_status"
+
+    print_dialog._show_generic_error_message()
+
+    assert print_dialog.header.text() == "Printing failed"
+    assert print_dialog.body.text() == "mock_error_status: See your administrator for help."
+    assert not print_dialog.header.isHidden()
+    assert not print_dialog.header_line.isHidden()
+    assert print_dialog.error_details.isHidden()
+    assert not print_dialog.body.isHidden()
+    assert not print_dialog.continue_button.isHidden()
+    assert not print_dialog.cancel_button.isHidden()
+
+
+def test_PrintFileDialog__print_file(mocker, print_dialog):
+    print_dialog.close = mocker.MagicMock()
+
+    print_dialog._print_file()
+
+    print_dialog.close.assert_called_once_with()
+
+
+def test_PrintFileDialog__on_preflight_success(mocker, print_dialog):
+    print_dialog._print_file = mocker.MagicMock()
+    print_dialog.continue_button = mocker.MagicMock()
+    print_dialog.continue_button.clicked = mocker.MagicMock()
+    mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
+
+    print_dialog._on_preflight_success()
+
+    print_dialog._print_file.assert_not_called()
+    print_dialog.continue_button.clicked.connect.assert_called_once_with(print_dialog._print_file)
+
+
+def test_PrintFileDialog__on_preflight_success_when_continue_enabled(mocker, print_dialog):
+    print_dialog._print_file = mocker.MagicMock()
+    print_dialog.continue_button.setEnabled(True)
+
+    print_dialog._on_preflight_success()
+
+    print_dialog._print_file.assert_called_once_with()
+
+
+def test_PrintFileDialog__on_preflight_success_enabled_after_preflight_success(
+    mocker, print_dialog
+):
+    assert not print_dialog.continue_button.isEnabled()
+    print_dialog._on_preflight_success()
+    assert print_dialog.continue_button.isEnabled()
+
+
+def test_PrintFileDialog__on_preflight_success_enabled_after_preflight_failure(
+    mocker, print_dialog
+):
+    assert not print_dialog.continue_button.isEnabled()
+    print_dialog._on_preflight_failure(mocker.MagicMock())
+    assert print_dialog.continue_button.isEnabled()
+
+
+def test_PrintFileDialog__on_preflight_failure_when_status_is_PRINTER_NOT_FOUND(
+    mocker, print_dialog
+):
+    print_dialog._show_insert_usb_message = mocker.MagicMock()
+    print_dialog.continue_button = mocker.MagicMock()
+    print_dialog.continue_button.clicked = mocker.MagicMock()
+    mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
+
+    # When the continue button is enabled, ensure clicking continue will show next instructions
+    print_dialog._on_preflight_failure(ExportError(ExportStatus.PRINTER_NOT_FOUND.value))
+    print_dialog.continue_button.clicked.connect.assert_called_once_with(
+        print_dialog._show_insert_usb_message
+    )
+
+    # When the continue button is enabled, ensure next instructions are shown
+    mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=True)
+    print_dialog._on_preflight_failure(ExportError(ExportStatus.PRINTER_NOT_FOUND.value))
+    print_dialog._show_insert_usb_message.assert_called_once_with()
+
+
+def test_PrintFileDialog__on_preflight_failure_when_status_is_MISSING_PRINTER_URI(
+    mocker, print_dialog
+):
+    print_dialog._show_generic_error_message = mocker.MagicMock()
+    print_dialog.continue_button = mocker.MagicMock()
+    print_dialog.continue_button.clicked = mocker.MagicMock()
+    mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
+
+    # When the continue button is enabled, ensure clicking continue will show next instructions
+    print_dialog._on_preflight_failure(ExportError(ExportStatus.MISSING_PRINTER_URI.value))
+    print_dialog.continue_button.clicked.connect.assert_called_once_with(
+        print_dialog._show_generic_error_message
+    )
+    assert print_dialog.error_status == ExportStatus.MISSING_PRINTER_URI.value
+
+    # When the continue button is enabled, ensure next instructions are shown
+    mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=True)
+    print_dialog._on_preflight_failure(ExportError(ExportStatus.MISSING_PRINTER_URI.value))
+    print_dialog._show_generic_error_message.assert_called_once_with()
+    assert print_dialog.error_status == ExportStatus.MISSING_PRINTER_URI.value
+
+
+def test_PrintFileDialog__on_preflight_failure_when_status_is_CALLED_PROCESS_ERROR(
+    mocker, print_dialog
+):
+    print_dialog._show_generic_error_message = mocker.MagicMock()
+    print_dialog.continue_button = mocker.MagicMock()
+    print_dialog.continue_button.clicked = mocker.MagicMock()
+    mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
+
+    # When the continue button is enabled, ensure clicking continue will show next instructions
+    print_dialog._on_preflight_failure(ExportError(ExportStatus.CALLED_PROCESS_ERROR.value))
+    print_dialog.continue_button.clicked.connect.assert_called_once_with(
+        print_dialog._show_generic_error_message
+    )
+    assert print_dialog.error_status == ExportStatus.CALLED_PROCESS_ERROR.value
+
+    # When the continue button is enabled, ensure next instructions are shown
+    mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=True)
+    print_dialog._on_preflight_failure(ExportError(ExportStatus.CALLED_PROCESS_ERROR.value))
+    print_dialog._show_generic_error_message.assert_called_once_with()
+    assert print_dialog.error_status == ExportStatus.CALLED_PROCESS_ERROR.value
+
+
+def test_PrintFileDialog__on_preflight_failure_when_status_is_unknown(mocker, print_dialog):
+    print_dialog._show_generic_error_message = mocker.MagicMock()
+    print_dialog.continue_button = mocker.MagicMock()
+    print_dialog.continue_button.clicked = mocker.MagicMock()
+    mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
+
+    # When the continue button is enabled, ensure clicking continue will show next instructions
+    print_dialog._on_preflight_failure(ExportError("Some Unknown Error Status"))
+    print_dialog.continue_button.clicked.connect.assert_called_once_with(
+        print_dialog._show_generic_error_message
+    )
+    assert print_dialog.error_status == "Some Unknown Error Status"
+
+    # When the continue button is enabled, ensure next instructions are shown
+    mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=True)
+    print_dialog._on_preflight_failure(ExportError("Some Unknown Error Status"))
+    print_dialog._show_generic_error_message.assert_called_once_with()
+    assert print_dialog.error_status == "Some Unknown Error Status"

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -17,7 +17,6 @@ from PyQt5.QtWidgets import QApplication, QVBoxLayout, QWidget
 from sqlalchemy.orm import attributes, scoped_session, sessionmaker
 
 from securedrop_client import db, logic, storage
-from securedrop_client.export import ExportError, ExportStatus
 from securedrop_client.gui.source import DeleteSourceDialog
 from securedrop_client.gui.widgets import (
     ActivityStatusBar,
@@ -29,7 +28,6 @@ from securedrop_client.gui.widgets import (
     LoginButton,
     MainView,
     MessageWidget,
-    PrintDialog,
     ReplyBoxWidget,
     ReplyTextEdit,
     ReplyTextEditPlaceholder,
@@ -3656,7 +3654,7 @@ def test_FileWidget__on_print_clicked(mocker, session, source):
     controller.print_file = mocker.MagicMock()
     controller.downloaded_file_exists = mocker.MagicMock(return_value=True)
 
-    dialog = mocker.patch("securedrop_client.gui.widgets.PrintDialog")
+    dialog = mocker.patch("securedrop_client.gui.widgets.PrintFileDialog")
 
     fw._on_print_clicked()
 
@@ -3681,7 +3679,7 @@ def test_FileWidget__on_print_clicked_missing_file(mocker, session, source):
     mocker.patch("PyQt5.QtWidgets.QDialog.exec")
     controller.print_file = mocker.MagicMock()
     controller.downloaded_file_exists = mocker.MagicMock(return_value=False)
-    dialog = mocker.patch("securedrop_client.gui.widgets.PrintDialog")
+    dialog = mocker.patch("securedrop_client.gui.widgets.PrintFileDialog")
 
     fw._on_print_clicked()
 
@@ -3706,205 +3704,6 @@ def test_FileWidget_update_file_size_with_deleted_file(
     mocker.patch("securedrop_client.gui.widgets.humanize_filesize", side_effect=Exception("boom!"))
     fw.update_file_size()
     assert fw.file_size.text() == ""
-
-
-def test_PrintDialog_init(mocker):
-    _show_starting_instructions_fn = mocker.patch(
-        "securedrop_client.gui.widgets.PrintDialog._show_starting_instructions"
-    )
-
-    PrintDialog(mocker.MagicMock(), "mock_uuid", "mock.jpg")
-
-    _show_starting_instructions_fn.assert_called_once_with()
-
-
-def test_PrintDialog_init_sanitizes_filename(mocker):
-    secure_qlabel = mocker.patch("securedrop_client.gui.widgets.SecureQLabel")
-    filename = '<script>alert("boom!");</script>'
-
-    PrintDialog(mocker.MagicMock(), "mock_uuid", filename)
-
-    secure_qlabel.call_args_list[0].assert_called_with(filename)
-
-
-def test_PrintDialog__show_starting_instructions(mocker, print_dialog):
-    print_dialog._show_starting_instructions()
-
-    # file123.jpg comes from the print_dialog fixture
-    assert (
-        print_dialog.header.text() == "Preparing to print:"
-        "<br />"
-        '<span style="font-weight:normal">file123.jpg</span>'
-    )
-    assert (
-        print_dialog.body.text() == "<h2>Managing printout risks</h2>"
-        "<b>QR codes and web addresses</b>"
-        "<br />"
-        "Never type in and open web addresses or scan QR codes contained in printed "
-        "documents without taking security precautions. If you are unsure how to "
-        "manage this risk, please contact your administrator."
-        "<br /><br />"
-        "<b>Printer dots</b>"
-        "<br />"
-        "Any part of a printed page may contain identifying information "
-        "invisible to the naked eye, such as printer dots. Please carefully "
-        "consider this risk when working with or publishing scanned printouts."
-    )
-    assert not print_dialog.header.isHidden()
-    assert not print_dialog.header_line.isHidden()
-    assert print_dialog.error_details.isHidden()
-    assert not print_dialog.body.isHidden()
-    assert not print_dialog.continue_button.isHidden()
-    assert not print_dialog.cancel_button.isHidden()
-
-
-def test_PrintDialog__show_insert_usb_message(mocker, print_dialog):
-    print_dialog._show_insert_usb_message()
-
-    assert print_dialog.header.text() == "Connect USB printer"
-    assert print_dialog.body.text() == "Please connect your printer to a USB port."
-    assert not print_dialog.header.isHidden()
-    assert not print_dialog.header_line.isHidden()
-    assert print_dialog.error_details.isHidden()
-    assert not print_dialog.body.isHidden()
-    assert not print_dialog.continue_button.isHidden()
-    assert not print_dialog.cancel_button.isHidden()
-
-
-def test_PrintDialog__show_generic_error_message(mocker, print_dialog):
-    print_dialog.error_status = "mock_error_status"
-
-    print_dialog._show_generic_error_message()
-
-    assert print_dialog.header.text() == "Printing failed"
-    assert print_dialog.body.text() == "mock_error_status: See your administrator for help."
-    assert not print_dialog.header.isHidden()
-    assert not print_dialog.header_line.isHidden()
-    assert print_dialog.error_details.isHidden()
-    assert not print_dialog.body.isHidden()
-    assert not print_dialog.continue_button.isHidden()
-    assert not print_dialog.cancel_button.isHidden()
-
-
-def test_PrintDialog__print_file(mocker, print_dialog):
-    print_dialog.close = mocker.MagicMock()
-
-    print_dialog._print_file()
-
-    print_dialog.close.assert_called_once_with()
-
-
-def test_PrintDialog__on_preflight_success(mocker, print_dialog):
-    print_dialog._print_file = mocker.MagicMock()
-    print_dialog.continue_button = mocker.MagicMock()
-    print_dialog.continue_button.clicked = mocker.MagicMock()
-    mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
-
-    print_dialog._on_preflight_success()
-
-    print_dialog._print_file.assert_not_called()
-    print_dialog.continue_button.clicked.connect.assert_called_once_with(print_dialog._print_file)
-
-
-def test_PrintDialog__on_preflight_success_when_continue_enabled(mocker, print_dialog):
-    print_dialog._print_file = mocker.MagicMock()
-    print_dialog.continue_button.setEnabled(True)
-
-    print_dialog._on_preflight_success()
-
-    print_dialog._print_file.assert_called_once_with()
-
-
-def test_PrintDialog__on_preflight_success_enabled_after_preflight_success(mocker, print_dialog):
-    assert not print_dialog.continue_button.isEnabled()
-    print_dialog._on_preflight_success()
-    assert print_dialog.continue_button.isEnabled()
-
-
-def test_PrintDialog__on_preflight_success_enabled_after_preflight_failure(mocker, print_dialog):
-    assert not print_dialog.continue_button.isEnabled()
-    print_dialog._on_preflight_failure(mocker.MagicMock())
-    assert print_dialog.continue_button.isEnabled()
-
-
-def test_PrintDialog__on_preflight_failure_when_status_is_PRINTER_NOT_FOUND(mocker, print_dialog):
-    print_dialog._show_insert_usb_message = mocker.MagicMock()
-    print_dialog.continue_button = mocker.MagicMock()
-    print_dialog.continue_button.clicked = mocker.MagicMock()
-    mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
-
-    # When the continue button is enabled, ensure clicking continue will show next instructions
-    print_dialog._on_preflight_failure(ExportError(ExportStatus.PRINTER_NOT_FOUND.value))
-    print_dialog.continue_button.clicked.connect.assert_called_once_with(
-        print_dialog._show_insert_usb_message
-    )
-
-    # When the continue button is enabled, ensure next instructions are shown
-    mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=True)
-    print_dialog._on_preflight_failure(ExportError(ExportStatus.PRINTER_NOT_FOUND.value))
-    print_dialog._show_insert_usb_message.assert_called_once_with()
-
-
-def test_PrintDialog__on_preflight_failure_when_status_is_MISSING_PRINTER_URI(mocker, print_dialog):
-    print_dialog._show_generic_error_message = mocker.MagicMock()
-    print_dialog.continue_button = mocker.MagicMock()
-    print_dialog.continue_button.clicked = mocker.MagicMock()
-    mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
-
-    # When the continue button is enabled, ensure clicking continue will show next instructions
-    print_dialog._on_preflight_failure(ExportError(ExportStatus.MISSING_PRINTER_URI.value))
-    print_dialog.continue_button.clicked.connect.assert_called_once_with(
-        print_dialog._show_generic_error_message
-    )
-    assert print_dialog.error_status == ExportStatus.MISSING_PRINTER_URI.value
-
-    # When the continue button is enabled, ensure next instructions are shown
-    mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=True)
-    print_dialog._on_preflight_failure(ExportError(ExportStatus.MISSING_PRINTER_URI.value))
-    print_dialog._show_generic_error_message.assert_called_once_with()
-    assert print_dialog.error_status == ExportStatus.MISSING_PRINTER_URI.value
-
-
-def test_PrintDialog__on_preflight_failure_when_status_is_CALLED_PROCESS_ERROR(
-    mocker, print_dialog
-):
-    print_dialog._show_generic_error_message = mocker.MagicMock()
-    print_dialog.continue_button = mocker.MagicMock()
-    print_dialog.continue_button.clicked = mocker.MagicMock()
-    mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
-
-    # When the continue button is enabled, ensure clicking continue will show next instructions
-    print_dialog._on_preflight_failure(ExportError(ExportStatus.CALLED_PROCESS_ERROR.value))
-    print_dialog.continue_button.clicked.connect.assert_called_once_with(
-        print_dialog._show_generic_error_message
-    )
-    assert print_dialog.error_status == ExportStatus.CALLED_PROCESS_ERROR.value
-
-    # When the continue button is enabled, ensure next instructions are shown
-    mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=True)
-    print_dialog._on_preflight_failure(ExportError(ExportStatus.CALLED_PROCESS_ERROR.value))
-    print_dialog._show_generic_error_message.assert_called_once_with()
-    assert print_dialog.error_status == ExportStatus.CALLED_PROCESS_ERROR.value
-
-
-def test_PrintDialog__on_preflight_failure_when_status_is_unknown(mocker, print_dialog):
-    print_dialog._show_generic_error_message = mocker.MagicMock()
-    print_dialog.continue_button = mocker.MagicMock()
-    print_dialog.continue_button.clicked = mocker.MagicMock()
-    mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
-
-    # When the continue button is enabled, ensure clicking continue will show next instructions
-    print_dialog._on_preflight_failure(ExportError("Some Unknown Error Status"))
-    print_dialog.continue_button.clicked.connect.assert_called_once_with(
-        print_dialog._show_generic_error_message
-    )
-    assert print_dialog.error_status == "Some Unknown Error Status"
-
-    # When the continue button is enabled, ensure next instructions are shown
-    mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=True)
-    print_dialog._on_preflight_failure(ExportError("Some Unknown Error Status"))
-    print_dialog._show_generic_error_message.assert_called_once_with()
-    assert print_dialog.error_status == "Some Unknown Error Status"
 
 
 def test_SourceConversationWrapper_on_conversation_updated(mocker, qtbot):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,9 +1,9 @@
 import pytest
 from PyQt5.QtWidgets import QApplication
 
-from securedrop_client.gui.conversation import ExportFileDialog
+from securedrop_client.gui.base import ModalDialog
+from securedrop_client.gui.conversation import ExportFileDialog, PrintFileDialog
 from securedrop_client.gui.main import Window
-from securedrop_client.gui.widgets import ModalDialog, PrintDialog
 from securedrop_client.logic import Controller
 from tests import factory
 
@@ -118,7 +118,7 @@ def print_dialog(mocker, homedir):
     gui.setup(controller)
     gui.login_dialog.close()
     app.setActiveWindow(gui)
-    dialog = PrintDialog(controller, "file_uuid", "file_name")
+    dialog = PrintFileDialog(controller, "file_uuid", "file_name")
 
     yield dialog
 


### PR DESCRIPTION
# Description

Moves `widgets.PrintDialog` to `conversation.PrintFileDialog` in order to make future changes easier to review.
Very similar to https://github.com/freedomofpress/securedrop-client/pull/1492 

Removes the last reference to the non-GUI `export` module from `gui/widgets.py`. :confetti_ball:
Opens the way to uncoupling both export dialogs from the `Controller`, and encapsulating all references to that non-GUI export service into a single GUI object (interface if you wish). 

# Test Plan

- [ ] Confirm that the class hasn't changed significantly
- [ ] Confirm that the corresponding tests haven't changed significantly
- [ ] Confirm that the UI strings haven't changed
- [ ] Confirm that the print dialog _looks_ the same as usual
- [ ] Confirm that you can still print files

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes _because the UI would break even outside Qubes OS if anything was wrong_

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
