### PR TITLE
Allow development environment to work on arm based macOS machines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 .PHONY: all
 all: help
 
-# Default to plain "python3"
-PYTHON ?= python3
+# We prefer to use python3.9 if it's availabe, especially on arm64 based Macs,
+# which would not be able to install the virtual environment without an x86_64
+# Python 3.9, but we're also OK with just python3 if that's all we've got
+PYTHON := $(if $(shell bash -c "command -v python3.9"), python3.9, python3)
 VERSION_CODENAME ?= bullseye
 
 .PHONY: venv
@@ -27,7 +29,9 @@ venv-sdw: hooks ## Provision a Python 3 virtualenv for development on a prod-lik
 venv-mac: hooks ## Provision a Python 3 virtualenv for development on macOS
 	$(PYTHON) -m venv .venv
 	.venv/bin/pip install --upgrade pip wheel
-	.venv/bin/pip install -r "requirements/dev-mac-requirements.in"
+	# There are no M1/arm wheels for the version of PyQt5 we require, and
+	# unfortunately it also doesn't compile. So we're forcing x86_64 mode here
+	arch -x86_64 .venv/bin/pip install -r "requirements/dev-mac-requirements.in"
 	@echo "#################"
 	@echo "Make sure to run: source .venv/bin/activate"
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Or, if you want to persist data across restarts, you will need to run the client
 
 ### Developer environment on macOS
 
-It is possible to run the development environment in macOS on non-Apple Silicon (M1) systems, but some functionality may not be available:
+It is possible to run the development environment in macOS systems, but some functionality may not be available:
  * If you want to be able to open or export file submissions in a disposable AppVM, then you'll need to follow the instructions for running this in a [developer environment](#developer-environment) in Qubes.
  * Tor is not used in the developer environment. If you want to use a Tor connection between the client and server, then you'll need to follow the [staging environment](#staging-environment) instructions instead.
 
@@ -135,15 +135,16 @@ socat TCP4-LISTEN:8081,fork,reuseaddr TCP4:A.B.C.D:8081
 
 #### Set up the SecureDrop Client
 1. Open a new terminal window.
-2. If it is not already installed, install Homebrew via the instructions at https://brew.sh/
-3. Install dependencies via Homebrew: `brew install pyenv gnupg oath-toolkit`
-4. Set up pyenv following the steps here: https://github.com/pyenv/pyenv#basic-github-checkout -  starting with #2 ("Configure your shell's environment for Pyenv"). You may need to close and reopen the terminal window for changes to be applied.
-5. install and select the latest version of python 3.9.x
-   ```
-   pyenv install 3.9.x
-   pyenv local 3.9.x
-   ```
-6. clone the SecureDrop Client repo and set up its virtual environment
+2. Install Homebrew
+  a. If you use an Intel based machine, follow the instructions at https://brew.sh/
+  b. If you use an Apple Silicon based machine (M1 or M2 Macs):
+    1. (Informational) If you already have a native `arm64` version of Homebrew, you will wind up with a separate Homebrew installation for each architecture. While they do not conflict, combining them in your `PATH` permanently may cause confusion about which brews are installed where. You may want to modify your `PATH` temporarily to perform this installation. The virtual environment you create in this session will continue to work in subsequent sessions.
+    2. Run `/usr/sbin/softwareupdate --install-rosetta` to allow you to run `x86_64` binaries
+    3. Enter a shell in `x86_64` mode with `arch -x86_64 bash`
+    4. Install Homebrew via the instructions at https://brew.sh/
+    5. Install the dependencies below in the same `x86_64` shell session
+3. Install dependencies via Homebrew: `brew install python@3.9 gnupg oath-toolkit`
+4. clone the SecureDrop Client repo and set up its virtual environment
    ```
    git clone git@github.com:freedomofpress/securedrop-client.git
    cd securedrop-client
@@ -152,13 +153,13 @@ socat TCP4-LISTEN:8081,fork,reuseaddr TCP4:A.B.C.D:8081
    ```
    * `make venv-mac` will also run `make hooks`, which will configure Git to use the hooks found in `.githooks/` to check certain code-quality standards on new commits in this repository.  These checks are also enforced in CI.
 
-7. Run SecureDrop Client
+5. Run SecureDrop Client
    ```
    ./run.sh
    ```
 
 To log in, use one of the journalist usernames/passwords displayed in the Docker server output, such as
-`journalist/correct horse battery staple profanity oil chewy`. To generate the required 2FA token, use 
+`journalist/correct horse battery staple profanity oil chewy`. To generate the required 2FA token, use
 the `oathtool` command, eg: `oathtool -b --totp "JHCOGO7VCER3EJ4L"` in your terminal.
 
 Note: to persist data and config across multiple client runs, specify a home directory, e.g. `./run.sh --sdc_home=~/.sd_client`

--- a/run.sh
+++ b/run.sh
@@ -19,6 +19,11 @@ done
 
 source scripts/setup-tmp-directories.sh
 
+PYTHON="python"
+if [[ $OSTYPE == 'darwin'* ]] && [[ "$(uname -m)" == "arm64" ]]; then
+    PYTHON="arch -x86_64 ${PYTHON}"
+fi
+
 GNUPGHOME="$SDC_HOME/gpg"
 export GNUPGHOME
 mkdir -p "$GNUPGHOME"
@@ -56,4 +61,4 @@ fi
 wait
 
 echo "Starting client, log available at: $SDC_HOME/logs/client.log"
-python -m securedrop_client --sdc-home "$SDC_HOME" --no-proxy "$qubes_flag" "$@"
+$PYTHON -m securedrop_client --sdc-home "$SDC_HOME" --no-proxy "$qubes_flag" "$@"


### PR DESCRIPTION
# Description

Fixes #1591

This also changes the install instructions on macOS in general, unifying the setup for Intel and arm64 machines. This also drops instructions to use pyenv in favour of installing Python 3.9 via Homebrew. This is necessary to allow x86_64 mode Python 3.9 virtual environments to work as we need them to.

# Test Plan

- [x] Client runs after following instructions on a macOS machine with an Intel processor
- [x] Client runs after following instructions on a macOS machine with an arm64 processor

# Checklist

 - [x] These changes should not need testing in Qubes
 - [x] No update to the AppArmor profile is required for these changes
 - [x] No database schema changes are needed

