### PR TITLE
Add /dev/xen/hypercall to AppArmor allow-list

### DIFF
--- a/files/usr.bin.securedrop-client
+++ b/files/usr.bin.securedrop-client
@@ -12,6 +12,7 @@
   /dev/tty rw,
   /dev/xen/evtchn rw,
   /dev/xen/gntalloc rw,
+  /dev/xen/hypercall rw,
   /dev/xen/privcmd rw,
   /dev/xen/xenbus rw,
   /etc/group r,


### PR DESCRIPTION
Access to this device-node is required on kernel versions 4.18 or greater (per commit message https://github.com/QubesOS/qubes-linux-utils/commit/4fe08d31e4d168688bfa246929ebbcdf54f54352 and AppArmor denials when testing with the newer kernel that ships with the Bullseye template).

# Description

Fixes the proxy error and disposable VM opening errors described in https://github.com/freedomofpress/securedrop-workstation/issues/600#issuecomment-1168104477

# Test Plan

On a system that exhibits the issue, apply this fix (either by modifying the AppArmor profile in `/etc/apparmor.d`, or building a new package from this branch and installing it), restart AppArmor and verify that the issue is resolved.

# Checklist

 - [x] I have tested these changes in the appropriate Qubes environment
 - [x] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No database schema changes are needed
