### PR TITLE
Add debug logging around authentication errors

### DIFF
--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -630,6 +630,7 @@ class Controller(QObject):
                 "make sure to use a new two-factor code."
             )
         else:
+            logging.debug(f"Unexpected error while authenticating: {result}")
             error = _("That didn't work. Please check everything and try again.")
 
         self.gui.show_login_error(error=error)


### PR DESCRIPTION
## Description

Adds some _debug_ logging around unexpected authentication errors. This should provide additional information when troubleshooting communication errors between `sd-app` and `sd-proxy`.

## Test Plan

- [ ] Confirm that CI is green :green_apple:
- [ ] Run the client in debug mode in Qubes OS (`LOGLEVEL=debug ./run.sh --sdc-home ~/.securedrop-client`), and simulate an error by shutting down `sd-proxy` for example. Confirm that the error message is printed to the debug log (`tail -f ~/.securedrop-client/logs/client.log`).

## How to create a useful test plan    
     
### Qubes OS environment    
     
If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes OS testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes OS is required. Please make sure you mention it in the **tests plan**.
     
### AppArmor profile    
     
If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please make sure you mention it in the **tests plan**.
     
### Database migrations    
     
If these changes modify the database schema, you should include a database migration. Testing that the migration applies cleanly on the `main` branch is necessary. Please make sure you mention it in the **tests plan**.
