### PR TITLE
Refactor export tests for portability

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -441,8 +441,7 @@ class Controller(QObject):
     ):
         """
         Calls the function in a non-blocking manner. Upon completion calls the
-        callback with the result. Calls timeout if the timer associated with
-        the call emits a timeout signal. Any further arguments are passed to
+        callback with the result. Any further arguments are passed to
         the function to be called.
         """
         new_thread_id = str(uuid.uuid4())  # Uniquely id the new thread.

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -58,10 +58,10 @@ def test_APICallRunner_call_api(mocker):
     mock_api_call.__name__ = "my_function"
     mock_current_object = mocker.MagicMock()
     cr = APICallRunner(mock_api_call, mock_current_object, "foo", bar="baz")
-    cr.call_succeeded = mocker.MagicMock()
+    call_succeeded_emissions = QSignalSpy(cr.call_succeeded)
     cr.call_api()
     assert cr.result == "foo"
-    cr.call_succeeded.emit.assert_called_once_with()
+    assert len(call_succeeded_emissions) == 1
 
 
 def test_APICallRunner_with_exception(mocker):
@@ -73,11 +73,11 @@ def test_APICallRunner_with_exception(mocker):
     mock_api_call.__name__ = "my_function"
     mock_current_object = mocker.MagicMock()
     cr = APICallRunner(mock_api_call, mock_current_object, "foo", bar="baz")
-    cr.call_failed = mocker.MagicMock()
+    call_failed_emissions = QSignalSpy(cr.call_failed)
     mocker.patch("securedrop_client.logic.QTimer")
     cr.call_api()
     assert cr.result == ex
-    cr.call_failed.emit.assert_called_once_with()
+    assert len(call_failed_emissions) == 1
 
 
 def test_Controller_init(homedir, config, mocker, session_maker):
@@ -250,7 +250,7 @@ def test_Controller_on_authenticate_success(homedir, config, mocker, session_mak
     co.api.first_name = co.authenticated_user.firstname
     co.api.last_name = co.authenticated_user.lastname
     co.resume_queues = mocker.MagicMock()
-    co.update_authenticated_user = mocker.MagicMock()
+    update_authenticated_user_emissions = QSignalSpy(co.update_authenticated_user)
 
     co.on_authenticate_success(True)
 
@@ -258,7 +258,8 @@ def test_Controller_on_authenticate_success(homedir, config, mocker, session_mak
     co.api_sync.start.assert_called_once_with(co.api)
     co.api_job_queue.start.assert_called_once_with(co.api)
     assert co.is_authenticated
-    co.update_authenticated_user.emit.assert_called_once_with(co.authenticated_user)
+    assert len(update_authenticated_user_emissions) == 1
+    assert update_authenticated_user_emissions[0] == [co.authenticated_user]
 
 
 def test_Controller_completed_api_call_without_current_object(
@@ -409,11 +410,11 @@ def test_Controller_on_sync_started(mocker, homedir):
 
     co.on_sync_started()
 
-    sync_started = mocker.patch.object(co, "sync_started")
+    sync_started_emissions = QSignalSpy(co.sync_started)
 
     co.on_sync_started()
 
-    sync_started.emit.assert_called_once()
+    assert len(sync_started_emissions) == 1
 
 
 def test_Controller_on_sync_failure(homedir, config, mocker, session_maker):
@@ -517,7 +518,7 @@ def test_Controller_on_sync_success(homedir, config, mocker):
     co.download_new_replies = mocker.MagicMock()
     co.gpg = mocker.MagicMock()
     co.resume_queues = mocker.MagicMock()
-    co.file_missing = mocker.MagicMock()
+    file_missing_emissions = QSignalSpy(co.file_missing)
     mock_storage = mocker.patch("securedrop_client.logic.storage")
     source = factory.Source()
     missing = factory.File(is_downloaded=None, is_decrypted=None, source=source)
@@ -530,7 +531,8 @@ def test_Controller_on_sync_success(homedir, config, mocker):
     co.download_new_messages.assert_called_once_with()
     co.download_new_replies.assert_called_once_with()
     co.resume_queues.assert_called_once_with()
-    co.file_missing.emit.assert_called_once_with(missing.source.uuid, missing.uuid, str(missing))
+    assert len(file_missing_emissions) == 1
+    assert file_missing_emissions[0] == [missing.source.uuid, missing.uuid, str(missing)]
 
 
 def test_Controller_on_sync_success_when_current_user_deleted(mocker, homedir):
@@ -581,12 +583,13 @@ def test_Controller_on_sync_success_username_change(homedir, session, config, mo
     co.api = mocker.MagicMock(
         username="imdifferent", first_name=user.firstname, last_name=user.lastname
     )
-    co.update_authenticated_user = mocker.MagicMock()
+    update_authenticated_user_emissions = QSignalSpy(co.update_authenticated_user)
 
     co.on_sync_success()
 
     co.authenticated_user.username == "baz"
-    co.update_authenticated_user.emit.assert_called_once_with(co.authenticated_user)
+    assert len(update_authenticated_user_emissions) == 1
+    assert update_authenticated_user_emissions[0] == [co.authenticated_user]
 
 
 def test_Controller_on_sync_success_firstname_change(homedir, session, config, mocker):
@@ -602,12 +605,13 @@ def test_Controller_on_sync_success_firstname_change(homedir, session, config, m
     co.api = mocker.MagicMock(
         username=user.username, first_name="imdifferent", last_name=user.lastname
     )
-    co.update_authenticated_user = mocker.MagicMock()
+    update_authenticated_user_emissions = QSignalSpy(co.update_authenticated_user)
 
     co.on_sync_success()
 
     co.authenticated_user.firstname == "baz"
-    co.update_authenticated_user.emit.assert_called_once_with(co.authenticated_user)
+    assert len(update_authenticated_user_emissions) == 1
+    assert update_authenticated_user_emissions[0] == [co.authenticated_user]
 
 
 def test_Controller_on_sync_success_lastname_change(homedir, session, config, mocker):
@@ -623,12 +627,13 @@ def test_Controller_on_sync_success_lastname_change(homedir, session, config, mo
     co.api = mocker.MagicMock(
         username=user.username, first_name=user.firstname, last_name="imdifferent"
     )
-    co.update_authenticated_user = mocker.MagicMock()
+    update_authenticated_user_emissions = QSignalSpy(co.update_authenticated_user)
 
     co.on_sync_success()
 
     co.authenticated_user.lastname == "baz"
-    co.update_authenticated_user.emit.assert_called_once_with(co.authenticated_user)
+    assert len(update_authenticated_user_emissions) == 1
+    assert update_authenticated_user_emissions[0] == [co.authenticated_user]
 
 
 def test_Controller_show_last_sync(homedir, config, mocker, session_maker):
@@ -673,7 +678,7 @@ def test_Controller_update_sources(homedir, config, mocker):
 def test_Controller_mark_seen(homedir, config, mocker, session, session_maker):
     co = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
     co.authenticated_user = factory.User()
-    co.add_job = mocker.MagicMock()
+    add_job_emissions = QSignalSpy(co.add_job)
     source = factory.Source()
     file = factory.File(source=source)
     message = factory.Message(source=source)
@@ -689,7 +694,8 @@ def test_Controller_mark_seen(homedir, config, mocker, session, session_maker):
 
     co.mark_seen(source)
 
-    co.add_job.emit.assert_called_once_with(job)
+    assert len(add_job_emissions) == 1
+    assert add_job_emissions[0] == [job]
     job.success_signal.connect.assert_called_once_with(co.on_seen_success, type=Qt.QueuedConnection)
     job.failure_signal.connect.assert_called_once_with(co.on_seen_failure, type=Qt.QueuedConnection)
 
@@ -767,7 +773,6 @@ def test_Controller_mark_seen_with_unseen_file_only(
 ):
     co = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
     co.authenticated_user = factory.User()
-    co.add_job = mocker.MagicMock()
     source = factory.Source()
     file = factory.File(source=source, uuid="file-uuid-1")
     session.add(file)
@@ -784,7 +789,6 @@ def test_Controller_mark_seen_with_unseen_message_only(
 ):
     co = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
     co.authenticated_user = factory.User()
-    co.add_job = mocker.MagicMock()
     source = factory.Source()
     message = factory.Message(source=source, uuid="msg-uuid-1")
     session.add(message)
@@ -801,7 +805,6 @@ def test_Controller_mark_seen_with_unseen_reply_only(
 ):
     co = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
     co.authenticated_user = factory.User()
-    co.add_job = mocker.MagicMock()
     source = factory.Source()
     reply = factory.Reply(source=source, uuid="reply-uuid-1")
     session.add(reply)
@@ -818,7 +821,7 @@ def test_Controller_mark_seen_skips_if_no_unseen_items(
 ):
     co = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
     co.authenticated_user = factory.User()
-    co.add_job = mocker.MagicMock()
+    add_job_emissions = QSignalSpy(co.add_job)
 
     job = mocker.MagicMock()
     job.success_signal = mocker.MagicMock()
@@ -827,7 +830,7 @@ def test_Controller_mark_seen_skips_if_no_unseen_items(
 
     co.mark_seen(factory.Source())
 
-    co.add_job.emit.assert_not_called()
+    assert len(add_job_emissions) == 0
     job.success_signal.connect.assert_not_called()
     job.failure_signal.connect.assert_not_called()
 
@@ -837,7 +840,7 @@ def test_Controller_mark_seen_skips_op_if_user_offline(
 ):
     co = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
     co.authenticated_user = None
-    co.add_job = mocker.MagicMock()
+    add_job_emissions = QSignalSpy(co.add_job)
     source = factory.Source()
     file = factory.File(source=source)
     message = factory.Message(source=source)
@@ -853,7 +856,7 @@ def test_Controller_mark_seen_skips_op_if_user_offline(
 
     co.mark_seen(source)
 
-    co.add_job.emit.assert_not_called()
+    assert len(add_job_emissions) == 0
     job.success_signal.connect.assert_not_called()
     job.failure_signal.connect.assert_not_called()
 
@@ -975,14 +978,15 @@ def test_Controller_on_update_star_failed(homedir, config, mocker):
     """
     gui = mocker.MagicMock()
     co = Controller("http://localhost", gui, mocker.MagicMock(), homedir, None)
-    co.star_update_failed = mocker.MagicMock()
+    star_update_failed_emissions = QSignalSpy(co.star_update_failed)
     source = factory.Source()
     co.session.query().filter_by().one.return_value = source
 
     error = UpdateStarJobError("mock_message", source.uuid)
     co.on_update_star_failure(error)
 
-    co.star_update_failed.emit.assert_called_once_with(source.uuid, source.is_starred)
+    assert len(star_update_failed_emissions) == 1
+    assert star_update_failed_emissions[0] == [source.uuid, source.is_starred]
     gui.update_error_status.assert_called_once_with("Failed to update star.")
 
 
@@ -993,12 +997,12 @@ def test_Controller_on_update_star_failed_due_to_timeout(homedir, config, mocker
     """
     gui = mocker.MagicMock()
     co = Controller("http://localhost", gui, mocker.MagicMock(), homedir, None)
-    co.star_update_failed = mocker.MagicMock()
+    star_update_failed_emissions = QSignalSpy(co.star_update_failed)
 
     error = UpdateStarJobTimeoutError("mock_message", "mock_uuid")
     co.on_update_star_failure(error)
 
-    co.star_update_failed.emit.assert_not_called()
+    assert len(star_update_failed_emissions) == 0
     gui.update_error_status.assert_not_called()
 
 
@@ -1022,7 +1026,7 @@ def test_Controller_logout_with_pending_replies(mocker, session_maker, homedir, 
     co.api_job_queue = mocker.MagicMock()
     co.api_job_queue.stop = mocker.MagicMock()
     co.call_api = mocker.MagicMock()
-    co.reply_failed = mocker.MagicMock()
+    reply_failed_emissions = QSignalSpy(co.reply_failed)
 
     source = factory.Source()
     session = session_maker()
@@ -1043,7 +1047,8 @@ def test_Controller_logout_with_pending_replies(mocker, session_maker, homedir, 
     for draft in session.query(db.DraftReply).all():
         assert draft.send_status == failed_status
 
-    co.reply_failed.emit.assert_called_once_with(pending_draft_reply.uuid)
+    assert len(reply_failed_emissions) == 1
+    assert reply_failed_emissions[0] == [pending_draft_reply.uuid]
     co.api_job_queue.stop.assert_called_once_with()
 
 
@@ -1243,10 +1248,8 @@ def test_Controller_download_conversation_requires_authenticated_journalist(
     co = Controller("http://localhost", gui, session_maker, homedir, app_state)
     co.api = None  # journalist is not authenticated
 
-    co.add_job = mocker.MagicMock()
-    co.add_job.emit = mocker.MagicMock()
-    co.file_download_started = mocker.MagicMock()
-    co.file_download_started.emit = mocker.MagicMock()
+    add_job_emissions = QSignalSpy(co.add_job)
+    file_download_started_emissions = QSignalSpy(co.file_download_started)
     co.on_action_requiring_login = mocker.MagicMock()
 
     job_success_signal = mocker.MagicMock()
@@ -1269,10 +1272,10 @@ def test_Controller_download_conversation_requires_authenticated_journalist(
     co.download_conversation(conversation_id)
 
     assert not file_download_job_constructor.called
-    assert not co.add_job.emit.called
+    assert len(add_job_emissions) == 0
     assert not job_success_signal.connect.called
     assert not job_failure_signal.connect.called
-    assert not co.file_download_started.emit.called
+    assert len(file_download_started_emissions) == 0
     assert co.on_action_requiring_login.called
 
 
@@ -1292,8 +1295,7 @@ def test_Controller_on_file_download_Submission(homedir, config, session, mocker
         success_signal=mock_success_signal, failure_signal=mock_failure_signal
     )
     mock_job_cls = mocker.patch("securedrop_client.logic.FileDownloadJob", return_value=mock_job)
-    co.add_job = mocker.MagicMock()
-    co.add_job.emit = mocker.MagicMock()
+    add_job_emissions = QSignalSpy(co.add_job)
 
     source = factory.Source()
     file_ = factory.File(is_downloaded=None, is_decrypted=None, source=source)
@@ -1304,7 +1306,8 @@ def test_Controller_on_file_download_Submission(homedir, config, session, mocker
     co.on_submission_download(db.File, file_.uuid)
 
     mock_job_cls.assert_called_once_with(file_.uuid, co.data_dir, co.gpg)
-    co.add_job.emit.assert_called_once_with(mock_job)
+    assert len(add_job_emissions) == 1
+    assert add_job_emissions[0] == [mock_job]
     mock_success_signal.connect.assert_called_once_with(
         co.on_file_download_success, type=Qt.QueuedConnection
     )
@@ -1328,8 +1331,7 @@ def test_Controller_on_file_download_Submission_no_auth(
         success_signal=mock_success_signal, failure_signal=mock_failure_signal
     )
     mock_job_cls = mocker.patch("securedrop_client.logic.FileDownloadJob", return_value=mock_job)
-    co.add_job = mocker.MagicMock()
-    co.add_job.emit = mocker.MagicMock()
+    add_job_emissions = QSignalSpy(co.add_job)
 
     source = factory.Source()
     file_ = factory.File(is_downloaded=None, is_decrypted=None, source=source)
@@ -1340,7 +1342,7 @@ def test_Controller_on_file_download_Submission_no_auth(
     co.on_submission_download(db.File, file_.uuid)
 
     assert not mock_job_cls.called
-    assert not co.add_job.emit.called
+    assert len(add_job_emissions) == 0
     assert not mock_success_signal.connect.called
     assert not mock_failure_signal.connect.called
     assert co.on_action_requiring_login.called
@@ -1357,8 +1359,7 @@ def test_Controller_on_file_downloaded_success(homedir, config, mocker, session_
     co = Controller("http://localhost", mock_gui, session_maker, homedir, app_state)
     co.session = mocker.MagicMock()
 
-    # signal when file is downloaded
-    mock_file_ready = mocker.patch.object(co, "file_ready")
+    file_ready_emissions = QSignalSpy(co.file_ready)
 
     mock_storage = mocker.MagicMock()
     mock_file = mocker.MagicMock()
@@ -1370,7 +1371,8 @@ def test_Controller_on_file_downloaded_success(homedir, config, mocker, session_
 
     co.on_file_download_success("file_uuid")
 
-    mock_file_ready.emit.assert_called_once_with("a_uuid", "file_uuid", "foo.txt")
+    assert len(file_ready_emissions) == 1
+    assert file_ready_emissions[0] == ["a_uuid", "file_uuid", "foo.txt"]
 
 
 def test_Controller_on_file_downloaded_success_updates_application_state(
@@ -1409,15 +1411,14 @@ def test_Controller_on_file_downloaded_api_failure(homedir, config, mocker, sess
     mock_gui = mocker.MagicMock()
     co = Controller("http://localhost", mock_gui, session_maker, homedir, None)
 
-    # signal when file is downloaded
-    mock_file_ready = mocker.patch.object(co, "file_ready")
+    file_ready_emissions = QSignalSpy(co.file_ready)
     mock_update_error_status = mocker.patch.object(mock_gui, "update_error_status")
     result_data = DownloadException("error message", type(db.File), "test-uuid")
 
     co.on_file_download_failure(result_data)
 
     mock_update_error_status.assert_called_once_with("The file download failed. Please try again.")
-    mock_file_ready.emit.assert_not_called()
+    assert len(file_ready_emissions) == 0
 
 
 def test_Controller_on_file_downloaded_checksum_failure(homedir, config, mocker, session_maker):
@@ -1430,14 +1431,14 @@ def test_Controller_on_file_downloaded_checksum_failure(homedir, config, mocker,
     file_ = factory.File(is_downloaded=None, is_decrypted=None, source=factory.Source())
 
     mock_set_status = mocker.patch.object(co, "set_status")
-    mock_file_ready = mocker.patch.object(co, "file_ready")
+    file_ready_emissions = QSignalSpy(co.file_ready)
 
     warning_logger = mocker.patch("securedrop_client.logic.logger.warning")
     co._submit_download_job = mocker.MagicMock()
 
     co.on_file_download_failure(DownloadChecksumMismatchException("bang!", type(file_), file_.uuid))
 
-    mock_file_ready.emit.assert_not_called()
+    assert len(file_ready_emissions) == 0
 
     # Job should get resubmitted and we should log this is happening
     assert co._submit_download_job.call_count == 1
@@ -1463,7 +1464,7 @@ def test_Controller_on_file_decryption_failure(homedir, config, mocker, session,
     session.commit()
 
     mock_set_status = mocker.patch.object(co, "set_status")
-    mock_file_ready = mocker.patch.object(co, "file_ready")
+    file_ready_emissions = QSignalSpy(co.file_ready)
     mock_update_error_status = mocker.patch.object(mock_gui, "update_error_status")
 
     error_logger = mocker.patch("securedrop_client.logic.logger.error")
@@ -1471,7 +1472,7 @@ def test_Controller_on_file_decryption_failure(homedir, config, mocker, session,
 
     co.on_file_download_failure(DownloadDecryptionException("bang!", type(file_), file_.uuid))
 
-    mock_file_ready.emit.assert_not_called()
+    assert len(file_ready_emissions) == 0
     mock_update_error_status.assert_called_once_with("The file download failed. Please try again.")
 
     assert co._submit_download_job.call_count == 0
@@ -1626,12 +1627,12 @@ def test_Controller_download_new_replies_with_new_reply(mocker, session, session
     failure_signal = mocker.MagicMock()
     job = mocker.MagicMock(success_signal=success_signal, failure_signal=failure_signal)
     mocker.patch("securedrop_client.logic.ReplyDownloadJob", return_value=job)
-    co.add_job = mocker.MagicMock()
-    co.add_job.emit = mocker.MagicMock()
+    add_job_emissions = QSignalSpy(co.add_job)
 
     co.download_new_replies()
 
-    co.add_job.emit.assert_called_once_with(job)
+    assert len(add_job_emissions) == 1
+    assert add_job_emissions[0] == [job]
     success_signal.connect.assert_called_once_with(
         co.on_reply_download_success, type=Qt.QueuedConnection
     )
@@ -1651,13 +1652,12 @@ def test_Controller_download_new_replies_without_replies(mocker, session, sessio
     failure_signal = mocker.MagicMock()
     job = mocker.MagicMock(success_signal=success_signal, failure_signal=failure_signal)
     mocker.patch("securedrop_client.logic.ReplyDownloadJob", return_value=job)
-    co.add_job = mocker.MagicMock()
-    co.add_job.emit = mocker.MagicMock()
+    add_job_emissions = QSignalSpy(co.add_job)
     set_status = mocker.patch.object(co, "set_status")
 
     co.download_new_replies()
 
-    co.add_job.emit.assert_not_called()
+    assert len(add_job_emissions) == 0
     success_signal.connect.assert_not_called()
     failure_signal.connect.assert_not_called()
     set_status.assert_not_called()
@@ -1668,13 +1668,14 @@ def test_Controller_on_reply_downloaded_success(mocker, homedir, session_maker):
     Check that a successful download emits proper signal.
     """
     co = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
-    reply_ready = mocker.patch.object(co, "reply_ready")
+    reply_ready_emissions = QSignalSpy(co.reply_ready)
     reply = factory.Reply(source=factory.Source())
     mocker.patch("securedrop_client.storage.get_reply", return_value=reply)
 
     co.on_reply_download_success(reply.uuid)
 
-    reply_ready.emit.assert_called_once_with(reply.source.uuid, reply.uuid, str(reply))
+    assert len(reply_ready_emissions) == 1
+    assert reply_ready_emissions[0] == [reply.source.uuid, reply.uuid, str(reply)]
 
 
 def test_Controller_on_reply_downloaded_failure(mocker, homedir, session_maker):
@@ -1682,14 +1683,14 @@ def test_Controller_on_reply_downloaded_failure(mocker, homedir, session_maker):
     Check that a failed download informs the user.
     """
     co = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
-    reply_ready = mocker.patch.object(co, "reply_ready")
+    reply_ready_emissions = QSignalSpy(co.reply_ready)
     reply = factory.Reply(source=factory.Source())
     mocker.patch("securedrop_client.storage.get_reply", return_value=reply)
     co._submit_download_job = mocker.MagicMock()
 
     co.on_reply_download_failure(Exception("mock_exception"))
 
-    reply_ready.emit.assert_not_called()
+    assert len(reply_ready_emissions) == 0
 
     # Job should not get automatically resubmitted if the failure was generic
     co._submit_download_job.assert_not_called()
@@ -1700,7 +1701,7 @@ def test_Controller_on_reply_downloaded_checksum_failure(mocker, homedir, sessio
     Check that a failed download due to checksum resubmits the job and informs the user.
     """
     co = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
-    reply_ready = mocker.patch.object(co, "reply_ready")
+    reply_ready_emissions = QSignalSpy(co.reply_ready)
     reply = factory.Reply(source=factory.Source())
     mocker.patch("securedrop_client.storage.get_reply", return_value=reply)
     warning_logger = mocker.patch("securedrop_client.logic.logger.warning")
@@ -1710,7 +1711,7 @@ def test_Controller_on_reply_downloaded_checksum_failure(mocker, homedir, sessio
         DownloadChecksumMismatchException("bang!", type(reply), reply.uuid)
     )
 
-    reply_ready.emit.assert_not_called()
+    assert len(reply_ready_emissions) == 0
 
     # Job should get resubmitted and we should log this is happening
     assert co._submit_download_job.call_count == 1
@@ -1724,16 +1725,17 @@ def test_Controller_on_reply_downloaded_decryption_failure(mocker, homedir, sess
     Check that a failed download due to a decryption error informs the user.
     """
     co = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
-    reply_ready = mocker.patch.object(co, "reply_ready")
-    reply_download_failed = mocker.patch.object(co, "reply_download_failed")
+    reply_ready_emissions = QSignalSpy(co.reply_ready)
+    reply_download_failed_emissions = QSignalSpy(co.reply_download_failed)
     reply = factory.Reply(source=factory.Source())
     mocker.patch("securedrop_client.storage.get_reply", return_value=reply)
 
     decryption_exception = DownloadDecryptionException("bang!", type(reply), reply.uuid)
     co.on_reply_download_failure(decryption_exception)
 
-    reply_ready.emit.assert_not_called()
-    reply_download_failed.emit.assert_called_with(reply.source.uuid, reply.uuid, str(reply))
+    assert len(reply_ready_emissions) == 0
+    assert len(reply_download_failed_emissions) == 1
+    assert reply_download_failed_emissions[0] == [reply.source.uuid, reply.uuid, str(reply)]
 
 
 def test_Controller_download_new_messages_with_new_message(mocker, session, session_maker, homedir):
@@ -1747,15 +1749,15 @@ def test_Controller_download_new_messages_with_new_message(mocker, session, sess
     mocker.patch("securedrop_client.storage.find_new_messages", return_value=[message])
     success_signal = mocker.MagicMock()
     failure_signal = mocker.MagicMock()
-    co.add_job = mocker.MagicMock()
-    co.add_job.emit = mocker.MagicMock()
+    add_job_emissions = QSignalSpy(co.add_job)
     job = mocker.MagicMock(success_signal=success_signal, failure_signal=failure_signal)
     mocker.patch("securedrop_client.logic.MessageDownloadJob", return_value=job)
     set_status = mocker.patch.object(co, "set_status")
 
     co.download_new_messages()
 
-    co.add_job.emit.assert_called_once_with(job)
+    assert len(add_job_emissions) == 1
+    assert add_job_emissions[0] == [job]
     success_signal.connect.assert_called_once_with(
         co.on_message_download_success, type=Qt.QueuedConnection
     )
@@ -1776,13 +1778,12 @@ def test_Controller_download_new_messages_without_messages(mocker, session, sess
     failure_signal = mocker.MagicMock()
     job = mocker.MagicMock(success_signal=success_signal, failure_signal=failure_signal)
     mocker.patch("securedrop_client.logic.MessageDownloadJob", return_value=job)
-    co.add_job = mocker.MagicMock()
-    co.add_job.emit = mocker.MagicMock()
+    add_job_emissions = QSignalSpy(co.add_job)
     set_status = mocker.patch.object(co, "set_status")
 
     co.download_new_messages()
 
-    co.add_job.emit.assert_not_called()
+    assert len(add_job_emissions) == 0
     success_signal.connect.assert_not_called()
     failure_signal.connect.assert_not_called()
     set_status.assert_not_called()
@@ -1796,8 +1797,7 @@ def test_Controller_download_new_messages_skips_recent_failures(
     """
     co = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
     co.api = "Api token has a value"
-    co.add_job = mocker.MagicMock()
-    co.add_job.emit = mocker.MagicMock()
+    add_job_emissions = QSignalSpy(co.add_job)
 
     # record the download failures
     download_error = (
@@ -1816,7 +1816,7 @@ def test_Controller_download_new_messages_skips_recent_failures(
 
     co.download_new_messages()
 
-    co.add_job.emit.assert_not_called()
+    assert len(add_job_emissions) == 0
     info_logger.call_args_list[0][0][0] == (
         f"Download of message {message.uuid} failed since client start; not retrying."
     )
@@ -1830,8 +1830,7 @@ def test_Controller_download_new_replies_skips_recent_failures(
     """
     co = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
     co.api = "Api token has a value"
-    co.add_job = mocker.MagicMock()
-    co.add_job.emit = mocker.MagicMock()
+    add_job_emissions = QSignalSpy(co.add_job)
 
     # record the download failures
     download_error = (
@@ -1851,7 +1850,7 @@ def test_Controller_download_new_replies_skips_recent_failures(
 
     co.download_new_replies()
 
-    co.add_job.emit.assert_not_called()
+    assert len(add_job_emissions) == 0
     info_logger.call_args_list[0][0][0] == (
         f"Download of reply {reply.uuid} failed since client start; not retrying."
     )
@@ -1862,13 +1861,14 @@ def test_Controller_on_message_downloaded_success(mocker, homedir, session_maker
     Check that a successful download emits proper signal.
     """
     co = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
-    message_ready = mocker.patch.object(co, "message_ready")
+    message_ready_emissions = QSignalSpy(co.message_ready)
     message = factory.Message(source=factory.Source())
     mocker.patch("securedrop_client.storage.get_message", return_value=message)
 
     co.on_message_download_success(message.uuid)
 
-    message_ready.emit.assert_called_once_with(message.source.uuid, message.uuid, str(message))
+    assert len(message_ready_emissions) == 1
+    assert message_ready_emissions[0] == [message.source.uuid, message.uuid, str(message)]
 
 
 def test_Controller_on_message_downloaded_failure(mocker, homedir, session_maker):
@@ -1876,14 +1876,14 @@ def test_Controller_on_message_downloaded_failure(mocker, homedir, session_maker
     Check that a failed download informs the user.
     """
     co = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
-    message_ready = mocker.patch.object(co, "message_ready")
+    message_ready_emissions = QSignalSpy(co.message_ready)
     message = factory.Message(source=factory.Source())
     mocker.patch("securedrop_client.storage.get_message", return_value=message)
     co._submit_download_job = mocker.MagicMock()
 
     co.on_message_download_failure(Exception("mock_exception"))
 
-    message_ready.emit.assert_not_called()
+    assert len(message_ready_emissions) == 0
 
     # Job should not get automatically resubmitted if the failure was generic
     co._submit_download_job.assert_not_called()
@@ -1894,7 +1894,7 @@ def test_Controller_on_message_downloaded_checksum_failure(mocker, homedir, sess
     Check that a failed download due to checksum resubmits the job and informs the user.
     """
     co = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
-    message_ready = mocker.patch.object(co, "message_ready")
+    message_ready_emissions = QSignalSpy(co.message_ready)
     message = factory.Message(source=factory.Source())
     mocker.patch("securedrop_client.storage.get_message", return_value=message)
     co._submit_download_job = mocker.MagicMock()
@@ -1902,8 +1902,7 @@ def test_Controller_on_message_downloaded_checksum_failure(mocker, homedir, sess
     co.on_message_download_failure(
         DownloadChecksumMismatchException("bang!", type(message), message.uuid)
     )
-
-    message_ready.emit.assert_not_called()
+    assert len(message_ready_emissions) == 0
 
     # Job should get resubmitted and we should log this is happening
     assert co._submit_download_job.call_count == 1
@@ -1914,16 +1913,17 @@ def test_Controller_on_message_downloaded_decryption_failure(mocker, homedir, se
     Check that a failed download due to a decryption error informs the user.
     """
     co = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
-    message_ready = mocker.patch.object(co, "message_ready")
-    message_download_failed = mocker.patch.object(co, "message_download_failed")
+    message_ready_emissions = QSignalSpy(co.message_ready)
+    message_download_failed_emissions = QSignalSpy(co.message_download_failed)
     message = factory.Message(source=factory.Source())
     mocker.patch("securedrop_client.storage.get_message", return_value=message)
 
     decryption_exception = DownloadDecryptionException("bang!", type(message), message.uuid)
     co.on_message_download_failure(decryption_exception)
 
-    message_ready.emit.assert_not_called()
-    message_download_failed.emit.assert_called_with(message.source.uuid, message.uuid, str(message))
+    assert len(message_ready_emissions) == 0
+    assert len(message_download_failed_emissions) == 1
+    assert message_download_failed_emissions[0] == [message.source.uuid, message.uuid, str(message)]
 
 
 def test_Controller_on_delete_source_success(mocker, homedir, session_maker):
@@ -1973,9 +1973,8 @@ def test_Controller_delete_source(homedir, config, mocker, session_maker, sessio
     co = Controller("http://localhost", mock_gui, session_maker, homedir, None)
     co.call_api = mocker.MagicMock()
     co.api = mocker.MagicMock()
-    co.source_deleted = mocker.MagicMock()
-    co.add_job = mocker.MagicMock()
-    co.add_job.emit = mocker.MagicMock()
+    add_job_emissions = QSignalSpy(co.add_job)
+    source_deleted_emissions = QSignalSpy(co.source_deleted)
 
     mock_success_signal = mocker.MagicMock()
     mock_failure_signal = mocker.MagicMock()
@@ -1990,9 +1989,11 @@ def test_Controller_delete_source(homedir, config, mocker, session_maker, sessio
 
     co.delete_source(source)
 
-    co.source_deleted.emit.assert_called_once_with(source.uuid)
+    assert len(source_deleted_emissions) == 1
+    assert source_deleted_emissions[0] == [source.uuid]
     mock_job_cls.assert_called_once_with(source.uuid)
-    co.add_job.emit.assert_called_once_with(mock_job)
+    assert len(add_job_emissions) == 1
+    assert add_job_emissions[0] == [mock_job]
     mock_success_signal.connect.assert_called_once_with(
         co.on_delete_source_success, type=Qt.QueuedConnection
     )
@@ -2050,9 +2051,8 @@ def test_Controller_delete_conversation(homedir, config, mocker, session_maker, 
     co = Controller("http://localhost", mock_gui, session_maker, homedir, None)
     co.call_api = mocker.MagicMock()
     co.api = mocker.MagicMock()
-    co.conversation_deleted = mocker.MagicMock()
-    co.add_job = mocker.MagicMock()
-    co.add_job.emit = mocker.MagicMock()
+    conversation_deleted_emissions = QSignalSpy(co.conversation_deleted)
+    add_job_emissions = QSignalSpy(co.add_job)
 
     mock_success_signal = mocker.MagicMock()
     mock_failure_signal = mocker.MagicMock()
@@ -2069,9 +2069,11 @@ def test_Controller_delete_conversation(homedir, config, mocker, session_maker, 
 
     co.delete_conversation(source)
 
-    co.conversation_deleted.emit.assert_called_once_with(source.uuid)
+    assert len(conversation_deleted_emissions) == 1
+    assert conversation_deleted_emissions[0] == [source.uuid]
     mock_job_cls.assert_called_once_with(source.uuid)
-    co.add_job.emit.assert_called_once_with(mock_job)
+    assert len(add_job_emissions) == 1
+    assert add_job_emissions[0] == [mock_job]
     mock_success_signal.connect.assert_called_once_with(
         co.on_delete_conversation_success, type=Qt.QueuedConnection
     )
@@ -2101,8 +2103,7 @@ def test_Controller_send_reply_success(
         success_signal=mock_success_signal, failure_signal=mock_failure_signal
     )
     mock_job_cls = mocker.patch("securedrop_client.logic.SendReplyJob", return_value=mock_job)
-    co.add_job = mocker.MagicMock()
-    co.add_job.emit = mocker.MagicMock()
+    add_job_emissions = QSignalSpy(co.add_job)
 
     source = factory.Source()
     session.add(source)
@@ -2112,7 +2113,8 @@ def test_Controller_send_reply_success(
 
     mock_job_cls.assert_called_once_with(source.uuid, user.uuid, "mock_msg", co.gpg)
 
-    co.add_job.emit.assert_called_once_with(mock_job)
+    assert len(add_job_emissions) == 1
+    assert add_job_emissions[0] == [mock_job]
     mock_success_signal.connect.assert_called_once_with(
         co.on_reply_success, type=Qt.QueuedConnection
     )
@@ -2200,8 +2202,8 @@ def test_Controller_on_reply_success(homedir, mocker, session_maker, session):
     Check that when the method is called, the client emits the correct signal.
     """
     co = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
-    reply_succeeded = mocker.patch.object(co, "reply_succeeded")
-    reply_failed = mocker.patch.object(co, "reply_failed")
+    reply_succeeded_emissions = QSignalSpy(co.reply_succeeded)
+    reply_failed_emissions = QSignalSpy(co.reply_failed)
     reply = factory.Reply(source=factory.Source())
     info_logger = mocker.patch("securedrop_client.logic.logger.info")
 
@@ -2215,8 +2217,9 @@ def test_Controller_on_reply_success(homedir, mocker, session_maker, session):
     co.on_reply_success(reply.uuid)
 
     assert info_logger.call_args_list[0][0][0] == "{} sent successfully".format(reply.uuid)
-    reply_succeeded.emit.assert_called_once_with("source_uuid", reply.uuid, "reply_message_mock")
-    reply_failed.emit.assert_not_called()
+    assert len(reply_succeeded_emissions) == 1
+    assert reply_succeeded_emissions[0] == ["source_uuid", reply.uuid, "reply_message_mock"]
+    assert len(reply_failed_emissions) == 0
 
 
 def test_Controller_on_reply_failure(homedir, mocker, session_maker):
@@ -2224,16 +2227,17 @@ def test_Controller_on_reply_failure(homedir, mocker, session_maker):
     Check that when the method is called, the client emits the correct signal.
     """
     co = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
-    reply_succeeded = mocker.patch.object(co, "reply_succeeded")
-    reply_failed = mocker.patch.object(co, "reply_failed")
+    reply_succeeded_emissions = QSignalSpy(co.reply_succeeded)
+    reply_failed_emissions = QSignalSpy(co.reply_failed)
     debug_logger = mocker.patch("securedrop_client.logic.logger.debug")
 
     exception = SendReplyJobError("mock_error_message", "mock_reply_uuid")
     co.on_reply_failure(exception)
 
     debug_logger.assert_called_once_with("{} failed to send".format("mock_reply_uuid"))
-    reply_failed.emit.assert_called_once_with("mock_reply_uuid")
-    reply_succeeded.emit.assert_not_called()
+    assert len(reply_failed_emissions) == 1
+    assert reply_failed_emissions[0] == ["mock_reply_uuid"]
+    assert len(reply_succeeded_emissions) == 0
 
 
 def test_Controller_on_reply_failure_for_timeout(homedir, mocker, session_maker):
@@ -2241,16 +2245,16 @@ def test_Controller_on_reply_failure_for_timeout(homedir, mocker, session_maker)
     Check that when the method is called, the client emits the correct signal.
     """
     co = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
-    reply_succeeded = mocker.patch.object(co, "reply_succeeded")
-    reply_failed = mocker.patch.object(co, "reply_failed")
+    reply_succeeded_emissions = QSignalSpy(co.reply_succeeded)
+    reply_failed_emissions = QSignalSpy(co.reply_failed)
     debug_logger = mocker.patch("securedrop_client.logic.logger.debug")
 
     exception = SendReplyJobTimeoutError("mock_error_message", "mock_reply_uuid")
     co.on_reply_failure(exception)
 
     debug_logger.assert_called_once_with("{} failed to send".format("mock_reply_uuid"))
-    reply_failed.emit.assert_not_called()
-    reply_succeeded.emit.assert_not_called()
+    assert len(reply_failed_emissions) == 0
+    assert len(reply_succeeded_emissions) == 0
 
 
 def test_Controller_is_authenticated_property(homedir, mocker, session_maker):
@@ -2263,7 +2267,7 @@ def test_Controller_is_authenticated_property(homedir, mocker, session_maker):
     mock_gui = mocker.MagicMock()
 
     co = Controller("http://localhost", mock_gui, session_maker, homedir, None)
-    mock_signal = mocker.patch.object(co, "authentication_state")
+    authentication_state_emissions = QSignalSpy(co.authentication_state)
 
     # default state is unauthenticated
     assert co.is_authenticated is False
@@ -2274,18 +2278,18 @@ def test_Controller_is_authenticated_property(homedir, mocker, session_maker):
 
     # setting the signal to its current value does not fire the signal
     co.is_authenticated = False
-    assert not mock_signal.emit.called
+    assert len(authentication_state_emissions) == 0
     assert co.is_authenticated is False
 
     # setting the property to True sends a signal
     co.is_authenticated = True
-    mock_signal.emit.assert_called_once_with(True)
+    assert len(authentication_state_emissions) == 1
+    assert authentication_state_emissions[0] == [True]
     assert co.is_authenticated is True
 
-    mock_signal.reset_mock()
-
     co.is_authenticated = False
-    mock_signal.emit.assert_called_once_with(False)
+    assert len(authentication_state_emissions) == 2
+    assert authentication_state_emissions[1] == [False]
     assert co.is_authenticated is False
 
 
@@ -2309,14 +2313,14 @@ def test_APICallRunner_api_call_timeout(mocker, exception):
 
     runner = APICallRunner(mock_api.fake_request)
 
-    mock_failure_signal = mocker.patch.object(runner, "call_failed")
-    mock_timeout_signal = mocker.patch.object(runner, "call_timed_out")
+    call_failed_emissions = QSignalSpy(runner.call_failed)
+    call_timed_out_emissions = QSignalSpy(runner.call_timed_out)
 
     runner.call_api()
 
     mock_api.fake_request.assert_called_once_with()
-    mock_failure_signal.emit.assert_called_once_with()
-    mock_timeout_signal.emit.assert_called_once_with()
+    assert len(call_failed_emissions) == 1
+    assert len(call_timed_out_emissions) == 1
 
 
 def test_Controller_on_queue_paused(homedir, config, mocker, session_maker):
@@ -2350,8 +2354,7 @@ def test_Controller_call_update_star_success(homedir, config, mocker, session_ma
         success_signal=star_update_successful, failure_signal=star_update_failed
     )
     mock_job_cls = mocker.patch("securedrop_client.logic.UpdateStarJob", return_value=mock_job)
-    co.add_job = mocker.MagicMock()
-    co.add_job.emit = mocker.MagicMock()
+    add_job_emissions = QSignalSpy(co.add_job)
 
     source = factory.Source()
     session.add(source)
@@ -2360,7 +2363,8 @@ def test_Controller_call_update_star_success(homedir, config, mocker, session_ma
     co.update_star(source.uuid, source.is_starred)
 
     mock_job_cls.assert_called_once_with(source.uuid, source.is_starred)
-    co.add_job.emit.assert_called_once_with(mock_job)
+    assert len(add_job_emissions) == 1
+    assert add_job_emissions[0] == [mock_job]
     assert star_update_successful.connect.call_count == 1
     star_update_failed.connect.assert_called_once_with(
         co.on_update_star_failure, type=Qt.QueuedConnection
@@ -2372,34 +2376,28 @@ def test_Controller_call_update_star_success(homedir, config, mocker, session_ma
 
 def test_Controller_run_printer_preflight_checks(homedir, mocker, session, source):
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
-    co.export = mocker.MagicMock()
-    co.export.begin_printer_preflight = mocker.MagicMock()
-    co.export.begin_printer_preflight.emit = mocker.MagicMock()
+    begin_printer_preflight_emissions = QSignalSpy(co.export.begin_printer_preflight)
 
     co.run_printer_preflight_checks()
 
-    assert co.export.begin_printer_preflight.emit.call_count == 1
+    assert len(begin_printer_preflight_emissions) == 1
 
 
 def test_Controller_run_printer_preflight_checks_not_qubes(homedir, mocker, session, source):
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
     co.qubes = False
-    co.export = mocker.MagicMock()
-    co.export.begin_printer_preflight = mocker.MagicMock()
-    co.export.begin_printer_preflight.emit = mocker.MagicMock()
-    co.export.printer_preflight_success = mocker.MagicMock()
-    co.export.printer_preflight_success.emit = mocker.MagicMock()
+    begin_printer_preflight_emissions = QSignalSpy(co.export.begin_printer_preflight)
+    printer_preflight_success_emissions = QSignalSpy(co.export.printer_preflight_success)
 
     co.run_printer_preflight_checks()
 
-    assert co.export.begin_printer_preflight.emit.call_count == 0
-    assert co.export.printer_preflight_success.emit.call_count == 1
+    assert len(begin_printer_preflight_emissions) == 0
+    assert len(printer_preflight_success_emissions) == 1
 
 
 def test_Controller_run_print_file(mocker, session, homedir):
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
-    co.export = mocker.MagicMock()
-    co.export.begin_print.emit = mocker.MagicMock()
+    begin_print_emissions = QSignalSpy(co.export.begin_print)
     file = factory.File(source=factory.Source())
     session.add(file)
     session.commit()
@@ -2412,15 +2410,13 @@ def test_Controller_run_print_file(mocker, session, homedir):
 
     co.print_file(file.uuid)
 
-    assert co.export.begin_print.emit.call_count == 1
+    assert len(begin_print_emissions) == 1
 
 
 def test_Controller_run_print_file_not_qubes(mocker, session, homedir):
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
     co.qubes = False
-    co.export = mocker.MagicMock()
-    co.export.begin_print = mocker.MagicMock()
-    co.export.begin_print.emit = mocker.MagicMock()
+    begin_print_emissions = QSignalSpy(co.export.begin_print)
     file = factory.File(source=factory.Source())
     session.add(file)
     session.commit()
@@ -2433,7 +2429,7 @@ def test_Controller_run_print_file_not_qubes(mocker, session, homedir):
 
     co.print_file(file.uuid)
 
-    assert co.export.begin_print.emit.call_count == 0
+    assert len(begin_print_emissions) == 0
 
 
 def test_Controller_print_file_file_missing(homedir, mocker, session, session_maker):
@@ -2480,10 +2476,8 @@ def test_Controller_print_file_when_orig_file_already_exists(
     The signal `begin_print` should still be emmited if the original file already exists.
     """
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
-    co.export = mocker.MagicMock()
-    co.export.begin_print = mocker.MagicMock()
-    co.export.begin_print.emit = mocker.MagicMock()
     file = factory.File(source=factory.Source())
+    begin_print_emissions = QSignalSpy(co.export.begin_print)
     session.add(file)
     session.commit()
     mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
@@ -2491,7 +2485,7 @@ def test_Controller_print_file_when_orig_file_already_exists(
 
     co.print_file(file.uuid)
 
-    assert co.export.begin_print.emit.call_count == 1
+    assert len(begin_print_emissions) == 1
     co.get_file.assert_called_with(file.uuid)
 
 
@@ -2503,9 +2497,7 @@ def test_Controller_print_file_when_orig_file_already_exists_not_qubes(
     """
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
     co.qubes = False
-    co.export = mocker.MagicMock()
-    co.export.begin_print = mocker.MagicMock()
-    co.export.begin_print.emit = mocker.MagicMock()
+    begin_print_emissions = QSignalSpy(co.export.begin_print)
     file = factory.File(source=factory.Source())
     session.add(file)
     session.commit()
@@ -2518,15 +2510,14 @@ def test_Controller_print_file_when_orig_file_already_exists_not_qubes(
 
     co.export_file_to_usb_drive(file.uuid, "mock passphrase")
 
-    assert co.export.begin_print.emit.call_count == 0
+    assert len(begin_print_emissions) == 0
+    co.get_file.assert_called_with(file.uuid)
     co.get_file.assert_called_with(file.uuid)
 
 
 def test_Controller_run_export_preflight_checks(homedir, mocker, session, source):
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
-    co.export = mocker.MagicMock()
-    co.export.begin_preflight_check = mocker.MagicMock()
-    co.export.begin_preflight_check.emit = mocker.MagicMock()
+    begin_preflight_check_emissions = QSignalSpy(co.export.begin_preflight_check)
     file = factory.File(source=source["source"])
     session.add(file)
     session.commit()
@@ -2534,15 +2525,13 @@ def test_Controller_run_export_preflight_checks(homedir, mocker, session, source
 
     co.run_export_preflight_checks()
 
-    assert co.export.begin_preflight_check.emit.call_count == 1
+    assert len(begin_preflight_check_emissions) == 1
 
 
 def test_Controller_run_export_preflight_checks_not_qubes(homedir, mocker, session, source):
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
     co.qubes = False
-    co.export = mocker.MagicMock()
-    co.export.begin_preflight_check = mocker.MagicMock()
-    co.export.begin_preflight_check.emit = mocker.MagicMock()
+    begin_preflight_check_emissions = QSignalSpy(co.export.begin_preflight_check)
     file = factory.File(source=source["source"])
     session.add(file)
     session.commit()
@@ -2550,7 +2539,7 @@ def test_Controller_run_export_preflight_checks_not_qubes(homedir, mocker, sessi
 
     co.run_export_preflight_checks()
 
-    assert co.export.begin_preflight_check.emit.call_count == 0
+    assert len(begin_preflight_check_emissions) == 0
 
 
 def test_Controller_export_file_to_usb_drive(homedir, mocker, session):
@@ -2558,9 +2547,7 @@ def test_Controller_export_file_to_usb_drive(homedir, mocker, session):
     The signal `begin_usb_export` should be emmited during export_file_to_usb_drive.
     """
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
-    co.export = mocker.MagicMock()
-    co.export.begin_usb_export = mocker.MagicMock()
-    co.export.begin_usb_export.emit = mocker.MagicMock()
+    begin_usb_export_emissions = QSignalSpy(co.export.begin_usb_export)
     file = factory.File(source=factory.Source())
     session.add(file)
     session.commit()
@@ -2573,7 +2560,7 @@ def test_Controller_export_file_to_usb_drive(homedir, mocker, session):
 
     co.export_file_to_usb_drive(file.uuid, "mock passphrase")
 
-    assert co.export.begin_usb_export.emit.call_count == 1
+    assert len(begin_usb_export_emissions) == 1
 
 
 def test_Controller_export_file_to_usb_drive_not_qubes(homedir, mocker, session):
@@ -2582,9 +2569,8 @@ def test_Controller_export_file_to_usb_drive_not_qubes(homedir, mocker, session)
     """
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
     co.qubes = False
-    co.export = mocker.MagicMock()
-    co.export.begin_usb_export = mocker.MagicMock()
-    co.export.begin_usb_export.emit = mocker.MagicMock()
+    begin_usb_export_emissions = QSignalSpy(co.export.begin_usb_export)
+    co.export.send_file_to_usb_device = mocker.MagicMock()
     file = factory.File(source=factory.Source())
     session.add(file)
     session.commit()
@@ -2598,7 +2584,7 @@ def test_Controller_export_file_to_usb_drive_not_qubes(homedir, mocker, session)
     co.export_file_to_usb_drive(file.uuid, "mock passphrase")
 
     co.export.send_file_to_usb_device.assert_not_called()
-    assert co.export.begin_usb_export.emit.call_count == 0
+    assert len(begin_usb_export_emissions) == 0
 
 
 def test_Controller_export_file_to_usb_drive_file_missing(homedir, mocker, session, session_maker):
@@ -2647,9 +2633,7 @@ def test_Controller_export_file_to_usb_drive_when_orig_file_already_exists(
     The signal `begin_usb_export` should still be emmited if the original file already exists.
     """
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
-    co.export = mocker.MagicMock()
-    co.export.begin_usb_export = mocker.MagicMock()
-    co.export.begin_usb_export.emit = mocker.MagicMock()
+    begin_usb_export_emissions = QSignalSpy(co.export.begin_usb_export)
     file = factory.File(source=factory.Source())
     session.add(file)
     session.commit()
@@ -2658,7 +2642,7 @@ def test_Controller_export_file_to_usb_drive_when_orig_file_already_exists(
 
     co.export_file_to_usb_drive(file.uuid, "mock passphrase")
 
-    assert co.export.begin_usb_export.emit.call_count == 1
+    assert len(begin_usb_export_emissions) == 1
     co.get_file.assert_called_with(file.uuid)
 
 
@@ -2670,9 +2654,7 @@ def test_Controller_export_file_to_usb_drive_when_orig_file_already_exists_not_q
     """
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
     co.qubes = False
-    co.export = mocker.MagicMock()
-    co.export.begin_usb_export = mocker.MagicMock()
-    co.export.begin_usb_export.emit = mocker.MagicMock()
+    begin_usb_export_emissions = QSignalSpy(co.export.begin_usb_export)
     file = factory.File(source=factory.Source())
     session.add(file)
     session.commit()
@@ -2685,7 +2667,7 @@ def test_Controller_export_file_to_usb_drive_when_orig_file_already_exists_not_q
 
     co.export_file_to_usb_drive(file.uuid, "mock passphrase")
 
-    assert co.export.begin_usb_export.emit.call_count == 0
+    assert len(begin_usb_export_emissions) == 0
     co.get_file.assert_called_with(file.uuid)
 
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -143,9 +143,9 @@ def test_Controller_call_api(homedir, config, mocker, session_maker):
     thread.started.connect.assert_called_once_with(runner.call_api)
     thread.start.assert_called_once_with()
     runner.moveToThread.assert_called_once_with(thread)
-    runner.call_succeeded.connect.call_count == 1
-    runner.call_failed.connect.call_count == 1
-    runner.call_timed_out.connect.call_count == 1
+    assert runner.call_succeeded.connect.call_count == 1
+    assert runner.call_failed.connect.call_count == 1
+    assert runner.call_timed_out.connect.call_count == 0
 
 
 def test_Controller_login(homedir, config, mocker, session_maker):
@@ -1474,7 +1474,7 @@ def test_Controller_on_file_decryption_failure(homedir, config, mocker, session,
     mock_file_ready.emit.assert_not_called()
     mock_update_error_status.assert_called_once_with("The file download failed. Please try again.")
 
-    co._submit_download_job.call_count == 1
+    assert co._submit_download_job.call_count == 0
     error_logger.call_args_list[0][0][0] == "Failed to decrypt {}".format(file_.uuid)
 
     mock_set_status.assert_not_called()
@@ -1713,7 +1713,7 @@ def test_Controller_on_reply_downloaded_checksum_failure(mocker, homedir, sessio
     reply_ready.emit.assert_not_called()
 
     # Job should get resubmitted and we should log this is happening
-    co._submit_download_job.call_count == 1
+    assert co._submit_download_job.call_count == 1
     warning_logger.call_args_list[0][0][
         0
     ] == "Failure due to checksum mismatch, retrying {}".format(reply.uuid)
@@ -1906,7 +1906,7 @@ def test_Controller_on_message_downloaded_checksum_failure(mocker, homedir, sess
     message_ready.emit.assert_not_called()
 
     # Job should get resubmitted and we should log this is happening
-    co._submit_download_job.call_count == 1
+    assert co._submit_download_job.call_count == 1
 
 
 def test_Controller_on_message_downloaded_decryption_failure(mocker, homedir, session_maker):
@@ -2378,7 +2378,7 @@ def test_Controller_run_printer_preflight_checks(homedir, mocker, session, sourc
 
     co.run_printer_preflight_checks()
 
-    co.export.begin_printer_preflight.emit.call_count == 1
+    assert co.export.begin_printer_preflight.emit.call_count == 1
 
 
 def test_Controller_run_printer_preflight_checks_not_qubes(homedir, mocker, session, source):
@@ -2392,8 +2392,8 @@ def test_Controller_run_printer_preflight_checks_not_qubes(homedir, mocker, sess
 
     co.run_printer_preflight_checks()
 
-    co.export.begin_printer_preflight.emit.call_count == 0
-    co.export.printer_preflight_success.emit.call_count == 1
+    assert co.export.begin_printer_preflight.emit.call_count == 0
+    assert co.export.printer_preflight_success.emit.call_count == 1
 
 
 def test_Controller_run_print_file(mocker, session, homedir):
@@ -2412,7 +2412,7 @@ def test_Controller_run_print_file(mocker, session, homedir):
 
     co.print_file(file.uuid)
 
-    co.export.begin_print.emit.call_count == 1
+    assert co.export.begin_print.emit.call_count == 1
 
 
 def test_Controller_run_print_file_not_qubes(mocker, session, homedir):
@@ -2433,7 +2433,7 @@ def test_Controller_run_print_file_not_qubes(mocker, session, homedir):
 
     co.print_file(file.uuid)
 
-    co.export.begin_print.emit.call_count == 0
+    assert co.export.begin_print.emit.call_count == 0
 
 
 def test_Controller_print_file_file_missing(homedir, mocker, session, session_maker):
@@ -2491,7 +2491,7 @@ def test_Controller_print_file_when_orig_file_already_exists(
 
     co.print_file(file.uuid)
 
-    co.export.begin_print.emit.call_count == 1
+    assert co.export.begin_print.emit.call_count == 1
     co.get_file.assert_called_with(file.uuid)
 
 
@@ -2518,7 +2518,7 @@ def test_Controller_print_file_when_orig_file_already_exists_not_qubes(
 
     co.export_file_to_usb_drive(file.uuid, "mock passphrase")
 
-    co.export.begin_print.emit.call_count == 1
+    assert co.export.begin_print.emit.call_count == 0
     co.get_file.assert_called_with(file.uuid)
 
 
@@ -2534,7 +2534,7 @@ def test_Controller_run_export_preflight_checks(homedir, mocker, session, source
 
     co.run_export_preflight_checks()
 
-    co.export.begin_usb_export.emit.call_count == 1
+    assert co.export.begin_preflight_check.emit.call_count == 1
 
 
 def test_Controller_run_export_preflight_checks_not_qubes(homedir, mocker, session, source):
@@ -2550,7 +2550,7 @@ def test_Controller_run_export_preflight_checks_not_qubes(homedir, mocker, sessi
 
     co.run_export_preflight_checks()
 
-    co.export.begin_usb_export.emit.call_count == 0
+    assert co.export.begin_preflight_check.emit.call_count == 0
 
 
 def test_Controller_export_file_to_usb_drive(homedir, mocker, session):
@@ -2573,7 +2573,7 @@ def test_Controller_export_file_to_usb_drive(homedir, mocker, session):
 
     co.export_file_to_usb_drive(file.uuid, "mock passphrase")
 
-    co.export.begin_usb_export.emit.call_count == 1
+    assert co.export.begin_usb_export.emit.call_count == 1
 
 
 def test_Controller_export_file_to_usb_drive_not_qubes(homedir, mocker, session):
@@ -2598,7 +2598,7 @@ def test_Controller_export_file_to_usb_drive_not_qubes(homedir, mocker, session)
     co.export_file_to_usb_drive(file.uuid, "mock passphrase")
 
     co.export.send_file_to_usb_device.assert_not_called()
-    co.export.begin_usb_export.emit.call_count == 0
+    assert co.export.begin_usb_export.emit.call_count == 0
 
 
 def test_Controller_export_file_to_usb_drive_file_missing(homedir, mocker, session, session_maker):
@@ -2658,7 +2658,7 @@ def test_Controller_export_file_to_usb_drive_when_orig_file_already_exists(
 
     co.export_file_to_usb_drive(file.uuid, "mock passphrase")
 
-    co.export.begin_usb_export.emit.call_count == 1
+    assert co.export.begin_usb_export.emit.call_count == 1
     co.get_file.assert_called_with(file.uuid)
 
 
@@ -2685,7 +2685,7 @@ def test_Controller_export_file_to_usb_drive_when_orig_file_already_exists_not_q
 
     co.export_file_to_usb_drive(file.uuid, "mock passphrase")
 
-    co.export.begin_usb_export.emit.call_count == 1
+    assert co.export.begin_usb_export.emit.call_count == 0
     co.get_file.assert_called_with(file.uuid)
 
 


### PR DESCRIPTION
# Description

Removes necessary mocking and increases the test ~coverage~ depth by relying on [`QSignalSpy`][docs] to test Qt signals.
Builds upon https://github.com/freedomofpress/securedrop-client/pull/1501

This is a preliminary step to extracting the "export" responsibility out of the `Controller`. (I wanted to make sure the tests were working as intended and slightly more compact before moving them over.)

  [docs]: https://doc.qt.io/qt-5/qsignalspy.html

:crystal_ball: **Reviewers**: once #1501 is merged, only the last commit will remain :slightly_smiling_face: 

# Test Plan

- [ ] Confirm that the meaning of the tests hasn't changed (good news: the tests are self-contained)
- [ ] Confirm that the test suite is green

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
