### PR TITLE
Remove dependency on py package (deprecated)

### DIFF
--- a/requirements/dev-bookworm-requirements.txt
+++ b/requirements/dev-bookworm-requirements.txt
@@ -438,10 +438,6 @@ pluggy==1.0.0 \
     --hash=sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159 \
     --hash=sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3
     # via pytest
-py==1.11.0 \
-    --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \
-    --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378
-    # via -r requirements/dev-sdw-requirements.in
 pyautogui==0.9.53 \
     --hash=sha256:d31de8f712218d90be7fc98091fce1a12a3e9196e0c814eb9afd73bb2ec97035
     # via -r requirements/dev-sdw-requirements.in
@@ -546,9 +542,9 @@ pytest-mock==3.8.2 \
     --hash=sha256:77f03f4554392558700295e05aed0b1096a20d4a60a4f3ddcde58b0c31c8fca2 \
     --hash=sha256:8a9e226d6c0ef09fcf20c94eb3405c388af438a90f3e39687f84166da82d5948
     # via -r requirements/dev-sdw-requirements.in
-pytest-qt==4.1.0 \
-    --hash=sha256:027f3d3f5dd04af0530d846cf50fb858f719f7e87c2e4a1c686abd4e0f72172a \
-    --hash=sha256:edd08dae3b207405edddfc482d4dda4b848e85a8e6a0e7c36f20bac11ab328de
+pytest-qt==4.2.0 \
+    --hash=sha256:00a17b586dd530b6d7a9399923a40489ca4a9a309719011175f55dc6b5dc8f41 \
+    --hash=sha256:a7659960a1ab2af8fc944655a157ff45d714b80ed7a6af96a4b5bb99ecf40a22
     # via -r requirements/dev-sdw-requirements.in
 pytest-random-order==1.0.4 \
     --hash=sha256:6b2159342a4c8c10855bc4fc6d65ee890fc614cb2b4ff688979b008a82a0ff52 \

--- a/requirements/dev-bullseye-requirements.txt
+++ b/requirements/dev-bullseye-requirements.txt
@@ -438,10 +438,6 @@ pluggy==1.0.0 \
     --hash=sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159 \
     --hash=sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3
     # via pytest
-py==1.11.0 \
-    --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \
-    --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378
-    # via -r requirements/dev-sdw-requirements.in
 pyautogui==0.9.53 \
     --hash=sha256:d31de8f712218d90be7fc98091fce1a12a3e9196e0c814eb9afd73bb2ec97035
     # via -r requirements/dev-sdw-requirements.in
@@ -546,9 +542,9 @@ pytest-mock==3.8.2 \
     --hash=sha256:77f03f4554392558700295e05aed0b1096a20d4a60a4f3ddcde58b0c31c8fca2 \
     --hash=sha256:8a9e226d6c0ef09fcf20c94eb3405c388af438a90f3e39687f84166da82d5948
     # via -r requirements/dev-sdw-requirements.in
-pytest-qt==4.1.0 \
-    --hash=sha256:027f3d3f5dd04af0530d846cf50fb858f719f7e87c2e4a1c686abd4e0f72172a \
-    --hash=sha256:edd08dae3b207405edddfc482d4dda4b848e85a8e6a0e7c36f20bac11ab328de
+pytest-qt==4.2.0 \
+    --hash=sha256:00a17b586dd530b6d7a9399923a40489ca4a9a309719011175f55dc6b5dc8f41 \
+    --hash=sha256:a7659960a1ab2af8fc944655a157ff45d714b80ed7a6af96a4b5bb99ecf40a22
     # via -r requirements/dev-sdw-requirements.in
 pytest-random-order==1.0.4 \
     --hash=sha256:6b2159342a4c8c10855bc4fc6d65ee890fc614cb2b4ff688979b008a82a0ff52 \

--- a/requirements/dev-sdw-requirements.in
+++ b/requirements/dev-sdw-requirements.in
@@ -8,14 +8,13 @@ MarkupSafe
 mypy
 Pillow>=9.0.1  # for mouseinfo, pyscreeze as of CVE-2022-{22817,24303}
 pip-tools>=6.8.0  # for jazzband/piptools#1617
-py
 PyAutoGUI
 pyobjc-core;platform_system=="Darwin"
 pyobjc;platform_system=="Darwin"
 pytest>=7.2.0  # CVE-2022-42969
 pytest-cov
 pytest-mock
-pytest-qt
+pytest-qt>=4.2.0  # to drop requirement of deprecated py package
 pytest-random-order
 pytest-vcr
 pytest-xdist>=3.0.2  # CVE-2022-42969

--- a/requirements/dev-sdw-requirements.txt
+++ b/requirements/dev-sdw-requirements.txt
@@ -428,10 +428,6 @@ pluggy==1.0.0 \
     --hash=sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159 \
     --hash=sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3
     # via pytest
-py==1.11.0 \
-    --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \
-    --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378
-    # via -r requirements/dev-sdw-requirements.in
 pyautogui==0.9.53 \
     --hash=sha256:d31de8f712218d90be7fc98091fce1a12a3e9196e0c814eb9afd73bb2ec97035
     # via -r requirements/dev-sdw-requirements.in
@@ -504,9 +500,9 @@ pytest-mock==3.8.2 \
     --hash=sha256:77f03f4554392558700295e05aed0b1096a20d4a60a4f3ddcde58b0c31c8fca2 \
     --hash=sha256:8a9e226d6c0ef09fcf20c94eb3405c388af438a90f3e39687f84166da82d5948
     # via -r requirements/dev-sdw-requirements.in
-pytest-qt==4.1.0 \
-    --hash=sha256:027f3d3f5dd04af0530d846cf50fb858f719f7e87c2e4a1c686abd4e0f72172a \
-    --hash=sha256:edd08dae3b207405edddfc482d4dda4b848e85a8e6a0e7c36f20bac11ab328de
+pytest-qt==4.2.0 \
+    --hash=sha256:00a17b586dd530b6d7a9399923a40489ca4a9a309719011175f55dc6b5dc8f41 \
+    --hash=sha256:a7659960a1ab2af8fc944655a157ff45d714b80ed7a6af96a4b5bb99ecf40a22
     # via -r requirements/dev-sdw-requirements.in
 pytest-random-order==1.0.4 \
     --hash=sha256:6b2159342a4c8c10855bc4fc6d65ee890fc614cb2b4ff688979b008a82a0ff52 \


### PR DESCRIPTION
## Description

Upgrades **pytest-qt** so that **py** is not required anymore.

Additional context: the **py** package is in maintenance mode, and the parts we use were integrated into **pytest**. The **pytest-qt** package was still referring to the original **py** modules before `pytest-qt==4.2.0`.

Fixes #1595 

## Test plan

- [x] The CI pipeline passes
- [x] Confirm that no diff review is needed for `pytest-qt==4.2.0`