### PR TITLE
Fix filename sanitization tests to ensure they can actually fail

### DIFF
--- a/tests/gui/conversation/export/test_dialog.py
+++ b/tests/gui/conversation/export/test_dialog.py
@@ -21,7 +21,7 @@ def test_ExportDialog_init_sanitizes_filename(mocker):
 
     ExportFileDialog(mocker.MagicMock(), "mock_uuid", filename)
 
-    secure_qlabel.call_args_list[1].assert_called_with(filename)
+    secure_qlabel.assert_any_call(filename, wordwrap=False, max_length=260)
 
 
 def test_ExportDialog__show_starting_instructions(mocker, export_dialog):

--- a/tests/gui/conversation/export/test_print_dialog.py
+++ b/tests/gui/conversation/export/test_print_dialog.py
@@ -21,7 +21,7 @@ def test_PrintFileDialog_init_sanitizes_filename(mocker):
 
     PrintFileDialog(mocker.MagicMock(), "mock_uuid", filename)
 
-    secure_qlabel.call_args_list[0].assert_called_with(filename)
+    secure_qlabel.assert_any_call(filename, wordwrap=False, max_length=260)
 
 
 def test_PrintFileDialog__show_starting_instructions(mocker, print_dialog):


### PR DESCRIPTION
# Description

The file name tests in the conversation export and print dialogs was never failing (e.g. `secure_qlabel.call_args_list[1].assert_called_with('whatever')` would pass). This PR fixes that as a pelimiary step to refactoring the dialog.

**Note**: Improving the test to ensure that the dialog doesn't actually render the tainted string is out of scope of this PR.

# Test Plan

- [ ] Confirm that you can make the test fail by changing the string in the assertion.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
