### PR TITLE
Remove unused export dialog string

### DIFF
--- a/securedrop_client/gui/conversation/export/dialog.py
+++ b/securedrop_client/gui/conversation/export/dialog.py
@@ -84,9 +84,6 @@ class ExportDialog(ModalDialog):
         )
         self.passphrase_error_message = _("The passphrase provided did not work. Please try again.")
         self.generic_error_message = _("See your administrator for help.")
-        self.continue_disabled_message = _(
-            "The CONTINUE button will be disabled until the Export VM is ready"
-        )
         self.success_message = _(
             "Remember to be careful when working with files outside of your Workstation machine."
         )

--- a/securedrop_client/locale/messages.pot
+++ b/securedrop_client/locale/messages.pot
@@ -268,9 +268,6 @@ msgstr ""
 msgid "See your administrator for help."
 msgstr ""
 
-msgid "The CONTINUE button will be disabled until the Export VM is ready"
-msgstr ""
-
 msgid "Remember to be careful when working with files outside of your Workstation machine."
 msgstr ""
 


### PR DESCRIPTION
# Description

Removes an unused string that seems to be a holdover from 64ef17d832b7f738ac038e1a5c6ab2e085909efe

# Test Plan

Confirmation that the string is not used anywhere in the code should be sufficient.

# Checklist
- [x] These changes should not need testing in Qubes
- [x] No update to the AppArmor profile is required for these changes
- [x] No database schema changes are needed