### PR TITLE
Refactor ensure signals are used as recommended by Qt

### DIFF
--- a/securedrop_client/gui/conversation/export/dialog.py
+++ b/securedrop_client/gui/conversation/export/dialog.py
@@ -34,10 +34,10 @@ class ExportDialog(ModalDialog):
         self.error_status = ""  # Hold onto the error status we receive from the Export VM
 
         # Connect controller signals to slots
-        self.controller.export.preflight_check_call_success.connect(self._on_preflight_success)
-        self.controller.export.preflight_check_call_failure.connect(self._on_preflight_failure)
-        self.controller.export.export_usb_call_success.connect(self._on_export_success)
-        self.controller.export.export_usb_call_failure.connect(self._on_export_failure)
+        self.controller.export_preflight_check_succeeded.connect(self._on_preflight_success)
+        self.controller.export_preflight_check_failed.connect(self._on_preflight_failure)
+        self.controller.export_succeeded.connect(self._on_export_success)
+        self.controller.export_failed.connect(self._on_export_failure)
 
         # Connect parent signals to slots
         self.continue_button.setEnabled(False)

--- a/securedrop_client/gui/conversation/export/dialog.py
+++ b/securedrop_client/gui/conversation/export/dialog.py
@@ -34,10 +34,14 @@ class ExportDialog(ModalDialog):
         self.error_status = ""  # Hold onto the error status we receive from the Export VM
 
         # Connect controller signals to slots
-        self.controller.export_preflight_check_succeeded.connect(self._on_preflight_success)
-        self.controller.export_preflight_check_failed.connect(self._on_preflight_failure)
-        self.controller.export_succeeded.connect(self._on_export_success)
-        self.controller.export_failed.connect(self._on_export_failure)
+        self.controller.export_preflight_check_succeeded.connect(
+            self._on_export_preflight_check_succeeded
+        )
+        self.controller.export_preflight_check_failed.connect(
+            self._on_export_preflight_check_failed
+        )
+        self.controller.export_succeeded.connect(self._on_export_succeeded)
+        self.controller.export_failed.connect(self._on_export_failed)
 
         # Connect parent signals to slots
         self.continue_button.setEnabled(False)
@@ -217,7 +221,7 @@ class ExportDialog(ModalDialog):
         self.controller.export_file_to_usb_drive(self.file_uuid, self.passphrase_field.text())
 
     @pyqtSlot()
-    def _on_preflight_success(self) -> None:
+    def _on_export_preflight_check_succeeded(self) -> None:
         # If the continue button is disabled then this is the result of a background preflight check
         self.stop_animate_header()
         self.header_icon.update_image("savetodisk.svg", QSize(64, 64))
@@ -232,18 +236,18 @@ class ExportDialog(ModalDialog):
         self._show_passphrase_request_message()
 
     @pyqtSlot(object)
-    def _on_preflight_failure(self, error: ExportError) -> None:
+    def _on_export_preflight_check_failed(self, error: ExportError) -> None:
         self.stop_animate_header()
         self.header_icon.update_image("savetodisk.svg", QSize(64, 64))
         self._update_dialog(error.status)
 
     @pyqtSlot()
-    def _on_export_success(self) -> None:
+    def _on_export_succeeded(self) -> None:
         self.stop_animate_activestate()
         self._show_success_message()
 
     @pyqtSlot(object)
-    def _on_export_failure(self, error: ExportError) -> None:
+    def _on_export_failed(self, error: ExportError) -> None:
         self.stop_animate_activestate()
         self.cancel_button.setEnabled(True)
         self.passphrase_field.setDisabled(False)

--- a/securedrop_client/gui/conversation/export/print_dialog.py
+++ b/securedrop_client/gui/conversation/export/print_dialog.py
@@ -22,8 +22,8 @@ class PrintDialog(ModalDialog):
         self.error_status = ""  # Hold onto the error status we receive from the Export VM
 
         # Connect controller signals to slots
-        self.controller.export.printer_preflight_success.connect(self._on_preflight_success)
-        self.controller.export.printer_preflight_failure.connect(self._on_preflight_failure)
+        self.controller.print_preflight_check_succeeded.connect(self._on_preflight_success)
+        self.controller.print_preflight_check_failed.connect(self._on_preflight_failure)
 
         # Connect parent signals to slots
         self.continue_button.setEnabled(False)

--- a/securedrop_client/gui/conversation/export/print_dialog.py
+++ b/securedrop_client/gui/conversation/export/print_dialog.py
@@ -22,8 +22,10 @@ class PrintDialog(ModalDialog):
         self.error_status = ""  # Hold onto the error status we receive from the Export VM
 
         # Connect controller signals to slots
-        self.controller.print_preflight_check_succeeded.connect(self._on_preflight_success)
-        self.controller.print_preflight_check_failed.connect(self._on_preflight_failure)
+        self.controller.print_preflight_check_succeeded.connect(
+            self._on_print_preflight_check_succeeded
+        )
+        self.controller.print_preflight_check_failed.connect(self._on_print_preflight_check_failed)
 
         # Connect parent signals to slots
         self.continue_button.setEnabled(False)
@@ -98,7 +100,7 @@ class PrintDialog(ModalDialog):
         self.close()
 
     @pyqtSlot()
-    def _on_preflight_success(self) -> None:
+    def _on_print_preflight_check_succeeded(self) -> None:
         # If the continue button is disabled then this is the result of a background preflight check
         self.stop_animate_header()
         self.header_icon.update_image("printer.svg", svg_size=QSize(64, 64))
@@ -113,7 +115,7 @@ class PrintDialog(ModalDialog):
         self._print_file()
 
     @pyqtSlot(object)
-    def _on_preflight_failure(self, error: ExportError) -> None:
+    def _on_print_preflight_check_failed(self, error: ExportError) -> None:
         self.stop_animate_header()
         self.header_icon.update_image("printer.svg", svg_size=QSize(64, 64))
         self.error_status = error.status

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -310,6 +310,23 @@ class Controller(QObject):
     """
     add_job = pyqtSignal("PyQt_PyObject")
 
+    export_preflight_check_requested = pyqtSignal()
+    export_preflight_check_succeeded = pyqtSignal()
+    export_preflight_check_failed = pyqtSignal(object)
+
+    export_requested = pyqtSignal(list, str)
+    export_succeeded = pyqtSignal()
+    export_failed = pyqtSignal(object)
+    export_completed = pyqtSignal(list)
+
+    print_preflight_check_requested = pyqtSignal()
+    print_preflight_check_succeeded = pyqtSignal()
+    print_preflight_check_failed = pyqtSignal(object)
+
+    print_requested = pyqtSignal(list)
+    print_succeeded = pyqtSignal()
+    print_failed = pyqtSignal(object)
+
     def __init__(  # type: ignore [no-untyped-def]
         self,
         hostname: str,
@@ -369,7 +386,26 @@ class Controller(QObject):
 
         self.gpg = GpgHelper(home, self.session_maker, proxy)
 
-        self.export = Export()
+        self.export = Export(
+            self.export_preflight_check_requested,
+            self.export_requested,
+            self.print_preflight_check_requested,
+            self.print_requested,
+        )
+
+        # Abstract the Export instance away from the GUI
+        self.export.preflight_check_call_success.connect(self.export_preflight_check_succeeded)
+        self.export.preflight_check_call_failure.connect(self.export_preflight_check_failed)
+
+        self.export.export_usb_call_success.connect(self.export_succeeded)
+        self.export.export_usb_call_failure.connect(self.export_failed)
+        self.export.export_completed.connect(self.export_completed)
+
+        self.export.printer_preflight_success.connect(self.print_preflight_check_succeeded)
+        self.export.printer_preflight_failure.connect(self.print_preflight_check_failed)
+
+        self.export.print_call_failure.connect(self.print_failed)
+        self.export.print_call_success.connect(self.print_succeeded)
 
         # File data.
         self.data_dir = os.path.join(self.home, "data")
@@ -936,10 +972,10 @@ class Controller(QObject):
         logger.info("Running printer preflight check")
 
         if not self.qubes:
-            self.export.printer_preflight_success.emit()
+            self.print_preflight_check_succeeded.emit()
             return
 
-        self.export.begin_printer_preflight.emit()
+        self.print_preflight_check_requested.emit()
 
     def run_export_preflight_checks(self) -> None:
         """
@@ -948,10 +984,10 @@ class Controller(QObject):
         logger.info("Running export preflight check")
 
         if not self.qubes:
-            self.export.preflight_check_call_success.emit()
+            self.export_preflight_check_succeeded.emit()
             return
 
-        self.export.begin_preflight_check.emit()
+        self.export_preflight_check_requested.emit()
 
     def export_file_to_usb_drive(self, file_uuid: str, passphrase: str) -> None:
         """
@@ -967,10 +1003,10 @@ class Controller(QObject):
             return
 
         if not self.qubes:
-            self.export.export_usb_call_success.emit()
+            self.export_succeeded.emit()
             return
 
-        self.export.begin_usb_export.emit([file_location], passphrase)
+        self.export_requested.emit([file_location], passphrase)
 
     def print_file(self, file_uuid: str) -> None:
         """
@@ -987,7 +1023,7 @@ class Controller(QObject):
         if not self.qubes:
             return
 
-        self.export.begin_print.emit([file_location])
+        self.print_requested.emit([file_location])
 
     @login_required
     def on_submission_download(

--- a/tests/gui/conversation/export/test_dialog.py
+++ b/tests/gui/conversation/export/test_dialog.py
@@ -177,13 +177,13 @@ def test_ExportDialog__export_file(mocker, export_dialog):
     )
 
 
-def test_ExportDialog__on_preflight_success(mocker, export_dialog):
+def test_ExportDialog__on_export_preflight_check_succeeded(mocker, export_dialog):
     export_dialog._show_passphrase_request_message = mocker.MagicMock()
     export_dialog.continue_button = mocker.MagicMock()
     export_dialog.continue_button.clicked = mocker.MagicMock()
     mocker.patch.object(export_dialog.continue_button, "isEnabled", return_value=False)
 
-    export_dialog._on_preflight_success()
+    export_dialog._on_export_preflight_check_succeeded()
 
     export_dialog._show_passphrase_request_message.assert_not_called()
     export_dialog.continue_button.clicked.connect.assert_called_once_with(
@@ -191,49 +191,55 @@ def test_ExportDialog__on_preflight_success(mocker, export_dialog):
     )
 
 
-def test_ExportDialog__on_preflight_success_when_continue_enabled(mocker, export_dialog):
+def test_ExportDialog__on_export_preflight_check_succeeded_when_continue_enabled(
+    mocker, export_dialog
+):
     export_dialog._show_passphrase_request_message = mocker.MagicMock()
     export_dialog.continue_button.setEnabled(True)
 
-    export_dialog._on_preflight_success()
+    export_dialog._on_export_preflight_check_succeeded()
 
     export_dialog._show_passphrase_request_message.assert_called_once_with()
 
 
-def test_ExportDialog__on_preflight_success_enabled_after_preflight_success(mocker, export_dialog):
+def test_ExportDialog__on_export_preflight_check_succeeded_enabled_after_preflight_success(
+    mocker, export_dialog
+):
     assert not export_dialog.continue_button.isEnabled()
-    export_dialog._on_preflight_success()
+    export_dialog._on_export_preflight_check_succeeded()
     assert export_dialog.continue_button.isEnabled()
 
 
-def test_ExportDialog__on_preflight_success_enabled_after_preflight_failure(mocker, export_dialog):
+def test_ExportDialog__on_export_preflight_check_succeeded_enabled_after_preflight_failure(
+    mocker, export_dialog
+):
     assert not export_dialog.continue_button.isEnabled()
-    export_dialog._on_preflight_failure(mocker.MagicMock())
+    export_dialog._on_export_preflight_check_failed(mocker.MagicMock())
     assert export_dialog.continue_button.isEnabled()
 
 
-def test_ExportDialog__on_preflight_failure(mocker, export_dialog):
+def test_ExportDialog__on_export_preflight_check_failed(mocker, export_dialog):
     export_dialog._update_dialog = mocker.MagicMock()
 
     error = ExportError("mock_error_status")
-    export_dialog._on_preflight_failure(error)
+    export_dialog._on_export_preflight_check_failed(error)
 
     export_dialog._update_dialog.assert_called_with("mock_error_status")
 
 
-def test_ExportDialog__on_export_success(mocker, export_dialog):
+def test_ExportDialog__on_export_succeeded(mocker, export_dialog):
     export_dialog._show_success_message = mocker.MagicMock()
 
-    export_dialog._on_export_success()
+    export_dialog._on_export_succeeded()
 
     export_dialog._show_success_message.assert_called_once_with()
 
 
-def test_ExportDialog__on_export_failure(mocker, export_dialog):
+def test_ExportDialog__on_export_failed(mocker, export_dialog):
     export_dialog._update_dialog = mocker.MagicMock()
 
     error = ExportError("mock_error_status")
-    export_dialog._on_export_failure(error)
+    export_dialog._on_export_failed(error)
 
     export_dialog._update_dialog.assert_called_with("mock_error_status")
 

--- a/tests/gui/conversation/export/test_print_dialog.py
+++ b/tests/gui/conversation/export/test_print_dialog.py
@@ -94,44 +94,46 @@ def test_PrintFileDialog__print_file(mocker, print_dialog):
     print_dialog.close.assert_called_once_with()
 
 
-def test_PrintFileDialog__on_preflight_success(mocker, print_dialog):
+def test_PrintFileDialog__on_print_preflight_check_succeeded(mocker, print_dialog):
     print_dialog._print_file = mocker.MagicMock()
     print_dialog.continue_button = mocker.MagicMock()
     print_dialog.continue_button.clicked = mocker.MagicMock()
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
 
-    print_dialog._on_preflight_success()
+    print_dialog._on_print_preflight_check_succeeded()
 
     print_dialog._print_file.assert_not_called()
     print_dialog.continue_button.clicked.connect.assert_called_once_with(print_dialog._print_file)
 
 
-def test_PrintFileDialog__on_preflight_success_when_continue_enabled(mocker, print_dialog):
+def test_PrintFileDialog__on_print_preflight_check_succeeded_when_continue_enabled(
+    mocker, print_dialog
+):
     print_dialog._print_file = mocker.MagicMock()
     print_dialog.continue_button.setEnabled(True)
 
-    print_dialog._on_preflight_success()
+    print_dialog._on_print_preflight_check_succeeded()
 
     print_dialog._print_file.assert_called_once_with()
 
 
-def test_PrintFileDialog__on_preflight_success_enabled_after_preflight_success(
+def test_PrintFileDialog__on_print_preflight_check_succeeded_enabled_after_preflight_success(
     mocker, print_dialog
 ):
     assert not print_dialog.continue_button.isEnabled()
-    print_dialog._on_preflight_success()
+    print_dialog._on_print_preflight_check_succeeded()
     assert print_dialog.continue_button.isEnabled()
 
 
-def test_PrintFileDialog__on_preflight_success_enabled_after_preflight_failure(
+def test_PrintFileDialog__on_print_preflight_check_succeeded_enabled_after_preflight_failure(
     mocker, print_dialog
 ):
     assert not print_dialog.continue_button.isEnabled()
-    print_dialog._on_preflight_failure(mocker.MagicMock())
+    print_dialog._on_print_preflight_check_failed(mocker.MagicMock())
     assert print_dialog.continue_button.isEnabled()
 
 
-def test_PrintFileDialog__on_preflight_failure_when_status_is_PRINTER_NOT_FOUND(
+def test_PrintFileDialog__on_print_preflight_check_failed_when_status_is_PRINTER_NOT_FOUND(
     mocker, print_dialog
 ):
     print_dialog._show_insert_usb_message = mocker.MagicMock()
@@ -140,18 +142,18 @@ def test_PrintFileDialog__on_preflight_failure_when_status_is_PRINTER_NOT_FOUND(
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
 
     # When the continue button is enabled, ensure clicking continue will show next instructions
-    print_dialog._on_preflight_failure(ExportError(ExportStatus.PRINTER_NOT_FOUND.value))
+    print_dialog._on_print_preflight_check_failed(ExportError(ExportStatus.PRINTER_NOT_FOUND.value))
     print_dialog.continue_button.clicked.connect.assert_called_once_with(
         print_dialog._show_insert_usb_message
     )
 
     # When the continue button is enabled, ensure next instructions are shown
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=True)
-    print_dialog._on_preflight_failure(ExportError(ExportStatus.PRINTER_NOT_FOUND.value))
+    print_dialog._on_print_preflight_check_failed(ExportError(ExportStatus.PRINTER_NOT_FOUND.value))
     print_dialog._show_insert_usb_message.assert_called_once_with()
 
 
-def test_PrintFileDialog__on_preflight_failure_when_status_is_MISSING_PRINTER_URI(
+def test_PrintFileDialog__on_print_preflight_check_failed_when_status_is_MISSING_PRINTER_URI(
     mocker, print_dialog
 ):
     print_dialog._show_generic_error_message = mocker.MagicMock()
@@ -160,7 +162,9 @@ def test_PrintFileDialog__on_preflight_failure_when_status_is_MISSING_PRINTER_UR
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
 
     # When the continue button is enabled, ensure clicking continue will show next instructions
-    print_dialog._on_preflight_failure(ExportError(ExportStatus.MISSING_PRINTER_URI.value))
+    print_dialog._on_print_preflight_check_failed(
+        ExportError(ExportStatus.MISSING_PRINTER_URI.value)
+    )
     print_dialog.continue_button.clicked.connect.assert_called_once_with(
         print_dialog._show_generic_error_message
     )
@@ -168,12 +172,14 @@ def test_PrintFileDialog__on_preflight_failure_when_status_is_MISSING_PRINTER_UR
 
     # When the continue button is enabled, ensure next instructions are shown
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=True)
-    print_dialog._on_preflight_failure(ExportError(ExportStatus.MISSING_PRINTER_URI.value))
+    print_dialog._on_print_preflight_check_failed(
+        ExportError(ExportStatus.MISSING_PRINTER_URI.value)
+    )
     print_dialog._show_generic_error_message.assert_called_once_with()
     assert print_dialog.error_status == ExportStatus.MISSING_PRINTER_URI.value
 
 
-def test_PrintFileDialog__on_preflight_failure_when_status_is_CALLED_PROCESS_ERROR(
+def test_PrintFileDialog__on_print_preflight_check_failed_when_status_is_CALLED_PROCESS_ERROR(
     mocker, print_dialog
 ):
     print_dialog._show_generic_error_message = mocker.MagicMock()
@@ -182,7 +188,9 @@ def test_PrintFileDialog__on_preflight_failure_when_status_is_CALLED_PROCESS_ERR
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
 
     # When the continue button is enabled, ensure clicking continue will show next instructions
-    print_dialog._on_preflight_failure(ExportError(ExportStatus.CALLED_PROCESS_ERROR.value))
+    print_dialog._on_print_preflight_check_failed(
+        ExportError(ExportStatus.CALLED_PROCESS_ERROR.value)
+    )
     print_dialog.continue_button.clicked.connect.assert_called_once_with(
         print_dialog._show_generic_error_message
     )
@@ -190,19 +198,23 @@ def test_PrintFileDialog__on_preflight_failure_when_status_is_CALLED_PROCESS_ERR
 
     # When the continue button is enabled, ensure next instructions are shown
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=True)
-    print_dialog._on_preflight_failure(ExportError(ExportStatus.CALLED_PROCESS_ERROR.value))
+    print_dialog._on_print_preflight_check_failed(
+        ExportError(ExportStatus.CALLED_PROCESS_ERROR.value)
+    )
     print_dialog._show_generic_error_message.assert_called_once_with()
     assert print_dialog.error_status == ExportStatus.CALLED_PROCESS_ERROR.value
 
 
-def test_PrintFileDialog__on_preflight_failure_when_status_is_unknown(mocker, print_dialog):
+def test_PrintFileDialog__on_print_preflight_check_failed_when_status_is_unknown(
+    mocker, print_dialog
+):
     print_dialog._show_generic_error_message = mocker.MagicMock()
     print_dialog.continue_button = mocker.MagicMock()
     print_dialog.continue_button.clicked = mocker.MagicMock()
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
 
     # When the continue button is enabled, ensure clicking continue will show next instructions
-    print_dialog._on_preflight_failure(ExportError("Some Unknown Error Status"))
+    print_dialog._on_print_preflight_check_failed(ExportError("Some Unknown Error Status"))
     print_dialog.continue_button.clicked.connect.assert_called_once_with(
         print_dialog._show_generic_error_message
     )
@@ -210,6 +222,6 @@ def test_PrintFileDialog__on_preflight_failure_when_status_is_unknown(mocker, pr
 
     # When the continue button is enabled, ensure next instructions are shown
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=True)
-    print_dialog._on_preflight_failure(ExportError("Some Unknown Error Status"))
+    print_dialog._on_print_preflight_check_failed(ExportError("Some Unknown Error Status"))
     print_dialog._show_generic_error_message.assert_called_once_with()
     assert print_dialog.error_status == "Some Unknown Error Status"

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -2376,28 +2376,28 @@ def test_Controller_call_update_star_success(homedir, config, mocker, session_ma
 
 def test_Controller_run_printer_preflight_checks(homedir, mocker, session, source):
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
-    begin_printer_preflight_emissions = QSignalSpy(co.export.begin_printer_preflight)
+    print_preflight_check_requested_emissions = QSignalSpy(co.print_preflight_check_requested)
 
     co.run_printer_preflight_checks()
 
-    assert len(begin_printer_preflight_emissions) == 1
+    assert len(print_preflight_check_requested_emissions) == 1
 
 
 def test_Controller_run_printer_preflight_checks_not_qubes(homedir, mocker, session, source):
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
     co.qubes = False
-    begin_printer_preflight_emissions = QSignalSpy(co.export.begin_printer_preflight)
-    printer_preflight_success_emissions = QSignalSpy(co.export.printer_preflight_success)
+    print_preflight_check_requested_emissions = QSignalSpy(co.print_preflight_check_requested)
+    print_preflight_check_succeeded_emissions = QSignalSpy(co.print_preflight_check_succeeded)
 
     co.run_printer_preflight_checks()
 
-    assert len(begin_printer_preflight_emissions) == 0
-    assert len(printer_preflight_success_emissions) == 1
+    assert len(print_preflight_check_requested_emissions) == 0
+    assert len(print_preflight_check_succeeded_emissions) == 1
 
 
 def test_Controller_run_print_file(mocker, session, homedir):
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
-    begin_print_emissions = QSignalSpy(co.export.begin_print)
+    print_requested_emissions = QSignalSpy(co.print_requested)
     file = factory.File(source=factory.Source())
     session.add(file)
     session.commit()
@@ -2410,13 +2410,13 @@ def test_Controller_run_print_file(mocker, session, homedir):
 
     co.print_file(file.uuid)
 
-    assert len(begin_print_emissions) == 1
+    assert len(print_requested_emissions) == 1
 
 
 def test_Controller_run_print_file_not_qubes(mocker, session, homedir):
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
     co.qubes = False
-    begin_print_emissions = QSignalSpy(co.export.begin_print)
+    print_requested_emissions = QSignalSpy(co.print_requested)
     file = factory.File(source=factory.Source())
     session.add(file)
     session.commit()
@@ -2429,7 +2429,7 @@ def test_Controller_run_print_file_not_qubes(mocker, session, homedir):
 
     co.print_file(file.uuid)
 
-    assert len(begin_print_emissions) == 0
+    assert len(print_requested_emissions) == 0
 
 
 def test_Controller_print_file_file_missing(homedir, mocker, session, session_maker):
@@ -2473,11 +2473,11 @@ def test_Controller_print_file_when_orig_file_already_exists(
     homedir, config, mocker, session, session_maker, source
 ):
     """
-    The signal `begin_print` should still be emmited if the original file already exists.
+    The signal `print_requested` should still be emmited if the original file already exists.
     """
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
     file = factory.File(source=factory.Source())
-    begin_print_emissions = QSignalSpy(co.export.begin_print)
+    print_requested_emissions = QSignalSpy(co.print_requested)
     session.add(file)
     session.commit()
     mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
@@ -2485,7 +2485,7 @@ def test_Controller_print_file_when_orig_file_already_exists(
 
     co.print_file(file.uuid)
 
-    assert len(begin_print_emissions) == 1
+    assert len(print_requested_emissions) == 1
     co.get_file.assert_called_with(file.uuid)
 
 
@@ -2493,11 +2493,11 @@ def test_Controller_print_file_when_orig_file_already_exists_not_qubes(
     homedir, config, mocker, session, session_maker, source
 ):
     """
-    The signal `begin_print` should still be emmited if the original file already exists.
+    The signal `print_requested` should still be emmited if the original file already exists.
     """
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
     co.qubes = False
-    begin_print_emissions = QSignalSpy(co.export.begin_print)
+    print_requested_emissions = QSignalSpy(co.print_requested)
     file = factory.File(source=factory.Source())
     session.add(file)
     session.commit()
@@ -2510,14 +2510,14 @@ def test_Controller_print_file_when_orig_file_already_exists_not_qubes(
 
     co.export_file_to_usb_drive(file.uuid, "mock passphrase")
 
-    assert len(begin_print_emissions) == 0
+    assert len(print_requested_emissions) == 0
     co.get_file.assert_called_with(file.uuid)
     co.get_file.assert_called_with(file.uuid)
 
 
 def test_Controller_run_export_preflight_checks(homedir, mocker, session, source):
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
-    begin_preflight_check_emissions = QSignalSpy(co.export.begin_preflight_check)
+    export_preflight_check_requested_emissions = QSignalSpy(co.export_preflight_check_requested)
     file = factory.File(source=source["source"])
     session.add(file)
     session.commit()
@@ -2525,13 +2525,14 @@ def test_Controller_run_export_preflight_checks(homedir, mocker, session, source
 
     co.run_export_preflight_checks()
 
-    assert len(begin_preflight_check_emissions) == 1
+    assert len(export_preflight_check_requested_emissions) == 1
 
 
 def test_Controller_run_export_preflight_checks_not_qubes(homedir, mocker, session, source):
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
     co.qubes = False
-    begin_preflight_check_emissions = QSignalSpy(co.export.begin_preflight_check)
+    export_preflight_check_requested_emissions = QSignalSpy(co.export_preflight_check_requested)
+    export_preflight_check_succeeded_emissions = QSignalSpy(co.export_preflight_check_succeeded)
     file = factory.File(source=source["source"])
     session.add(file)
     session.commit()
@@ -2539,15 +2540,16 @@ def test_Controller_run_export_preflight_checks_not_qubes(homedir, mocker, sessi
 
     co.run_export_preflight_checks()
 
-    assert len(begin_preflight_check_emissions) == 0
+    assert len(export_preflight_check_requested_emissions) == 0
+    assert len(export_preflight_check_succeeded_emissions) == 1
 
 
 def test_Controller_export_file_to_usb_drive(homedir, mocker, session):
     """
-    The signal `begin_usb_export` should be emmited during export_file_to_usb_drive.
+    The signal `export_requested` should be emmited during export_file_to_usb_drive.
     """
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
-    begin_usb_export_emissions = QSignalSpy(co.export.begin_usb_export)
+    export_requested_emissions = QSignalSpy(co.export_requested)
     file = factory.File(source=factory.Source())
     session.add(file)
     session.commit()
@@ -2560,16 +2562,16 @@ def test_Controller_export_file_to_usb_drive(homedir, mocker, session):
 
     co.export_file_to_usb_drive(file.uuid, "mock passphrase")
 
-    assert len(begin_usb_export_emissions) == 1
+    assert len(export_requested_emissions) == 1
 
 
 def test_Controller_export_file_to_usb_drive_not_qubes(homedir, mocker, session):
     """
-    The signal `begin_usb_export` should be emmited during export_file_to_usb_drive.
+    The signal `export_requested` should be emmited during export_file_to_usb_drive.
     """
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
     co.qubes = False
-    begin_usb_export_emissions = QSignalSpy(co.export.begin_usb_export)
+    export_requested_emissions = QSignalSpy(co.export_requested)
     co.export.send_file_to_usb_device = mocker.MagicMock()
     file = factory.File(source=factory.Source())
     session.add(file)
@@ -2584,7 +2586,7 @@ def test_Controller_export_file_to_usb_drive_not_qubes(homedir, mocker, session)
     co.export_file_to_usb_drive(file.uuid, "mock passphrase")
 
     co.export.send_file_to_usb_device.assert_not_called()
-    assert len(begin_usb_export_emissions) == 0
+    assert len(export_requested_emissions) == 0
 
 
 def test_Controller_export_file_to_usb_drive_file_missing(homedir, mocker, session, session_maker):
@@ -2630,10 +2632,10 @@ def test_Controller_export_file_to_usb_drive_when_orig_file_already_exists(
     homedir, config, mocker, session, session_maker, source
 ):
     """
-    The signal `begin_usb_export` should still be emmited if the original file already exists.
+    The signal `export_requested` should still be emmited if the original file already exists.
     """
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
-    begin_usb_export_emissions = QSignalSpy(co.export.begin_usb_export)
+    export_requested_emissions = QSignalSpy(co.export_requested)
     file = factory.File(source=factory.Source())
     session.add(file)
     session.commit()
@@ -2642,7 +2644,7 @@ def test_Controller_export_file_to_usb_drive_when_orig_file_already_exists(
 
     co.export_file_to_usb_drive(file.uuid, "mock passphrase")
 
-    assert len(begin_usb_export_emissions) == 1
+    assert len(export_requested_emissions) == 1
     co.get_file.assert_called_with(file.uuid)
 
 
@@ -2650,11 +2652,11 @@ def test_Controller_export_file_to_usb_drive_when_orig_file_already_exists_not_q
     homedir, config, mocker, session, session_maker, source
 ):
     """
-    The signal `begin_usb_export` should still be emmited if the original file already exists.
+    The signal `export_requested` should still be emmited if the original file already exists.
     """
     co = Controller("http://localhost", mocker.MagicMock(), mocker.MagicMock(), homedir, None)
     co.qubes = False
-    begin_usb_export_emissions = QSignalSpy(co.export.begin_usb_export)
+    export_requested_emissions = QSignalSpy(co.export_requested)
     file = factory.File(source=factory.Source())
     session.add(file)
     session.commit()
@@ -2667,7 +2669,7 @@ def test_Controller_export_file_to_usb_drive_when_orig_file_already_exists_not_q
 
     co.export_file_to_usb_drive(file.uuid, "mock passphrase")
 
-    assert len(begin_usb_export_emissions) == 0
+    assert len(export_requested_emissions) == 0
     co.get_file.assert_called_with(file.uuid)
 
 


### PR DESCRIPTION
# Description

The controller used to imperatively emit signals on the Export instances. This breaks the encapsulation provided by the Export class and defeats one of the main benefits of using signal: de-coupling components.

That, in turn, is one of the situations that made it more difficult for me to wrap my head around this code.

From Qt's documentation:

>  Signals are public access functions and can be emitted from anywhere,
    but we recommend to only emit them from the class that defines the signal
    and its subclasses.

The controller now emits a signal indicating that a preflight check is desirable (for example) and the Export instance connects its own slots to that signal.

See https://doc.qt.io/qt-5/signalsandslots.html

**Note**: As soon as we think of signals as a representation of events, it becomes a lot easier to conventionally name them as past tense phrases (e.g. `some_event_happened`), like we've been trying to do for a little while.

_Redo of #1506 - follow up on my mini-rant comment: as I suspected, re-doing this with a fresh head was less painful that anticipated._ :slightly_smiling_face: 

# Test Plan

- [ ] Confirm that the signal names are meaningful _(I think they make a lot more sense than they used to, if we think of them as _events_ that happened, which is how Qt uses them everywhere.)_
- [ ] Verify that the test suite is green :green_apple: 
- [ ] Confirm that you can export a file as usual
- [ ] Confirm that you can print a file as usual

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [x] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [x] I need help writing a database migration
 - [ ] No database schema changes are needed
