### PR TITLE
Ensure threads are exited before qthread instances are destroyed 3

### DIFF
--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -194,6 +194,10 @@ def thread() -> Any:
     yield thread
     thread.exit()
 
+    # Wait until the thread has finished, or the deadline expires.
+    TWO_SECONDS_IN_MILLISECONDS = 2000
+    thread.wait(TWO_SECONDS_IN_MILLISECONDS)
+
 
 def start_app(args, qt_args) -> NoReturn:  # type: ignore [no-untyped-def]
     """

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -353,22 +353,22 @@ class Controller(QObject):
 
         if export_thread is not None:
             self.export_thread = export_thread
-        else:  # pragma: no cover
+        else:
             self.export_thread = QThread()
 
         if sync_thread is not None:
             self.sync_thread = sync_thread
-        else:  # pragma: no cover
+        else:
             self.sync_thread = QThread()
 
         if main_queue_thread is not None:
             self.main_queue_thread = main_queue_thread
-        else:  # pragma: no cover
+        else:
             self.main_queue_thread = QThread()
 
         if file_download_queue_thread is not None:
             self.file_download_queue_thread = file_download_queue_thread
-        else:  # pragma: no cover
+        else:
             self.file_download_queue_thread = QThread()
 
         # Controller is unauthenticated by default

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -349,7 +349,7 @@ class Controller(QObject):
         self._state = state
 
         if export_thread is not None:
-            self.export_thread = export_thread
+            self.export_thread: QThread = export_thread
         else:  # pragma: no cover
             self.export_thread = QThread()
 
@@ -539,6 +539,9 @@ class Controller(QObject):
             user_callback(result_data, current_object=runner.current_object)
         else:
             user_callback(result_data)
+
+        thread = thread_info["thread"]
+        thread.exit()
 
     def login(self, username: str, password: str, totp: str) -> None:
         """

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -542,6 +542,9 @@ class Controller(QObject):
 
         thread = thread_info["thread"]
         thread.exit()
+        # Wait until the thread has finished, or the deadline expires.
+        TWO_SECONDS_IN_MILLISECONDS = 2000
+        thread.wait(TWO_SECONDS_IN_MILLISECONDS)
 
     def login(self, username: str, password: str, totp: str) -> None:
         """

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -23,7 +23,7 @@ import os
 import uuid
 from datetime import datetime
 from gettext import gettext as _
-from typing import Dict, List, Type, Union  # noqa: F401
+from typing import Dict, List, Optional, Type, Union
 
 import arrow
 import sdclientapi
@@ -336,6 +336,7 @@ class Controller(QObject):
         state: state.State,
         proxy: bool = True,
         qubes: bool = True,
+        export_thread: Optional[QThread] = None,
     ) -> None:
         """
         The hostname, gui and session objects are used to coordinate with the
@@ -346,6 +347,11 @@ class Controller(QObject):
         super().__init__()
 
         self._state = state
+
+        if export_thread is not None:
+            self.export_thread = export_thread
+        else:  # pragma: no cover
+            self.export_thread = QThread()
 
         # Controller is unauthenticated by default
         self.__is_authenticated = False
@@ -460,7 +466,6 @@ class Controller(QObject):
         # thread is kept on self such that it does not get garbage collected
         # after this method returns) - we want to keep our export thread around for
         # later processing.
-        self.export_thread = QThread()
         self.export.moveToThread(self.export_thread)
         self.export_thread.start()
 

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -212,12 +212,12 @@ class ApiJobQueue(QObject):
 
         if main_thread is not None:
             self.main_thread = main_thread
-        else:  # pragma: no cover
+        else:
             self.main_thread = QThread()
 
         if download_file_thread is not None:
             self.download_file_thread = download_file_thread
-        else:  # pragma: no cover
+        else:
             self.download_file_thread = QThread()
 
         self.main_queue = RunnableQueue(api_client, session_maker)

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -2,7 +2,7 @@ import itertools
 import logging
 import threading
 from queue import PriorityQueue
-from typing import Optional, Tuple  # noqa: F401
+from typing import Optional, Tuple
 
 from PyQt5.QtCore import QObject, QThread, pyqtSignal, pyqtSlot
 from sdclientapi import API, RequestTimeoutError, ServerConnectionError
@@ -201,11 +201,24 @@ class ApiJobQueue(QObject):
     # Signal that is emitted after a queue is paused.
     paused = pyqtSignal()
 
-    def __init__(self, api_client: API, session_maker: scoped_session) -> None:
+    def __init__(
+        self,
+        api_client: API,
+        session_maker: scoped_session,
+        main_thread: Optional[QThread] = None,
+        download_file_thread: Optional[QThread] = None,
+    ) -> None:
         super().__init__(None)
 
-        self.main_thread = QThread()
-        self.download_file_thread = QThread()
+        if main_thread is not None:
+            self.main_thread = main_thread
+        else:  # pragma: no cover
+            self.main_thread = QThread()
+
+        if download_file_thread is not None:
+            self.download_file_thread = download_file_thread
+        else:  # pragma: no cover
+            self.download_file_thread = QThread()
 
         self.main_queue = RunnableQueue(api_client, session_maker)
         self.download_file_queue = RunnableQueue(api_client, session_maker)

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -205,20 +205,13 @@ class ApiJobQueue(QObject):
         self,
         api_client: API,
         session_maker: scoped_session,
-        main_thread: Optional[QThread] = None,
-        download_file_thread: Optional[QThread] = None,
+        main_thread: QThread,
+        download_file_thread: QThread,
     ) -> None:
         super().__init__(None)
 
-        if main_thread is not None:
-            self.main_thread = main_thread
-        else:
-            self.main_thread = QThread()
-
-        if download_file_thread is not None:
-            self.download_file_thread = download_file_thread
-        else:
-            self.download_file_thread = QThread()
+        self.main_thread = main_thread
+        self.download_file_thread = download_file_thread
 
         self.main_queue = RunnableQueue(api_client, session_maker)
         self.download_file_queue = RunnableQueue(api_client, session_maker)

--- a/securedrop_client/sync.py
+++ b/securedrop_client/sync.py
@@ -38,7 +38,7 @@ class ApiSync(QObject):
 
         if sync_thread is not None:
             self.sync_thread = sync_thread
-        else:  # pragma: no cover
+        else:
             self.sync_thread = QThread()
 
         self.api_sync_bg_task = ApiSyncBackgroundTask(

--- a/securedrop_client/sync.py
+++ b/securedrop_client/sync.py
@@ -31,11 +31,16 @@ class ApiSync(QObject):
         gpg: GpgHelper,
         data_dir: str,
         app_state: Optional[state.State] = None,
+        sync_thread: Optional[QThread] = None,
     ):
         super().__init__()
         self.api_client = api_client
 
-        self.sync_thread = QThread()
+        if sync_thread is not None:
+            self.sync_thread = sync_thread
+        else:  # pragma: no cover
+            self.sync_thread = QThread()
+
         self.api_sync_bg_task = ApiSyncBackgroundTask(
             api_client,
             session_maker,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -142,6 +142,7 @@ def test_start_app(homedir, mocker):
 
     mocker.patch("securedrop_client.app.configure_logging")
     mock_app = mocker.patch("securedrop_client.app.QApplication")
+    export_thread = mocker.patch("securedrop_client.app.QThread")
     mock_win = mocker.patch("securedrop_client.app.Window")
     mocker.patch("securedrop_client.resources.path", return_value=mock_args.sdc_home + "dummy.jpg")
     mock_controller = mocker.patch("securedrop_client.app.Controller")
@@ -161,6 +162,7 @@ def test_start_app(homedir, mocker):
         app_state,
         False,
         False,
+        export_thread(),
     )
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -142,7 +142,7 @@ def test_start_app(homedir, mocker):
 
     mocker.patch("securedrop_client.app.configure_logging")
     mock_app = mocker.patch("securedrop_client.app.QApplication")
-    export_thread = mocker.patch("securedrop_client.app.QThread")
+    thread = mocker.patch("securedrop_client.app.QThread")
     mock_win = mocker.patch("securedrop_client.app.Window")
     mocker.patch("securedrop_client.resources.path", return_value=mock_args.sdc_home + "dummy.jpg")
     mock_controller = mocker.patch("securedrop_client.app.Controller")
@@ -162,7 +162,10 @@ def test_start_app(homedir, mocker):
         app_state,
         False,
         False,
-        export_thread(),
+        thread(),
+        thread(),
+        thread(),
+        thread(),
     )
 
 


### PR DESCRIPTION
# Description

Future-proves #1518 by ensuring that queue job instances don't ever create `QThread` instances on the fly, that will be destroyed without the underlying thread being closed.

# Test Plan

- [ ] Confirm that the build is green :green_apple: 

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
