### PR TITLE
feat: enable `pt_PT` and `zh_Hans` as supported languages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -30,3 +30,4 @@ prune securedrop_client/locale
 #
 # Please keep this list alphabetized.
 graft securedrop_client/locale/pt_PT
+graft securedrop_client/locale/zh_Hans

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -29,3 +29,4 @@ prune securedrop_client/locale
 #     graft securedrop_client/locale/$LANG
 #
 # Please keep this list alphabetized.
+graft securedrop_client/locale/pt_PT


### PR DESCRIPTION
* [x] Depends on #1527

# Description

As of #1527, 2 languages are 100% translated and approved (listed in Weblate sort order)

1. `zh_Hans`: Chinese (Simplified)
2. `pt_PT`: Portuguese (Portugal)

Another 5 are 100% translated but only partially approved (listed in Weblate sort order):

3. `de`: German
4. `ca`: Catalan
5. `is`: Icelandic
6. `sv`: Swedish
7. `tr`: Turkish

To err on the side of conservatism for now, here we enable only `pt_PT` and `zh_Hans` as 100% translated and approved.

# Test Plan

- [ ] Both `pt_PT` and `zh_Hans` are packaged:
    ```sh-session
    (.venv) user@sd-dev:~/securedrop-client$ python setup.py sdist 2> /dev/null | grep -E "(pt_PT|zh_Hans)"
    creating securedrop-client-0.7.0/securedrop_client/locale/pt_PT
    creating securedrop-client-0.7.0/securedrop_client/locale/pt_PT/LC_MESSAGES
    creating securedrop-client-0.7.0/securedrop_client/locale/zh_Hans
    creating securedrop-client-0.7.0/securedrop_client/locale/zh_Hans/LC_MESSAGES
    copying securedrop_client/locale/pt_PT/LC_MESSAGES/messages.mo -> securedrop-client-0.7.0/securedrop_client/locale/pt_PT/LC_MESSAGES
    copying securedrop_client/locale/pt_PT/LC_MESSAGES/messages.po -> securedrop-client-0.7.0/securedrop_client/locale/pt_PT/LC_MESSAGES
    copying securedrop_client/locale/zh_Hans/LC_MESSAGES/messages.mo -> securedrop-client-0.7.0/securedrop_client/locale/zh_Hans/LC_MESSAGES
    copying securedrop_client/locale/zh_Hans/LC_MESSAGES/messages.po -> securedrop-client-0.7.0/securedrop_client/locale/zh_Hans/LC_MESSAGES
    ```
- Install this package into your venv:
    ```sh-session
    (.venv) user@sd-dev:~/securedrop-client$ pip install dist/securedrop-client-0.7.0.tar.gz
    ```
- [ ] The Client loads in Portuguese (Portugal):
    ```sh-session
    (.venv) user@sd-dev:~/securedrop-client$ LANG=pt_PT .venv/bin/sd-client
    ```
- [ ] The Client loads in Chinese (Simplified):
    ```sh-session
    (.venv) user@sd-dev:~/securedrop-client$ LANG=zh_Hans .venv/bin/sd-client
    ```

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - I have tested these changes in the appropriate Qubes environment
 - I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations