### PR TITLE
Refactor remove controller dependency from export device (Part 1)

### DIFF
--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -34,7 +34,7 @@ from typing import Any, NewType, NoReturn
 from PyQt5.QtCore import Qt, QThread, QTimer
 from PyQt5.QtWidgets import QApplication, QMessageBox
 
-from securedrop_client import __version__, state
+from securedrop_client import __version__, export, state
 from securedrop_client.database import Database
 from securedrop_client.db import make_session_maker
 from securedrop_client.gui.main import Window
@@ -237,9 +237,19 @@ def start_app(args, qt_args) -> NoReturn:  # type: ignore [no-untyped-def]
     session = session_maker()
     database = Database(session)
     app_state = state.State(database)
-    gui = Window(app_state)
 
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
+    with threads(4) as [
+        export_service_thread,
+        sync_thread,
+        main_queue_thread,
+        file_download_queue_thread,
+    ]:
+        export_service = export.Service()
+        export_service.moveToThread(export_service_thread)
+        export_service_thread.start()
+
+        gui = Window(app_state, export_service)
+
         controller = Controller(
             "http://localhost:8081/",
             gui,
@@ -248,7 +258,7 @@ def start_app(args, qt_args) -> NoReturn:  # type: ignore [no-untyped-def]
             app_state,
             not args.no_proxy,
             not args.no_qubes,
-            export_thread,
+            export_service_thread,
             sync_thread,
             main_queue_thread,
             file_download_queue_thread,

--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -258,7 +258,6 @@ def start_app(args, qt_args) -> NoReturn:  # type: ignore [no-untyped-def]
             app_state,
             not args.no_proxy,
             not args.no_qubes,
-            export_service_thread,
             sync_thread,
             main_queue_thread,
             file_download_queue_thread,

--- a/securedrop_client/config.py
+++ b/securedrop_client/config.py
@@ -1,12 +1,8 @@
 import json
 import logging
 import os
-from typing import Type, TypeVar
 
 logger = logging.getLogger(__name__)
-
-# See: https://mypy.readthedocs.io/en/stable/generics.html#generic-methods-and-generic-self
-T = TypeVar("T", bound="Config")
 
 
 class Config:
@@ -17,8 +13,8 @@ class Config:
         self.journalist_key_fingerprint = journalist_key_fingerprint
 
     @classmethod
-    def from_home_dir(cls: Type[T], sdc_home: str) -> T:
-        full_path = os.path.join(sdc_home, cls.CONFIG_NAME)
+    def from_home_dir(cls, sdc_home: str) -> "Config":
+        full_path = os.path.join(sdc_home, Config.CONFIG_NAME)
 
         try:
             with open(full_path) as f:
@@ -27,7 +23,9 @@ class Config:
             logger.error("Error opening config file at {}: {}".format(full_path, e))
             json_config = {}
 
-        return cls(journalist_key_fingerprint=json_config.get("journalist_key_fingerprint", None))
+        return Config(
+            journalist_key_fingerprint=json_config.get("journalist_key_fingerprint", None)
+        )
 
     @property
     def is_valid(self) -> bool:

--- a/securedrop_client/export.py
+++ b/securedrop_client/export.py
@@ -87,6 +87,21 @@ class Export(QObject):
     ) -> None:
         super().__init__()
 
+        self.connect_signals(
+            export_preflight_check_requested,
+            export_requested,
+            print_preflight_check_requested,
+            print_requested,
+        )
+
+    def connect_signals(
+        self,
+        export_preflight_check_requested: Optional[pyqtSignal] = None,
+        export_requested: Optional[pyqtSignal] = None,
+        print_preflight_check_requested: Optional[pyqtSignal] = None,
+        print_requested: Optional[pyqtSignal] = None,
+    ) -> None:
+
         # This instance can optionally react to events to prevent
         # coupling it to dependent code.
         if export_preflight_check_requested is not None:
@@ -350,3 +365,6 @@ class Export(QObject):
                 self.print_call_failure.emit(e)
 
         self.export_completed.emit(filepaths)
+
+
+Service = Export

--- a/securedrop_client/gui/conversation/export/device.py
+++ b/securedrop_client/gui/conversation/export/device.py
@@ -2,9 +2,9 @@ import logging
 import os
 from typing import Optional
 
-from PyQt5.QtCore import QObject, QThread, pyqtSignal
+from PyQt5.QtCore import QObject, pyqtSignal
 
-from securedrop_client.export import Export
+from securedrop_client import export
 from securedrop_client.logic import Controller
 
 logger = logging.getLogger(__name__)
@@ -36,54 +36,48 @@ class Device(QObject):
     print_failed = pyqtSignal(object)
 
     def __init__(
-        self, controller: Controller, export_service_thread: Optional[QThread] = None
+        self, controller: Controller, export_service: Optional[export.Service] = None
     ) -> None:
         super().__init__()
 
         self._controller = controller
+        self._export_service = export_service
 
-        self._export_service = Export(
-            self.export_preflight_check_requested,
-            self.export_requested,
-            self.print_preflight_check_requested,
-            self.print_requested,
-        )
+        if self._export_service is not None:
+            self._export_service.connect_signals(
+                self.export_preflight_check_requested,
+                self.export_requested,
+                self.print_preflight_check_requested,
+                self.print_requested,
+            )
 
-        # Abstract the Export instance away from the GUI
-        self._export_service.preflight_check_call_success.connect(
-            self.export_preflight_check_succeeded
-        )
-        self._export_service.preflight_check_call_failure.connect(
-            self.export_preflight_check_failed
-        )
+            # Abstract the Export instance away from the GUI
+            self._export_service.preflight_check_call_success.connect(
+                self.export_preflight_check_succeeded
+            )
+            self._export_service.preflight_check_call_failure.connect(
+                self.export_preflight_check_failed
+            )
 
-        self._export_service.export_usb_call_success.connect(self.export_succeeded)
-        self._export_service.export_usb_call_failure.connect(self.export_failed)
-        self._export_service.export_completed.connect(self.export_completed)
+            self._export_service.export_usb_call_success.connect(self.export_succeeded)
+            self._export_service.export_usb_call_failure.connect(self.export_failed)
+            self._export_service.export_completed.connect(self.export_completed)
 
-        self._export_service.printer_preflight_success.connect(self.print_preflight_check_succeeded)
-        self._export_service.printer_preflight_failure.connect(self.print_preflight_check_failed)
+            self._export_service.printer_preflight_success.connect(
+                self.print_preflight_check_succeeded
+            )
+            self._export_service.printer_preflight_failure.connect(
+                self.print_preflight_check_failed
+            )
 
-        self._export_service.print_call_failure.connect(self.print_failed)
-        self._export_service.print_call_success.connect(self.print_succeeded)
-
-        if export_service_thread is not None:
-            # Run export object in a separate thread context (a reference to the
-            # thread is kept on self such that it does not get garbage collected
-            # after this method returns) - we want to keep our export thread around for
-            # later processing.
-            self._move_export_service_to_thread(export_service_thread)
+            self._export_service.print_call_failure.connect(self.print_failed)
+            self._export_service.print_call_success.connect(self.print_succeeded)
 
     def run_printer_preflight_checks(self) -> None:
         """
         Run preflight checks to make sure the Export VM is configured correctly.
         """
         logger.info("Running printer preflight check")
-
-        if not self._controller.qubes:
-            self.print_preflight_check_succeeded.emit()
-            return
-
         self.print_preflight_check_requested.emit()
 
     def run_export_preflight_checks(self) -> None:
@@ -91,11 +85,6 @@ class Device(QObject):
         Run preflight checks to make sure the Export VM is configured correctly.
         """
         logger.info("Running export preflight check")
-
-        if not self._controller.qubes:
-            self.export_preflight_check_succeeded.emit()
-            return
-
         self.export_preflight_check_requested.emit()
 
     def export_file_to_usb_drive(self, file_uuid: str, passphrase: str) -> None:
@@ -109,10 +98,6 @@ class Device(QObject):
         logger.info("Exporting file in: {}".format(os.path.dirname(file_location)))
 
         if not self._controller.downloaded_file_exists(file):
-            return
-
-        if not self._controller.qubes:
-            self.export_succeeded.emit()
             return
 
         self.export_requested.emit([file_location], passphrase)
@@ -129,13 +114,4 @@ class Device(QObject):
         if not self._controller.downloaded_file_exists(file):
             return
 
-        if not self._controller.qubes:
-            return
-
         self.print_requested.emit([file_location])
-
-    def _move_export_service_to_thread(self, thread: QThread) -> None:
-        self._export_service_thread = thread
-
-        self._export_service.moveToThread(self._export_service_thread)
-        self._export_service_thread.start()

--- a/securedrop_client/gui/conversation/export/device.py
+++ b/securedrop_client/gui/conversation/export/device.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from typing import Optional
 
 from PyQt5.QtCore import QObject, pyqtSignal
 
@@ -35,43 +34,36 @@ class Device(QObject):
     print_succeeded = pyqtSignal()
     print_failed = pyqtSignal(object)
 
-    def __init__(
-        self, controller: Controller, export_service: Optional[export.Service] = None
-    ) -> None:
+    def __init__(self, controller: Controller, export_service: export.Service) -> None:
         super().__init__()
 
         self._controller = controller
         self._export_service = export_service
 
-        if self._export_service is not None:
-            self._export_service.connect_signals(
-                self.export_preflight_check_requested,
-                self.export_requested,
-                self.print_preflight_check_requested,
-                self.print_requested,
-            )
+        self._export_service.connect_signals(
+            self.export_preflight_check_requested,
+            self.export_requested,
+            self.print_preflight_check_requested,
+            self.print_requested,
+        )
 
-            # Abstract the Export instance away from the GUI
-            self._export_service.preflight_check_call_success.connect(
-                self.export_preflight_check_succeeded
-            )
-            self._export_service.preflight_check_call_failure.connect(
-                self.export_preflight_check_failed
-            )
+        # Abstract the Export instance away from the GUI
+        self._export_service.preflight_check_call_success.connect(
+            self.export_preflight_check_succeeded
+        )
+        self._export_service.preflight_check_call_failure.connect(
+            self.export_preflight_check_failed
+        )
 
-            self._export_service.export_usb_call_success.connect(self.export_succeeded)
-            self._export_service.export_usb_call_failure.connect(self.export_failed)
-            self._export_service.export_completed.connect(self.export_completed)
+        self._export_service.export_usb_call_success.connect(self.export_succeeded)
+        self._export_service.export_usb_call_failure.connect(self.export_failed)
+        self._export_service.export_completed.connect(self.export_completed)
 
-            self._export_service.printer_preflight_success.connect(
-                self.print_preflight_check_succeeded
-            )
-            self._export_service.printer_preflight_failure.connect(
-                self.print_preflight_check_failed
-            )
+        self._export_service.printer_preflight_success.connect(self.print_preflight_check_succeeded)
+        self._export_service.printer_preflight_failure.connect(self.print_preflight_check_failed)
 
-            self._export_service.print_call_failure.connect(self.print_failed)
-            self._export_service.print_call_success.connect(self.print_succeeded)
+        self._export_service.print_call_failure.connect(self.print_failed)
+        self._export_service.print_call_success.connect(self.print_succeeded)
 
     def run_printer_preflight_checks(self) -> None:
         """

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -27,7 +27,7 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QClipboard, QGuiApplication, QIcon, QKeySequence
 from PyQt5.QtWidgets import QAction, QApplication, QHBoxLayout, QMainWindow, QVBoxLayout, QWidget
 
-from securedrop_client import __version__, state
+from securedrop_client import __version__, export, state
 from securedrop_client.db import Source, User
 from securedrop_client.gui.auth import LoginDialog
 from securedrop_client.gui.widgets import LeftPane, MainView, TopPane
@@ -45,7 +45,11 @@ class Window(QMainWindow):
 
     icon = "icon.png"
 
-    def __init__(self, app_state: Optional[state.State] = None) -> None:
+    def __init__(
+        self,
+        app_state: Optional[state.State] = None,
+        export_service: Optional[export.Service] = None,
+    ) -> None:
         """
         Create the default start state. The window contains a root widget into
         which is placed:
@@ -73,7 +77,7 @@ class Window(QMainWindow):
         layout.setSpacing(0)
         self.main_pane.setLayout(layout)
         self.left_pane = LeftPane()
-        self.main_view = MainView(self.main_pane, app_state)
+        self.main_view = MainView(self.main_pane, app_state, export_service)
         layout.addWidget(self.left_pane)
         layout.addWidget(self.main_view)
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2205,6 +2205,12 @@ class FileWidget(QWidget):
 
         self.controller = controller
 
+        if export_service is None:
+            # Note that injecting an export service that runs in a separate
+            # thread is greatly encouraged! But it is optional because strictly
+            # speaking it is not a dependency of this FileWidget.
+            export_service = export.Service()
+
         self._export_device = conversation.ExportDevice(controller, export_service)
 
         self.file = self.controller.get_file(file_uuid)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -58,7 +58,7 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
-from securedrop_client import state
+from securedrop_client import export, state
 from securedrop_client.db import (
     DraftReply,
     File,
@@ -564,10 +564,16 @@ class MainView(QWidget):
     and main context view).
     """
 
-    def __init__(self, parent: QObject, app_state: Optional[state.State] = None) -> None:
+    def __init__(
+        self,
+        parent: QObject,
+        app_state: Optional[state.State] = None,
+        export_service: Optional[export.Service] = None,
+    ) -> None:
         super().__init__(parent)
 
         self._state = app_state
+        self._export_service = export_service
 
         # Set id and styles
         self.setObjectName("MainView")
@@ -665,7 +671,7 @@ class MainView(QWidget):
                 conversation_wrapper.conversation_view.update_conversation(source.collection)
             else:
                 conversation_wrapper = SourceConversationWrapper(
-                    source, self.controller, self._state
+                    source, self.controller, self._state, self._export_service
                 )
                 self.source_conversations[source.uuid] = conversation_wrapper
 
@@ -2190,6 +2196,7 @@ class FileWidget(QWidget):
         file_missing: pyqtBoundSignal,
         index: int,
         container_width: int,
+        export_service: Optional[export.Service] = None,
     ) -> None:
         """
         Given some text and a reference to the controller, make something to display a file.
@@ -2197,7 +2204,9 @@ class FileWidget(QWidget):
         super().__init__()
 
         self.controller = controller
-        self._export_device = conversation.ExportDevice(controller, controller.export_thread)
+
+        self._export_device = conversation.ExportDevice(controller, export_service)
+
         self.file = self.controller.get_file(file_uuid)
         self.uuid = file_uuid
         self.index = index
@@ -2602,8 +2611,15 @@ class ConversationView(QWidget):
 
     SCROLL_BAR_WIDTH = 15
 
-    def __init__(self, source_db_object: Source, controller: Controller) -> None:
+    def __init__(
+        self,
+        source_db_object: Source,
+        controller: Controller,
+        export_service: Optional[export.Service] = None,
+    ) -> None:
         super().__init__()
+
+        self._export_service = export_service
 
         self.source = source_db_object
         self.source_uuid = source_db_object.uuid
@@ -2790,6 +2806,7 @@ class ConversationView(QWidget):
             self.controller.file_missing,
             index,
             self.scroll.widget().width(),
+            self._export_service,
         )
         self.scroll.add_widget_to_conversation(index, conversation_item, Qt.AlignLeft)
         self.current_messages[file.uuid] = conversation_item
@@ -2893,7 +2910,11 @@ class SourceConversationWrapper(QWidget):
     deleting_conversation = False
 
     def __init__(
-        self, source: Source, controller: Controller, app_state: Optional[state.State] = None
+        self,
+        source: Source,
+        controller: Controller,
+        app_state: Optional[state.State] = None,
+        export_service: Optional[export.Service] = None,
     ) -> None:
         super().__init__()
 
@@ -2919,7 +2940,7 @@ class SourceConversationWrapper(QWidget):
 
         # Create widgets
         self.conversation_title_bar = SourceProfileShortWidget(source, controller, app_state)
-        self.conversation_view = ConversationView(source, controller)
+        self.conversation_view = ConversationView(source, controller, export_service)
         self.reply_box = ReplyBoxWidget(source, controller)
         self.deletion_indicator = SourceDeletionIndicator()
         self.conversation_deletion_indicator = ConversationDeletionIndicator()

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -318,7 +318,6 @@ class Controller(QObject):
         state: state.State,
         proxy: bool = True,
         qubes: bool = True,
-        export_thread: Optional[QThread] = None,
         sync_thread: Optional[QThread] = None,
         main_queue_thread: Optional[QThread] = None,
         file_download_queue_thread: Optional[QThread] = None,
@@ -332,11 +331,6 @@ class Controller(QObject):
         super().__init__()
 
         self._state = state
-
-        if export_thread is not None:
-            self.export_thread = export_thread
-        else:
-            self.export_thread = QThread()
 
         if sync_thread is not None:
             self.sync_thread = sync_thread

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,9 +131,11 @@ def export_service():
     """An export service that assumes the Qubes RPC calls are successful and skips them."""
     export_service = export.Service()
     # Ensure the export_service doesn't rely on Qubes OS:
-    export_service._run_disk_test = lambda dir: print("_run_disk_test")
-    export_service._run_usb_test = lambda dir: print("_run_usb_test")
-    export_service._run_disk_export = lambda dir, path, pasphrase: print("_run_disk_export")
+    export_service._run_disk_test = lambda dir: None
+    export_service._run_usb_test = lambda dir: None
+    export_service._run_disk_export = lambda dir, paths, pasphrase: None
+    export_service._run_printer_preflight = lambda dir: None
+    export_service._run_print = lambda dir, paths: None
     return export_service
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import pytest
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QMainWindow
 
-from securedrop_client import state
+from securedrop_client import export, state
 from securedrop_client.app import configure_locale_and_language
 from securedrop_client.config import Config
 from securedrop_client.db import (
@@ -127,14 +127,27 @@ def homedir(i18n):
 
 
 @pytest.fixture(scope="function")
-def functional_test_app_started_context(homedir, reply_status_codes, session, config, qtbot):
+def export_service():
+    """An export service that assumes the Qubes RPC calls are successful and skips them."""
+    export_service = export.Service()
+    # Ensure the export_service doesn't rely on Qubes OS:
+    export_service._run_disk_test = lambda dir: print("_run_disk_test")
+    export_service._run_usb_test = lambda dir: print("_run_usb_test")
+    export_service._run_disk_export = lambda dir, path, pasphrase: print("_run_disk_export")
+    return export_service
+
+
+@pytest.fixture(scope="function")
+def functional_test_app_started_context(
+    homedir, reply_status_codes, session, config, qtbot, export_service
+):
     """
     Returns a tuple containing the gui window and controller of a configured client. This should be
     used to for tests that need to start from the login dialog before the main application window
     is visible.
     """
     app_state = state.State()
-    gui = Window(app_state)
+    gui = Window(app_state, export_service)
     create_gpg_test_context(homedir)  # Configure test keys
     session_maker = make_session_maker(homedir)  # Configure and create the database
     controller = Controller(HOSTNAME, gui, session_maker, homedir, app_state, False, False)

--- a/tests/gui/conversation/export/test_device.py
+++ b/tests/gui/conversation/export/test_device.py
@@ -16,14 +16,13 @@ def no_session():
 
 def test_Device_run_printer_preflight_checks(homedir, mocker, source):
     gui = mocker.MagicMock(spec=Window)
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
+    with threads(3) as [sync_thread, main_queue_thread, file_download_queue_thread]:
         controller = Controller(
             "http://localhost",
             gui,
             no_session,
             homedir,
             None,
-            export_thread=export_thread,
             sync_thread=sync_thread,
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
@@ -41,14 +40,13 @@ def test_Device_run_printer_preflight_checks(homedir, mocker, source):
 
 def test_Device_run_print_file(mocker, homedir):
     gui = mocker.MagicMock(spec=Window)
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
+    with threads(3) as [sync_thread, main_queue_thread, file_download_queue_thread]:
         controller = Controller(
             "http://localhost",
             gui,
             no_session,
             homedir,
             None,
-            export_thread=export_thread,
             sync_thread=sync_thread,
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
@@ -75,14 +73,13 @@ def test_Device_print_file_file_missing(homedir, mocker, session):
     should be communicated to the user.
     """
     gui = mocker.MagicMock()
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
+    with threads(3) as [sync_thread, main_queue_thread, file_download_queue_thread]:
         controller = Controller(
             "http://localhost",
             gui,
             session,
             homedir,
             None,
-            export_thread=export_thread,
             sync_thread=sync_thread,
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
@@ -106,14 +103,13 @@ def test_Device_print_file_when_orig_file_already_exists(homedir, config, mocker
     The signal `print_requested` should still be emitted if the original file already exists.
     """
     gui = mocker.MagicMock(spec=Window)
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
+    with threads(3) as [sync_thread, main_queue_thread, file_download_queue_thread]:
         controller = Controller(
             "http://localhost",
             gui,
             no_session,
             homedir,
             None,
-            export_thread=export_thread,
             sync_thread=sync_thread,
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
@@ -133,14 +129,13 @@ def test_Device_print_file_when_orig_file_already_exists(homedir, config, mocker
 
 def test_Device_run_export_preflight_checks(homedir, mocker, source):
     gui = mocker.MagicMock(spec=Window)
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
+    with threads(3) as [sync_thread, main_queue_thread, file_download_queue_thread]:
         controller = Controller(
             "http://localhost",
             gui,
             no_session,
             homedir,
             None,
-            export_thread=export_thread,
             sync_thread=sync_thread,
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
@@ -162,14 +157,13 @@ def test_Device_export_file_to_usb_drive(homedir, mocker):
     The signal `export_requested` should be emmited during export_file_to_usb_drive.
     """
     gui = mocker.MagicMock(spec=Window)
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
+    with threads(3) as [sync_thread, main_queue_thread, file_download_queue_thread]:
         controller = Controller(
             "http://localhost",
             gui,
             no_session,
             homedir,
             None,
-            export_thread=export_thread,
             sync_thread=sync_thread,
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
@@ -196,14 +190,13 @@ def test_Device_export_file_to_usb_drive_file_missing(homedir, mocker, session):
     should be communicated to the user.
     """
     gui = mocker.MagicMock(spec=Window)
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
+    with threads(3) as [sync_thread, main_queue_thread, file_download_queue_thread]:
         controller = Controller(
             "http://localhost",
             gui,
             session,
             homedir,
             None,
-            export_thread=export_thread,
             sync_thread=sync_thread,
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
@@ -229,14 +222,13 @@ def test_Device_export_file_to_usb_drive_when_orig_file_already_exists(
     The signal `export_requested` should still be emmited if the original file already exists.
     """
     gui = mocker.MagicMock(spec=Window)
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
+    with threads(3) as [sync_thread, main_queue_thread, file_download_queue_thread]:
         controller = Controller(
             "http://localhost",
             gui,
             no_session,
             homedir,
             None,
-            export_thread=export_thread,
             sync_thread=sync_thread,
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,

--- a/tests/gui/conversation/export/test_device.py
+++ b/tests/gui/conversation/export/test_device.py
@@ -28,7 +28,7 @@ def test_Device_run_printer_preflight_checks(homedir, mocker, source):
             file_download_queue_thread=file_download_queue_thread,
         )
         export_service = export.Service()
-        device = Device(controller, export_service=export_service)
+        device = Device(controller, export_service)
         print_preflight_check_requested_emissions = QSignalSpy(
             device.print_preflight_check_requested
         )
@@ -52,7 +52,7 @@ def test_Device_run_print_file(mocker, homedir):
             file_download_queue_thread=file_download_queue_thread,
         )
         export_service = export.Service()
-        device = Device(controller, export_service=export_service)
+        device = Device(controller, export_service)
         print_requested_emissions = QSignalSpy(device.print_requested)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
@@ -85,7 +85,7 @@ def test_Device_print_file_file_missing(homedir, mocker, session):
             file_download_queue_thread=file_download_queue_thread,
         )
         export_service = export.Service()
-        device = Device(controller, export_service=export_service)
+        device = Device(controller, export_service)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
         warning_logger = mocker.patch("securedrop_client.logic.logger.warning")
@@ -115,7 +115,7 @@ def test_Device_print_file_when_orig_file_already_exists(homedir, config, mocker
             file_download_queue_thread=file_download_queue_thread,
         )
         export_service = export.Service()
-        device = Device(controller, export_service=export_service)
+        device = Device(controller, export_service)
         file = factory.File(source=factory.Source())
         print_requested_emissions = QSignalSpy(device.print_requested)
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
@@ -169,7 +169,7 @@ def test_Device_export_file_to_usb_drive(homedir, mocker):
             file_download_queue_thread=file_download_queue_thread,
         )
         export_service = export.Service()
-        device = Device(controller, export_service=export_service)
+        device = Device(controller, export_service)
         export_requested_emissions = QSignalSpy(device.export_requested)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
@@ -202,7 +202,7 @@ def test_Device_export_file_to_usb_drive_file_missing(homedir, mocker, session):
             file_download_queue_thread=file_download_queue_thread,
         )
         export_service = export.Service()
-        device = Device(controller, export_service=export_service)
+        device = Device(controller, export_service)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
         warning_logger = mocker.patch("securedrop_client.logic.logger.warning")
@@ -234,7 +234,7 @@ def test_Device_export_file_to_usb_drive_when_orig_file_already_exists(
             file_download_queue_thread=file_download_queue_thread,
         )
         export_service = export.Service()
-        device = Device(controller, export_service=export_service)
+        device = Device(controller, export_service)
         export_requested_emissions = QSignalSpy(device.export_requested)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)

--- a/tests/gui/conversation/export/test_device.py
+++ b/tests/gui/conversation/export/test_device.py
@@ -2,8 +2,8 @@ import os
 
 from PyQt5.QtTest import QSignalSpy
 
+from securedrop_client import export
 from securedrop_client.app import threads
-from securedrop_client.export import Export
 from securedrop_client.gui.conversation.export import Device
 from securedrop_client.gui.main import Window
 from securedrop_client.logic import Controller
@@ -28,7 +28,8 @@ def test_Device_run_printer_preflight_checks(homedir, mocker, source):
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service_thread=export_thread)
+        export_service = export.Service()
+        device = Device(controller, export_service=export_service)
         print_preflight_check_requested_emissions = QSignalSpy(
             device.print_preflight_check_requested
         )
@@ -36,35 +37,6 @@ def test_Device_run_printer_preflight_checks(homedir, mocker, source):
         device.run_printer_preflight_checks()
 
         assert len(print_preflight_check_requested_emissions) == 1
-
-
-def test_Device_run_printer_preflight_checks_not_qubes(homedir, mocker, source):
-    gui = mocker.MagicMock(spec=Window)
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
-        controller = Controller(
-            "http://localhost",
-            gui,
-            no_session,
-            homedir,
-            None,
-            export_thread=export_thread,
-            sync_thread=sync_thread,
-            main_queue_thread=main_queue_thread,
-            file_download_queue_thread=file_download_queue_thread,
-        )
-        device = Device(controller, export_service_thread=export_thread)
-        controller.qubes = False
-        print_preflight_check_requested_emissions = QSignalSpy(
-            device.print_preflight_check_requested
-        )
-        print_preflight_check_succeeded_emissions = QSignalSpy(
-            device.print_preflight_check_succeeded
-        )
-
-        device.run_printer_preflight_checks()
-
-        assert len(print_preflight_check_requested_emissions) == 0
-        assert len(print_preflight_check_succeeded_emissions) == 1
 
 
 def test_Device_run_print_file(mocker, homedir):
@@ -81,8 +53,8 @@ def test_Device_run_print_file(mocker, homedir):
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service_thread=export_thread)
-        device._export_service = mocker.MagicMock(spec=Export)
+        export_service = export.Service()
+        device = Device(controller, export_service=export_service)
         print_requested_emissions = QSignalSpy(device.print_requested)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
@@ -95,36 +67,6 @@ def test_Device_run_print_file(mocker, homedir):
         device.print_file(file.uuid)
 
         assert len(print_requested_emissions) == 1
-
-
-def test_Device_run_print_file_not_qubes(mocker, homedir):
-    gui = mocker.MagicMock(spec=Window)
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
-        controller = Controller(
-            "http://localhost",
-            gui,
-            no_session,
-            homedir,
-            None,
-            export_thread=export_thread,
-            sync_thread=sync_thread,
-            main_queue_thread=main_queue_thread,
-            file_download_queue_thread=file_download_queue_thread,
-        )
-        device = Device(controller, export_service_thread=export_thread)
-        controller.qubes = False
-        print_requested_emissions = QSignalSpy(device.print_requested)
-        file = factory.File(source=factory.Source())
-        mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
-
-        filepath = file.location(controller.data_dir)
-        os.makedirs(os.path.dirname(filepath), mode=0o700, exist_ok=True)
-        with open(filepath, "w"):
-            pass
-
-        device.print_file(file.uuid)
-
-        assert len(print_requested_emissions) == 0
 
 
 def test_Device_print_file_file_missing(homedir, mocker, session):
@@ -145,39 +87,8 @@ def test_Device_print_file_file_missing(homedir, mocker, session):
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service_thread=export_thread)
-        file = factory.File(source=factory.Source())
-        mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
-        warning_logger = mocker.patch("securedrop_client.logic.logger.warning")
-
-        device.print_file(file.uuid)
-
-        log_msg = "Cannot find file in {}. File does not exist.".format(
-            os.path.dirname(file.filename)
-        )
-        warning_logger.assert_called_once_with(log_msg)
-
-
-def test_Device_print_file_file_missing_not_qubes(homedir, mocker, session):
-    """
-    If the file is missing from the data dir, is_downloaded should be set to False and the failure
-    should be communicated to the user.
-    """
-    gui = mocker.MagicMock(spec=Window)
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
-        controller = Controller(
-            "http://localhost",
-            gui,
-            session,
-            homedir,
-            None,
-            export_thread=export_thread,
-            sync_thread=sync_thread,
-            main_queue_thread=main_queue_thread,
-            file_download_queue_thread=file_download_queue_thread,
-        )
-        device = Device(controller, export_service_thread=export_thread)
-        controller.qubes = False
+        export_service = export.Service()
+        device = Device(controller, export_service=export_service)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
         warning_logger = mocker.patch("securedrop_client.logic.logger.warning")
@@ -192,7 +103,7 @@ def test_Device_print_file_file_missing_not_qubes(homedir, mocker, session):
 
 def test_Device_print_file_when_orig_file_already_exists(homedir, config, mocker, source):
     """
-    The signal `print_requested` should still be emited if the original file already exists.
+    The signal `print_requested` should still be emitted if the original file already exists.
     """
     gui = mocker.MagicMock(spec=Window)
     with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
@@ -207,9 +118,9 @@ def test_Device_print_file_when_orig_file_already_exists(homedir, config, mocker
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service_thread=export_thread)
+        export_service = export.Service()
+        device = Device(controller, export_service=export_service)
         file = factory.File(source=factory.Source())
-        device._export_service = mocker.MagicMock(spec=Export)
         print_requested_emissions = QSignalSpy(device.print_requested)
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
         mocker.patch("os.path.exists", return_value=True)
@@ -217,36 +128,6 @@ def test_Device_print_file_when_orig_file_already_exists(homedir, config, mocker
         device.print_file(file.uuid)
 
         assert len(print_requested_emissions) == 1
-        controller.get_file.assert_called_with(file.uuid)
-
-
-def test_Device_print_file_when_orig_file_already_exists_not_qubes(homedir, config, mocker, source):
-    """
-    The signal `print_requested` should not be emited if the original file already exists.
-    """
-    gui = mocker.MagicMock(spec=Window)
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
-        controller = Controller(
-            "http://localhost",
-            gui,
-            no_session,
-            homedir,
-            None,
-            export_thread=export_thread,
-            sync_thread=sync_thread,
-            main_queue_thread=main_queue_thread,
-            file_download_queue_thread=file_download_queue_thread,
-        )
-        device = Device(controller, export_service_thread=export_thread)
-        controller.qubes = False
-        print_requested_emissions = QSignalSpy(device.print_requested)
-        file = factory.File(source=factory.Source())
-        mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
-        mocker.patch("os.path.exists", return_value=True)
-
-        device.print_file(file.uuid)
-
-        assert len(print_requested_emissions) == 0
         controller.get_file.assert_called_with(file.uuid)
 
 
@@ -264,8 +145,7 @@ def test_Device_run_export_preflight_checks(homedir, mocker, source):
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service_thread=export_thread)
-        device._export_service = mocker.MagicMock(spec=Export)
+        device = Device(controller, mocker.MagicMock(spec=export.Service))
         export_preflight_check_requested_emissions = QSignalSpy(
             device.export_preflight_check_requested
         )
@@ -275,37 +155,6 @@ def test_Device_run_export_preflight_checks(homedir, mocker, source):
         device.run_export_preflight_checks()
 
         assert len(export_preflight_check_requested_emissions) == 1
-
-
-def test_Device_run_export_preflight_checks_not_qubes(homedir, mocker, source):
-    gui = mocker.MagicMock(spec=Window)
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
-        controller = Controller(
-            "http://localhost",
-            gui,
-            no_session,
-            homedir,
-            None,
-            export_thread=export_thread,
-            sync_thread=sync_thread,
-            main_queue_thread=main_queue_thread,
-            file_download_queue_thread=file_download_queue_thread,
-        )
-        device = Device(controller, export_service_thread=export_thread)
-        controller.qubes = False
-        export_preflight_check_requested_emissions = QSignalSpy(
-            device.export_preflight_check_requested
-        )
-        export_preflight_check_succeeded_emissions = QSignalSpy(
-            device.export_preflight_check_succeeded
-        )
-        file = factory.File(source=source["source"])
-        mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
-
-        device.run_export_preflight_checks()
-
-        assert len(export_preflight_check_requested_emissions) == 0
-        assert len(export_preflight_check_succeeded_emissions) == 1
 
 
 def test_Device_export_file_to_usb_drive(homedir, mocker):
@@ -325,8 +174,8 @@ def test_Device_export_file_to_usb_drive(homedir, mocker):
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service_thread=export_thread)
-        device._export_service = mocker.MagicMock(spec=Export)
+        export_service = export.Service()
+        device = Device(controller, export_service=export_service)
         export_requested_emissions = QSignalSpy(device.export_requested)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
@@ -339,41 +188,6 @@ def test_Device_export_file_to_usb_drive(homedir, mocker):
         device.export_file_to_usb_drive(file.uuid, "mock passphrase")
 
         assert len(export_requested_emissions) == 1
-
-
-def test_Device_export_file_to_usb_drive_not_qubes(homedir, mocker):
-    """
-    The signal `export_requested` should be emmited during export_file_to_usb_drive.
-    """
-    gui = mocker.MagicMock(spec=Window)
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
-        controller = Controller(
-            "http://localhost",
-            gui,
-            no_session,
-            homedir,
-            None,
-            export_thread=export_thread,
-            sync_thread=sync_thread,
-            main_queue_thread=main_queue_thread,
-            file_download_queue_thread=file_download_queue_thread,
-        )
-        device = Device(controller, export_service_thread=export_thread)
-        controller.qubes = False
-        export_requested_emissions = QSignalSpy(device.export_requested)
-        device._export_service.send_file_to_usb_device = mocker.MagicMock()
-        file = factory.File(source=factory.Source())
-        mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
-
-        filepath = file.location(controller.data_dir)
-        os.makedirs(os.path.dirname(filepath), mode=0o700, exist_ok=True)
-        with open(filepath, "w"):
-            pass
-
-        device.export_file_to_usb_drive(file.uuid, "mock passphrase")
-
-        device._export_service.send_file_to_usb_device.assert_not_called()
-        assert len(export_requested_emissions) == 0
 
 
 def test_Device_export_file_to_usb_drive_file_missing(homedir, mocker, session):
@@ -394,39 +208,8 @@ def test_Device_export_file_to_usb_drive_file_missing(homedir, mocker, session):
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service_thread=export_thread)
-        file = factory.File(source=factory.Source())
-        mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
-        warning_logger = mocker.patch("securedrop_client.logic.logger.warning")
-
-        device.export_file_to_usb_drive(file.uuid, "mock passphrase")
-
-        log_msg = "Cannot find file in {}. File does not exist.".format(
-            os.path.dirname(file.filename)
-        )
-        warning_logger.assert_called_once_with(log_msg)
-
-
-def test_Device_export_file_to_usb_drive_file_missing_not_qubes(homedir, mocker, session):
-    """
-    If the file is missing from the data dir, is_downloaded should be set to False and the failure
-    should be communicated to the user.
-    """
-    gui = mocker.MagicMock(spec=Window)
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
-        controller = Controller(
-            "http://localhost",
-            gui,
-            session,
-            homedir,
-            None,
-            export_thread=export_thread,
-            sync_thread=sync_thread,
-            main_queue_thread=main_queue_thread,
-            file_download_queue_thread=file_download_queue_thread,
-        )
-        device = Device(controller, export_service_thread=export_thread)
-        controller.qubes = False
+        export_service = export.Service()
+        device = Device(controller, export_service=export_service)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
         warning_logger = mocker.patch("securedrop_client.logic.logger.warning")
@@ -458,8 +241,8 @@ def test_Device_export_file_to_usb_drive_when_orig_file_already_exists(
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service_thread=export_thread)
-        device._export_service = mocker.MagicMock(spec=Export)
+        export_service = export.Service()
+        device = Device(controller, export_service=export_service)
         export_requested_emissions = QSignalSpy(device.export_requested)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
@@ -468,41 +251,4 @@ def test_Device_export_file_to_usb_drive_when_orig_file_already_exists(
         device.export_file_to_usb_drive(file.uuid, "mock passphrase")
 
         assert len(export_requested_emissions) == 1
-        controller.get_file.assert_called_with(file.uuid)
-
-
-def test_Device_export_file_to_usb_drive_when_orig_file_already_exists_not_qubes(
-    homedir, config, mocker, source
-):
-    """
-    The signal `export_requested` should still be emmited if the original file already exists.
-    """
-    gui = mocker.MagicMock(spec=Window)
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
-        controller = Controller(
-            "http://localhost",
-            gui,
-            no_session,
-            homedir,
-            None,
-            export_thread=export_thread,
-            sync_thread=sync_thread,
-            main_queue_thread=main_queue_thread,
-            file_download_queue_thread=file_download_queue_thread,
-        )
-        device = Device(controller, export_service_thread=export_thread)
-        controller.qubes = False
-        controller.data_dir = ""
-        export_requested_emissions = QSignalSpy(device.export_requested)
-        file = factory.File(source=factory.Source())
-        mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
-
-        filepath = file.location(controller.data_dir)
-        os.makedirs(os.path.dirname(filepath), mode=0o700, exist_ok=True)
-        with open(filepath, "w"):
-            pass
-
-        device.export_file_to_usb_drive(file.uuid, "mock passphrase")
-
-        assert len(export_requested_emissions) == 0
         controller.get_file.assert_called_with(file.uuid)

--- a/tests/gui/conversation/export/test_device.py
+++ b/tests/gui/conversation/export/test_device.py
@@ -192,7 +192,7 @@ def test_Device_print_file_file_missing_not_qubes(homedir, mocker, session):
 
 def test_Device_print_file_when_orig_file_already_exists(homedir, config, mocker, source):
     """
-    The signal `print_requested` should still be emmited if the original file already exists.
+    The signal `print_requested` should still be emited if the original file already exists.
     """
     gui = mocker.MagicMock(spec=Window)
     with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
@@ -222,7 +222,7 @@ def test_Device_print_file_when_orig_file_already_exists(homedir, config, mocker
 
 def test_Device_print_file_when_orig_file_already_exists_not_qubes(homedir, config, mocker, source):
     """
-    The signal `print_requested` should still be emmited if the original file already exists.
+    The signal `print_requested` should not be emited if the original file already exists.
     """
     gui = mocker.MagicMock(spec=Window)
     with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
@@ -242,16 +242,11 @@ def test_Device_print_file_when_orig_file_already_exists_not_qubes(homedir, conf
         print_requested_emissions = QSignalSpy(device.print_requested)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
+        mocker.patch("os.path.exists", return_value=True)
 
-        filepath = file.location(controller.data_dir)
-        os.makedirs(os.path.dirname(filepath), mode=0o700, exist_ok=True)
-        with open(filepath, "w"):
-            pass
-
-        device.export_file_to_usb_drive(file.uuid, "mock passphrase")
+        device.print_file(file.uuid)
 
         assert len(print_requested_emissions) == 0
-        controller.get_file.assert_called_with(file.uuid)
         controller.get_file.assert_called_with(file.uuid)
 
 

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -5,7 +5,7 @@ import unittest
 
 from PyQt5.QtWidgets import QHBoxLayout
 
-from securedrop_client import state
+from securedrop_client import export, state
 from securedrop_client.gui.main import Window
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_icon
@@ -38,11 +38,12 @@ def test_init(mocker):
     load_css = mocker.patch("securedrop_client.gui.main.load_css")
 
     app_state = state.State()
-    w = Window(app_state)
+    export_service = export.Service()
+    w = Window(app_state, export_service)
 
     mock_li.assert_called_once_with(w.icon)
     mock_lp.assert_called_once_with()
-    mock_mv.assert_called_once_with(w.main_pane, app_state)
+    mock_mv.assert_called_once_with(w.main_pane, app_state, export_service)
     assert mock_lo().addWidget.call_count == 2
     load_css.assert_called_once_with("sdclient.css")
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -3052,21 +3052,20 @@ def test_FileWidget_init_file_not_downloaded(mocker, source, session):
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        fw = FileWidget(
-            "mock", controller, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), 0, 123
-        )
+    fw = FileWidget(
+        "mock", controller, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), 0, 123
+    )
 
-        assert fw.controller == controller
-        assert fw.file.is_downloaded is False
-        assert not fw.download_button.isHidden()
-        assert not fw.no_file_name.isHidden()
-        assert fw.export_button.isHidden()
-        assert fw.middot.isHidden()
-        assert fw.print_button.isHidden()
-        assert fw.file_name.isHidden()
+    assert fw.controller == controller
+    assert fw.file.is_downloaded is False
+    assert not fw.download_button.isHidden()
+    assert not fw.no_file_name.isHidden()
+    assert fw.export_button.isHidden()
+    assert fw.middot.isHidden()
+    assert fw.print_button.isHidden()
+    assert fw.file_name.isHidden()
 
 
 def test_FileWidget_init_file_downloaded(mocker, source, session):
@@ -3078,21 +3077,20 @@ def test_FileWidget_init_file_downloaded(mocker, source, session):
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        fw = FileWidget(
-            "mock", controller, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), 0, 123
-        )
+    fw = FileWidget(
+        "mock", controller, mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock(), 0, 123
+    )
 
-        assert fw.controller == controller
-        assert fw.file.is_downloaded is True
-        assert fw.download_button.isHidden()
-        assert fw.no_file_name.isHidden()
-        assert not fw.export_button.isHidden()
-        assert not fw.middot.isHidden()
-        assert not fw.print_button.isHidden()
-        assert not fw.file_name.isHidden()
+    assert fw.controller == controller
+    assert fw.file.is_downloaded is True
+    assert fw.download_button.isHidden()
+    assert fw.no_file_name.isHidden()
+    assert not fw.export_button.isHidden()
+    assert not fw.middot.isHidden()
+    assert not fw.print_button.isHidden()
+    assert not fw.file_name.isHidden()
 
 
 def test_FileWidget_adjust_width(mocker):
@@ -3103,24 +3101,23 @@ def test_FileWidget_adjust_width(mocker):
     """
     file = factory.File(source=factory.Source(), is_downloaded=True)
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        fw = FileWidget(
-            "abc123-ima-uuid",
-            controller,
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            0,
-            123,
-        )
+    fw = FileWidget(
+        "abc123-ima-uuid",
+        controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
 
-        fw.adjust_width(fw.MIN_CONTAINER_WIDTH - 1)
-        assert fw.width() == fw.MIN_WIDTH
+    fw.adjust_width(fw.MIN_CONTAINER_WIDTH - 1)
+    assert fw.width() == fw.MIN_WIDTH
 
-        fw.adjust_width(fw.MIN_CONTAINER_WIDTH)
-        assert fw.width() == math.floor(fw.MIN_CONTAINER_WIDTH * fw.WIDTH_TO_CONTAINER_WIDTH_RATIO)
+    fw.adjust_width(fw.MIN_CONTAINER_WIDTH)
+    assert fw.width() == math.floor(fw.MIN_CONTAINER_WIDTH * fw.WIDTH_TO_CONTAINER_WIDTH_RATIO)
 
 
 def test_FileWidget__set_file_state_under_mouse(mocker, source, session):
@@ -3133,24 +3130,23 @@ def test_FileWidget__set_file_state_under_mouse(mocker, source, session):
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file_)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        fw = FileWidget(
-            file_.uuid,
-            controller,
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            0,
-            123,
-        )
-        fw.download_button.underMouse = mocker.MagicMock(return_value=True)
-        fw.download_button.setIcon = mocker.MagicMock()
-        mock_load = mocker.MagicMock()
-        mocker.patch("securedrop_client.gui.widgets.load_icon", mock_load)
-        fw._set_file_state()
-        mock_load.assert_called_once_with("download_file_hover.svg")
+    fw = FileWidget(
+        file_.uuid,
+        controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
+    fw.download_button.underMouse = mocker.MagicMock(return_value=True)
+    fw.download_button.setIcon = mocker.MagicMock()
+    mock_load = mocker.MagicMock()
+    mocker.patch("securedrop_client.gui.widgets.load_icon", mock_load)
+    fw._set_file_state()
+    mock_load.assert_called_once_with("download_file_hover.svg")
 
 
 def test_FileWidget_event_handler_left_click(mocker, session, source):
@@ -3162,25 +3158,24 @@ def test_FileWidget_event_handler_left_click(mocker, session, source):
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file_)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        test_event = QEvent(QEvent.MouseButtonPress)
-        test_event.button = mocker.MagicMock(return_value=Qt.LeftButton)
+    test_event = QEvent(QEvent.MouseButtonPress)
+    test_event.button = mocker.MagicMock(return_value=Qt.LeftButton)
 
-        fw = FileWidget(
-            file_.uuid,
-            controller,
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            0,
-            123,
-        )
-        fw._on_left_click = mocker.MagicMock()
+    fw = FileWidget(
+        file_.uuid,
+        controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
+    fw._on_left_click = mocker.MagicMock()
 
-        fw.eventFilter(fw, test_event)
-        fw._on_left_click.call_count == 1
+    fw.eventFilter(fw, test_event)
+    fw._on_left_click.call_count == 1
 
 
 def test_FileWidget_event_handler_hover(mocker, session, source):
@@ -3193,30 +3188,29 @@ def test_FileWidget_event_handler_hover(mocker, session, source):
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file_)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        fw = FileWidget(
-            file_.uuid,
-            controller,
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            0,
-            123,
-        )
-        fw.download_button = mocker.MagicMock()
+    fw = FileWidget(
+        file_.uuid,
+        controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
+    fw.download_button = mocker.MagicMock()
 
-        # Hover enter
-        test_event = QEvent(QEvent.HoverEnter)
-        fw.eventFilter(fw, test_event)
-        assert fw.download_button.setIcon.call_count == 1
-        fw.download_button.setIcon.reset_mock()
-        # Hover leave
-        test_event = QEvent(QEvent.HoverLeave)
-        fw.eventFilter(fw, test_event)
-        assert fw.download_button.setIcon.call_count == 1
-        fw.download_button.setIcon.reset_mock()
+    # Hover enter
+    test_event = QEvent(QEvent.HoverEnter)
+    fw.eventFilter(fw, test_event)
+    assert fw.download_button.setIcon.call_count == 1
+    fw.download_button.setIcon.reset_mock()
+    # Hover leave
+    test_event = QEvent(QEvent.HoverLeave)
+    fw.eventFilter(fw, test_event)
+    assert fw.download_button.setIcon.call_count == 1
+    fw.download_button.setIcon.reset_mock()
 
 
 def test_FileWidget_on_left_click_download(mocker, session, source):
@@ -3229,25 +3223,24 @@ def test_FileWidget_on_left_click_download(mocker, session, source):
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file_)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        fw = FileWidget(
-            file_.uuid,
-            controller,
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            0,
-            123,
-        )
-        fw.download_button = mocker.MagicMock()
-        get_file.assert_called_once_with(file_.uuid)
-        get_file.reset_mock()
+    fw = FileWidget(
+        file_.uuid,
+        controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
+    fw.download_button = mocker.MagicMock()
+    get_file.assert_called_once_with(file_.uuid)
+    get_file.reset_mock()
 
-        fw._on_left_click()
-        get_file.assert_called_once_with(file_.uuid)
-        controller.on_submission_download.assert_called_once_with(db.File, file_.uuid)
+    fw._on_left_click()
+    get_file.assert_called_once_with(file_.uuid)
+    controller.on_submission_download.assert_called_once_with(db.File, file_.uuid)
 
 
 def test_FileWidget_on_left_click_downloading_in_progress(mocker, session, source):
@@ -3260,26 +3253,25 @@ def test_FileWidget_on_left_click_downloading_in_progress(mocker, session, sourc
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file_)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        fw = FileWidget(
-            file_.uuid,
-            controller,
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            0,
-            123,
-        )
-        fw.downloading = True
-        fw.download_button = mocker.MagicMock()
-        get_file.assert_called_once_with(file_.uuid)
-        get_file.reset_mock()
+    fw = FileWidget(
+        file_.uuid,
+        controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
+    fw.downloading = True
+    fw.download_button = mocker.MagicMock()
+    get_file.assert_called_once_with(file_.uuid)
+    get_file.reset_mock()
 
-        fw._on_left_click()
-        get_file.call_count == 0
-        controller.on_submission_download.call_count == 0
+    fw._on_left_click()
+    get_file.call_count == 0
+    controller.on_submission_download.call_count == 0
 
 
 def test_FileWidget_start_button_animation(mocker, session, source):
@@ -3291,22 +3283,21 @@ def test_FileWidget_start_button_animation(mocker, session, source):
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file_)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        fw = FileWidget(
-            file_.uuid,
-            controller,
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            0,
-            123,
-        )
-        fw.download_button = mocker.MagicMock()
-        fw.start_button_animation()
-        # Check indicators of activity have been updated.
-        assert fw.download_button.setIcon.call_count == 1
+    fw = FileWidget(
+        file_.uuid,
+        controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
+    fw.download_button = mocker.MagicMock()
+    fw.start_button_animation()
+    # Check indicators of activity have been updated.
+    assert fw.download_button.setIcon.call_count == 1
 
 
 def test_FileWidget_on_left_click_open(mocker, session, source):
@@ -3318,20 +3309,19 @@ def test_FileWidget_on_left_click_open(mocker, session, source):
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file_)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        fw = FileWidget(
-            file_.uuid,
-            controller,
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            0,
-            123,
-        )
-        fw._on_left_click()
-        fw.controller.on_file_open.assert_called_once_with(file_)
+    fw = FileWidget(
+        file_.uuid,
+        controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
+    fw._on_left_click()
+    fw.controller.on_file_open.assert_called_once_with(file_)
 
 
 def test_FileWidget_set_button_animation_frame(mocker, session, source):
@@ -3344,21 +3334,20 @@ def test_FileWidget_set_button_animation_frame(mocker, session, source):
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file_)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        fw = FileWidget(
-            file_.uuid,
-            controller,
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            0,
-            123,
-        )
-        fw.download_button = mocker.MagicMock()
-        fw.set_button_animation_frame(1)
-        assert fw.download_button.setIcon.call_count == 1
+    fw = FileWidget(
+        file_.uuid,
+        controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
+    fw.download_button = mocker.MagicMock()
+    fw.set_button_animation_frame(1)
+    assert fw.download_button.setIcon.call_count == 1
 
 
 def test_FileWidget_update(mocker, session, source):
@@ -3370,24 +3359,23 @@ def test_FileWidget_update(mocker, session, source):
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        fw = FileWidget(
-            file.uuid,
-            controller,
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            0,
-            123,
-        )
+    fw = FileWidget(
+        file.uuid,
+        controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
 
-        fw.update()
+    fw.update()
 
-        assert fw.download_button.isHidden()
-        assert fw.no_file_name.isHidden()
-        assert not fw.file_name.isHidden()
+    assert fw.download_button.isHidden()
+    assert fw.no_file_name.isHidden()
+    assert not fw.file_name.isHidden()
 
 
 def test_FileWidget_on_file_download_updates_items_when_uuid_matches(mocker, source, session):
@@ -3399,28 +3387,27 @@ def test_FileWidget_on_file_download_updates_items_when_uuid_matches(mocker, sou
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        fw = FileWidget(
-            file.uuid,
-            controller,
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            0,
-            123,
-        )
-        fw.update = mocker.MagicMock()
+    fw = FileWidget(
+        file.uuid,
+        controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
+    fw.update = mocker.MagicMock()
 
-        fw._on_file_downloaded(file.source.uuid, file.uuid, str(file))
+    fw._on_file_downloaded(file.source.uuid, file.uuid, str(file))
 
-        assert fw.download_button.isHidden()
-        assert not fw.export_button.isHidden()
-        assert not fw.middot.isHidden()
-        assert not fw.print_button.isHidden()
-        assert fw.no_file_name.isHidden()
-        assert not fw.file_name.isHidden()
+    assert fw.download_button.isHidden()
+    assert not fw.export_button.isHidden()
+    assert not fw.middot.isHidden()
+    assert not fw.print_button.isHidden()
+    assert fw.no_file_name.isHidden()
+    assert not fw.file_name.isHidden()
 
 
 def test_FileWidget_on_file_download_started_updates_items_when_uuid_matches(
@@ -3434,25 +3421,24 @@ def test_FileWidget_on_file_download_started_updates_items_when_uuid_matches(
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        fw = FileWidget(
-            file.uuid,
-            controller,
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            0,
-            123,
-        )
-        fw.update = mocker.MagicMock()
+    fw = FileWidget(
+        file.uuid,
+        controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
+    fw.update = mocker.MagicMock()
 
-        assert not fw.downloading
+    assert not fw.downloading
 
-        fw._on_file_download_started(file.uuid)
+    fw._on_file_download_started(file.uuid)
 
-        assert fw.downloading
+    assert fw.downloading
 
 
 def test_FileWidget_filename_truncation(mocker, source, session):
@@ -3467,24 +3453,23 @@ def test_FileWidget_filename_truncation(mocker, source, session):
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        fw = FileWidget(
-            file.uuid,
-            controller,
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            0,
-            123,
-        )
-        fw.update = mocker.MagicMock()
+    fw = FileWidget(
+        file.uuid,
+        controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
+    fw.update = mocker.MagicMock()
 
-        fw._on_file_downloaded(file.source.uuid, file.uuid, str(file))
+    fw._on_file_downloaded(file.source.uuid, file.uuid, str(file))
 
-        assert fw.file_name.text().endswith("...")
-        assert fw.file_name.toolTip() == filename
+    assert fw.file_name.text().endswith("...")
+    assert fw.file_name.toolTip() == filename
 
 
 def test_FileWidget_on_file_download_updates_items_when_uuid_does_not_match(
@@ -3498,30 +3483,29 @@ def test_FileWidget_on_file_download_updates_items_when_uuid_does_not_match(
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        fw = FileWidget(
-            file.uuid,
-            controller,
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            0,
-            123,
-        )
-        fw.clear = mocker.MagicMock()
-        fw.update = mocker.MagicMock()
+    fw = FileWidget(
+        file.uuid,
+        controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
+    fw.clear = mocker.MagicMock()
+    fw.update = mocker.MagicMock()
 
-        fw._on_file_downloaded("not a matching source uuid", "not a matching file uuid", "mock")
+    fw._on_file_downloaded("not a matching source uuid", "not a matching file uuid", "mock")
 
-        fw.clear.assert_not_called()
-        assert fw.download_button.isHidden()
-        assert not fw.export_button.isHidden()
-        assert not fw.middot.isHidden()
-        assert not fw.print_button.isHidden()
-        assert fw.no_file_name.isHidden()
-        assert not fw.file_name.isHidden()
+    fw.clear.assert_not_called()
+    assert fw.download_button.isHidden()
+    assert not fw.export_button.isHidden()
+    assert not fw.middot.isHidden()
+    assert not fw.print_button.isHidden()
+    assert fw.no_file_name.isHidden()
+    assert not fw.file_name.isHidden()
 
 
 def test_FileWidget_on_file_missing_show_download_button_when_uuid_matches(
@@ -3535,31 +3519,30 @@ def test_FileWidget_on_file_missing_show_download_button_when_uuid_matches(
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        fw = FileWidget(
-            file.uuid,
-            controller,
-            controller.file_download_started,
-            controller.file_ready,
-            controller.file_missing,
-            0,
-            123,
-        )
-        fw._on_file_missing(file.source.uuid, file.uuid, str(file))
+    fw = FileWidget(
+        file.uuid,
+        controller,
+        controller.file_download_started,
+        controller.file_ready,
+        controller.file_missing,
+        0,
+        123,
+    )
+    fw._on_file_missing(file.source.uuid, file.uuid, str(file))
 
-        # this is necessary for the timer that stops the download
-        # animation to execute
-        QTest.qWait(1000)
+    # this is necessary for the timer that stops the download
+    # animation to execute
+    QTest.qWait(1000)
 
-        assert not fw.download_button.isHidden()
-        assert fw.export_button.isHidden()
-        assert fw.middot.isHidden()
-        assert fw.print_button.isHidden()
-        assert not fw.no_file_name.isHidden()
-        assert fw.file_name.isHidden()
-        assert fw.download_animation.state() == QMovie.NotRunning
+    assert not fw.download_button.isHidden()
+    assert fw.export_button.isHidden()
+    assert fw.middot.isHidden()
+    assert fw.print_button.isHidden()
+    assert not fw.no_file_name.isHidden()
+    assert fw.file_name.isHidden()
+    assert fw.download_animation.state() == QMovie.NotRunning
 
 
 def test_FileWidget_on_file_missing_does_not_show_download_button_when_uuid_does_not_match(
@@ -3573,25 +3556,22 @@ def test_FileWidget_on_file_missing_does_not_show_download_button_when_uuid_does
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        fw = FileWidget(
-            file.uuid,
-            controller,
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            0,
-            123,
-        )
-        fw.download_button.show = mocker.MagicMock()
+    fw = FileWidget(
+        file.uuid,
+        controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
+    fw.download_button.show = mocker.MagicMock()
 
-        fw._on_file_missing(
-            "not a matching source uuid", "not a matching file uuid", "mock filename"
-        )
+    fw._on_file_missing("not a matching source uuid", "not a matching file uuid", "mock filename")
 
-        fw.download_button.show.assert_not_called()
+    fw.download_button.show.assert_not_called()
 
 
 def test_FileWidget__on_export_clicked(mocker, session, source):
@@ -3629,28 +3609,27 @@ def test_FileWidget__on_export_clicked_missing_file(mocker, session, source):
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        fw = FileWidget(
-            file.uuid,
-            controller,
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            0,
-            123,
-        )
-        fw.update = mocker.MagicMock()
-        mocker.patch("PyQt5.QtWidgets.QDialog.exec")
-        controller.run_export_preflight_checks = mocker.MagicMock()
-        controller.downloaded_file_exists = mocker.MagicMock(return_value=False)
-        dialog = mocker.patch("securedrop_client.gui.conversation.ExportFileDialog")
+    fw = FileWidget(
+        file.uuid,
+        controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
+    fw.update = mocker.MagicMock()
+    mocker.patch("PyQt5.QtWidgets.QDialog.exec")
+    controller.run_export_preflight_checks = mocker.MagicMock()
+    controller.downloaded_file_exists = mocker.MagicMock(return_value=False)
+    dialog = mocker.patch("securedrop_client.gui.conversation.ExportFileDialog")
 
-        fw._on_export_clicked()
+    fw._on_export_clicked()
 
-        controller.run_export_preflight_checks.assert_not_called()
-        dialog.assert_not_called()
+    controller.run_export_preflight_checks.assert_not_called()
+    dialog.assert_not_called()
 
 
 def test_FileWidget__on_print_clicked(mocker, session, source):
@@ -3662,29 +3641,28 @@ def test_FileWidget__on_print_clicked(mocker, session, source):
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
-        export_device = mocker.patch("securedrop_client.gui.conversation.ExportDevice")
+    controller = mocker.MagicMock(get_file=get_file)
+    export_device = mocker.patch("securedrop_client.gui.conversation.ExportDevice")
 
-        fw = FileWidget(
-            file.uuid,
-            controller,
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            0,
-            123,
-        )
-        fw.update = mocker.MagicMock()
-        mocker.patch("PyQt5.QtWidgets.QDialog.exec")
-        controller.print_file = mocker.MagicMock()
-        controller.downloaded_file_exists = mocker.MagicMock(return_value=True)
+    fw = FileWidget(
+        file.uuid,
+        controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
+    fw.update = mocker.MagicMock()
+    mocker.patch("PyQt5.QtWidgets.QDialog.exec")
+    controller.print_file = mocker.MagicMock()
+    controller.downloaded_file_exists = mocker.MagicMock(return_value=True)
 
-        dialog = mocker.patch("securedrop_client.gui.conversation.PrintFileDialog")
+    dialog = mocker.patch("securedrop_client.gui.conversation.PrintFileDialog")
 
-        fw._on_print_clicked()
+    fw._on_print_clicked()
 
-        dialog.assert_called_once_with(export_device(), file.uuid, file.filename)
+    dialog.assert_called_once_with(export_device(), file.uuid, file.filename)
 
 
 def test_FileWidget__on_print_clicked_missing_file(mocker, session, source):
@@ -3696,42 +3674,40 @@ def test_FileWidget__on_print_clicked_missing_file(mocker, session, source):
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        fw = FileWidget(
-            file.uuid,
-            controller,
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            mocker.MagicMock(),
-            0,
-            123,
-        )
-        fw.update = mocker.MagicMock()
-        mocker.patch("PyQt5.QtWidgets.QDialog.exec")
-        controller.print_file = mocker.MagicMock()
-        controller.downloaded_file_exists = mocker.MagicMock(return_value=False)
-        dialog = mocker.patch("securedrop_client.gui.conversation.PrintFileDialog")
+    fw = FileWidget(
+        file.uuid,
+        controller,
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        0,
+        123,
+    )
+    fw.update = mocker.MagicMock()
+    mocker.patch("PyQt5.QtWidgets.QDialog.exec")
+    controller.print_file = mocker.MagicMock()
+    controller.downloaded_file_exists = mocker.MagicMock(return_value=False)
+    dialog = mocker.patch("securedrop_client.gui.conversation.PrintFileDialog")
 
-        fw._on_print_clicked()
+    fw._on_print_clicked()
 
-        controller.print_file.assert_not_called()
-        dialog.assert_not_called()
+    controller.print_file.assert_not_called()
+    dialog.assert_not_called()
 
 
 def test_FileWidget_update_file_size_with_deleted_file(
     mocker, homedir, config, session_maker, source
 ):
     gui = mocker.MagicMock()
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
+    with threads(3) as [sync_thread, main_queue_thread, file_download_queue_thread]:
         controller = logic.Controller(
             "http://localhost",
             gui,
             session_maker,
             homedir,
             None,
-            export_thread=export_thread,
             sync_thread=sync_thread,
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
@@ -3763,20 +3739,19 @@ def test_SourceConversationWrapper_on_conversation_updated(mocker, qtbot):
     file = factory.File(source=source, is_downloaded=True)
 
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        scw = SourceConversationWrapper(source, controller, None)
-        scw.conversation_title_bar.updated.setText("CANARY")
+    scw = SourceConversationWrapper(source, controller, None)
+    scw.conversation_title_bar.updated.setText("CANARY")
 
-        scw.conversation_view.add_file(file=file, index=1)
+    scw.conversation_view.add_file(file=file, index=1)
 
-        expected_timestamp = arrow.get(source.last_updated).format("MMM D")
+    expected_timestamp = arrow.get(source.last_updated).format("MMM D")
 
-        def check_timestamp():
-            assert scw.conversation_title_bar.updated.text() == expected_timestamp
+    def check_timestamp():
+        assert scw.conversation_title_bar.updated.text() == expected_timestamp
 
-        qtbot.waitUntil(check_timestamp, timeout=2000)
+    qtbot.waitUntil(check_timestamp, timeout=2000)
 
 
 def test_SourceConversationWrapper_on_source_deleted(mocker):
@@ -3954,29 +3929,24 @@ def test_ConversationView_ConversationScrollArea_resize(mocker):
     user = factory.User()
 
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(
-            get_file=get_file, authenticated_user=user, export_thread=export_thread
-        )
+    controller = mocker.MagicMock(get_file=get_file, authenticated_user=user)
 
-        cv = ConversationView(factory.Source(), controller)
-        message = factory.Message(source=factory.Source(), content=">^..^<")
-        cv.add_message(message=message, index=0)
-        speech_bubble_adjust_width = mocker.patch(
-            "securedrop_client.gui.widgets.SpeechBubble.adjust_width"
-        )
-        cv.add_file(file=file, index=1)
-        file_widget_adjust_width = mocker.patch(
-            "securedrop_client.gui.widgets.FileWidget.adjust_width"
-        )
+    cv = ConversationView(factory.Source(), controller)
+    message = factory.Message(source=factory.Source(), content=">^..^<")
+    cv.add_message(message=message, index=0)
+    speech_bubble_adjust_width = mocker.patch(
+        "securedrop_client.gui.widgets.SpeechBubble.adjust_width"
+    )
+    cv.add_file(file=file, index=1)
+    file_widget_adjust_width = mocker.patch("securedrop_client.gui.widgets.FileWidget.adjust_width")
 
-        cv.setFixedWidth(800)
-        event = QResizeEvent(cv.scroll.size(), QSize(123_456_789, 123_456_789))
-        cv.scroll.resizeEvent(event)
+    cv.setFixedWidth(800)
+    event = QResizeEvent(cv.scroll.size(), QSize(123_456_789, 123_456_789))
+    cv.scroll.resizeEvent(event)
 
-        assert cv.scroll.widget().width() == cv.scroll.width()
-        speech_bubble_adjust_width.assert_called_with(cv.scroll.widget().width())
-        file_widget_adjust_width.assert_called_with(cv.scroll.widget().width())
+    assert cv.scroll.widget().width() == cv.scroll.width()
+    speech_bubble_adjust_width.assert_called_with(cv.scroll.widget().width())
+    file_widget_adjust_width.assert_called_with(cv.scroll.widget().width())
 
 
 def test_ConversationView__on_sync_started(mocker, session):
@@ -4323,22 +4293,21 @@ def test_ConversationView_add_downloaded_file(mocker, homedir, source, session):
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        cv = ConversationView(source, controller)
-        cv.conversation_updated = mocker.MagicMock()
+    cv = ConversationView(source, controller)
+    cv.conversation_updated = mocker.MagicMock()
 
-        mock_label = mocker.patch("securedrop_client.gui.widgets.SecureQLabel")
-        mocker.patch("securedrop_client.gui.widgets.QHBoxLayout.addWidget")
+    mock_label = mocker.patch("securedrop_client.gui.widgets.SecureQLabel")
+    mocker.patch("securedrop_client.gui.widgets.QHBoxLayout.addWidget")
 
-        cv.add_file(file, 0)
+    cv.add_file(file, 0)
 
-        mock_label.assert_called_with("123B")  # default factory filesize
-        assert cv.conversation_updated.emit.call_count == 1
+    mock_label.assert_called_with("123B")  # default factory filesize
+    assert cv.conversation_updated.emit.call_count == 1
 
-        file_widget = cv.scroll.conversation_layout.itemAt(1).widget()
-        assert isinstance(file_widget, FileWidget)
+    file_widget = cv.scroll.conversation_layout.itemAt(1).widget()
+    assert isinstance(file_widget, FileWidget)
 
 
 def test_ConversationView_add_not_downloaded_file(mocker, homedir, source, session):
@@ -4352,22 +4321,21 @@ def test_ConversationView_add_not_downloaded_file(mocker, homedir, source, sessi
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(get_file=get_file, export_thread=export_thread)
+    controller = mocker.MagicMock(get_file=get_file)
 
-        cv = ConversationView(source, controller)
-        cv.conversation_updated = mocker.MagicMock()
+    cv = ConversationView(source, controller)
+    cv.conversation_updated = mocker.MagicMock()
 
-        mock_label = mocker.patch("securedrop_client.gui.widgets.SecureQLabel")
-        mocker.patch("securedrop_client.gui.widgets.QHBoxLayout.addWidget")
+    mock_label = mocker.patch("securedrop_client.gui.widgets.SecureQLabel")
+    mocker.patch("securedrop_client.gui.widgets.QHBoxLayout.addWidget")
 
-        cv.add_file(file, 0)
+    cv.add_file(file, 0)
 
-        mock_label.assert_called_with("123B")  # default factory filesize
-        assert cv.conversation_updated.emit.call_count == 1
+    mock_label.assert_called_with("123B")  # default factory filesize
+    assert cv.conversation_updated.emit.call_count == 1
 
-        file_widget = cv.scroll.conversation_layout.itemAt(1).widget()
-        assert isinstance(file_widget, FileWidget)
+    file_widget = cv.scroll.conversation_layout.itemAt(1).widget()
+    assert isinstance(file_widget, FileWidget)
 
 
 def test_DeleteSource_from_source_menu_when_user_is_loggedout(mocker):
@@ -4879,17 +4847,14 @@ def test_update_conversation_maintains_old_items(mocker, session):
 
     user = factory.User()
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(
-            get_file=get_file, authenticated_user=user, export_thread=export_thread
-        )
+    controller = mocker.MagicMock(get_file=get_file, authenticated_user=user)
 
-        cv = ConversationView(source, controller)
-        assert cv.scroll.conversation_layout.count() == 3
+    cv = ConversationView(source, controller)
+    assert cv.scroll.conversation_layout.count() == 3
 
-        cv.update_conversation(cv.source.collection)
+    cv.update_conversation(cv.source.collection)
 
-        assert cv.scroll.conversation_layout.count() == 3
+    assert cv.scroll.conversation_layout.count() == 3
 
 
 def test_update_conversation_does_not_remove_pending_draft_items(mocker, session):
@@ -4913,22 +4878,19 @@ def test_update_conversation_does_not_remove_pending_draft_items(mocker, session
 
     user = factory.User()
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(
-            get_file=get_file, authenticated_user=user, export_thread=export_thread
-        )
+    controller = mocker.MagicMock(get_file=get_file, authenticated_user=user)
 
-        cv = ConversationView(source, controller)
-        assert cv.scroll.conversation_layout.count() == 3  # precondition with draft
+    cv = ConversationView(source, controller)
+    assert cv.scroll.conversation_layout.count() == 3  # precondition with draft
 
-        # add the new message and persist
-        new_message = factory.Message(filename="4-source-msg.gpg", source=source)
-        session.add(new_message)
-        session.commit()
+    # add the new message and persist
+    new_message = factory.Message(filename="4-source-msg.gpg", source=source)
+    session.add(new_message)
+    session.commit()
 
-        # New message added, draft message persists.
-        cv.update_conversation(cv.source.collection)
-        assert cv.scroll.conversation_layout.count() == 4
+    # New message added, draft message persists.
+    cv.update_conversation(cv.source.collection)
+    assert cv.scroll.conversation_layout.count() == 4
 
 
 def test_update_conversation_does_remove_successful_draft_items(mocker, session):
@@ -4952,26 +4914,23 @@ def test_update_conversation_does_remove_successful_draft_items(mocker, session)
 
     user = factory.User()
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(
-            get_file=get_file, authenticated_user=user, export_thread=export_thread
-        )
+    controller = mocker.MagicMock(get_file=get_file, authenticated_user=user)
 
-        cv = ConversationView(source, controller)
-        assert cv.scroll.conversation_layout.count() == 3  # precondition with draft
+    cv = ConversationView(source, controller)
+    assert cv.scroll.conversation_layout.count() == 3  # precondition with draft
 
-        # add the new message and persist
-        new_message = factory.Message(filename="4-source-msg.gpg", source=source)
-        session.add(new_message)
-        session.commit()
+    # add the new message and persist
+    new_message = factory.Message(filename="4-source-msg.gpg", source=source)
+    session.add(new_message)
+    session.commit()
 
-        # remove draft
-        session.delete(draft_reply)
-        session.commit()
+    # remove draft
+    session.delete(draft_reply)
+    session.commit()
 
-        # New message added, draft message is gone.
-        cv.update_conversation(cv.source.collection)
-        assert cv.scroll.conversation_layout.count() == 3
+    # New message added, draft message is gone.
+    cv.update_conversation(cv.source.collection)
+    assert cv.scroll.conversation_layout.count() == 3
 
 
 def test_update_conversation_keeps_failed_draft_items(mocker, session):
@@ -4995,22 +4954,19 @@ def test_update_conversation_keeps_failed_draft_items(mocker, session):
     session.commit()
 
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(
-            get_file=get_file, authenticated_user=user, export_thread=export_thread
-        )
+    controller = mocker.MagicMock(get_file=get_file, authenticated_user=user)
 
-        cv = ConversationView(source, controller)
-        assert cv.scroll.conversation_layout.count() == 3  # precondition with draft
+    cv = ConversationView(source, controller)
+    assert cv.scroll.conversation_layout.count() == 3  # precondition with draft
 
-        # add the new message and persist
-        new_message = factory.Message(filename="4-source-msg.gpg", source=source)
-        session.add(new_message)
-        session.commit()
+    # add the new message and persist
+    new_message = factory.Message(filename="4-source-msg.gpg", source=source)
+    session.add(new_message)
+    session.commit()
 
-        # New message added, draft message retained.
-        cv.update_conversation(cv.source.collection)
-        assert cv.scroll.conversation_layout.count() == 4
+    # New message added, draft message retained.
+    cv.update_conversation(cv.source.collection)
+    assert cv.scroll.conversation_layout.count() == 4
 
 
 def test_update_conversation_adds_new_items(mocker, session):
@@ -5031,21 +4987,18 @@ def test_update_conversation_adds_new_items(mocker, session):
 
     user = factory.User()
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(
-            get_file=get_file, authenticated_user=user, export_thread=export_thread
-        )
+    controller = mocker.MagicMock(get_file=get_file, authenticated_user=user)
 
-        cv = ConversationView(source, controller)
-        assert cv.scroll.conversation_layout.count() == 3  # precondition
+    cv = ConversationView(source, controller)
+    assert cv.scroll.conversation_layout.count() == 3  # precondition
 
-        # add the new message and persist
-        new_message = factory.Message(filename="4-source-msg.gpg", source=source)
-        session.add(new_message)
-        session.commit()
+    # add the new message and persist
+    new_message = factory.Message(filename="4-source-msg.gpg", source=source)
+    session.add(new_message)
+    session.commit()
 
-        cv.update_conversation(cv.source.collection)
-        assert cv.scroll.conversation_layout.count() == 4
+    cv.update_conversation(cv.source.collection)
+    assert cv.scroll.conversation_layout.count() == 4
 
 
 def test_update_conversation_position_updates(mocker, session):
@@ -5066,26 +5019,23 @@ def test_update_conversation_position_updates(mocker, session):
 
     user = factory.User()
     get_file = mocker.MagicMock(return_value=file)
-    with threads(1) as [export_thread]:
-        controller = mocker.MagicMock(
-            get_file=get_file, authenticated_user=user, export_thread=export_thread
-        )
+    controller = mocker.MagicMock(get_file=get_file, authenticated_user=user)
 
-        cv = ConversationView(source, controller)
-        assert cv.scroll.conversation_layout.count() == 3  # precondition
+    cv = ConversationView(source, controller)
+    assert cv.scroll.conversation_layout.count() == 3  # precondition
 
-        # Change the position of the Reply.
-        reply_widget = cv.current_messages[reply.uuid]
-        reply_widget.index = 1
+    # Change the position of the Reply.
+    reply_widget = cv.current_messages[reply.uuid]
+    reply_widget.index = 1
 
-        # add the new message and persist
-        new_message = factory.Message(filename="4-source-msg.gpg", source=source)
-        session.add(new_message)
-        session.commit()
+    # add the new message and persist
+    new_message = factory.Message(filename="4-source-msg.gpg", source=source)
+    session.add(new_message)
+    session.commit()
 
-        cv.update_conversation(cv.source.collection)
-        assert cv.scroll.conversation_layout.count() == 4
-        assert reply_widget.index == 2  # re-ordered.
+    cv.update_conversation(cv.source.collection)
+    assert cv.scroll.conversation_layout.count() == 4
+    assert reply_widget.index == 2  # re-ordered.
 
 
 def test_update_conversation_content_updates(mocker, session):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from PyQt5.QtWidgets import QApplication
 
+from securedrop_client import export
 from securedrop_client.app import threads
 from securedrop_client.gui import conversation
 from securedrop_client.gui.base import ModalDialog
@@ -150,7 +151,8 @@ def modal_dialog(mocker, homedir):
 @pytest.fixture(scope="function")
 def print_dialog(mocker, homedir):
     app = QApplication([])
-    gui = Window()
+    export_service = export.Service()
+    gui = Window(export_service=export_service)
     app.setActiveWindow(gui)
     gui.show()
     with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_thread]:
@@ -186,7 +188,8 @@ def print_dialog(mocker, homedir):
 @pytest.fixture(scope="function")
 def export_dialog(mocker, homedir):
     app = QApplication([])
-    gui = Window()
+    export_service = export.Service()
+    gui = Window(export_service=export_service)
     app.setActiveWindow(gui)
     gui.show()
     with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_thread]:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,14 +17,13 @@ def main_window(mocker, homedir):
     gui = Window()
     app.setActiveWindow(gui)
     gui.show()
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_thread]:
+    with threads(3) as [sync_thread, main_queue_thread, file_download_thread]:
         controller = Controller(
             "http://localhost",
             gui,
             mocker.MagicMock(),
             homedir,
             None,
-            export_thread=export_thread,
             sync_thread=sync_thread,
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_thread,
@@ -70,14 +69,13 @@ def main_window_no_key(mocker, homedir):
     gui = Window()
     app.setActiveWindow(gui)
     gui.show()
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_thread]:
+    with threads(3) as [sync_thread, main_queue_thread, file_download_thread]:
         controller = Controller(
             "http://localhost",
             gui,
             mocker.MagicMock(),
             homedir,
             None,
-            export_thread=export_thread,
             sync_thread=sync_thread,
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_thread,
@@ -122,14 +120,13 @@ def modal_dialog(mocker, homedir):
     gui = Window()
     app.setActiveWindow(gui)
     gui.show()
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_thread]:
+    with threads(3) as [sync_thread, main_queue_thread, file_download_thread]:
         controller = Controller(
             "http://localhost",
             gui,
             mocker.MagicMock(),
             homedir,
             None,
-            export_thread=export_thread,
             sync_thread=sync_thread,
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_thread,
@@ -155,14 +152,13 @@ def print_dialog(mocker, homedir):
     gui = Window(export_service=export_service)
     app.setActiveWindow(gui)
     gui.show()
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_thread]:
+    with threads(3) as [sync_thread, main_queue_thread, file_download_thread]:
         controller = Controller(
             "http://localhost",
             gui,
             mocker.MagicMock(),
             homedir,
             None,
-            export_thread=export_thread,
             sync_thread=sync_thread,
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_thread,
@@ -192,14 +188,13 @@ def export_dialog(mocker, homedir):
     gui = Window(export_service=export_service)
     app.setActiveWindow(gui)
     gui.show()
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_thread]:
+    with threads(3) as [sync_thread, main_queue_thread, file_download_thread]:
         controller = Controller(
             "http://localhost",
             gui,
             mocker.MagicMock(),
             homedir,
             None,
-            export_thread=export_thread,
             sync_thread=sync_thread,
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_thread,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -166,7 +166,6 @@ def test_start_app(homedir, mocker):
         mocker.ANY,
         mocker.ANY,
         mocker.ANY,
-        mocker.ANY,
     )
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,7 +7,7 @@ import sys
 
 import pytest
 
-from securedrop_client import state
+from securedrop_client import export, state
 from securedrop_client.app import (
     DEFAULT_SDC_HOME,
     ENCODING,
@@ -139,10 +139,11 @@ def test_start_app(homedir, mocker):
     mock_args.proxy = False
     app_state = state.State()
     mocker.patch("securedrop_client.state.State", return_value=app_state)
+    export_service = export.Service()
+    mocker.patch("securedrop_client.export.Service", return_value=export_service)
 
     mocker.patch("securedrop_client.app.configure_logging")
     mock_app = mocker.patch("securedrop_client.app.QApplication")
-    thread = mocker.patch("securedrop_client.app.QThread")
     mock_win = mocker.patch("securedrop_client.app.Window")
     mocker.patch("securedrop_client.resources.path", return_value=mock_args.sdc_home + "dummy.jpg")
     mock_controller = mocker.patch("securedrop_client.app.Controller")
@@ -153,7 +154,7 @@ def test_start_app(homedir, mocker):
     start_app(mock_args, mock_qt_args)
 
     mock_app.assert_called_once_with(mock_qt_args)
-    mock_win.assert_called_once_with(app_state)
+    mock_win.assert_called_once_with(app_state, export_service)
     mock_controller.assert_called_once_with(
         "http://localhost:8081/",
         mock_win(),
@@ -162,10 +163,10 @@ def test_start_app(homedir, mocker):
         app_state,
         False,
         False,
-        thread(),
-        thread(),
-        thread(),
-        thread(),
+        mocker.ANY,
+        mocker.ANY,
+        mocker.ANY,
+        mocker.ANY,
     )
 
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -108,14 +108,13 @@ def test_Controller_setup(homedir, config, mocker, session_maker, session):
     Ensure the application is set up with the following default state:
     Using the `config` fixture to ensure the config is written to disk.
     """
-    with threads(4) as [export_thread, sync_thread, main_queue_thread, file_download_queue_thread]:
+    with threads(3) as [sync_thread, main_queue_thread, file_download_queue_thread]:
         co = Controller(
             "http://localhost",
             mocker.MagicMock(),
             session_maker,
             homedir,
             None,
-            export_thread=export_thread,
             sync_thread=sync_thread,
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,


### PR DESCRIPTION
## Description

:crystal_ball: _**Reviewers (@rocodes)**: This PR really makes sense to review commit by commit, especially because there is some refactoring / clean up / fixing in the beginning. However, the final approach was settled in the last three commits, so you may want to skip ahead._ :slightly_smiling_face: 

> **General idea**: The export service is a dependency of the GUI's `export.Device`. This PR ensures it is injected into the GUI. One immediate benefit is that the functional tests can now inhibit the Qubes OS dependency without knowing anything about the GUI internals, by providing a custom _export service_ when initializing the app. This allows to remove all the code that was specific to testing but was interleaved with the production code - inside `controller.qubes` conditionals.


This is a follow up on #1524. That pull request extracted the export code from the `Controller` class, but retained a dependency on the controller for the purpose of accessing some environment information (`controller.qubes`), some configuration (`controller.data_dir`), some database access (`controller.get_file`), and some local filesystem access (`controller.downloaded_file_exists`).

This PR moves the `controller.qubes` check around so that we're one step closer to `export.Device` not depending on `Controller` anymore.

Replaces the implemented part of #1537

## To Dos

- [x] `controller.qubes` :confetti_ball: Gone.

I also incorporated the observations made in https://github.com/freedomofpress/securedrop-client/pull/1537#discussion_r924165100 and https://github.com/freedomofpress/securedrop-client/pull/1537#discussion_r924166789.

For context, Part 2 will be:

- `controller.data_dir`
- `controller.get_file`
- `controller.downloaded_file_exists`

## Test Plan

- [ ] Confirm that files can be exported as usual
- [ ] Confirm that the test coverage hasn't changed significantly
