### PR TITLE
Add granularity to ci pipeline for readability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ common-steps:
       command: |
         set -e
         pip uninstall virtualenv -y || true
-        sudo apt update && sudo apt install -y make git gnupg
+        apt update && apt install -y sudo make git gnupg python3-venv
 
   - &install_deps_on_buster
     run:
@@ -14,7 +14,7 @@ common-steps:
       command: |
         set -e
         pip uninstall virtualenv -y || true
-        apt-get update && apt-get install -y sudo make git gnupg python3 python3-venv
+        apt update && apt install -y sudo make git gnupg python3 python3-venv
 
   - &run_tests
     run:
@@ -104,7 +104,7 @@ version: 2
 jobs:
   build-bullseye:
     docker:
-      - image: circleci/python:3.9-bullseye
+      - image: debian:bullseye
     steps:
       - *install_deps
       - checkout
@@ -114,7 +114,7 @@ jobs:
 
   test-bullseye:
     docker:
-      - image: circleci/python:3.9-bullseye
+      - image: debian:bullseye
     steps:
       - *install_deps
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,33 @@
 ---
 common-steps:
-  - &install_deps
+  - &install_testing_dependencies
     run:
-      name: Install base dependencies for Bullseye python
+      name: Install testing dependencies
       command: |
         set -e
-        pip uninstall virtualenv -y || true
-        apt update && apt install -y sudo make git gnupg python3-venv
+        apt update && apt install -y git gnupg libqt5x11extras5 make python3-tk python3-dev gnupg python3-venv sqlite3 xvfb
 
-  - &install_deps_on_buster
+  - &install_testing_dependencies_on_buster
     run:
-      name: Install base dependencies for Buster python
+      name: Install testing dependencies (Buster)
+      command: |
+        set -e
+        apt update && apt install -y git gnupg libqt5x11extras5 make python3 python3-tk python3-dev gnupg python3-venv sqlite3 xvfb
+
+  - &install_build_dependencies
+    run:
+      name: Install build dependencies
+      command: |
+        set -e
+        apt update && apt install -y git make sudo
+
+  - &install_build_dependencies_on_buster
+    run:
+      name: Install build dependencies (Buster)
       command: |
         set -e
         pip uninstall virtualenv -y || true
-        apt update && apt install -y sudo make git gnupg python3 python3-venv
+        apt update && apt install -y git gnupg make python3 python3-venv sudo
 
   - &run_tests
     run:
@@ -28,7 +41,7 @@ common-steps:
 
   - &run_tests_on_buster
     run:
-      name: Install requirements and run tests
+      name: Install requirements and run tests (Buster)
       command: |
         set -e
         make venv-buster
@@ -44,7 +57,7 @@ common-steps:
         source .venv/bin/activate
         make check-black check-isort lint bandit check-strings
 
-  - &check_python_dependencies_for_vulns
+  - &check_python_dependencies_for_vulnerabilities
     run:
       name: Check Python dependencies for known vulnerabilities
       command: |
@@ -54,21 +67,7 @@ common-steps:
 
   - &install_packaging_dependencies
     run:
-      name: Install Debian packaging dependencies and download wheels
-      command: |
-        set -x
-        mkdir ~/packaging && cd ~/packaging
-        # local builds may not have an ssh url, so || true
-        git config --global --unset url.ssh://git@github.com.insteadof || true
-        git clone https://github.com/freedomofpress/securedrop-debian-packaging.git
-        cd securedrop-debian-packaging
-        sudo apt update && sudo apt install -y make
-        make install-deps
-        PKG_DIR=~/project make requirements
-
-  - &install_packaging_dependencies_buster
-    run:
-      name: Install Debian packaging dependencies and download wheels
+      name: Install Debian packaging dependencies and download Python wheels
       command: |
         set -x
         mkdir ~/packaging && cd ~/packaging
@@ -106,7 +105,7 @@ jobs:
     docker:
       - image: debian:bullseye
     steps:
-      - *install_deps
+      - *install_build_dependencies
       - checkout
       - *install_packaging_dependencies
       - *verify_requirements
@@ -116,22 +115,21 @@ jobs:
     docker:
       - image: debian:bullseye
     steps:
-      - *install_deps
+      - *install_testing_dependencies
       - checkout
-      - run: sudo apt update && sudo apt install -y sqlite3 libqt5x11extras5 xvfb python3-tk python3-dev
       - *run_tests
       - store_test_results:
           path: test-results
       - *run_lint
-      - *check_python_dependencies_for_vulns
+      - *check_python_dependencies_for_vulnerabilities
 
   build-buster:
     docker:
       - image: debian:buster
     steps:
-      - *install_deps_on_buster
+      - *install_build_dependencies_on_buster
       - checkout
-      - *install_packaging_dependencies_buster
+      - *install_packaging_dependencies
       - *verify_requirements
       - *build_debian_package
 
@@ -139,14 +137,13 @@ jobs:
     docker:
       - image: debian:buster
     steps:
-      - *install_deps_on_buster
+      - *install_testing_dependencies_on_buster
       - checkout
-      - run: apt-get update && apt-get install -y sqlite3 libqt5x11extras5 xvfb python3-tk python3-dev
       - *run_tests_on_buster
       - store_test_results:
           path: test-results
       - *run_lint
-      - *check_python_dependencies_for_vulns
+      - *check_python_dependencies_for_vulnerabilities
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,29 +14,69 @@ common-steps:
         set -e
         apt update && apt install -y git make sudo
 
-  - &run_tests
+  - &run_unit_tests
     run:
-      name: Install requirements and run tests
+      name: Install requirements and run unit tests
       command: |
         set -e
         make venv
         source .venv/bin/activate
         export PYTHONPATH=$PYTHONPATH:.  # so alembic can get to Base metadata
-        make check --keep-going
+        make test-random
+
+  - &run_integration_tests
+    run:
+      name: Install requirements and run integration tests
+      command: |
+        set -e
+        make venv
+        source .venv/bin/activate
+        export PYTHONPATH=$PYTHONPATH:.  # so alembic can get to Base metadata
+        make test-integration
+
+  - &run_functional_tests
+    run:
+      name: Install requirements and run functional tests
+      command: |
+        set -e
+        make venv
+        source .venv/bin/activate
+        export PYTHONPATH=$PYTHONPATH:.  # so alembic can get to Base metadata
+        make test-functional
 
   - &run_lint
     run:
-      name: Run lint, then static analysis on source code to find security issues
+      name: Run lint, type checking, code formatting
       command: |
         set -e
+        make venv
         source .venv/bin/activate
-        make check-black check-isort lint bandit check-strings
+        make check-black check-isort lint mypy
+
+  - &check_security
+    run:
+      name: Run static analysis on source code to find security issues
+      command: |
+        set -e
+        make venv
+        source .venv/bin/activate
+        make semgrep bandit
+
+  - &check_internationalization
+    run:
+      name: Run internationalization check
+      command: |
+        set -e
+        make venv
+        source .venv/bin/activate
+        make check-strings
 
   - &check_python_dependencies_for_vulnerabilities
     run:
       name: Check Python dependencies for known vulnerabilities
       command: |
         set -e
+        make venv
         source .venv/bin/activate
         make safety
 
@@ -86,23 +126,76 @@ jobs:
       - *verify_requirements
       - *build_debian_package
 
-  test-bullseye:
+  unit-test-bullseye:
     docker:
       - image: debian:bullseye
     steps:
       - *install_testing_dependencies
       - checkout
-      - *run_tests
+      - *run_unit_tests
       - store_test_results:
           path: test-results
+
+  integration-test-bullseye:
+    docker:
+      - image: debian:bullseye
+    steps:
+      - *install_testing_dependencies
+      - checkout
+      - *run_integration_tests
+
+  functional-test-bullseye:
+    docker:
+      - image: debian:bullseye
+    steps:
+      - *install_testing_dependencies
+      - checkout
+      - *run_functional_tests
+
+  lint-bullseye:
+    docker:
+      - image: debian:bullseye
+    steps:
+      - *install_testing_dependencies
+      - checkout
       - *run_lint
+
+  check-security-bullseye:
+    docker:
+      - image: debian:bullseye
+    steps:
+      - *install_testing_dependencies
+      - checkout
+      - *check_security
+
+  check-python-security-bullseye:
+    docker:
+      - image: debian:bullseye
+    steps:
+      - *install_testing_dependencies
+      - checkout
       - *check_python_dependencies_for_vulnerabilities
+
+
+  check-internationalization-bullseye:
+    docker:
+      - image: debian:bullseye
+    steps:
+      - *install_testing_dependencies
+      - checkout
+      - *check_internationalization
 
 workflows:
   version: 2
   securedrop_client_ci:
     jobs:
-      - test-bullseye
+      - unit-test-bullseye
+      - integration-test-bullseye
+      - functional-test-bullseye
+      - lint-bullseye
+      - check-security-bullseye
+      - check-python-security-bullseye
+      - check-internationalization-bullseye
       - build-bullseye
 
   nightly:
@@ -114,5 +207,11 @@ workflows:
               only:
                 - main
     jobs:
-      - test-bullseye
+      - unit-test-bullseye
+      - integration-test-bullseye
+      - functional-test-bullseye
+      - lint-bullseye
+      - check-security-bullseye
+      - check-python-security-bullseye
+      - check-internationalization-bullseye
       - build-bullseye

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,13 +7,6 @@ common-steps:
         set -e
         apt update && apt install -y git gnupg libqt5x11extras5 make python3-tk python3-dev gnupg python3-venv sqlite3 xvfb
 
-  - &install_testing_dependencies_on_buster
-    run:
-      name: Install testing dependencies (Buster)
-      command: |
-        set -e
-        apt update && apt install -y git gnupg libqt5x11extras5 make python3 python3-tk python3-dev gnupg python3-venv sqlite3 xvfb
-
   - &install_build_dependencies
     run:
       name: Install build dependencies
@@ -21,30 +14,12 @@ common-steps:
         set -e
         apt update && apt install -y git make sudo
 
-  - &install_build_dependencies_on_buster
-    run:
-      name: Install build dependencies (Buster)
-      command: |
-        set -e
-        pip uninstall virtualenv -y || true
-        apt update && apt install -y git gnupg make python3 python3-venv sudo
-
   - &run_tests
     run:
       name: Install requirements and run tests
       command: |
         set -e
         make venv
-        source .venv/bin/activate
-        export PYTHONPATH=$PYTHONPATH:.  # so alembic can get to Base metadata
-        make check --keep-going
-
-  - &run_tests_on_buster
-    run:
-      name: Install requirements and run tests (Buster)
-      command: |
-        set -e
-        make venv-buster
         source .venv/bin/activate
         export PYTHONPATH=$PYTHONPATH:.  # so alembic can get to Base metadata
         make check --keep-going
@@ -123,36 +98,12 @@ jobs:
       - *run_lint
       - *check_python_dependencies_for_vulnerabilities
 
-  build-buster:
-    docker:
-      - image: debian:buster
-    steps:
-      - *install_build_dependencies_on_buster
-      - checkout
-      - *install_packaging_dependencies
-      - *verify_requirements
-      - *build_debian_package
-
-  test-buster:
-    docker:
-      - image: debian:buster
-    steps:
-      - *install_testing_dependencies_on_buster
-      - checkout
-      - *run_tests_on_buster
-      - store_test_results:
-          path: test-results
-      - *run_lint
-      - *check_python_dependencies_for_vulnerabilities
-
 workflows:
   version: 2
   securedrop_client_ci:
     jobs:
       - test-bullseye
       - build-bullseye
-      - test-buster
-      - build-buster
 
   nightly:
     triggers:
@@ -165,5 +116,3 @@ workflows:
     jobs:
       - test-bullseye
       - build-bullseye
-      - test-buster
-      - build-buster


### PR DESCRIPTION
## Description

> :crystal_ball: **Reviewers**: This PR is ready to review, but includes three commits from #1544 because they make the work easier. Only the very **last** commit (https://github.com/freedomofpress/securedrop-client/pull/1546/commits/0a6d4d7a43cf6b96d69c15ec271703f6fe6e5526 [click me!](https://github.com/freedomofpress/securedrop-client/pull/1546/commits/0a6d4d7a43cf6b96d69c15ec271703f6fe6e5526)) needs to be reviewed here. (I'll update this branch as soon as #1544 is merged.)

Splits the testing, linting, and diverse checks into distinct CI jobs. 
**Bonus**: a ~20% decrease in wall clock time (the trade-offs are called out in #1543).

Fixes #1543 

## Result

![Preview of the distinct CI jobs, with a duration of 3:40min](https://user-images.githubusercontent.com/1619067/185032023-8104f70e-1d0a-4179-a6ca-7ddbea335421.png)

## Test Plan

- [ ] Confirm that all the checks contained in `make check` are performed at some stage of the pipeline
- [ ] Confirm that the grouping of checks makes sense
- [ ] Confirm that CI is green :green_apple: 

