### PR TITLE
Ensure QApplication is instanciated only once in tests

### DIFF
--- a/tests/gui/auth/sign_in/test_error_bar.py
+++ b/tests/gui/auth/sign_in/test_error_bar.py
@@ -1,8 +1,5 @@
-from PyQt5.QtWidgets import QApplication
-
 from securedrop_client.gui.auth.sign_in import LoginErrorBar
-
-app = QApplication([])
+from tests.helper import app  # noqa: F401
 
 
 def test_LoginErrorBar_set_message(mocker):

--- a/tests/gui/auth/test_dialog.py
+++ b/tests/gui/auth/test_dialog.py
@@ -1,9 +1,7 @@
 import pytest
-from PyQt5.QtWidgets import QApplication
 
 from securedrop_client.gui.auth import LoginDialog
-
-app = QApplication([])
+from tests.helper import app  # noqa: F401
 
 
 @pytest.mark.parametrize("lang", ["es"], indirect=True)

--- a/tests/gui/base/test_dialogs.py
+++ b/tests/gui/base/test_dialogs.py
@@ -1,11 +1,10 @@
 import pytest
 from PyQt5.QtCore import QEvent, Qt
 from PyQt5.QtGui import QKeyEvent
-from PyQt5.QtWidgets import QApplication, QMainWindow
+from PyQt5.QtWidgets import QMainWindow
 
 from securedrop_client.gui.base import ModalDialog
-
-app = QApplication([])
+from tests.helper import app  # noqa: F401
 
 
 @pytest.fixture(scope="function")

--- a/tests/gui/base/test_inputs.py
+++ b/tests/gui/base/test_inputs.py
@@ -1,8 +1,7 @@
-from PyQt5.QtWidgets import QApplication, QCheckBox, QLineEdit
+from PyQt5.QtWidgets import QCheckBox, QLineEdit
 
 from securedrop_client.gui.base import PasswordEdit
-
-app = QApplication([])
+from tests.helper import app  # noqa: F401
 
 
 def test_PasswordEdit(mocker):

--- a/tests/gui/base/test_misc.py
+++ b/tests/gui/base/test_misc.py
@@ -2,11 +2,9 @@
 Tests for the gui helper functions in __init__.py
 """
 from PyQt5.QtCore import QSize, Qt
-from PyQt5.QtWidgets import QApplication
 
 from securedrop_client.gui.base import SecureQLabel, SvgLabel, SvgPushButton, SvgToggleButton
-
-app = QApplication([])
+from tests.helper import app  # noqa: F401
 
 
 def test_SvgToggleButton_init(mocker):

--- a/tests/gui/base/test_sdcheckbox.py
+++ b/tests/gui/base/test_sdcheckbox.py
@@ -1,9 +1,7 @@
 from PyQt5.QtTest import QSignalSpy
-from PyQt5.QtWidgets import QApplication
 
 from securedrop_client.gui.base.checkbox import SDCheckBox
-
-app = QApplication([])
+from tests.helper import app  # noqa: F401
 
 
 def test_SDCheckBox():

--- a/tests/gui/conversation/delete/test_dialog.py
+++ b/tests/gui/conversation/delete/test_dialog.py
@@ -1,12 +1,10 @@
 import unittest
 
 from PyQt5.QtCore import QTimer
-from PyQt5.QtWidgets import QApplication
 
 from securedrop_client.gui.conversation.delete import DeleteConversationDialog as Dialog
 from tests import factory
-
-app = QApplication([])
+from tests.helper import app  # noqa: F401
 
 
 class DeleteConversationDialogTest(unittest.TestCase):

--- a/tests/gui/conversation/export/test_dialog.py
+++ b/tests/gui/conversation/export/test_dialog.py
@@ -1,9 +1,6 @@
-from PyQt5.QtWidgets import QApplication
-
 from securedrop_client.export import ExportError, ExportStatus
 from securedrop_client.gui.conversation import ExportFileDialog
-
-app = QApplication([])
+from tests.helper import app  # noqa: F401
 
 
 def test_ExportDialog_init(mocker):

--- a/tests/gui/conversation/export/test_print_dialog.py
+++ b/tests/gui/conversation/export/test_print_dialog.py
@@ -1,9 +1,6 @@
-from PyQt5.QtWidgets import QApplication
-
 from securedrop_client.export import ExportError, ExportStatus
 from securedrop_client.gui.conversation import PrintFileDialog
-
-app = QApplication([])
+from tests.helper import app  # noqa: F401
 
 
 def test_PrintFileDialog_init(mocker):

--- a/tests/gui/source/delete/test_dialog.py
+++ b/tests/gui/source/delete/test_dialog.py
@@ -1,11 +1,8 @@
 import unittest
 
-from PyQt5.QtWidgets import QApplication
-
 from securedrop_client.gui.source.delete import DeleteSourceDialog as Dialog
 from tests import factory
-
-app = QApplication([])
+from tests.helper import app  # noqa: F401
 
 
 class DeleteSourceDialogTest(unittest.TestCase):

--- a/tests/gui/test_actions.py
+++ b/tests/gui/test_actions.py
@@ -3,7 +3,7 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 from PyQt5.QtCore import QTimer
-from PyQt5.QtWidgets import QApplication, QDialog, QMenu
+from PyQt5.QtWidgets import QDialog, QMenu
 
 from securedrop_client import state
 from securedrop_client.db import Source
@@ -14,8 +14,7 @@ from securedrop_client.gui.actions import (
 )
 from securedrop_client.logic import Controller
 from tests import factory
-
-app = QApplication([])
+from tests.helper import app  # noqa: F401
 
 
 class DeleteConversationActionTest(unittest.TestCase):

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -3,14 +3,13 @@ Check the core Window UI class works as expected.
 """
 import unittest
 
-from PyQt5.QtWidgets import QApplication, QHBoxLayout
+from PyQt5.QtWidgets import QHBoxLayout
 
 from securedrop_client import state
 from securedrop_client.gui.main import Window
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_icon
-
-app = QApplication([])
+from tests.helper import app  # noqa: F401
 
 
 class WindowTest(unittest.TestCase):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -13,7 +13,7 @@ import sqlalchemy.orm.exc
 from PyQt5.QtCore import QEvent, QSize, Qt
 from PyQt5.QtGui import QFocusEvent, QMovie, QResizeEvent
 from PyQt5.QtTest import QTest
-from PyQt5.QtWidgets import QApplication, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QVBoxLayout, QWidget
 from sqlalchemy.orm import attributes, scoped_session, sessionmaker
 
 from securedrop_client import db, logic, storage
@@ -51,8 +51,7 @@ from securedrop_client.gui.widgets import (
     UserProfile,
 )
 from tests import factory
-
-app = QApplication([])
+from tests.helper import app  # noqa: F401
 
 
 def test_TopPane_init(mocker):

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,0 +1,3 @@
+from PyQt5.QtWidgets import QApplication
+
+app = QApplication([])

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,17 +1,16 @@
 import pytest
-from PyQt5.QtWidgets import QApplication
 
 from securedrop_client.gui.base import ModalDialog
 from securedrop_client.gui.conversation import ExportFileDialog, PrintFileDialog
 from securedrop_client.gui.main import Window
 from securedrop_client.logic import Controller
 from tests import factory
+from tests.helper import app  # noqa: F401
 
 
 @pytest.fixture(scope="function")
 def main_window(mocker, homedir):
     # Setup
-    app = QApplication([])
     gui = Window()
     app.setActiveWindow(gui)
     gui.show()
@@ -51,7 +50,6 @@ def main_window(mocker, homedir):
 @pytest.fixture(scope="function")
 def main_window_no_key(mocker, homedir):
     # Setup
-    app = QApplication([])
     gui = Window()
     app.setActiveWindow(gui)
     gui.show()
@@ -90,7 +88,6 @@ def main_window_no_key(mocker, homedir):
 
 @pytest.fixture(scope="function")
 def modal_dialog(mocker, homedir):
-    app = QApplication([])
     gui = Window()
     gui.show()
     controller = Controller("http://localhost", gui, mocker.MagicMock(), homedir, None, proxy=False)
@@ -109,7 +106,6 @@ def modal_dialog(mocker, homedir):
 
 @pytest.fixture(scope="function")
 def print_dialog(mocker, homedir):
-    app = QApplication([])
     gui = Window()
     gui.show()
     controller = Controller("http://localhost", gui, mocker.MagicMock(), homedir, None, proxy=False)
@@ -128,7 +124,6 @@ def print_dialog(mocker, homedir):
 
 @pytest.fixture(scope="function")
 def export_dialog(mocker, homedir):
-    app = QApplication([])
     gui = Window()
     gui.show()
     controller = Controller("http://localhost", gui, mocker.MagicMock(), homedir, None, proxy=False)

--- a/tests/state/test_state.py
+++ b/tests/state/test_state.py
@@ -3,14 +3,12 @@ from collections import namedtuple
 from unittest import mock
 
 from PyQt5.QtTest import QSignalSpy
-from PyQt5.QtWidgets import QApplication
 
 from securedrop_client import state
+from tests.helper import app  # noqa: F401
 
 Source = namedtuple("Source", ["uuid"])
 File = namedtuple("File", ["uuid", "source", "is_downloaded"])
-
-app = QApplication([])
 
 
 class TestState(unittest.TestCase):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,7 +6,6 @@ import platform
 import sys
 
 import pytest
-from PyQt5.QtWidgets import QApplication
 
 from securedrop_client import state
 from securedrop_client.app import (
@@ -21,8 +20,7 @@ from securedrop_client.app import (
     run,
     start_app,
 )
-
-app = QApplication([])
+from tests.helper import app  # noqa: F401
 
 
 def test_application_sets_en_as_default_language_code(mocker):

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -3,11 +3,9 @@ Tests for the resources sub-module.
 """
 from PyQt5.QtGui import QIcon, QMovie, QPixmap
 from PyQt5.QtSvg import QSvgWidget
-from PyQt5.QtWidgets import QApplication
 
 import securedrop_client.resources
-
-app = QApplication([])
+from tests.helper import app  # noqa: F401
 
 
 def test_path(mocker):


### PR DESCRIPTION
# Description

Fixes #1514 

Explanation:

An instance of `QApplication` must be in scope when rendering Qt widgets. _My understanding is that the instanciation of `QApplication` is what creates and starts the event loop._

In hindsight, the fact that only one application instance must be running at once not only make sense, but also could explain
why all test files would run fine individually (see **Comments** in #1514)  yet some combinations of files would often cause errors: if `QApplication` instances are destroyed and created in quick succession, a segfault would occur if the second instance was created before the first once (and the corresponding stuff, e.g. thread...) was properly gone.

# Implementation

In order to make sure that only one instance of `QApplication` was created, I moved the creation to a separate module (that will be loaded only once, no matter how many times it is imported). Each test file that requires a `QApplication` instance in scope can then `import` that one instance.

Naming note: `tests/helper` is not a great name, but I though in this case it seemed to convey the intent better than say `tests/application` which use could be unclear.

# Test Plan

- [ ] Confirm that the Buster (Python 3.7) test suite is green :green_apple: :green_apple: :green_apple:  (not only the unit test suite, the entire suite)
- [ ] Confirm that the Bullseye (Python 3.9) **unit test suite** at least is green :green_apple: (the functional test suite is failing because of #1510) ([Example CI build](https://app.circleci.com/pipelines/github/freedomofpress/securedrop-client/2166/workflows/d6db676e-97f6-4bdb-81d9-8cfb45aa217c) but local testing is desirable.)
- [ ] Optionally, confirm that the Bullseye entire test suite is green once this patch and the patch that fixes #1510 are applied. Here is such a build for convenience: https://app.circleci.com/pipelines/github/freedomofpress/securedrop-client/2164/workflows/6f97dbaf-731a-4454-86a2-115af9083b7c

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
