### PR TITLE
Ensure that the export and API threads are closed before the corresponding QThread instances are destroyed (Part 2)

### DIFF
--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -2,7 +2,7 @@ import itertools
 import logging
 import threading
 from queue import PriorityQueue
-from typing import Optional, Tuple  # noqa: F401
+from typing import Optional, Tuple
 
 from PyQt5.QtCore import QObject, QThread, pyqtSignal, pyqtSlot
 from sdclientapi import API, RequestTimeoutError, ServerConnectionError
@@ -201,11 +201,24 @@ class ApiJobQueue(QObject):
     # Signal that is emitted after a queue is paused.
     paused = pyqtSignal()
 
-    def __init__(self, api_client: API, session_maker: scoped_session) -> None:
+    def __init__(
+        self,
+        api_client: API,
+        session_maker: scoped_session,
+        main_thread: Optional[QThread] = None,
+        download_file_thread: Optional[QThread] = None,
+    ) -> None:
         super().__init__(None)
 
-        self.main_thread = QThread()
-        self.download_file_thread = QThread()
+        if main_thread is not None:
+            self.main_thread = main_thread
+        else:  # pragma: no cover
+            self.main_thread = QThread()
+
+        if download_file_thread is not None:
+            self.download_file_thread = download_file_thread
+        else:  # pragma: no cover
+            self.download_file_thread = QThread()
 
         self.main_queue = RunnableQueue(api_client, session_maker)
         self.download_file_queue = RunnableQueue(api_client, session_maker)

--- a/securedrop_client/sync.py
+++ b/securedrop_client/sync.py
@@ -31,11 +31,16 @@ class ApiSync(QObject):
         gpg: GpgHelper,
         data_dir: str,
         app_state: Optional[state.State] = None,
+        sync_thread: Optional[QThread] = None,
     ):
         super().__init__()
         self.api_client = api_client
 
-        self.sync_thread = QThread()
+        if sync_thread is not None:
+            self.sync_thread = sync_thread
+        else:  # pragma: no cover
+            self.sync_thread = QThread()
+
         self.api_sync_bg_task = ApiSyncBackgroundTask(
             api_client,
             session_maker,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -142,7 +142,7 @@ def test_start_app(homedir, mocker):
 
     mocker.patch("securedrop_client.app.configure_logging")
     mock_app = mocker.patch("securedrop_client.app.QApplication")
-    export_thread = mocker.patch("securedrop_client.app.QThread")
+    thread = mocker.patch("securedrop_client.app.QThread")
     mock_win = mocker.patch("securedrop_client.app.Window")
     mocker.patch("securedrop_client.resources.path", return_value=mock_args.sdc_home + "dummy.jpg")
     mock_controller = mocker.patch("securedrop_client.app.Controller")
@@ -162,7 +162,10 @@ def test_start_app(homedir, mocker):
         app_state,
         False,
         False,
-        export_thread(),
+        thread(),
+        thread(),
+        thread(),
+        thread(),
     )
 
 


### PR DESCRIPTION
# Description

Follows up on #1512 fixing the remaining instances of `QThread`.

# Test Plan

- [ ] Confirm that the Buster build is green :green_apple: 
- [ ] Confirm that the Bullseye build is green :green_apple: ([example build][ci] but local testing is desirable)
- [ ] Confirm that the application **sync** works as usual
- [ ] Confirm that messages are downloaded as usual
- [ ] Confirm that files can be downloaded as usual

  [ci]: https://app.circleci.com/pipelines/github/freedomofpress/securedrop-client/2184/workflows/1f2c6141-4a4f-4791-abb6-1e844529562d

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
