### PR TITLE
Remove unverified string from user interface

### DIFF
--- a/securedrop_client/export.py
+++ b/securedrop_client/export.py
@@ -16,8 +16,8 @@ logger = logging.getLogger(__name__)
 
 
 class ExportError(Exception):
-    def __init__(self, status: str):
-        self.status = status
+    def __init__(self, status: "ExportStatus"):
+        self.status: "ExportStatus" = status
 
 
 class ExportStatus(Enum):
@@ -117,7 +117,7 @@ class Export(QObject):
                 self.run_printer_preflight, type=Qt.QueuedConnection
             )
 
-    def _export_archive(cls, archive_path: str) -> str:
+    def _export_archive(cls, archive_path: str) -> ExportStatus:
         """
         Make the subprocess call to send the archive to the Export VM, where the archive will be
         processed.
@@ -152,11 +152,14 @@ class Export(QObject):
                 ],
                 stderr=subprocess.STDOUT,
             )
-            return output.decode("utf-8").strip()
+            return ExportStatus(output.decode("utf-8").strip())
+        except ValueError as e:
+            logger.debug(f"Export subprocess returned unexpected value: {e}")
+            raise ExportError(ExportStatus.UNEXPECTED_RETURN_STATUS)
         except subprocess.CalledProcessError as e:
             logger.error("Subprocess failed")
             logger.debug(f"Subprocess failed: {e}")
-            raise ExportError(ExportStatus.CALLED_PROCESS_ERROR.value)
+            raise ExportError(ExportStatus.CALLED_PROCESS_ERROR)
 
     def _create_archive(
         cls, archive_dir: str, archive_fn: str, metadata: dict, filepaths: List[str] = []
@@ -238,7 +241,7 @@ class Export(QObject):
         """
         archive_path = self._create_archive(archive_dir, self.USB_TEST_FN, self.USB_TEST_METADATA)
         status = self._export_archive(archive_path)
-        if status != ExportStatus.USB_CONNECTED.value:
+        if status != ExportStatus.USB_CONNECTED:
             raise ExportError(status)
 
     def _run_disk_test(self, archive_dir: str) -> None:
@@ -254,7 +257,7 @@ class Export(QObject):
         archive_path = self._create_archive(archive_dir, self.DISK_TEST_FN, self.DISK_TEST_METADATA)
 
         status = self._export_archive(archive_path)
-        if status != ExportStatus.DISK_ENCRYPTED.value:
+        if status != ExportStatus.DISK_ENCRYPTED:
             raise ExportError(status)
 
     def _run_disk_export(self, archive_dir: str, filepaths: List[str], passphrase: str) -> None:

--- a/securedrop_client/gui/conversation/export/dialog.py
+++ b/securedrop_client/gui/conversation/export/dialog.py
@@ -2,6 +2,7 @@
 A dialog that allows journalists to export sensitive files to a USB drive.
 """
 from gettext import gettext as _
+from typing import Optional
 
 from pkg_resources import resource_string
 from PyQt5.QtCore import QSize, Qt, pyqtSlot
@@ -32,7 +33,8 @@ class ExportDialog(ModalDialog):
         self.file_name = SecureQLabel(
             file_name, wordwrap=False, max_length=self.FILENAME_WIDTH_PX
         ).text()
-        self.error_status = ""  # Hold onto the error status we receive from the Export VM
+        # Hold onto the error status we receive from the Export VM
+        self.error_status: Optional[ExportStatus] = None
 
         # Connect device signals to slots
         self._device.export_preflight_check_succeeded.connect(
@@ -248,16 +250,16 @@ class ExportDialog(ModalDialog):
         self.passphrase_field.setDisabled(False)
         self._update_dialog(error.status)
 
-    def _update_dialog(self, error_status: str) -> None:
+    def _update_dialog(self, error_status: ExportStatus) -> None:
         self.error_status = error_status
         # If the continue button is disabled then this is the result of a background preflight check
         if not self.continue_button.isEnabled():
             self.continue_button.clicked.disconnect()
-            if self.error_status == ExportStatus.BAD_PASSPHRASE.value:
+            if self.error_status == ExportStatus.BAD_PASSPHRASE:
                 self.continue_button.clicked.connect(self._show_passphrase_request_message_again)
-            elif self.error_status == ExportStatus.USB_NOT_CONNECTED.value:
+            elif self.error_status == ExportStatus.USB_NOT_CONNECTED:
                 self.continue_button.clicked.connect(self._show_insert_usb_message)
-            elif self.error_status == ExportStatus.DISK_ENCRYPTION_NOT_SUPPORTED_ERROR.value:
+            elif self.error_status == ExportStatus.DISK_ENCRYPTION_NOT_SUPPORTED_ERROR:
                 self.continue_button.clicked.connect(self._show_insert_encrypted_usb_message)
             else:
                 self.continue_button.clicked.connect(self._show_generic_error_message)
@@ -265,11 +267,11 @@ class ExportDialog(ModalDialog):
             self.continue_button.setEnabled(True)
             self.continue_button.setFocus()
         else:
-            if self.error_status == ExportStatus.BAD_PASSPHRASE.value:
+            if self.error_status == ExportStatus.BAD_PASSPHRASE:
                 self._show_passphrase_request_message_again()
-            elif self.error_status == ExportStatus.USB_NOT_CONNECTED.value:
+            elif self.error_status == ExportStatus.USB_NOT_CONNECTED:
                 self._show_insert_usb_message()
-            elif self.error_status == ExportStatus.DISK_ENCRYPTION_NOT_SUPPORTED_ERROR.value:
+            elif self.error_status == ExportStatus.DISK_ENCRYPTION_NOT_SUPPORTED_ERROR:
                 self._show_insert_encrypted_usb_message()
             else:
                 self._show_generic_error_message()

--- a/securedrop_client/gui/conversation/export/print_dialog.py
+++ b/securedrop_client/gui/conversation/export/print_dialog.py
@@ -1,4 +1,5 @@
 from gettext import gettext as _
+from typing import Optional
 
 from PyQt5.QtCore import QSize, pyqtSlot
 
@@ -20,7 +21,8 @@ class PrintDialog(ModalDialog):
         self.file_name = SecureQLabel(
             file_name, wordwrap=False, max_length=self.FILENAME_WIDTH_PX
         ).text()
-        self.error_status = ""  # Hold onto the error status we receive from the Export VM
+        # Hold onto the error status we receive from the Export VM
+        self.error_status: Optional[ExportStatus] = None
 
         # Connect device signals to slots
         self._device.print_preflight_check_succeeded.connect(
@@ -119,7 +121,7 @@ class PrintDialog(ModalDialog):
         # If the continue button is disabled then this is the result of a background preflight check
         if not self.continue_button.isEnabled():
             self.continue_button.clicked.disconnect()
-            if error.status == ExportStatus.PRINTER_NOT_FOUND.value:
+            if error.status == ExportStatus.PRINTER_NOT_FOUND:
                 self.continue_button.clicked.connect(self._show_insert_usb_message)
             else:
                 self.continue_button.clicked.connect(self._show_generic_error_message)
@@ -127,7 +129,7 @@ class PrintDialog(ModalDialog):
             self.continue_button.setEnabled(True)
             self.continue_button.setFocus()
         else:
-            if error.status == ExportStatus.PRINTER_NOT_FOUND.value:
+            if error.status == ExportStatus.PRINTER_NOT_FOUND:
                 self._show_insert_usb_message()
             else:
                 self._show_generic_error_message()

--- a/tests/gui/conversation/export/test_dialog.py
+++ b/tests/gui/conversation/export/test_dialog.py
@@ -248,14 +248,14 @@ def test_ExportDialog__update_dialog_when_status_is_USB_NOT_CONNECTED(mocker, ex
     mocker.patch.object(export_dialog.continue_button, "isEnabled", return_value=False)
 
     # When the continue button is enabled, ensure clicking continue will show next instructions
-    export_dialog._update_dialog(ExportStatus.USB_NOT_CONNECTED.value)
+    export_dialog._update_dialog(ExportStatus.USB_NOT_CONNECTED)
     export_dialog.continue_button.clicked.connect.assert_called_once_with(
         export_dialog._show_insert_usb_message
     )
 
     # When the continue button is enabled, ensure next instructions are shown
     mocker.patch.object(export_dialog.continue_button, "isEnabled", return_value=True)
-    export_dialog._update_dialog(ExportStatus.USB_NOT_CONNECTED.value)
+    export_dialog._update_dialog(ExportStatus.USB_NOT_CONNECTED)
     export_dialog._show_insert_usb_message.assert_called_once_with()
 
 
@@ -266,14 +266,14 @@ def test_ExportDialog__update_dialog_when_status_is_BAD_PASSPHRASE(mocker, expor
     mocker.patch.object(export_dialog.continue_button, "isEnabled", return_value=False)
 
     # When the continue button is enabled, ensure clicking continue will show next instructions
-    export_dialog._update_dialog(ExportStatus.BAD_PASSPHRASE.value)
+    export_dialog._update_dialog(ExportStatus.BAD_PASSPHRASE)
     export_dialog.continue_button.clicked.connect.assert_called_once_with(
         export_dialog._show_passphrase_request_message_again
     )
 
     # When the continue button is enabled, ensure next instructions are shown
     mocker.patch.object(export_dialog.continue_button, "isEnabled", return_value=True)
-    export_dialog._update_dialog(ExportStatus.BAD_PASSPHRASE.value)
+    export_dialog._update_dialog(ExportStatus.BAD_PASSPHRASE)
     export_dialog._show_passphrase_request_message_again.assert_called_once_with()
 
 
@@ -286,14 +286,14 @@ def test_ExportDialog__update_dialog_when_status_DISK_ENCRYPTION_NOT_SUPPORTED_E
     mocker.patch.object(export_dialog.continue_button, "isEnabled", return_value=False)
 
     # When the continue button is enabled, ensure clicking continue will show next instructions
-    export_dialog._update_dialog(ExportStatus.DISK_ENCRYPTION_NOT_SUPPORTED_ERROR.value)
+    export_dialog._update_dialog(ExportStatus.DISK_ENCRYPTION_NOT_SUPPORTED_ERROR)
     export_dialog.continue_button.clicked.connect.assert_called_once_with(
         export_dialog._show_insert_encrypted_usb_message
     )
 
     # When the continue button is enabled, ensure next instructions are shown
     mocker.patch.object(export_dialog.continue_button, "isEnabled", return_value=True)
-    export_dialog._update_dialog(ExportStatus.DISK_ENCRYPTION_NOT_SUPPORTED_ERROR.value)
+    export_dialog._update_dialog(ExportStatus.DISK_ENCRYPTION_NOT_SUPPORTED_ERROR)
     export_dialog._show_insert_encrypted_usb_message.assert_called_once_with()
 
 
@@ -304,17 +304,17 @@ def test_ExportDialog__update_dialog_when_status_is_CALLED_PROCESS_ERROR(mocker,
     mocker.patch.object(export_dialog.continue_button, "isEnabled", return_value=False)
 
     # When the continue button is enabled, ensure clicking continue will show next instructions
-    export_dialog._update_dialog(ExportStatus.CALLED_PROCESS_ERROR.value)
+    export_dialog._update_dialog(ExportStatus.CALLED_PROCESS_ERROR)
     export_dialog.continue_button.clicked.connect.assert_called_once_with(
         export_dialog._show_generic_error_message
     )
-    assert export_dialog.error_status == ExportStatus.CALLED_PROCESS_ERROR.value
+    assert export_dialog.error_status == ExportStatus.CALLED_PROCESS_ERROR
 
     # When the continue button is enabled, ensure next instructions are shown
     mocker.patch.object(export_dialog.continue_button, "isEnabled", return_value=True)
-    export_dialog._update_dialog(ExportStatus.CALLED_PROCESS_ERROR.value)
+    export_dialog._update_dialog(ExportStatus.CALLED_PROCESS_ERROR)
     export_dialog._show_generic_error_message.assert_called_once_with()
-    assert export_dialog.error_status == ExportStatus.CALLED_PROCESS_ERROR.value
+    assert export_dialog.error_status == ExportStatus.CALLED_PROCESS_ERROR
 
 
 def test_ExportDialog__update_dialog_when_status_is_unknown(mocker, export_dialog):

--- a/tests/gui/conversation/export/test_print_dialog.py
+++ b/tests/gui/conversation/export/test_print_dialog.py
@@ -139,14 +139,14 @@ def test_PrintFileDialog__on_print_preflight_check_failed_when_status_is_PRINTER
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
 
     # When the continue button is enabled, ensure clicking continue will show next instructions
-    print_dialog._on_print_preflight_check_failed(ExportError(ExportStatus.PRINTER_NOT_FOUND.value))
+    print_dialog._on_print_preflight_check_failed(ExportError(ExportStatus.PRINTER_NOT_FOUND))
     print_dialog.continue_button.clicked.connect.assert_called_once_with(
         print_dialog._show_insert_usb_message
     )
 
     # When the continue button is enabled, ensure next instructions are shown
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=True)
-    print_dialog._on_print_preflight_check_failed(ExportError(ExportStatus.PRINTER_NOT_FOUND.value))
+    print_dialog._on_print_preflight_check_failed(ExportError(ExportStatus.PRINTER_NOT_FOUND))
     print_dialog._show_insert_usb_message.assert_called_once_with()
 
 
@@ -159,21 +159,17 @@ def test_PrintFileDialog__on_print_preflight_check_failed_when_status_is_MISSING
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
 
     # When the continue button is enabled, ensure clicking continue will show next instructions
-    print_dialog._on_print_preflight_check_failed(
-        ExportError(ExportStatus.MISSING_PRINTER_URI.value)
-    )
+    print_dialog._on_print_preflight_check_failed(ExportError(ExportStatus.MISSING_PRINTER_URI))
     print_dialog.continue_button.clicked.connect.assert_called_once_with(
         print_dialog._show_generic_error_message
     )
-    assert print_dialog.error_status == ExportStatus.MISSING_PRINTER_URI.value
+    assert print_dialog.error_status == ExportStatus.MISSING_PRINTER_URI
 
     # When the continue button is enabled, ensure next instructions are shown
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=True)
-    print_dialog._on_print_preflight_check_failed(
-        ExportError(ExportStatus.MISSING_PRINTER_URI.value)
-    )
+    print_dialog._on_print_preflight_check_failed(ExportError(ExportStatus.MISSING_PRINTER_URI))
     print_dialog._show_generic_error_message.assert_called_once_with()
-    assert print_dialog.error_status == ExportStatus.MISSING_PRINTER_URI.value
+    assert print_dialog.error_status == ExportStatus.MISSING_PRINTER_URI
 
 
 def test_PrintFileDialog__on_print_preflight_check_failed_when_status_is_CALLED_PROCESS_ERROR(
@@ -185,21 +181,17 @@ def test_PrintFileDialog__on_print_preflight_check_failed_when_status_is_CALLED_
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=False)
 
     # When the continue button is enabled, ensure clicking continue will show next instructions
-    print_dialog._on_print_preflight_check_failed(
-        ExportError(ExportStatus.CALLED_PROCESS_ERROR.value)
-    )
+    print_dialog._on_print_preflight_check_failed(ExportError(ExportStatus.CALLED_PROCESS_ERROR))
     print_dialog.continue_button.clicked.connect.assert_called_once_with(
         print_dialog._show_generic_error_message
     )
-    assert print_dialog.error_status == ExportStatus.CALLED_PROCESS_ERROR.value
+    assert print_dialog.error_status == ExportStatus.CALLED_PROCESS_ERROR
 
     # When the continue button is enabled, ensure next instructions are shown
     mocker.patch.object(print_dialog.continue_button, "isEnabled", return_value=True)
-    print_dialog._on_print_preflight_check_failed(
-        ExportError(ExportStatus.CALLED_PROCESS_ERROR.value)
-    )
+    print_dialog._on_print_preflight_check_failed(ExportError(ExportStatus.CALLED_PROCESS_ERROR))
     print_dialog._show_generic_error_message.assert_called_once_with()
-    assert print_dialog.error_status == ExportStatus.CALLED_PROCESS_ERROR.value
+    assert print_dialog.error_status == ExportStatus.CALLED_PROCESS_ERROR
 
 
 def test_PrintFileDialog__on_print_preflight_check_failed_when_status_is_unknown(

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -4,7 +4,7 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 import pytest
 
-from securedrop_client.export import Export, ExportError
+from securedrop_client.export import Export, ExportError, ExportStatus
 
 
 def test_run_printer_preflight(mocker):
@@ -283,7 +283,7 @@ def test__run_disk_test(mocker):
     """
     export = Export()
     export._create_archive = mocker.MagicMock(return_value="mock_archive_path")
-    export._export_archive = mocker.MagicMock(return_value="USB_ENCRYPTED")
+    export._export_archive = mocker.MagicMock(return_value=ExportStatus("USB_ENCRYPTED"))
 
     export._run_disk_test("mock_archive_dir")
 
@@ -313,7 +313,7 @@ def test__run_usb_test(mocker):
     """
     export = Export()
     export._create_archive = mocker.MagicMock(return_value="mock_archive_path")
-    export._export_archive = mocker.MagicMock(return_value="USB_CONNECTED")
+    export._export_archive = mocker.MagicMock(return_value=ExportStatus("USB_CONNECTED"))
 
     export._run_usb_test("mock_archive_dir")
 
@@ -380,11 +380,14 @@ def test__export_archive(mocker):
     """
     Ensure the subprocess call returns the expected output.
     """
-    mocker.patch("subprocess.check_output", return_value=b"mock")
     export = Export()
+    mocker.patch("subprocess.check_output", return_value=b"USB_CONNECTED")
     status = export._export_archive("mock.sd-export")
+    assert status == ExportStatus.USB_CONNECTED
 
-    assert status == "mock"
+    mocker.patch("subprocess.check_output", return_value=b"mock")
+    with pytest.raises(ExportError, match="UNEXPECTED_RETURN_STATUS"):
+        export._export_archive("mock.sd-export")
 
 
 def test__export_archive_does_not_raise_ExportError_when_CalledProcessError(mocker):
@@ -407,7 +410,8 @@ def test__export_archive_with_evil_command(mocker):
     export = Export()
     check_output = mocker.patch("subprocess.check_output", return_value=b"")
 
-    export._export_archive("somefile; rm -rf ~")
+    with pytest.raises(ExportError, match="UNEXPECTED_RETURN_STATUS"):
+        export._export_archive("somefile; rm -rf ~")
 
     check_output.assert_called_once_with(
         [


### PR DESCRIPTION
# Description

Addresses the user interface aspect of [#4 ](https://github.com/freedomofpress/securedrop-client-security/issues/4)
Fixes [#4](https://github.com/freedomofpress/securedrop-client-security/issues/4)

# Test Plan

- [ ] Verify that no unverified strings are printed in the user interface
- [ ] Confirm that the information is still available in debug logs in case it's needed

