### PR TITLE
Rename desktop entry to follow freedesktop specifications

### DIFF
--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -45,7 +45,7 @@ LanguageCode = NewType("LanguageCode", str)
 
 DEFAULT_LANGUAGE = LanguageCode("en")
 DEFAULT_SDC_HOME = "~/.securedrop_client"
-DESKTOP_FILE_NAME = "org.freedomofthepress.securedrop.client"
+DESKTOP_FILE_NAME = "press.freedom.SecureDropClient.desktop"
 ENCODING = "utf-8"
 GETTEXT_DOMAIN = "messages"
 LOGLEVEL = os.environ.get("LOGLEVEL", "info").upper()


### PR DESCRIPTION
# Description

This changes the freedesktop filename to conform to reverse-dns hierarchy standards. It also ensures that the file name doesn't refer to a domain name that is no longer under FPF's control.

Fixes https://github.com/freedomofpress/securedrop-client/pull/1588#discussion_r1016195397

# Test Plan


# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [x] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [x] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
