### PR TITLE
feat: allow overriding `MetadataSyncJob` timeout via Qubes service flag

### DIFF
--- a/files/securedrop-client
+++ b/files/securedrop-client
@@ -10,5 +10,13 @@ cd /opt/venvs/securedrop-client
 # Check if qubes-db exists (and we are running in qubes)
 if [ ! -f "/usr/bin/qubesdb-read" ]; then echo "Not running in Qubes, client not starting." && exit; fi
 
+# EXPERIMENTAL(#1547): Check for the SDEXTENDEDTIMEOUT_N service flag and export it as
+# SDEXTENDEDTIMEOUT=N.
+timeout_flag_value=$(qubesdb-list /qubes-service/SDEXTENDEDTIMEOUT_)
+if [ -n "$timeout_flag_value" ]; then
+	echo "SDEXTENDEDTIMEOUT=$timeout_flag_value"
+	export SDEXTENDEDTIMEOUT="$timeout_flag_value"
+fi
+
 # Now execute the actual client, only if running in an sd-app
 if [ "$(qubesdb-read /name)" = "sd-app" ]; then ./bin/sd-client; else echo "Not running in sd-app, client not starting."; fi

--- a/securedrop_client/api_jobs/sync.py
+++ b/securedrop_client/api_jobs/sync.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Any, List, Optional
 
 from sdclientapi import API
@@ -41,7 +42,15 @@ class MetadataSyncJob(ApiJob):
         #
         # This timeout is used for 3 different requests: `get_sources`, `get_all_submissions`, and
         # `get_all_replies`
-        api_client.default_request_timeout = self.DEFAULT_REQUEST_TIMEOUT
+        api_client.default_request_timeout = int(
+            os.environ.get("SDEXTENDEDTIMEOUT", self.DEFAULT_REQUEST_TIMEOUT)
+        )
+        if api_client.default_request_timeout != self.DEFAULT_REQUEST_TIMEOUT:
+            logger.warn(
+                f"{self.__class__.__name__} will use "
+                f"default_request_timeout={api_client.default_request_timeout}"
+            )
+
         users = api_client.get_users()
         MetadataSyncJob._update_users(session, users)
         sources, submissions, replies = get_remote_data(api_client)

--- a/securedrop_client/api_jobs/sync.py
+++ b/securedrop_client/api_jobs/sync.py
@@ -18,6 +18,7 @@ class MetadataSyncJob(ApiJob):
     Update source metadata such that new download jobs can be added to the queue.
     """
 
+    DEFAULT_REQUEST_TIMEOUT = 60  # sec
     NUMBER_OF_TIMES_TO_RETRY_AN_API_CALL = 2
 
     def __init__(self, data_dir: str, app_state: Optional[state.State] = None) -> None:
@@ -40,7 +41,7 @@ class MetadataSyncJob(ApiJob):
         #
         # This timeout is used for 3 different requests: `get_sources`, `get_all_submissions`, and
         # `get_all_replies`
-        api_client.default_request_timeout = 60
+        api_client.default_request_timeout = self.DEFAULT_REQUEST_TIMEOUT
         users = api_client.get_users()
         MetadataSyncJob._update_users(session, users)
         sources, submissions, replies = get_remote_data(api_client)


### PR DESCRIPTION
# Description

Closes #1547 by:

1. teaching the `securedrop-client` script to check for a Qubes service flag like `SDEXTENDEDTIMEOUT_N` and export it as `SDEXTENDEDTIMEOUT=N`;
2. having the `MetadataSyncJob` (noisily) override its `sdclientapi.API.default_request_timeout` with `$SDEXTENDEDTIMEOUT` if set in the environment.

# Test Plan

Point your SecureDrop Workstation at [my testing instance](https://wiki.freedom.press/wiki/User:Cory/SecureDrop_instance) per <https://github.com/freedomofpress/securedrop-client/issues/1547#issuecomment-1224985491> and <https://github.com/freedomofpress/securedrop-client/issues/1547#issuecomment-1226640519>.  Then:

## To test the current failure mode (#1547)

1. Check out `1547-override-timeout` in `sd-app:/home/user/securedrop-client`.
2. Apply the following patch so that we can test `files/securedrop-client` within the virtual environment:
    
	```patch
	diff --git a/files/securedrop-client b/files/securedrop-client
	index 9674911..403e37f 100755
	--- a/files/securedrop-client
	+++ b/files/securedrop-client
	@@ -18,5 +18,6 @@ if [ -n "$timeout_flag_value" ]; then
	        export SDEXTENDEDTIMEOUT="$timeout_flag_value"
	 fi
	 
	+cd ~/securedrop-client
	 # Now execute the actual client, only if running in an sd-app
	-if [ "$(qubesdb-read /name)" = "sd-app" ]; then ./bin/sd-client; else echo "Not running in sd-app, client not starting."; fi
	+if [ "$(qubesdb-read /name)" = "sd-app" ]; then python -m securedrop_client; else echo "Not running in sd-app, client not starting."; fi
	```

3. Then:

	```sh-session
	user@sd-app:~/securedrop-client$ make venv
	user@sd-app:~/securedrop-client$ source .venv/bin/activate
	user@sd-app:~/securedrop-client$ files/securedrop-client
	```

4. Log in and wait for sync.  Against my testing instance (~3500 sources and submissions):
    - the initial sync succeeds (~10 min); and
    - [ ] subsequent syncs fail (~2 min).


## To test overriding the timeout

1. Set the service flag:

    ```sh-session
    [user@dom0 ~]$ qvm-service --enable sd-app SDEXTENDEDTIMEOUT_600
    [user@dom0 ~]$ qvm-shutdown sd-app && sleep 5 && qvm-start sd-app
    ```

    You can also do `SDEXTENDEDTIMEOUT_10` if you're impatient.  :-)

2. Explore how that flag is exposed within `sd-app`:

    ```sh-session
    user@sd-app:~$ qubesdb-list /qubes-service/
    SDEXTENDEDTIMEOUT_600
    meminfo-writer
    paxctld
    user@sd-app:~$ qubesdb-list /qubes-service/SD
    EXTENDEDTIMEOUT_600
    user@sd-app:~$ qubesdb-list /qubes-service/SDEXTENDEDTIMEOUT_
    600
    ```

3. Launch the client as above:

    ```sh-session
    user@sd-app:~/securedrop-client$ source .venv/bin/activate
    user@sd-app:~/securedrop-client$ files/securedrop-client
    ```

    * [ ] `SDEXTENDEDTIMEOUT=600` appears in `securedrop-client`'s standard output.

4. Log in and wait for sync.
    * [ ] Sync either (a) succeeds, if the `SDEXTENDEDTIMEOUT` you set is long enough, or (b) fails after `SDEXTENDEDTIMEOUT` seconds.
    * [ ] In `sd-log`, you see (e.g.): `WARNING: MetadataSyncJob will use default_request_timeout=600`


# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 
And see e21c163d2611d44fd97c46d9609b9091476808cd for why!
 
 - I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations