### PR TITLE
Rename desktop entry after freedesktop specifications

### DIFF
--- a/files/press.freedom.SecureDropClient.desktop
+++ b/files/press.freedom.SecureDropClient.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=SecureDrop Client
+Exec=securedrop-client
+Icon=utilities-terminal
+Type=Application


### PR DESCRIPTION
## Description

This is  follow up on https://github.com/freedomofpress/securedrop-client/pull/1589, that ensures that the file name that's referred to by the SecureDrop Client application actually exists.

**Note**: This commit creates a new file so that the application can be built while the build tooling is updated. Once the build tooling refers to the new file, the old one can be removed.

## Test plan

- [ ] The CI pipeline is successful (especially the `build-bullseye` and `build-bookworm` jobs)