### PR TITLE
Fix remove untrusted strings from production logs

### DIFF
--- a/securedrop_client/api_jobs/downloads.py
+++ b/securedrop_client/api_jobs/downloads.py
@@ -169,7 +169,8 @@ class DownloadJob(SingleObjectApiJob):
         except BaseError as e:
             raise e
         except (ValueError, FileNotFoundError, RuntimeError) as e:
-            logger.error(e)
+            logger.error("Download failed")
+            logger.debug(f"Download failed: {e}")
             raise DownloadDecryptionException(
                 f"Failed to download {db_object.uuid}", type(db_object), db_object.uuid
             ) from e
@@ -188,7 +189,8 @@ class DownloadJob(SingleObjectApiJob):
             )
             logger.info(f"File decrypted to {os.path.dirname(filepath)}")
         except CryptoError as e:
-            logger.error(e)
+            logger.error("Decryption failed")
+            logger.debug(f"Decryption failed: {e}")
             mark_as_decrypted(type(db_object), db_object.uuid, session, is_decrypted=False)
             download_error = (
                 session.query(DownloadError)

--- a/securedrop_client/api_jobs/uploads.py
+++ b/securedrop_client/api_jobs/uploads.py
@@ -140,16 +140,12 @@ class SendReplyJob(SingleObjectApiJob):
             session.add(draft_reply_db_object)
             session.commit()
         except SQLAlchemyError as e:
-            logger.info(
-                "SQL error when setting reply {uuid} as failed, skipping: {e}".format(
-                    uuid=self.reply_uuid, e=e
-                )
-            )
+            logger.info(f"SQL error when setting reply {self.reply_uuid} as failed, skipping")
+            logger.debug(f"SQL error when setting reply {self.reply_uuid} as failed, skipping: {e}")
         except Exception as e:
-            logger.error(
-                "Unknown error when setting reply {uuid} as failed, skipping: {e}".format(
-                    uuid=self.reply_uuid, e=e
-                )
+            logger.error(f"Unknown error when setting reply {self.reply_uuid} as failed, skipping")
+            logger.debug(
+                f"Unknown error when setting reply {self.reply_uuid} as failed, skipping: {e}"
             )
 
     def _make_call(self, encrypted_reply: str, api_client: API) -> sdclientapi.Reply:

--- a/securedrop_client/export.py
+++ b/securedrop_client/export.py
@@ -154,7 +154,8 @@ class Export(QObject):
             )
             return output.decode("utf-8").strip()
         except subprocess.CalledProcessError as e:
-            logger.error(e)
+            logger.error("Subprocess failed")
+            logger.debug(f"Subprocess failed: {e}")
             raise ExportError(ExportStatus.CALLED_PROCESS_ERROR.value)
 
     def _create_archive(
@@ -318,7 +319,8 @@ class Export(QObject):
                 self._run_printer_preflight(temp_dir)
                 self.printer_preflight_success.emit()
             except ExportError as e:
-                logger.error(e)
+                logger.error("Export failed")
+                logger.debug(f"Export failed: {e}")
                 self.printer_preflight_failure.emit(e)
 
     @pyqtSlot(list, str)
@@ -339,7 +341,8 @@ class Export(QObject):
                 self.export_usb_call_success.emit()
                 logger.debug("Export successful")
             except ExportError as e:
-                logger.error(e)
+                logger.error("Export failed")
+                logger.debug(f"Export failed: {e}")
                 self.export_usb_call_failure.emit(e)
 
         self.export_completed.emit(filepaths)
@@ -361,7 +364,8 @@ class Export(QObject):
                 self.print_call_success.emit()
                 logger.debug("Print successful")
             except ExportError as e:
-                logger.error(e)
+                logger.error("Export failed")
+                logger.debug(f"Export failed: {e}")
                 self.print_call_failure.emit(e)
 
         self.export_completed.emit(filepaths)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2337,7 +2337,8 @@ class FileWidget(QWidget):
         try:
             self.file_size.setText(humanize_filesize(self.file.size))
         except Exception as e:
-            logger.error(f"Could not update file size on FileWidget: {e}")
+            logger.error("Could not update file size on FileWidget")
+            logger.debug(f"Could not update file size on FileWidget: {e}")
             self.file_size.setText("")
 
     def _set_file_state(self) -> None:

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -122,7 +122,8 @@ class APICallRunner(QObject):
             if isinstance(ex, (RequestTimeoutError, ServerConnectionError)):
                 self.call_timed_out.emit()
 
-            logger.error(ex)
+            logger.error("Call failed")
+            logger.debug(f"Call failed: {ex}")
             self.result = ex
             self.call_failed.emit()
         else:
@@ -673,7 +674,8 @@ class Controller(QObject):
         a sync fails is ApiInaccessibleError then we need to log the user out for security reasons
         and show them the login window in order to get a new token.
         """
-        logger.warning("sync failure: {}".format(result))
+        logger.warning("sync failure")
+        logger.debug(f"sync failure: {result}")
 
         if isinstance(result, ApiInaccessibleError):
             # Don't show login window if the user is already logged out
@@ -872,7 +874,8 @@ class Controller(QObject):
             message = storage.get_message(self.session, exception.uuid)
             self.message_download_failed.emit(message.source.uuid, message.uuid, str(message))
         except Exception as e:
-            logger.error(f"Could not emit message_download_failed: {e}")
+            logger.error("Could not emit message_download_failed")
+            logger.debug(f"Could not emit message_download_failed: {e}")
 
     def download_new_replies(self) -> None:
         replies = storage.find_new_replies(self.session)
@@ -906,7 +909,8 @@ class Controller(QObject):
             reply = storage.get_reply(self.session, exception.uuid)
             self.reply_download_failed.emit(reply.source.uuid, reply.uuid, str(reply))
         except Exception as e:
-            logger.error(f"Could not emit reply_download_failed: {e}")
+            logger.error("Could not emit reply_download_failed")
+            logger.debug(f"Could not emit reply_download_failed: {e}")
 
     def downloaded_file_exists(self, file: db.File) -> bool:
         """

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -180,8 +180,8 @@ class RunnableQueue(QObject):
                     job, self.current_job = self.current_job, None
                     self._re_add_job(job)
             except Exception as e:
-                logger.error("{}: {}".format(type(e).__name__, e))
-                logger.debug("Skipping job")
+                logger.error("Skipping job")
+                logger.debug(f"Skipping job: {type(e).__name__}: {e}")
             finally:
                 with self.condition_add_or_remove_job:
                     self.current_job = None

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -136,7 +136,8 @@ def sanitize_submissions_or_replies(
     sanitized_sdk_objects = []
     for obj in remote_sdk_objects:
         if not VALID_FILENAME(obj.filename):
-            logger.error(f"Malformed filename: {obj.filename}")
+            logger.error("Malformed filename")
+            logger.debug(f"Malformed filename: {obj.filename}")
             continue
         sanitized_sdk_objects.append(obj)
     return sanitized_sdk_objects
@@ -149,7 +150,8 @@ def sanitize_sources(remote_sdk_objects: List[SDKSource]) -> List[SDKSource]:
     sanitized_sdk_objects = []
     for obj in remote_sdk_objects:
         if not VALID_JOURNALIST_DESIGNATION(obj.journalist_designation):
-            logger.error(f"Malformed journalist_designation: {obj.journalist_designation}")
+            logger.error("Malformed journalist_designation")
+            logger.debug(f"Malformed journalist_designation: {obj.journalist_designation}")
             continue
         sanitized_sdk_objects.append(obj)
     return sanitized_sdk_objects
@@ -1044,17 +1046,15 @@ def _delete_source_collection_from_db(session: Session, source: Source) -> None:
                 logger.debug("Add source {} to deletedconversation table".format(source.uuid))
                 session.add(flagged_conversation)
         except SQLAlchemyError as e:
-            logger.error(
-                "Could not add source {} to deletedconversation table: {}".format(source.uuid, e)
-            )
+            logger.error(f"Could not add source {source.uuid} to deletedconversation table")
+            logger.debug(f"Could not add source {source.uuid} to deletedconversation table: {e}")
             session.rollback()
 
     try:
         session.commit()
     except SQLAlchemyError as e:
-        logger.error(
-            "Could not locally delete conversation for source {}: {}".format(source.uuid, e)
-        )
+        logger.error(f"Could not locally delete conversation for source {source.uuid}")
+        logger.debug(f"Could not locally delete conversation for source {source.uuid}: {e}")
         session.rollback()
 
 


### PR DESCRIPTION
# Description

Addresses the logs aspect of https://github.com/freedomofpress/securedrop-client-security/issues/4

# Test Plan

- [ ] Verify that no unverified strings are printed in production logs within the `./securedrop_client` module
- [ ] Confirm that the information is still available in debug logs in case it's needed
