### PR TITLE
Improve OSX setup flow based on experience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ RANDOM_SEED ?= $(shell bash -c 'echo $$RANDOM')
 .PHONY: test
 test: ## Run the application tests in parallel (for rapid development)
 	@TEST_CMD="python -m pytest -v -n 4 --ignore=$(FTESTS) --ignore=$(ITESTS) $(TESTOPTS) $(TESTS)" ; \
+		source scripts/setup-tmp-directories.sh; \
 		if command -v xvfb-run > /dev/null; then \
 		xvfb-run -a $$TEST_CMD ; else \
 		$$TEST_CMD ; fi

--- a/requirements/dev-mac-requirements.in
+++ b/requirements/dev-mac-requirements.in
@@ -1,4 +1,2 @@
 -r dev-bullseye-requirements.in
-pyobjc-core
-pyobjc
-rubicon-objc
+rubicon-objc==0.4.2

--- a/run.sh
+++ b/run.sh
@@ -17,18 +17,7 @@ while [ -n "$1" ]; do
   shift
 done
 
-if [[ $OSTYPE == 'darwin'* ]]; then
-  # Override tempfile behavior in OS X as /var symlink conflicts with path traversal checks
-  TMP_BASE=$HOME/.sdc_tmp
-  [ -d $TMP_BASE ] && rm -rf $TMP_BASE
-  mkdir $TMP_BASE
-  export TMPDIR=$TMP_BASE
-  SDC_HOME=${SDC_HOME:-$(mktemp -d $TMP_BASE/sd_client.XXXX)}
-else
-  SDC_HOME=${SDC_HOME:-$(mktemp -d)}
-fi
-export SDC_HOME
-
+source scripts/setup-tmp-directories.sh
 
 GNUPGHOME="$SDC_HOME/gpg"
 export GNUPGHOME

--- a/scripts/setup-tmp-directories.sh
+++ b/scripts/setup-tmp-directories.sh
@@ -1,0 +1,11 @@
+if [[ $OSTYPE == 'darwin'* ]]; then
+  # Override tempfile behavior in OS X as /var symlink conflicts with path traversal checks
+  TMP_BASE=$HOME/.sdc_tmp
+  [ -d $TMP_BASE ] && rm -rf $TMP_BASE
+  mkdir $TMP_BASE
+  export TMPDIR=$TMP_BASE
+  SDC_HOME=${SDC_HOME:-$(mktemp -d $TMP_BASE/sd_client.XXXX)}
+else
+  SDC_HOME=${SDC_HOME:-$(mktemp -d)}
+fi
+export SDC_HOME


### PR DESCRIPTION
## Description

Changes:
* The code inside run.sh is pulled out into a script file setup-tmp-directories.sh as it needs to be run within the `make test` command as well
* New requirements files are added for Mac OS users.

## Test Plan

- [ ] Confirm that following the README instructions allows to run `make test`, `./run.sh`, and connecting to a development sever successfully on MacOS X
