### PR TITLE
Rename desktop entry after freedesktop specifications (2)

### DIFF
--- a/files/securedrop-client.desktop
+++ b/files/securedrop-client.desktop
@@ -1,5 +1,0 @@
-[Desktop Entry]
-Name=SecureDrop Client
-Exec=securedrop-client
-Icon=utilities-terminal
-Type=Application


### PR DESCRIPTION
## Description

This is a follow up on #1600 and https://github.com/freedomofpress/securedrop-builder/pull/402. It concludes the renaming of the SecureDrop Client desktop entry.

:crystal_ball: **Reviewers**: The CI pipeline will need to be re-triggered after https://github.com/freedomofpress/securedrop-builder/pull/402 is merged. Failures are expected before that.

Also related to: https://github.com/freedomofpress/securedrop-client/pull/1589

## Test plan

- [ ] The CI pipeline is successful (especially the `build-bullseye` and `build-bookworm` jobs)