### PR TITLE
Refactor assertions sequence for ease of troubleshooting

### DIFF
--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -491,7 +491,7 @@ def __update_submissions(
 
     # The uuids remaining in local_uuids do not exist on the remote server, so
     # delete the related records.
-    # We will also collect the journalist desginations of deleted submissions to
+    # We will also collect the journalist designations of deleted submissions to
     # check if we have left empty directories behind after deletion.
     deleted_submission_directory_names = set()
     for deleted_submission in local_submissions_by_uuid.values():

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -2054,11 +2054,12 @@ def test__cleanup_directory_if_empty(mocker, session, homedir):
     mocker.patch("securedrop_client.storage.logger.error", mock_error)
 
     _cleanup_directory_if_empty(empty_dir)
-    _cleanup_directory_if_empty(nonempty_dir)
-    _cleanup_directory_if_empty(not_a_dir)
-
     assert not os.path.exists(empty_dir)
+
+    _cleanup_directory_if_empty(nonempty_dir)
     assert os.path.exists(nonempty_dir)
+
+    _cleanup_directory_if_empty(not_a_dir)
     mock_error.assert_called_once_with("Error: method called on missing or malformed directory")
 
 


### PR DESCRIPTION
# Description

Follow up on https://github.com/freedomofpress/securedrop-client/pull/1475 (see https://github.com/freedomofpress/securedrop-client/pull/1475#pullrequestreview-1008589428)
Applying review suggestions before @rocodes is back, because they're trivial to undo whenever we want to.

# Test Plan

- [ ] Confirm that the CI build is green :green_apple: 

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed
