### PR TITLE
Fix command to install packaging dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ common-steps:
         cd securedrop-debian-packaging
         apt-get update && apt-get install -y sudo make
         make install-deps
-        PKG_DIR=~/project make requirements
+        ./scripts/update-requirements --pkg-dir=/root/project --project=securedrop-client
 
   - &check_packaging_requirements
     run:


### PR DESCRIPTION
## Description

The API changed today, and the backwards compatibility mechanism makes the (reasonable) guess that the directory will be named after the project, which is not the case in this CI pipeline.

Unblocks https://github.com/freedomofpress/securedrop-client/pull/1565

## Test Plan

We've got a :chicken: and :egg: problem here. CI is failing because both **mako** is outdated and because the [`securedrop-debian-packaging` API has changed](https://github.com/freedomofpress/securedrop-debian-packaging/pull/382).

I want to fix CI before upgrading **mako** or any other dependency. (I'm waiting on this fix to upgrade the [development dependencies for example][dev], and upgrading **mako**, and fixing CI for Bookworm.) Please bear with me as I push the limit of merging with a meaningfully failing CI. :bear: 

- [ ] Confirm that the change looks reasonable
- [ ] Confirm that CI for **Bullseye** is passing, **except**  for the [known vulnerability in **mako**][fail]

----

  [fail]: https://app.circleci.com/pipelines/github/freedomofpress/securedrop-client/2678/workflows/aa08638f-d151-417a-a058-82b4358422a5/jobs/11521?invite=true#step-103-415
  [dev]: