### PR TITLE
update securedrop-debian-packaging->securedrop-builder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,8 +95,8 @@ common-steps:
         mkdir ~/packaging && cd ~/packaging
         # local builds may not have an ssh url, so || true
         git config --global --unset url.ssh://git@github.com.insteadof || true
-        git clone https://github.com/freedomofpress/securedrop-debian-packaging.git
-        cd securedrop-debian-packaging
+        git clone https://github.com/freedomofpress/securedrop-builder.git
+        cd securedrop-builder
         apt-get update && apt-get install -y sudo make
         make install-deps
         PKG_DIR=~/project make requirements
@@ -126,7 +126,7 @@ common-steps:
       command: |
         cd ~/project
         ./update_version.sh 1000.0  # Dummy version number, doesn't matter what we put here
-        cd ~/packaging/securedrop-debian-packaging
+        cd ~/packaging/securedrop-builder
         export PKG_VERSION=1000.0
         export PKG_PATH=~/project/
         make securedrop-client

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -28,7 +28,7 @@ SecureDrop maintainers and testers: As you QA this release, please report back y
 - [ ] Create test plan
 - [ ] Refresh nightlies
 - [ ] Begin formal QA using nightlies; refresh nightlies as needed
-- [ ] Build production package in standard [build environment](https://github.com/freedomofpress/securedrop-debian-packaging/wiki/FAQ#how-do-i-create-a-local-environment-suitable-for-building-packages)
+- [ ] Build production package in standard [build environment](https://github.com/freedomofpress/securedrop-builder/wiki/FAQ#how-do-i-create-a-local-environment-suitable-for-building-packages)
 - [ ] Sign production package
 - [ ] Perform final pre-flight testing using apt-qa.freedom.press
   - [ ] **Localization:** In a dispVM, change your locale (e.g.: `export LANG=es_ES.utf-8; dpkg-reconfigure locales`), run the Client, and confirm that the application is translated.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ venv: hooks ## Provision a Python 3 virtualenv for development on Linux
 	@echo "Make sure to run: source .venv/bin/activate"
 
 .PHONY: venv-sdw
-venv-sdw: hooks ## Provision a Python 3 virtualenv for development on a prod-like system that has installed dependencies specified in https://github.com/freedomofpress/securedrop-debian-packaging/blob/main/securedrop-client/debian/control
+venv-sdw: hooks ## Provision a Python 3 virtualenv for development on a prod-like system that has installed dependencies specified in https://github.com/freedomofpress/securedrop-builder/blob/main/securedrop-client/debian/control
 	$(PYTHON) -m venv .venv --system-site-packages
 	.venv/bin/pip install --upgrade pip wheel
 	.venv/bin/pip install --require-hashes -r "requirements/dev-sdw-requirements.txt"

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ securedrop-client
 
 ## Updating dependencies
 
-`dev-requirements.txt` and `requirements.txt` point to python software foundation hashes, and `build-requirements.txt` points to our builds of the wheels from our own pip mirror (https://github.com/freedomofpress/securedrop-debian-packaging/tree/main/localwheels). Whenever a dependency in `build-requirements.txt` changes, our team needs to manually review the code in the dependency diff with a focus on spotting vulnerabilities.
+`dev-requirements.txt` and `requirements.txt` point to python software foundation hashes, and `build-requirements.txt` points to our builds of the wheels from our own pip mirror (https://github.com/freedomofpress/securedrop-builder/tree/main/localwheels). Whenever a dependency in `build-requirements.txt` changes, our team needs to manually review the code in the dependency diff with a focus on spotting vulnerabilities.
 
 If you're adding or updating a dependency, you need to:
 
@@ -258,7 +258,7 @@ For building a debian package from this project, we use the requirements in
 wheels on our pip mirror. A maintainer will need to add
 the updated dependency to our pip mirror (you can request this in the PR).
 
-3. Once the pip mirror is updated, you should checkout the [securedrop-debian-packaging repo](https://github.com/freedomofpress/securedrop-debian-packaging) and run `make requirements`. Commit the `build-requirements.txt` that results and add it to your PR.
+3. Once the pip mirror is updated, you should checkout the [securedrop-builder repo](https://github.com/freedomofpress/securedrop-builder) and run `make requirements`. Commit the `build-requirements.txt` that results and add it to your PR.
 
 
 ## Generating and running database migrations
@@ -394,7 +394,7 @@ Note: One of the functional tests deletes a source, so you may need to add it ba
 5. Perform the release signing ceremony on the tag. Push the tag.
 6. The signer should create the source tarball via `python3 setup.py sdist`.
 7. Add a detached signature (with the release key) for the source tarball.
-8. Submit the source tarball and signature via PR into this [repository](https://github.com/freedomofpress/securedrop-debian-packaging) along with the debian changelog addition. This tarball and changelog will be used by the package builder.
+8. Submit the source tarball and signature via PR into this [repository](https://github.com/freedomofpress/securedrop-builder) along with the debian changelog addition. This tarball and changelog will be used by the package builder.
 
 ## Debugging
 


### PR DESCRIPTION
# Description

Towards https://github.com/freedomofpress/securedrop-builder/issues/304 (follow-up after repo name change)

# Test Plan

- [ ] CI passes
- [ ] Changes look good upon visual inspection

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
