### PR TITLE
Refactor remove controller dependency from conversation export.Device

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,10 @@ dev-requirements:  ## Update dev-*requirements.txt files if pinned versions do n
 	pip-compile --allow-unsafe --generate-hashes --output-file requirements/dev-requirements.txt requirements/dev-requirements.in
 	pip-compile --allow-unsafe --generate-hashes --output-file requirements/dev-sdw-requirements.txt requirements/dev-sdw-requirements.in
 
+.PHONY: dev-buster-requirements
+dev-buster-requirements:  ## Update dev-*requirements.txt files if pinned versions do not comply with the dependency specifications in dev-*requirements.in
+	pip-compile --allow-unsafe --generate-hashes --output-file requirements/dev-buster-requirements.txt requirements/dev-buster-requirements.in
+
 .PHONY: update-dev-dependencies
 update-dev-dependencies:  ## Update dev requirements in case there are newer versions of packages or updates to prod dependencies
 	if test -f "requirements/dev-requirements.txt"; then rm -r requirements/dev-requirements.txt; fi

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ hooks:  ## Configure Git to use the hooks provided by this repository.
 SEMGREP_FLAGS := --exclude "tests/" --error --strict --verbose
 
 .PHONY: semgrep
-semgrep:semgrep-community semgrep-local
+semgrep:semgrep-community semgrep-local  ## Run semgrep with both semgrep.dev community and local rules
 
 .PHONY: semgrep-community
 semgrep-community:

--- a/requirements/dev-buster-requirements.in
+++ b/requirements/dev-buster-requirements.in
@@ -1,3 +1,5 @@
 -r dev-sdw-requirements.in
 PyQt5==5.11.3  # Match version of system package on Buster
 sip==4.19.8  # Match version of system package on Buster
+semgrep>=0.93.0  # Previous versions can't parse all the rules
+black>=22.3.0  # So that semgrep's click dependency doesn't break black

--- a/requirements/dev-buster-requirements.txt
+++ b/requirements/dev-buster-requirements.txt
@@ -18,6 +18,7 @@ attrs==21.4.0 \
     --hash=sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4 \
     --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
     # via
+    #   glom
     #   jsonschema
     #   pytest
     #   semgrep
@@ -25,31 +26,40 @@ babel==2.10.3 \
     --hash=sha256:7614553711ee97490f732126dc077f8d0ae084ebc6a96e23db1482afabdb2c51 \
     --hash=sha256:ff56f4892c1c4bf0d814575ea23471c230d544203c7748e8c68f0089478d48eb
     # via -r requirements/dev-sdw-requirements.in
-black==22.1.0 \
-    --hash=sha256:07e5c049442d7ca1a2fc273c79d1aecbbf1bc858f62e8184abe1ad175c4f7cc2 \
-    --hash=sha256:0e21e1f1efa65a50e3960edd068b6ae6d64ad6235bd8bfea116a03b21836af71 \
-    --hash=sha256:1297c63b9e1b96a3d0da2d85d11cd9bf8664251fd69ddac068b98dc4f34f73b6 \
-    --hash=sha256:228b5ae2c8e3d6227e4bde5920d2fc66cc3400fde7bcc74f480cb07ef0b570d5 \
-    --hash=sha256:2d6f331c02f0f40aa51a22e479c8209d37fcd520c77721c034517d44eecf5912 \
-    --hash=sha256:2ff96450d3ad9ea499fc4c60e425a1439c2120cbbc1ab959ff20f7c76ec7e866 \
-    --hash=sha256:3524739d76b6b3ed1132422bf9d82123cd1705086723bc3e235ca39fd21c667d \
-    --hash=sha256:35944b7100af4a985abfcaa860b06af15590deb1f392f06c8683b4381e8eeaf0 \
-    --hash=sha256:373922fc66676133ddc3e754e4509196a8c392fec3f5ca4486673e685a421321 \
-    --hash=sha256:5fa1db02410b1924b6749c245ab38d30621564e658297484952f3d8a39fce7e8 \
-    --hash=sha256:6f2f01381f91c1efb1451998bd65a129b3ed6f64f79663a55fe0e9b74a5f81fd \
-    --hash=sha256:742ce9af3086e5bd07e58c8feb09dbb2b047b7f566eb5f5bc63fd455814979f3 \
-    --hash=sha256:7835fee5238fc0a0baf6c9268fb816b5f5cd9b8793423a75e8cd663c48d073ba \
-    --hash=sha256:8871fcb4b447206904932b54b567923e5be802b9b19b744fdff092bd2f3118d0 \
-    --hash=sha256:a7c0192d35635f6fc1174be575cb7915e92e5dd629ee79fdaf0dcfa41a80afb5 \
-    --hash=sha256:b1a5ed73ab4c482208d20434f700d514f66ffe2840f63a6252ecc43a9bc77e8a \
-    --hash=sha256:c8226f50b8c34a14608b848dc23a46e5d08397d009446353dad45e04af0c8e28 \
-    --hash=sha256:ccad888050f5393f0d6029deea2a33e5ae371fd182a697313bdbd835d3edaf9c \
-    --hash=sha256:dae63f2dbf82882fa3b2a3c49c32bffe144970a573cd68d247af6560fc493ae1 \
-    --hash=sha256:e2f69158a7d120fd641d1fa9a921d898e20d52e44a74a6fbbcc570a62a6bc8ab \
-    --hash=sha256:efbadd9b52c060a8fc3b9658744091cb33c31f830b3f074422ed27bad2b18e8f \
-    --hash=sha256:f5660feab44c2e3cb24b2419b998846cbb01c23c7fe645fee45087efa3da2d61 \
-    --hash=sha256:fdb8754b453fb15fad3f72cd9cad3e16776f0964d67cf30ebcbf10327a3777a3
-    # via -r requirements/dev-sdw-requirements.in
+black==22.6.0 \
+    --hash=sha256:074458dc2f6e0d3dab7928d4417bb6957bb834434516f21514138437accdbe90 \
+    --hash=sha256:187d96c5e713f441a5829e77120c269b6514418f4513a390b0499b0987f2ff1c \
+    --hash=sha256:2ea29072e954a4d55a2ff58971b83365eba5d3d357352a07a7a4df0d95f51c78 \
+    --hash=sha256:4af5bc0e1f96be5ae9bd7aaec219c901a94d6caa2484c21983d043371c733fc4 \
+    --hash=sha256:560558527e52ce8afba936fcce93a7411ab40c7d5fe8c2463e279e843c0328ee \
+    --hash=sha256:568ac3c465b1c8b34b61cd7a4e349e93f91abf0f9371eda1cf87194663ab684e \
+    --hash=sha256:6797f58943fceb1c461fb572edbe828d811e719c24e03375fd25170ada53825e \
+    --hash=sha256:6c1734ab264b8f7929cef8ae5f900b85d579e6cbfde09d7387da8f04771b51c6 \
+    --hash=sha256:6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9 \
+    --hash=sha256:7ba9be198ecca5031cd78745780d65a3f75a34b2ff9be5837045dce55db83d1c \
+    --hash=sha256:94783f636bca89f11eb5d50437e8e17fbc6a929a628d82304c80fa9cd945f256 \
+    --hash=sha256:a218d7e5856f91d20f04e931b6f16d15356db1c846ee55f01bac297a705ca24f \
+    --hash=sha256:a3db5b6409b96d9bd543323b23ef32a1a2b06416d525d27e0f67e74f1446c8f2 \
+    --hash=sha256:ac609cf8ef5e7115ddd07d85d988d074ed00e10fbc3445aee393e70164a2219c \
+    --hash=sha256:b154e6bbde1e79ea3260c4b40c0b7b3109ffcdf7bc4ebf8859169a6af72cd70b \
+    --hash=sha256:b270a168d69edb8b7ed32c193ef10fd27844e5c60852039599f9184460ce0807 \
+    --hash=sha256:b9fd45787ba8aa3f5e0a0a98920c1012c884622c6c920dbe98dbd05bc7c70fbf \
+    --hash=sha256:c85928b9d5f83b23cee7d0efcb310172412fbf7cb9d9ce963bd67fd141781def \
+    --hash=sha256:c9a3ac16efe9ec7d7381ddebcc022119794872abce99475345c5a61aa18c45ad \
+    --hash=sha256:cfaf3895a9634e882bf9d2363fed5af8888802d670f58b279b0bece00e9a872d \
+    --hash=sha256:e439798f819d49ba1c0bd9664427a05aab79bfba777a6db94fd4e56fae0cb849 \
+    --hash=sha256:f586c26118bc6e714ec58c09df0157fe2d9ee195c764f630eb0d8e7ccce72e69 \
+    --hash=sha256:f6fe02afde060bbeef044af7996f335fbe90b039ccf3f5eb8f16df8b20f77666
+    # via
+    #   -r requirements/dev-buster-requirements.in
+    #   -r requirements/dev-sdw-requirements.in
+boltons==21.0.0 \
+    --hash=sha256:65e70a79a731a7fe6e98592ecfb5ccf2115873d01dbc576079874629e5c90f13 \
+    --hash=sha256:b9bb7b58b2b420bbe11a6025fdef6d3e5edc9f76a42fb467afe7ca212ef9948b
+    # via
+    #   face
+    #   glom
+    #   semgrep
 bracex==2.2.1 \
     --hash=sha256:096c4b788bf492f7af4e90ef8b5bcbfb99759ae3415ea1b83c9d29a5ed8f9a94 \
     --hash=sha256:1c8d1296e00ad9a91030ccb4c291f9e4dc7c054f12c707ba3c5ff3e9a81bcd21
@@ -70,9 +80,9 @@ charset-normalizer==2.0.4 \
     # via
     #   -r requirements/requirements.in
     #   requests
-click==8.0.4 \
-    --hash=sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1 \
-    --hash=sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb
+click==8.1.3 \
+    --hash=sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e \
+    --hash=sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48
     # via
     #   black
     #   click-option-group
@@ -137,6 +147,10 @@ execnet==1.9.0 \
     --hash=sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5 \
     --hash=sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142
     # via pytest-xdist
+face==20.1.1 \
+    --hash=sha256:3790311a7329e4b0d90baee346eecad54b337629576edf3a246683a5f0d24446 \
+    --hash=sha256:7d59ca5ba341316e58cf72c6aff85cca2541cf5056c4af45cb63af9a814bed3e
+    # via glom
 flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
@@ -145,6 +159,10 @@ flaky==3.7.0 \
     --hash=sha256:3ad100780721a1911f57a165809b7ea265a7863305acb66708220820caf8aa0d \
     --hash=sha256:d6eda73cab5ae7364504b7c44670f70abed9e75f77dd116352f662817592ec9c
     # via -r requirements/dev-sdw-requirements.in
+glom==22.1.0 \
+    --hash=sha256:1510c6587a8f9c64a246641b70033cbc5ebde99f02ad245693678038e821aeb5 \
+    --hash=sha256:5339da206bf3532e01a83a35aca202960ea885156986d190574b779598e9e772
+    # via semgrep
 idna==3.2 \
     --hash=sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a \
     --hash=sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3
@@ -164,6 +182,10 @@ importlib-metadata==4.2.0 \
     #   pep517
     #   pluggy
     #   pytest
+importlib-resources==5.8.0 \
+    --hash=sha256:568c9f16cb204f9decc8d6d24a572eeea27dacbb4cee9e6b03a8025736769751 \
+    --hash=sha256:7952325ffd516c05a8ad0858c74dff2c3343f136fe66a6002b2623dd1d43f223
+    # via jsonschema
 iniconfig==1.1.1 \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
@@ -172,9 +194,9 @@ isort==5.10.1 \
     --hash=sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7 \
     --hash=sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951
     # via -r requirements/dev-sdw-requirements.in
-jsonschema==3.2.0 \
-    --hash=sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163 \
-    --hash=sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a
+jsonschema==4.7.2 \
+    --hash=sha256:73764f461d61eb97a057c929368610a134d1d1fffd858acfe88864ee94f1f1d3 \
+    --hash=sha256:c7448a421b25e424fccfceea86b4e3a8672b4436e1988ccbde92c80828d4f085
     # via semgrep
 mako==1.0.7 \
     --hash=sha256:4e02fde57bd4abb5ec400181e4c314f56ac3e49ba4fb8b0d50bba18cb27d25ae
@@ -549,6 +571,10 @@ python-editor==1.0.3 \
     # via
     #   -r requirements/requirements.in
     #   alembic
+python-lsp-jsonrpc==1.0.0 \
+    --hash=sha256:079b143be64b0a378bdb21dff5e28a8c1393fe7e8a654ef068322d754e545fc7 \
+    --hash=sha256:7bec170733db628d3506ea3a5288ff76aa33c70215ed223abdb0d95e957660bd
+    # via semgrep
 python3-xlib==0.15 \
     --hash=sha256:dc4245f3ae4aa5949c1d112ee4723901ade37a96721ba9645f2bfa56e5b383f8
     # via
@@ -642,11 +668,14 @@ ruamel-yaml-clib==0.2.6 \
 securedrop-sdk==0.4.0 \
     --hash=sha256:c08f77bae5f900b1fbcd3b5aae1c931dc877e7289d69aa5a8b1e3c3f4e0dc561
     # via -r requirements/requirements.in
-semgrep==0.84.0 \
-    --hash=sha256:405f828c0c3db2236c2089c8fa2d1200ec9fa8eba2c60e9494c689995a4c4ac3 \
-    --hash=sha256:59388a8212aad2fadea82135a41178dbb31041cb896d4a63a8f3b803242df16d \
-    --hash=sha256:cc9d3361e01a597cf8c32649c44a7ebd8640d2ea11e91e014d231cd104157c05
-    # via -r requirements/dev-sdw-requirements.in
+semgrep==0.104.0 \
+    --hash=sha256:3a68d8e8f5b069a9ab99c69d52923534216b537165650088363df8cf70599170 \
+    --hash=sha256:6d71ddc4684f8bab3a75788f7e90dc26cd0c8f686192f9b33a2dedd727c8a871 \
+    --hash=sha256:ea4105fe0d61e4af478340646a5e67221c2b58754d3c0320520a0cc73579cea0 \
+    --hash=sha256:f84dcfb55b63fb4b91a63f284da2447329fbdeaffd912f0ac44b2e3b456decdc
+    # via
+    #   -r requirements/dev-buster-requirements.in
+    #   -r requirements/dev-sdw-requirements.in
 sip==4.19.8 \
     --hash=sha256:09f9a4e6c28afd0bafedb26ffba43375b97fe7207bd1a0d3513f79b7d168b331 \
     --hash=sha256:105edaaa1c8aa486662226360bd3999b4b89dd56de3e314d82b83ed0587d8783 \
@@ -666,7 +695,6 @@ six==1.11.0 \
     --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb
     # via
     #   -r requirements/requirements.in
-    #   jsonschema
     #   pathlib2
     #   python-dateutil
     #   vcrpy
@@ -729,14 +757,68 @@ types-setuptools==57.4.10 \
     --hash=sha256:9a13513679c640f6616e2d9ab50d431c99ca8ae9848a97243f887c80fd5cf294 \
     --hash=sha256:ddc98da82c12e1208012d65276641a132d3aadc78ecfff68fd3e17d85933a3c1
     # via -r requirements/dev-sdw-requirements.in
-typing-extensions==4.1.1 \
-    --hash=sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42 \
-    --hash=sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2
+typing-extensions==4.3.0 \
+    --hash=sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02 \
+    --hash=sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6
     # via
     #   black
     #   importlib-metadata
+    #   jsonschema
     #   mypy
+    #   semgrep
     #   yarl
+ujson==5.4.0 \
+    --hash=sha256:025758cf6561af6986d77cd4af9367ab56dde5c7c50f13f59e6964b4b25df73e \
+    --hash=sha256:0551c1ba0bc9e05b69d9c18266dbc93252b5fa3cd9940051bc88a0dd33607b19 \
+    --hash=sha256:05e411627e5d6ee773232960ca7307e66017f78e3fa74f7e95c3a8cc5cb05415 \
+    --hash=sha256:0b46aee21e5d75426c4058dfdb42f7e7b1d130c664ee5027a8dbbc50872dc32b \
+    --hash=sha256:0bcde3135265ecdd5714a7de4fdc167925390d7b17ca325e59980f4114c962b8 \
+    --hash=sha256:1120c8263f7d85e89533a2b46d80cc6def15114772010ede4d197739e111dba6 \
+    --hash=sha256:13297a7d501f9c8c53e409d4fa57cc574e4fbfbe8807ef2c4c7ce2e3ec933a85 \
+    --hash=sha256:191f88d5865740497b9827ef9b7c12f37a79872ac984e09f0901a10024019380 \
+    --hash=sha256:1a2e645325f844f9c890c9d956fc2d35ca91f38c857278238ef6516c2f99cf7c \
+    --hash=sha256:2974b17bc522ef86d98b498959d82f03c02e07d9eb08746026415298f4a4bca3 \
+    --hash=sha256:2d98248f1df1e1aab67e0374ab98945dd36bc1764753d71fd8aea5f296360b76 \
+    --hash=sha256:31bdb6d771d5ef6d37134b42211500bfe176c55d399f3317e569783dc42ed38e \
+    --hash=sha256:3212847d3885bfd4f5fd56cdc37645a8f8e8a80d6cb569505da22fd9eb0e1a02 \
+    --hash=sha256:326a96324ed9215b0bc9f1a5af324fb33900b6b0901516bcc421475d6596de0d \
+    --hash=sha256:381c97d326d1ec569d318cc0ae83940ea2df125ede1000871680fefd5b7fdea9 \
+    --hash=sha256:39bb702ca1612253b5e4b6004e0f20208c98a446606aa351f9a7ba5ceaff0eb8 \
+    --hash=sha256:3a0707f381f97e1287c0dbf94d95bd6c0bbf6e4eeeaa656f0076b7883010c818 \
+    --hash=sha256:400e4ca8a59f71398e8fa56c4d2d6f535e2a121ddb57284ec15752ffce2dd63a \
+    --hash=sha256:422653083c6df6cec17fdb5d6106c209aad9b0c94131c53b073980403db22167 \
+    --hash=sha256:511aa641a5b91d19280183b134fb6c473039d4dd82e987ac810cffba783521ac \
+    --hash=sha256:5df8b6369ee5ee2685fcc917f6c46b34e599c6e9a512fada6dfd752b909fa06a \
+    --hash=sha256:67f4e2fa81e1d99c01e7b1978ab0cbf3c9a8b663f683a709f87baad110d5b940 \
+    --hash=sha256:68c7f753aec490c6566fd3cd301887c413ac3a588316e446f30a4134ac665668 \
+    --hash=sha256:6a20f2f6e8818c1ab89dd4be6bbad3fc2ddb15287f89e7ea35f3eb849afebbd9 \
+    --hash=sha256:6b953e09441e307504130755e5bd6b15850178d591f66292bba4608c4f7f9b00 \
+    --hash=sha256:754f422aba8db8201a1073f25e2f732effc6471f8755708b16e6ebf19dd23634 \
+    --hash=sha256:784dbd12925845a3f0757a956447e2fd31418abb5aeaebf3aca1203195f16fd1 \
+    --hash=sha256:7d4c9ccd30e621e714ec24ca911ad8873567dc1ac1e5e914405ea9dd16b9d40c \
+    --hash=sha256:7e12272361e9722777c83b3f5b0bb91d402531f36e80c6e5fafb6acb89e897e3 \
+    --hash=sha256:8cce79ce47c37132373fbdf55b683883c262a3a60763130e080b8394c1201d32 \
+    --hash=sha256:8cd6117e33233f2de6bc896eea6a5a59b58a37db08f371157264e0ec5e51c76a \
+    --hash=sha256:8d472efa9c92e1b2933a22d2f1dbd5237087997136b24ac2b913bf4e8be03135 \
+    --hash=sha256:91edcf9978ee401119e9c8589376ae37fd3e6e75ee365c49385cb005eaff1535 \
+    --hash=sha256:9ae1d0094ce730e39e09656bc14074d9573cdd80adec1a55b06d8bf1f9613a01 \
+    --hash=sha256:aa00b746138835271653b0c3da171d2a8b510c579381f71e8b8e03484d50d825 \
+    --hash=sha256:aaa77af91df3f71858a1f792c74d3f2d3abf3875f93ab1a2b9a24b3797743b02 \
+    --hash=sha256:b045ca5497a950cc3492840adb3bcb3b9e305ed6599ed14c6aeaa08011aa463f \
+    --hash=sha256:b40a3757a563ef77c3f2f9ea1732c2924e8b3b2bda3fa89513f949472ad40b6e \
+    --hash=sha256:baa76a6f707a6d22437fe9c7ec9719672fb04d4d9435a3e80ee9b1aaeb2089d9 \
+    --hash=sha256:cec010d318a0238b1333ea9f40d5603d374cc026c29c4471e2661712c6682da1 \
+    --hash=sha256:dd0d4ec694cab8a0a4d85f45f81ae0065465c4670f0db72ba48d6c4e7ae42834 \
+    --hash=sha256:e2a9ddb5c6d1427056b8d62a1a172a18ae522b14d9ba5996b8281b09cba87edd \
+    --hash=sha256:e844be0831042aa91e847e5ab03bddd1089ab1a8dd0a1bf90411abf864f058b2 \
+    --hash=sha256:e91947fda8354ea7faf698b084ebcdbabd239e7b15d8436fb74394f59a207ac9 \
+    --hash=sha256:ea7fbc540bc04d5b05e5cd54e60ee8745ac665eedf2bad2ba9d12d5c7a7b7d2e \
+    --hash=sha256:ee29cf5cfc1e841708297633e1ce749aa851fb96830bbe51f2e5940741ff2441 \
+    --hash=sha256:ef985eb2770900a485431910bd3f333b56d1a34b65f8c26a6ed8e8adf55f98d9 \
+    --hash=sha256:f5c547d49a7e9d3f231e9323171bbbbcef63173fb007a2787cd4f05ac6269315 \
+    --hash=sha256:fbea46c0fbc1c3bc8f957afd8dbb25b4ea3a356e18ee6dd79ace6cf32bd4cff7 \
+    --hash=sha256:fd82932aaa224abd7d01e823b77aef9970f5ac1695027331d99e7f5fda9d37f5
+    # via python-lsp-jsonrpc
 urllib3==1.26.6 \
     --hash=sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4 \
     --hash=sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f
@@ -744,6 +826,7 @@ urllib3==1.26.6 \
     #   -r requirements/requirements.in
     #   requests
     #   securedrop-sdk
+    #   semgrep
 vcrpy==4.1.1 \
     --hash=sha256:12c3fcdae7b88ecf11fc0d3e6d77586549d4575a2ceee18e82eee75c1f626162 \
     --hash=sha256:57095bf22fc0a2d99ee9674cdafebed0f3ba763018582450706f7d3a74fff599
@@ -905,6 +988,7 @@ zipp==3.7.0 \
     --hash=sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375
     # via
     #   importlib-metadata
+    #   importlib-resources
     #   pep517
 
 # The following packages are considered to be unsafe in a requirements file:
@@ -915,7 +999,4 @@ pip==22.0.4 \
 setuptools==60.9.3 \
     --hash=sha256:2347b2b432c891a863acadca2da9ac101eae6169b1d3dfee2ec605ecd50dbfe5 \
     --hash=sha256:e4f30b9f84e5ab3decf945113119649fec09c1fc3507c6ebffec75646c56e62b
-    # via
-    #   jsonschema
-    #   pip-tools
-    #   semgrep
+    # via pip-tools

--- a/securedrop_client/config.py
+++ b/securedrop_client/config.py
@@ -1,12 +1,8 @@
 import json
 import logging
 import os
-from typing import Type, TypeVar
 
 logger = logging.getLogger(__name__)
-
-# See: https://mypy.readthedocs.io/en/stable/generics.html#generic-methods-and-generic-self
-T = TypeVar("T", bound="Config")
 
 
 class Config:
@@ -17,8 +13,8 @@ class Config:
         self.journalist_key_fingerprint = journalist_key_fingerprint
 
     @classmethod
-    def from_home_dir(cls: Type[T], sdc_home: str) -> T:
-        full_path = os.path.join(sdc_home, cls.CONFIG_NAME)
+    def from_home_dir(cls, sdc_home: str) -> "Config":
+        full_path = os.path.join(sdc_home, Config.CONFIG_NAME)
 
         try:
             with open(full_path) as f:
@@ -27,7 +23,9 @@ class Config:
             logger.error("Error opening config file at {}: {}".format(full_path, e))
             json_config = {}
 
-        return cls(journalist_key_fingerprint=json_config.get("journalist_key_fingerprint", None))
+        return Config(
+            journalist_key_fingerprint=json_config.get("journalist_key_fingerprint", None)
+        )
 
     @property
     def is_valid(self) -> bool:

--- a/securedrop_client/gui/conversation/__init__.py
+++ b/securedrop_client/gui/conversation/__init__.py
@@ -6,3 +6,4 @@ from .delete import DeleteConversationDialog  # noqa: F401
 from .export import Device as ExportDevice  # noqa: F401
 from .export import Dialog as ExportFileDialog  # noqa: F401
 from .export import PrintDialog as PrintFileDialog  # noqa: F401
+from .export import StubDevice as StubExportDevice  # noqa: F401

--- a/securedrop_client/gui/conversation/export/__init__.py
+++ b/securedrop_client/gui/conversation/export/__init__.py
@@ -1,3 +1,3 @@
-from .device import Device  # noqa: F401
+from .device import Device, StubDevice  # noqa: F401
 from .dialog import ExportDialog as Dialog  # noqa: F401
 from .print_dialog import PrintDialog  # noqa: F401

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2401,6 +2401,13 @@ class FileWidget(QWidget):
         """
         Called when the export button is clicked.
         """
+        # Note that we also check + side-effect this in the export device.
+        # That makes me think we're trying to prevent errors when the file
+        # is removed from disk while the dialog is open. If that's the case,
+        # I don't think asking again and again is a good solution, and
+        # we should probably look into treating this as a concurrency problem
+        # with either concurrency tools or by removing the concurrency altogether,
+        # for example, by copying the file we need and working on a copy.
         if not self.controller.downloaded_file_exists(self.file):
             return
 
@@ -2414,6 +2421,7 @@ class FileWidget(QWidget):
         """
         Called when the print button is clicked.
         """
+        # Same comment as _on_export_clicked regarding handling the file presence.
         if not self.controller.downloaded_file_exists(self.file):
             return
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2197,7 +2197,14 @@ class FileWidget(QWidget):
         super().__init__()
 
         self.controller = controller
-        self._export_device = conversation.ExportDevice(controller, controller.export_thread)
+
+        if self.controller.qubes:
+            self._export_device = conversation.ExportDevice(controller, controller.export_thread)
+        else:
+            self._export_device = conversation.StubExportDevice(
+                controller, controller.export_thread
+            )  # pragma: nocover
+
         self.file = self.controller.get_file(file_uuid)
         self.uuid = file_uuid
         self.index = index

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -356,6 +356,9 @@ class Controller(QObject):
         # Controller is unauthenticated by default
         self.__is_authenticated = False
 
+        # Note: self.home is part of the application configuration. It is never updated
+        # while the application is running.
+
         # used for finding DB in sync thread
         self.home = home
 

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -359,6 +359,10 @@ class Controller(QObject):
         # used for finding DB in sync thread
         self.home = home
 
+        # Note: both self.proxy and self.qubes are static. They represent charateristics
+        # of the environment and are never updated when the application is running.
+        # Is the controller the best place to store that information?
+
         # boolean flag for whether or not the client is operating behind a proxy
         self.proxy = proxy
 

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -914,11 +914,16 @@ class Controller(QObject):
         except Exception as e:
             logger.error(f"Could not emit reply_download_failed: {e}")
 
+    # Note: this method groups a query (does the file exist?) and a command (notify the GUI
+    # that the file doesnt exist).
     def downloaded_file_exists(self, file: db.File) -> bool:
         """
         Check if the file specified by file_uuid exists. If it doesn't update the local db and
         GUI to show the file as not downloaded.
         """
+        # Note: this method definition depends on db.File, a database type, but doesn't actually
+        # make use of any database-specific behavior of that type. Depending on the db package
+        # seems unnecessary.
         if not os.path.exists(file.location(self.data_dir)):
             self.gui.update_error_status(
                 _("File does not exist in the data directory. Please try re-downloading.")
@@ -928,9 +933,12 @@ class Controller(QObject):
                     os.path.dirname(file.filename)
                 )
             )
+            # This is a command.
             missing_files = storage.update_missing_files(self.data_dir, self.session)
             for f in missing_files:
                 self.file_missing.emit(f.source.uuid, f.uuid, str(f))
+
+            # This return value is a query response.
             return False
         return True
 

--- a/tests/gui/conversation/export/test_device.py
+++ b/tests/gui/conversation/export/test_device.py
@@ -4,7 +4,7 @@ from PyQt5.QtTest import QSignalSpy
 
 from securedrop_client.app import threads
 from securedrop_client.export import Export
-from securedrop_client.gui.conversation.export import Device
+from securedrop_client.gui.conversation.export import Device, StubDevice
 from securedrop_client.gui.main import Window
 from securedrop_client.logic import Controller
 from tests import factory
@@ -38,7 +38,7 @@ def test_Device_run_printer_preflight_checks(homedir, mocker, source):
         assert len(print_preflight_check_requested_emissions) == 1
 
 
-def test_Device_run_printer_preflight_checks_not_qubes(homedir, mocker, source):
+def test_StubDevice_run_printer_preflight_checks(homedir, mocker, source):
     gui = mocker.MagicMock(spec=Window)
     with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
         controller = Controller(
@@ -52,18 +52,14 @@ def test_Device_run_printer_preflight_checks_not_qubes(homedir, mocker, source):
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service_thread=export_thread)
-        controller.qubes = False
-        print_preflight_check_requested_emissions = QSignalSpy(
-            device.print_preflight_check_requested
-        )
+        device = StubDevice(controller, export_service_thread=export_thread)
         print_preflight_check_succeeded_emissions = QSignalSpy(
             device.print_preflight_check_succeeded
         )
 
         device.run_printer_preflight_checks()
 
-        assert len(print_preflight_check_requested_emissions) == 0
+        assert not hasattr(device, "print_preflight_check_requested_emissions")
         assert len(print_preflight_check_succeeded_emissions) == 1
 
 
@@ -97,7 +93,7 @@ def test_Device_run_print_file(mocker, homedir):
         assert len(print_requested_emissions) == 1
 
 
-def test_Device_run_print_file_not_qubes(mocker, homedir):
+def test_StubDevice_run_print_file(mocker, homedir):
     gui = mocker.MagicMock(spec=Window)
     with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
         controller = Controller(
@@ -111,20 +107,9 @@ def test_Device_run_print_file_not_qubes(mocker, homedir):
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service_thread=export_thread)
-        controller.qubes = False
-        print_requested_emissions = QSignalSpy(device.print_requested)
-        file = factory.File(source=factory.Source())
-        mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
+        device = StubDevice(controller, export_service_thread=export_thread)
 
-        filepath = file.location(controller.data_dir)
-        os.makedirs(os.path.dirname(filepath), mode=0o700, exist_ok=True)
-        with open(filepath, "w"):
-            pass
-
-        device.print_file(file.uuid)
-
-        assert len(print_requested_emissions) == 0
+        assert not hasattr(device, "print_requested")
 
 
 def test_Device_print_file_file_missing(homedir, mocker, session):
@@ -158,7 +143,7 @@ def test_Device_print_file_file_missing(homedir, mocker, session):
         warning_logger.assert_called_once_with(log_msg)
 
 
-def test_Device_print_file_file_missing_not_qubes(homedir, mocker, session):
+def test_StubDevice_print_file_file_missing(homedir, mocker, session):
     """
     If the file is missing from the data dir, is_downloaded should be set to False and the failure
     should be communicated to the user.
@@ -176,8 +161,7 @@ def test_Device_print_file_file_missing_not_qubes(homedir, mocker, session):
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service_thread=export_thread)
-        controller.qubes = False
+        device = StubDevice(controller, export_service_thread=export_thread)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
         warning_logger = mocker.patch("securedrop_client.logic.logger.warning")
@@ -220,7 +204,7 @@ def test_Device_print_file_when_orig_file_already_exists(homedir, config, mocker
         controller.get_file.assert_called_with(file.uuid)
 
 
-def test_Device_print_file_when_orig_file_already_exists_not_qubes(homedir, config, mocker, source):
+def test_StubDevice_print_file_when_orig_file_already_exists(homedir, config, mocker, source):
     """
     The signal `print_requested` should not be emited if the original file already exists.
     """
@@ -237,16 +221,14 @@ def test_Device_print_file_when_orig_file_already_exists_not_qubes(homedir, conf
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service_thread=export_thread)
-        controller.qubes = False
-        print_requested_emissions = QSignalSpy(device.print_requested)
+        device = StubDevice(controller, export_service_thread=export_thread)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
         mocker.patch("os.path.exists", return_value=True)
 
         device.print_file(file.uuid)
 
-        assert len(print_requested_emissions) == 0
+        assert not hasattr(device, "print_requested")
         controller.get_file.assert_called_with(file.uuid)
 
 
@@ -277,7 +259,7 @@ def test_Device_run_export_preflight_checks(homedir, mocker, source):
         assert len(export_preflight_check_requested_emissions) == 1
 
 
-def test_Device_run_export_preflight_checks_not_qubes(homedir, mocker, source):
+def test_StubDevice_run_export_preflight_checks(homedir, mocker, source):
     gui = mocker.MagicMock(spec=Window)
     with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
         controller = Controller(
@@ -291,11 +273,7 @@ def test_Device_run_export_preflight_checks_not_qubes(homedir, mocker, source):
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service_thread=export_thread)
-        controller.qubes = False
-        export_preflight_check_requested_emissions = QSignalSpy(
-            device.export_preflight_check_requested
-        )
+        device = StubDevice(controller, export_service_thread=export_thread)
         export_preflight_check_succeeded_emissions = QSignalSpy(
             device.export_preflight_check_succeeded
         )
@@ -304,7 +282,7 @@ def test_Device_run_export_preflight_checks_not_qubes(homedir, mocker, source):
 
         device.run_export_preflight_checks()
 
-        assert len(export_preflight_check_requested_emissions) == 0
+        assert not hasattr(device, "export_preflight_check_requested_emissions")
         assert len(export_preflight_check_succeeded_emissions) == 1
 
 
@@ -341,7 +319,7 @@ def test_Device_export_file_to_usb_drive(homedir, mocker):
         assert len(export_requested_emissions) == 1
 
 
-def test_Device_export_file_to_usb_drive_not_qubes(homedir, mocker):
+def test_StubDevice_export_file_to_usb_drive(homedir, mocker):
     """
     The signal `export_requested` should be emmited during export_file_to_usb_drive.
     """
@@ -358,22 +336,9 @@ def test_Device_export_file_to_usb_drive_not_qubes(homedir, mocker):
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service_thread=export_thread)
-        controller.qubes = False
-        export_requested_emissions = QSignalSpy(device.export_requested)
-        device._export_service.send_file_to_usb_device = mocker.MagicMock()
-        file = factory.File(source=factory.Source())
-        mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
+        device = StubDevice(controller, export_service_thread=export_thread)
 
-        filepath = file.location(controller.data_dir)
-        os.makedirs(os.path.dirname(filepath), mode=0o700, exist_ok=True)
-        with open(filepath, "w"):
-            pass
-
-        device.export_file_to_usb_drive(file.uuid, "mock passphrase")
-
-        device._export_service.send_file_to_usb_device.assert_not_called()
-        assert len(export_requested_emissions) == 0
+        assert not hasattr(device, "export_requested")
 
 
 def test_Device_export_file_to_usb_drive_file_missing(homedir, mocker, session):
@@ -407,7 +372,7 @@ def test_Device_export_file_to_usb_drive_file_missing(homedir, mocker, session):
         warning_logger.assert_called_once_with(log_msg)
 
 
-def test_Device_export_file_to_usb_drive_file_missing_not_qubes(homedir, mocker, session):
+def test_StubDevice_export_file_to_usb_drive_file_missing(homedir, mocker, session):
     """
     If the file is missing from the data dir, is_downloaded should be set to False and the failure
     should be communicated to the user.
@@ -425,8 +390,7 @@ def test_Device_export_file_to_usb_drive_file_missing_not_qubes(homedir, mocker,
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service_thread=export_thread)
-        controller.qubes = False
+        device = StubDevice(controller, export_service_thread=export_thread)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
         warning_logger = mocker.patch("securedrop_client.logic.logger.warning")
@@ -471,8 +435,8 @@ def test_Device_export_file_to_usb_drive_when_orig_file_already_exists(
         controller.get_file.assert_called_with(file.uuid)
 
 
-def test_Device_export_file_to_usb_drive_when_orig_file_already_exists_not_qubes(
-    homedir, config, mocker, source
+def test_StubDevice_export_file_to_usb_drive_when_orig_file_already_exists(
+    homedir, config, session, mocker, source
 ):
     """
     The signal `export_requested` should still be emmited if the original file already exists.
@@ -482,7 +446,7 @@ def test_Device_export_file_to_usb_drive_when_orig_file_already_exists_not_qubes
         controller = Controller(
             "http://localhost",
             gui,
-            no_session,
+            session,
             homedir,
             None,
             export_thread=export_thread,
@@ -490,19 +454,12 @@ def test_Device_export_file_to_usb_drive_when_orig_file_already_exists_not_qubes
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service_thread=export_thread)
-        controller.qubes = False
-        controller.data_dir = ""
-        export_requested_emissions = QSignalSpy(device.export_requested)
+        device = StubDevice(controller, export_service_thread=export_thread)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
-
-        filepath = file.location(controller.data_dir)
-        os.makedirs(os.path.dirname(filepath), mode=0o700, exist_ok=True)
-        with open(filepath, "w"):
-            pass
+        mocker.patch("os.path.exists", return_value=True)
 
         device.export_file_to_usb_drive(file.uuid, "mock passphrase")
 
-        assert len(export_requested_emissions) == 0
+        assert not hasattr(device, "export_requested")
         controller.get_file.assert_called_with(file.uuid)

--- a/tests/gui/conversation/export/test_device.py
+++ b/tests/gui/conversation/export/test_device.py
@@ -192,7 +192,7 @@ def test_Device_print_file_file_missing_not_qubes(homedir, mocker, session):
 
 def test_Device_print_file_when_orig_file_already_exists(homedir, config, mocker, source):
     """
-    The signal `print_requested` should still be emmited if the original file already exists.
+    The signal `print_requested` should still be emited if the original file already exists.
     """
     gui = mocker.MagicMock(spec=Window)
     with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
@@ -222,7 +222,7 @@ def test_Device_print_file_when_orig_file_already_exists(homedir, config, mocker
 
 def test_Device_print_file_when_orig_file_already_exists_not_qubes(homedir, config, mocker, source):
     """
-    The signal `print_requested` should still be emmited if the original file already exists.
+    The signal `print_requested` should not be emited if the original file already exists.
     """
     gui = mocker.MagicMock(spec=Window)
     with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
@@ -242,16 +242,11 @@ def test_Device_print_file_when_orig_file_already_exists_not_qubes(homedir, conf
         print_requested_emissions = QSignalSpy(device.print_requested)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
+        mocker.patch("os.path.exists", return_value=True)
 
-        filepath = file.location(controller.data_dir)
-        os.makedirs(os.path.dirname(filepath), mode=0o700, exist_ok=True)
-        with open(filepath, "w"):
-            pass
-
-        device.export_file_to_usb_drive(file.uuid, "mock passphrase")
+        device.print_file(file.uuid)
 
         assert len(print_requested_emissions) == 0
-        controller.get_file.assert_called_with(file.uuid)
         controller.get_file.assert_called_with(file.uuid)
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -171,7 +171,7 @@ def print_dialog(mocker, homedir):
         )
         controller.authenticated_user = factory.User()
         controller.qubes = False
-        export_device = conversation.ExportDevice(controller)
+        export_device = conversation.StubExportDevice(controller)
         gui.setup(controller)
         gui.login_dialog.close()
         dialog = conversation.PrintFileDialog(export_device, "file_uuid", "file_name")
@@ -204,7 +204,7 @@ def export_dialog(mocker, homedir):
         )
         controller.authenticated_user = factory.User()
         controller.qubes = False
-        export_device = conversation.ExportDevice(controller)
+        export_device = conversation.StubExportDevice(controller)
         gui.setup(controller)
         gui.login_dialog.close()
         dialog = conversation.ExportFileDialog(export_device, "file_uuid", "file_name")


### PR DESCRIPTION
## Description

:crystal_ball: _**Reviewers (@rocodes)**: This PR really makes sense to review commit by commit, especially because there is some refactoring / clean up / fixing in the beginning._


This is a follow up on #1524. That pull request extracted the export code from the `Controller` class, but retained a dependency on the controller for the purpose of accessing some environment information (`controller.qubes`), some configuration (`controller.data_dir`), some database access (`controller.get_file`), and some local filesystem access (`controller.downloaded_file_exists`).

This PR moves those around so that `export.Device` doesn't need to depend on `Controller` anymore.

## To dos

- [x] `controller.qubes` :confetti_ball: Gone.
- [ ] `controller.data_dir`
- [ ] `controller.get_file`
- [ ] `controller.downloaded_file_exists`

## Test Plan

TK
