### PR TITLE
Ensure that the export and API threads are closed before the corresponding QThread instances are destroyed

### DIFF
--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -194,6 +194,10 @@ def thread() -> Any:
     yield thread
     thread.exit()
 
+    # Wait until the thread has finished, or the deadline expires.
+    TWO_SECONDS_IN_MILLISECONDS = 2000
+    thread.wait(TWO_SECONDS_IN_MILLISECONDS)
+
 
 def start_app(args, qt_args) -> NoReturn:  # type: ignore [no-untyped-def]
     """

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -349,7 +349,7 @@ class Controller(QObject):
         self._state = state
 
         if export_thread is not None:
-            self.export_thread = export_thread
+            self.export_thread: QThread = export_thread
         else:  # pragma: no cover
             self.export_thread = QThread()
 
@@ -539,6 +539,9 @@ class Controller(QObject):
             user_callback(result_data, current_object=runner.current_object)
         else:
             user_callback(result_data)
+
+        thread = thread_info["thread"]
+        thread.exit()
 
     def login(self, username: str, password: str, totp: str) -> None:
         """

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -542,6 +542,9 @@ class Controller(QObject):
 
         thread = thread_info["thread"]
         thread.exit()
+        # Wait until the thread has finished, or the deadline expires.
+        TWO_SECONDS_IN_MILLISECONDS = 2000
+        thread.wait(TWO_SECONDS_IN_MILLISECONDS)
 
     def login(self, username: str, password: str, totp: str) -> None:
         """

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -23,7 +23,7 @@ import os
 import uuid
 from datetime import datetime
 from gettext import gettext as _
-from typing import Dict, List, Type, Union  # noqa: F401
+from typing import Dict, List, Optional, Type, Union
 
 import arrow
 import sdclientapi
@@ -336,6 +336,7 @@ class Controller(QObject):
         state: state.State,
         proxy: bool = True,
         qubes: bool = True,
+        export_thread: Optional[QThread] = None,
     ) -> None:
         """
         The hostname, gui and session objects are used to coordinate with the
@@ -346,6 +347,11 @@ class Controller(QObject):
         super().__init__()
 
         self._state = state
+
+        if export_thread is not None:
+            self.export_thread = export_thread
+        else:  # pragma: no cover
+            self.export_thread = QThread()
 
         # Controller is unauthenticated by default
         self.__is_authenticated = False
@@ -460,7 +466,6 @@ class Controller(QObject):
         # thread is kept on self such that it does not get garbage collected
         # after this method returns) - we want to keep our export thread around for
         # later processing.
-        self.export_thread = QThread()
         self.export.moveToThread(self.export_thread)
         self.export_thread.start()
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -142,6 +142,7 @@ def test_start_app(homedir, mocker):
 
     mocker.patch("securedrop_client.app.configure_logging")
     mock_app = mocker.patch("securedrop_client.app.QApplication")
+    export_thread = mocker.patch("securedrop_client.app.QThread")
     mock_win = mocker.patch("securedrop_client.app.Window")
     mocker.patch("securedrop_client.resources.path", return_value=mock_args.sdc_home + "dummy.jpg")
     mock_controller = mocker.patch("securedrop_client.app.Controller")
@@ -161,6 +162,7 @@ def test_start_app(homedir, mocker):
         app_state,
         False,
         False,
+        export_thread(),
     )
 
 


### PR DESCRIPTION
# Description

Fixes #1510  
Builds upon (but is technically independent from) #1515 

:warning: **Clarification**: It does fix the issue insofar as it was defined by errors in the functional tests suite. More `QThread` objects exist that are destroyed before their threads are closed, but this PR is enough to unlock our way to Python 3.9. (Which means that we're probably not testing around those other threads. :bulb:)

Works towards unblocking #1496 and is based on research I've made in the context of "Export All Files" (original: [show the diff of this file](https://github.com/freedomofpress/securedrop-client/commit/249cc873c2b286e2ce548b85f14fc4a9cdaa6fb2#diff-b9f8828b97a9e5a9772e99886228db6659dd993060e33ecbeda19ffbdad310f9)).

# Test Plan

- [ ] Confirm that the changes actually make sense to you.
- [ ] Verify that the test suite is green under Python 3.7
- [ ] **This last check won't be successful until #1515 is merged (at which point I'll rebase this PR), see [comment](https://github.com/freedomofpress/securedrop-client/pull/1512#issuecomment-1148328672) below.** Verify that the test suite is green under Python 3.9 (You probably want to set up your virtual environment from the branch `update-dev-deps-to-match-bullseye-env` to get the new dependency versions, suited to Python 3.9.)

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
