### PR TITLE
Make dialog titles translatable; tweak Semgrep rules

### DIFF
--- a/.semgrep/custom-rules.yml
+++ b/.semgrep/custom-rules.yml
@@ -162,7 +162,7 @@ rules:
   message: String formatted before gettext
   patterns:
     - pattern-either:
-        - pattern-regex: |
-            _\(\s*"(.*)".format\(
-        - pattern-regex: |
+        - pattern-regex: |-
+            _\(\s*".*"\s*\.format\(
+        - pattern-regex: |-
             _\(\s*f"(.*)

--- a/securedrop_client/gui/conversation/export/dialog.py
+++ b/securedrop_client/gui/conversation/export/dialog.py
@@ -48,14 +48,10 @@ class ExportDialog(ModalDialog):
 
         # Dialog content
         self.starting_header = _(
-            "Preparing to export:"
-            "<br />"
-            '<span style="font-weight:normal">{}</span>'
+            "Preparing to export:<br />" '<span style="font-weight:normal">{}</span>'
         ).format(self.file_name)
         self.ready_header = _(
-            "Ready to export:"
-            "<br />"
-            '<span style="font-weight:normal">{}</span>'
+            "Ready to export:<br />" '<span style="font-weight:normal">{}</span>'
         ).format(self.file_name)
         self.insert_usb_header = _("Insert encrypted USB drive")
         self.passphrase_header = _("Enter passphrase for USB drive")

--- a/securedrop_client/gui/conversation/export/dialog.py
+++ b/securedrop_client/gui/conversation/export/dialog.py
@@ -50,13 +50,13 @@ class ExportDialog(ModalDialog):
         self.starting_header = _(
             "Preparing to export:"
             "<br />"
-            '<span style="font-weight:normal">{}</span>'.format(self.file_name)
-        )
+            '<span style="font-weight:normal">{}</span>'
+        ).format(self.file_name)
         self.ready_header = _(
             "Ready to export:"
             "<br />"
-            '<span style="font-weight:normal">{}</span>'.format(self.file_name)
-        )
+            '<span style="font-weight:normal">{}</span>'
+        ).format(self.file_name)
         self.insert_usb_header = _("Insert encrypted USB drive")
         self.passphrase_header = _("Enter passphrase for USB drive")
         self.success_header = _("Export successful")

--- a/securedrop_client/gui/conversation/export/print_dialog.py
+++ b/securedrop_client/gui/conversation/export/print_dialog.py
@@ -34,14 +34,10 @@ class PrintDialog(ModalDialog):
 
         # Dialog content
         self.starting_header = _(
-            "Preparing to print:"
-            "<br />"
-            '<span style="font-weight:normal">{}</span>'
+            "Preparing to print:<br />" '<span style="font-weight:normal">{}</span>'
         ).format(self.file_name)
         self.ready_header = _(
-            "Ready to print:"
-            "<br />"
-            '<span style="font-weight:normal">{}</span>'
+            "Ready to print:<br />" '<span style="font-weight:normal">{}</span>'
         ).format(self.file_name)
         self.insert_usb_header = _("Connect USB printer")
         self.error_header = _("Printing failed")

--- a/securedrop_client/gui/conversation/export/print_dialog.py
+++ b/securedrop_client/gui/conversation/export/print_dialog.py
@@ -36,13 +36,13 @@ class PrintDialog(ModalDialog):
         self.starting_header = _(
             "Preparing to print:"
             "<br />"
-            '<span style="font-weight:normal">{}</span>'.format(self.file_name)
-        )
+            '<span style="font-weight:normal">{}</span>'
+        ).format(self.file_name)
         self.ready_header = _(
             "Ready to print:"
             "<br />"
-            '<span style="font-weight:normal">{}</span>'.format(self.file_name)
-        )
+            '<span style="font-weight:normal">{}</span>'
+        ).format(self.file_name)
         self.insert_usb_header = _("Connect USB printer")
         self.error_header = _("Printing failed")
         self.starting_message = _(


### PR DESCRIPTION
# Description

- Fixes #1534
- Makes semgrep rules a bit more resilient (though they still wouldn't have caught these issues, sadly)

# Status

Ready for review

# Test Plan

## For dialog titles
Follow STR in #1534 and confirm that dialog titles now show up as translated.

## For semgrep tweaks

You can insert the following into `securedrop_client/gui/conversation/export/dialog.py` and run `make semgrep-local` to confirm that the two rules are working as expected:


For `.format()` method:

```
        self.starting_header = _(
            "Preparing to export:".format(self.file_name)
        )
```
For f-strings:

```
        self.starting_header = _(
            f"Preparing to export: {self.file_name}"
        )
```

Both should cause semgrep to exit nonzero and report an error.

# Checklist
- [x] These changes should not need testing in Qubes
- [x] No update to the AppArmor profile is required for these changes
- [x] No database schema changes are needed