### PR TITLE
Ensure that action menu items are named using verbs, and capitalized consistently

### DIFF
--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -23,7 +23,7 @@ class DownloadConversation(QAction):
     ) -> None:
         self._controller = controller
         self._state = app_state
-        self._text = _("All Files")
+        self._text = _("Download All Files")
         super().__init__(self._text, parent)
         self.setShortcut(Qt.CTRL + Qt.Key_D)
         self.triggered.connect(self.on_triggered)
@@ -74,7 +74,7 @@ class DeleteSourceAction(QAction):
     ) -> None:
         self.source = source
         self.controller = controller
-        self.text = _("Entire source account")
+        self.text = _("Delete Source Account")
 
         super().__init__(self.text, parent)
 
@@ -105,7 +105,7 @@ class DeleteConversationAction(QAction):
         self.source = source
         self.controller = controller
         self._state = app_state
-        self.text = _("Files and messages")
+        self.text = _("Delete All Files and Messages")
 
         super().__init__(self.text, parent)
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3342,19 +3342,8 @@ class SourceMenu(QMenu):
         self.controller = controller
 
         self.setStyleSheet(self.SOURCE_MENU_CSS)
-        separator_font = QFont()
-        separator_font.setLetterSpacing(QFont.AbsoluteSpacing, 2)
-        separator_font.setBold(True)
-
-        download_section = self.addSection(_("DOWNLOAD"))
-        download_section.setFont(separator_font)
-        download_section.setObjectName("first_section")
 
         self.addAction(DownloadConversation(self, self.controller, app_state))
-
-        delete_section = self.addSection(_("DELETE"))
-        delete_section.setFont(separator_font)
-
         self.addAction(
             DeleteConversationAction(
                 self.source, self, self.controller, DeleteConversationDialog, app_state

--- a/securedrop_client/locale/messages.pot
+++ b/securedrop_client/locale/messages.pot
@@ -59,13 +59,13 @@ msgstr ""
 msgid "Failed to delete source at server"
 msgstr ""
 
-msgid "All Files"
+msgid "Download All Files"
 msgstr ""
 
-msgid "Entire source account"
+msgid "Delete Source Account"
 msgstr ""
 
-msgid "Files and messages"
+msgid "Delete All Files and Messages"
 msgstr ""
 
 msgid "SecureDrop Client {}"
@@ -161,9 +161,6 @@ msgid "Sign in"
 msgstr ""
 
 msgid " to compose or send a reply"
-msgstr ""
-
-msgid "DELETE"
 msgstr ""
 
 msgid "Username"

--- a/securedrop_client/resources/css/source_menu.css
+++ b/securedrop_client/resources/css/source_menu.css
@@ -4,17 +4,6 @@ QMenu {
     font-size: 16px;
 }
 
-QMenu::separator {
-    margin: 1.0em 1.75em 0.5em 1.675em;
-    height: 1em;
-    font-weight: 900;
-    color: #b8c0de;
-}
-
-QMenu::separator#first_section {
-    margin-top: 0.5em;
-}
-
 QMenu::item {
     padding: 0.5em 2em;
 }


### PR DESCRIPTION
# Description

Adopts a verb-based naming convention for **actions** available to journalists.
This prevents the apparition of identically named actions in close proximity and allows to simplify the existing menu.

It is a prelimiary step to prepare the ground for the "Export All Files" feature.
See details in #1504

Fixes #1504

## Preview

### Before
![conversation-menu-21](https://user-images.githubusercontent.com/1619067/171082165-615de3f0-2e63-463c-adad-373aaa47e91e.png)

### After
![conversation-menu-30](https://user-images.githubusercontent.com/1619067/171082418-699fc071-ca7b-4fd8-9015-4069c3c499eb.png)
![conversation-menu-31](https://user-images.githubusercontent.com/1619067/171082424-0b61cf74-e0ee-4ef4-9a8e-aa946a7dfb7f.png)

# Test Plan

- [ ] Confirm that the "Download All Files" action keeps working as usual (including getting disabled ~~while and~~ after the files have been downloaded)
- [ ] Confirm that the "Delete All Files and Messages" action keeps working as usual. (It didn't ever get disabled, see #1503)
- [ ] Confirm that the "Delete source Account" action keeps working as usual
- [ ] Confirm that no unused code / translatable strings / CSS remain
- [ ] Confirm that the menu entry items are named following a consistent pattern
- [ ] Confirm that the menu entry items names are capitalized consistently as well (Title Case in Action Menus)

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
