### PR TITLE
Refactor ensure signals are used as such

### DIFF
--- a/securedrop_client/gui/conversation/export/dialog.py
+++ b/securedrop_client/gui/conversation/export/dialog.py
@@ -34,10 +34,10 @@ class ExportDialog(ModalDialog):
         self.error_status = ""  # Hold onto the error status we receive from the Export VM
 
         # Connect controller signals to slots
-        self.controller.export.preflight_check_call_success.connect(self._on_preflight_success)
-        self.controller.export.preflight_check_call_failure.connect(self._on_preflight_failure)
-        self.controller.export.export_usb_call_success.connect(self._on_export_success)
-        self.controller.export.export_usb_call_failure.connect(self._on_export_failure)
+        self.controller.export_preflight_check_succeeded.connect(self._on_preflight_success)
+        self.controller.export_preflight_check_failed.connect(self._on_preflight_failure)
+        self.controller.export_succeeded.connect(self._on_export_success)
+        self.controller.export_failed.connect(self._on_export_failure)
 
         # Connect parent signals to slots
         self.continue_button.setEnabled(False)

--- a/securedrop_client/gui/conversation/export/dialog.py
+++ b/securedrop_client/gui/conversation/export/dialog.py
@@ -34,10 +34,14 @@ class ExportDialog(ModalDialog):
         self.error_status = ""  # Hold onto the error status we receive from the Export VM
 
         # Connect controller signals to slots
-        self.controller.export_preflight_check_succeeded.connect(self._on_preflight_success)
-        self.controller.export_preflight_check_failed.connect(self._on_preflight_failure)
-        self.controller.export_succeeded.connect(self._on_export_success)
-        self.controller.export_failed.connect(self._on_export_failure)
+        self.controller.export_preflight_check_succeeded.connect(
+            self._on_export_preflight_check_succeeded
+        )
+        self.controller.export_preflight_check_failed.connect(
+            self._on_export_preflight_check_failed
+        )
+        self.controller.export_succeeded.connect(self._on_export_succeeded)
+        self.controller.export_failed.connect(self._on_export_failed)
 
         # Connect parent signals to slots
         self.continue_button.setEnabled(False)
@@ -217,7 +221,7 @@ class ExportDialog(ModalDialog):
         self.controller.export_file_to_usb_drive(self.file_uuid, self.passphrase_field.text())
 
     @pyqtSlot()
-    def _on_preflight_success(self) -> None:
+    def _on_export_preflight_check_succeeded(self) -> None:
         # If the continue button is disabled then this is the result of a background preflight check
         self.stop_animate_header()
         self.header_icon.update_image("savetodisk.svg", QSize(64, 64))
@@ -232,18 +236,18 @@ class ExportDialog(ModalDialog):
         self._show_passphrase_request_message()
 
     @pyqtSlot(object)
-    def _on_preflight_failure(self, error: ExportError) -> None:
+    def _on_export_preflight_check_failed(self, error: ExportError) -> None:
         self.stop_animate_header()
         self.header_icon.update_image("savetodisk.svg", QSize(64, 64))
         self._update_dialog(error.status)
 
     @pyqtSlot()
-    def _on_export_success(self) -> None:
+    def _on_export_succeeded(self) -> None:
         self.stop_animate_activestate()
         self._show_success_message()
 
     @pyqtSlot(object)
-    def _on_export_failure(self, error: ExportError) -> None:
+    def _on_export_failed(self, error: ExportError) -> None:
         self.stop_animate_activestate()
         self.cancel_button.setEnabled(True)
         self.passphrase_field.setDisabled(False)

--- a/securedrop_client/gui/conversation/export/print_dialog.py
+++ b/securedrop_client/gui/conversation/export/print_dialog.py
@@ -22,8 +22,8 @@ class PrintDialog(ModalDialog):
         self.error_status = ""  # Hold onto the error status we receive from the Export VM
 
         # Connect controller signals to slots
-        self.controller.export.printer_preflight_success.connect(self._on_preflight_success)
-        self.controller.export.printer_preflight_failure.connect(self._on_preflight_failure)
+        self.controller.print_preflight_check_succeeded.connect(self._on_preflight_success)
+        self.controller.print_preflight_check_failed.connect(self._on_preflight_failure)
 
         # Connect parent signals to slots
         self.continue_button.setEnabled(False)

--- a/securedrop_client/gui/conversation/export/print_dialog.py
+++ b/securedrop_client/gui/conversation/export/print_dialog.py
@@ -22,8 +22,10 @@ class PrintDialog(ModalDialog):
         self.error_status = ""  # Hold onto the error status we receive from the Export VM
 
         # Connect controller signals to slots
-        self.controller.print_preflight_check_succeeded.connect(self._on_preflight_success)
-        self.controller.print_preflight_check_failed.connect(self._on_preflight_failure)
+        self.controller.print_preflight_check_succeeded.connect(
+            self._on_print_preflight_check_succeeded
+        )
+        self.controller.print_preflight_check_failed.connect(self._on_print_preflight_check_failed)
 
         # Connect parent signals to slots
         self.continue_button.setEnabled(False)
@@ -98,7 +100,7 @@ class PrintDialog(ModalDialog):
         self.close()
 
     @pyqtSlot()
-    def _on_preflight_success(self) -> None:
+    def _on_print_preflight_check_succeeded(self) -> None:
         # If the continue button is disabled then this is the result of a background preflight check
         self.stop_animate_header()
         self.header_icon.update_image("printer.svg", svg_size=QSize(64, 64))
@@ -113,7 +115,7 @@ class PrintDialog(ModalDialog):
         self._print_file()
 
     @pyqtSlot(object)
-    def _on_preflight_failure(self, error: ExportError) -> None:
+    def _on_print_preflight_check_failed(self, error: ExportError) -> None:
         self.stop_animate_header()
         self.header_icon.update_image("printer.svg", svg_size=QSize(64, 64))
         self.error_status = error.status

--- a/tests/gui/conversation/export/test_dialog.py
+++ b/tests/gui/conversation/export/test_dialog.py
@@ -177,13 +177,13 @@ def test_ExportDialog__export_file(mocker, export_dialog):
     )
 
 
-def test_ExportDialog__on_preflight_success(mocker, export_dialog):
+def test_ExportDialog__on_export_preflight_check_succeeded(mocker, export_dialog):
     export_dialog._show_passphrase_request_message = mocker.MagicMock()
     export_dialog.continue_button = mocker.MagicMock()
     export_dialog.continue_button.clicked = mocker.MagicMock()
     mocker.patch.object(export_dialog.continue_button, "isEnabled", return_value=False)
 
-    export_dialog._on_preflight_success()
+    export_dialog._on_export_preflight_check_succeeded()
 
     export_dialog._show_passphrase_request_message.assert_not_called()
     export_dialog.continue_button.clicked.connect.assert_called_once_with(
@@ -191,49 +191,55 @@ def test_ExportDialog__on_preflight_success(mocker, export_dialog):
     )
 
 
-def test_ExportDialog__on_preflight_success_when_continue_enabled(mocker, export_dialog):
+def test_ExportDialog__on_export_preflight_check_succeeded_when_continue_enabled(
+    mocker, export_dialog
+):
     export_dialog._show_passphrase_request_message = mocker.MagicMock()
     export_dialog.continue_button.setEnabled(True)
 
-    export_dialog._on_preflight_success()
+    export_dialog._on_export_preflight_check_succeeded()
 
     export_dialog._show_passphrase_request_message.assert_called_once_with()
 
 
-def test_ExportDialog__on_preflight_success_enabled_after_preflight_success(mocker, export_dialog):
+def test_ExportDialog__on_export_preflight_check_succeeded_enabled_after_preflight_success(
+    mocker, export_dialog
+):
     assert not export_dialog.continue_button.isEnabled()
-    export_dialog._on_preflight_success()
+    export_dialog._on_export_preflight_check_succeeded()
     assert export_dialog.continue_button.isEnabled()
 
 
-def test_ExportDialog__on_preflight_success_enabled_after_preflight_failure(mocker, export_dialog):
+def test_ExportDialog__on_export_preflight_check_succeeded_enabled_after_preflight_failure(
+    mocker, export_dialog
+):
     assert not export_dialog.continue_button.isEnabled()
-    export_dialog._on_preflight_failure(mocker.MagicMock())
+    export_dialog._on_export_preflight_check_failed(mocker.MagicMock())
     assert export_dialog.continue_button.isEnabled()
 
 
-def test_ExportDialog__on_preflight_failure(mocker, export_dialog):
+def test_ExportDialog__on_export_preflight_check_failed(mocker, export_dialog):
     export_dialog._update_dialog = mocker.MagicMock()
 
     error = ExportError("mock_error_status")
-    export_dialog._on_preflight_failure(error)
+    export_dialog._on_export_preflight_check_failed(error)
 
     export_dialog._update_dialog.assert_called_with("mock_error_status")
 
 
-def test_ExportDialog__on_export_success(mocker, export_dialog):
+def test_ExportDialog__on_export_succeeded(mocker, export_dialog):
     export_dialog._show_success_message = mocker.MagicMock()
 
-    export_dialog._on_export_success()
+    export_dialog._on_export_succeeded()
 
     export_dialog._show_success_message.assert_called_once_with()
 
 
-def test_ExportDialog__on_export_failure(mocker, export_dialog):
+def test_ExportDialog__on_export_failed(mocker, export_dialog):
     export_dialog._update_dialog = mocker.MagicMock()
 
     error = ExportError("mock_error_status")
-    export_dialog._on_export_failure(error)
+    export_dialog._on_export_failed(error)
 
     export_dialog._update_dialog.assert_called_with("mock_error_status")
 

--- a/tests/gui/conversation/export/test_print_dialog.py
+++ b/tests/gui/conversation/export/test_print_dialog.py
@@ -94,44 +94,46 @@ def test_PrintFileDialog__print_file(mocker, print_dialog):
     print_dialog.close.assert_called_once_with()
 
 
-def test_PrintFileDialog__on_preflight_success(mocker, print_dialog):
+def test_PrintFileDialog__on_print_preflight_check_succeeded(mocker, print_dialog):
     print_dialog._print_file = mocker.MagicMock()
     print_dialog.continue_button = mocker.MagicMock()
     print_dialog.continue_button.clicked = mocker.MagicMock()
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
 
-    print_dialog._on_preflight_success()
+    print_dialog._on_print_preflight_check_succeeded()
 
     print_dialog._print_file.assert_not_called()
     print_dialog.continue_button.clicked.connect.assert_called_once_with(print_dialog._print_file)
 
 
-def test_PrintFileDialog__on_preflight_success_when_continue_enabled(mocker, print_dialog):
+def test_PrintFileDialog__on_print_preflight_check_succeeded_when_continue_enabled(
+    mocker, print_dialog
+):
     print_dialog._print_file = mocker.MagicMock()
     print_dialog.continue_button.setEnabled(True)
 
-    print_dialog._on_preflight_success()
+    print_dialog._on_print_preflight_check_succeeded()
 
     print_dialog._print_file.assert_called_once_with()
 
 
-def test_PrintFileDialog__on_preflight_success_enabled_after_preflight_success(
+def test_PrintFileDialog__on_print_preflight_check_succeeded_enabled_after_preflight_success(
     mocker, print_dialog
 ):
     assert not print_dialog.continue_button.isEnabled()
-    print_dialog._on_preflight_success()
+    print_dialog._on_print_preflight_check_succeeded()
     assert print_dialog.continue_button.isEnabled()
 
 
-def test_PrintFileDialog__on_preflight_success_enabled_after_preflight_failure(
+def test_PrintFileDialog__on_print_preflight_check_succeeded_enabled_after_preflight_failure(
     mocker, print_dialog
 ):
     assert not print_dialog.continue_button.isEnabled()
-    print_dialog._on_preflight_failure(mocker.MagicMock())
+    print_dialog._on_print_preflight_check_failed(mocker.MagicMock())
     assert print_dialog.continue_button.isEnabled()
 
 
-def test_PrintFileDialog__on_preflight_failure_when_status_is_PRINTER_NOT_FOUND(
+def test_PrintFileDialog__on_print_preflight_check_failed_when_status_is_PRINTER_NOT_FOUND(
     mocker, print_dialog
 ):
     print_dialog._show_insert_usb_message = mocker.MagicMock()
@@ -140,18 +142,18 @@ def test_PrintFileDialog__on_preflight_failure_when_status_is_PRINTER_NOT_FOUND(
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
 
     # When the continue button is enabled, ensure clicking continue will show next instructions
-    print_dialog._on_preflight_failure(ExportError(ExportStatus.PRINTER_NOT_FOUND.value))
+    print_dialog._on_print_preflight_check_failed(ExportError(ExportStatus.PRINTER_NOT_FOUND.value))
     print_dialog.continue_button.clicked.connect.assert_called_once_with(
         print_dialog._show_insert_usb_message
     )
 
     # When the continue button is enabled, ensure next instructions are shown
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=True)
-    print_dialog._on_preflight_failure(ExportError(ExportStatus.PRINTER_NOT_FOUND.value))
+    print_dialog._on_print_preflight_check_failed(ExportError(ExportStatus.PRINTER_NOT_FOUND.value))
     print_dialog._show_insert_usb_message.assert_called_once_with()
 
 
-def test_PrintFileDialog__on_preflight_failure_when_status_is_MISSING_PRINTER_URI(
+def test_PrintFileDialog__on_print_preflight_check_failed_when_status_is_MISSING_PRINTER_URI(
     mocker, print_dialog
 ):
     print_dialog._show_generic_error_message = mocker.MagicMock()
@@ -160,7 +162,9 @@ def test_PrintFileDialog__on_preflight_failure_when_status_is_MISSING_PRINTER_UR
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
 
     # When the continue button is enabled, ensure clicking continue will show next instructions
-    print_dialog._on_preflight_failure(ExportError(ExportStatus.MISSING_PRINTER_URI.value))
+    print_dialog._on_print_preflight_check_failed(
+        ExportError(ExportStatus.MISSING_PRINTER_URI.value)
+    )
     print_dialog.continue_button.clicked.connect.assert_called_once_with(
         print_dialog._show_generic_error_message
     )
@@ -168,12 +172,14 @@ def test_PrintFileDialog__on_preflight_failure_when_status_is_MISSING_PRINTER_UR
 
     # When the continue button is enabled, ensure next instructions are shown
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=True)
-    print_dialog._on_preflight_failure(ExportError(ExportStatus.MISSING_PRINTER_URI.value))
+    print_dialog._on_print_preflight_check_failed(
+        ExportError(ExportStatus.MISSING_PRINTER_URI.value)
+    )
     print_dialog._show_generic_error_message.assert_called_once_with()
     assert print_dialog.error_status == ExportStatus.MISSING_PRINTER_URI.value
 
 
-def test_PrintFileDialog__on_preflight_failure_when_status_is_CALLED_PROCESS_ERROR(
+def test_PrintFileDialog__on_print_preflight_check_failed_when_status_is_CALLED_PROCESS_ERROR(
     mocker, print_dialog
 ):
     print_dialog._show_generic_error_message = mocker.MagicMock()
@@ -182,7 +188,9 @@ def test_PrintFileDialog__on_preflight_failure_when_status_is_CALLED_PROCESS_ERR
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
 
     # When the continue button is enabled, ensure clicking continue will show next instructions
-    print_dialog._on_preflight_failure(ExportError(ExportStatus.CALLED_PROCESS_ERROR.value))
+    print_dialog._on_print_preflight_check_failed(
+        ExportError(ExportStatus.CALLED_PROCESS_ERROR.value)
+    )
     print_dialog.continue_button.clicked.connect.assert_called_once_with(
         print_dialog._show_generic_error_message
     )
@@ -190,19 +198,23 @@ def test_PrintFileDialog__on_preflight_failure_when_status_is_CALLED_PROCESS_ERR
 
     # When the continue button is enabled, ensure next instructions are shown
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=True)
-    print_dialog._on_preflight_failure(ExportError(ExportStatus.CALLED_PROCESS_ERROR.value))
+    print_dialog._on_print_preflight_check_failed(
+        ExportError(ExportStatus.CALLED_PROCESS_ERROR.value)
+    )
     print_dialog._show_generic_error_message.assert_called_once_with()
     assert print_dialog.error_status == ExportStatus.CALLED_PROCESS_ERROR.value
 
 
-def test_PrintFileDialog__on_preflight_failure_when_status_is_unknown(mocker, print_dialog):
+def test_PrintFileDialog__on_print_preflight_check_failed_when_status_is_unknown(
+    mocker, print_dialog
+):
     print_dialog._show_generic_error_message = mocker.MagicMock()
     print_dialog.continue_button = mocker.MagicMock()
     print_dialog.continue_button.clicked = mocker.MagicMock()
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
 
     # When the continue button is enabled, ensure clicking continue will show next instructions
-    print_dialog._on_preflight_failure(ExportError("Some Unknown Error Status"))
+    print_dialog._on_print_preflight_check_failed(ExportError("Some Unknown Error Status"))
     print_dialog.continue_button.clicked.connect.assert_called_once_with(
         print_dialog._show_generic_error_message
     )
@@ -210,6 +222,6 @@ def test_PrintFileDialog__on_preflight_failure_when_status_is_unknown(mocker, pr
 
     # When the continue button is enabled, ensure next instructions are shown
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=True)
-    print_dialog._on_preflight_failure(ExportError("Some Unknown Error Status"))
+    print_dialog._on_print_preflight_check_failed(ExportError("Some Unknown Error Status"))
     print_dialog._show_generic_error_message.assert_called_once_with()
     assert print_dialog.error_status == "Some Unknown Error Status"


### PR DESCRIPTION
# Description

The controller used to imperatively emit signals on the Export instances. This breaks the encapsulation provided by the Export class and defeats one of the main benefits of using signal: de-coupling components.

That, in turn, is one of the situations that made it more difficult for me to wrap my head around this code.

From Qt's documentation:

>  Signals are public access functions and can be emitted
    from anywhere, but we recommend to only emit them
    from the class that defines the signal and its subclasses.

The controller now emits a signal indicating that a preflight check is desirable (for example) and the Export instance connects its own slots to that signal.

See https://doc.qt.io/qt-5/signalsandslots.html

**Note**: As soon as we think of signals as a representation of events, it becomes a lot easier to conventionally name them as past tense phrases (e.g. `some_event_happened`), like we've been trying to do for a little while.

# Test Plan

- [ ] Confirm that the signal names are meaningful _(I think they make a lot more sense than they used to, if we think of them as _events_ that happened, which is how Qt uses them everywhere.)_
- [ ] Verify that the test suite is green :green_apple: 
- [ ] Confirm that you can export a file as usual
- [ ] Confirm that you can print a file as usual

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [x] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [x] I need help writing a database migration
 - [ ] No database schema changes are needed
