### PR TITLE
Fix CI build-buster job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,21 +58,15 @@ common-steps:
         # previous run step), else return 0.
         git diff --quiet
 
-  - &make_source_tarball
-    run:
-      name: Tag and make source tarball
-      command: |
-        cd ~/project
-        ./update_version.sh 1000.0  # Dummy version number, doesn't matter what we put here
-        python3 setup.py sdist
-
   - &build_debian_package
     run:
       name: Build debian package
       command: |
+        cd ~/project
+        ./update_version.sh 1000.0  # Dummy version number, doesn't matter what we put here
         cd ~/packaging/securedrop-debian-packaging
         export PKG_VERSION=1000.0
-        export PKG_PATH=~/project/dist/securedrop-client-$PKG_VERSION.tar.gz
+        export PKG_PATH=~/project/
         make securedrop-client
 
 version: 2
@@ -85,7 +79,6 @@ jobs:
       - checkout
       - *install_packaging_dependencies
       - *verify_requirements
-      - *make_source_tarball
       - *build_debian_package
 
   test-buster:


### PR DESCRIPTION
# Description

There's some bug in which building from a sdist tarball doesn't work.
Given that we wanted to move away from that anyways, switch to just
specifying the path to the directory instead.

Needs <https://github.com/freedomofpress/securedrop-debian-packaging/pull/332> to work.

:sparkles: @creviera for finding out the difference in behavior between the tarball and the directory builds!

# Test Plan

- [ ] CI passes (once s-d-p patch is merged)

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
