### PR TITLE
Fix deprecation warnings, comparing int and float values

### DIFF
--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1838,7 +1838,9 @@ class SpeechBubble(QWidget):
         if container_width < self.MIN_CONTAINER_WIDTH:
             self.speech_bubble.setFixedWidth(self.MIN_WIDTH)
         else:
-            self.speech_bubble.setFixedWidth(container_width * self.WIDTH_TO_CONTAINER_WIDTH_RATIO)
+            self.speech_bubble.setFixedWidth(
+                int(container_width * self.WIDTH_TO_CONTAINER_WIDTH_RATIO)
+            )
 
     @pyqtSlot(str, str, str)
     def _update_text(self, source_uuid: str, uuid: str, text: str) -> None:
@@ -2304,7 +2306,7 @@ class FileWidget(QWidget):
         if container_width < self.MIN_CONTAINER_WIDTH:
             self.setFixedWidth(self.MIN_WIDTH)
         else:
-            self.setFixedWidth(container_width * self.WIDTH_TO_CONTAINER_WIDTH_RATIO)
+            self.setFixedWidth(int(container_width * self.WIDTH_TO_CONTAINER_WIDTH_RATIO))
 
     def eventFilter(self, obj: QObject, event: QEvent) -> None:
         t = event.type()
@@ -3051,7 +3053,7 @@ class ReplyBoxWidget(QWidget):
         self.replybox = QWidget()
         self.replybox.setObjectName("ReplyBoxWidget_replybox")
         replybox_layout = QHBoxLayout(self.replybox)
-        replybox_layout.setContentsMargins(32.6, 19, 27.3, 18)
+        replybox_layout.setContentsMargins(32, 19, 28, 18)
         replybox_layout.setSpacing(0)
 
         # Create reply text box
@@ -3064,7 +3066,7 @@ class ReplyBoxWidget(QWidget):
         send_button_icon = QIcon(load_image("send.svg"))
         send_button_icon.addPixmap(load_image("send-disabled.svg"), QIcon.Disabled)
         self.send_button.setIcon(send_button_icon)
-        self.send_button.setIconSize(QSize(56.5, 47))
+        self.send_button.setIconSize(QSize(56, 47))
         self.send_button.setShortcut(QKeySequence("Ctrl+Return"))
         self.send_button.setDefault(True)
 


### PR DESCRIPTION
# Description

Fixes #1509 
Useful for #1496 

# Test Plan

- [ ] Run the `main` test suite under Python 3.7 (`make test`), confirm that deprecation warnings are absent
- [ ] Run the test suite under Python 3.9 (`make test`), confirm that deprecation warnings are **present**. You probably want to run it from the branch `update-dev-deps-to-match-bullseye-env` to get the new dependency versions, suited to Python 3.9.
- [ ] Check this branch out, run the test suite under Python 3.7 (`make test`), confirm that it is all green
- [ ] Check this branch out, run the test suite under Python 3.9 (`make test`), confirm that it is all green, no deprecation warnings

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
