### PR TITLE
Show message and reply retrieval progress message

### DIFF
--- a/securedrop_client/locale/messages.pot
+++ b/securedrop_client/locale/messages.pot
@@ -19,6 +19,11 @@ msgstr ""
 msgid "{application_name} is already running"
 msgstr ""
 
+msgid "Retrieving 1 message"
+msgid_plural "Retrieving {message_count} messages"
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "The SecureDrop server cannot be reached. Trying to reconnect..."
 msgstr ""
 
@@ -42,9 +47,6 @@ msgid "Your session expired. Please log in again."
 msgstr ""
 
 msgid "Failed to update star."
-msgstr ""
-
-msgid "Retrieving new messages"
 msgstr ""
 
 msgid "File does not exist in the data directory. Please try re-downloading."

--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -2,7 +2,7 @@ import itertools
 import logging
 import threading
 from queue import PriorityQueue
-from typing import Optional, Tuple, Any
+from typing import Any, Optional, Tuple
 
 from PyQt5.QtCore import QObject, QThread, pyqtBoundSignal, pyqtSignal, pyqtSlot
 from sdclientapi import API, RequestTimeoutError, ServerConnectionError
@@ -40,19 +40,19 @@ class RunnablePriorityQueue(PriorityQueue):
         self.queue_updated_signal = queue_updated_signal
         super().__init__(*args, **kwargs)
 
-    def get(self, *args, **kwargs):
+    def get(self, *args: Any, **kwargs: Any) -> Tuple[int, QueueJob]:
         item = super().get(*args, **kwargs)
         if self.queue_updated_signal:
             self.queue_updated_signal.emit(self._get_num_message_or_reply_download_jobs())
         return item
 
-    def put(self, *args, **kwargs):
+    def put(self, *args: Any, **kwargs: Any) -> None:
         item = super().put(*args, **kwargs)
         if self.queue_updated_signal:
             self.queue_updated_signal.emit(self._get_num_message_or_reply_download_jobs())
         return item
 
-    def _get_num_message_or_reply_download_jobs(self):
+    def _get_num_message_or_reply_download_jobs(self) -> int:
         message_and_reply_download_jobs = list(
             # PriorityQueue items are a tuple of (priority, job)
             filter(lambda job: type(job[1]) in (MessageDownloadJob, ReplyDownloadJob), self.queue)


### PR DESCRIPTION
## Description

Fixes #1607.

- Currently after a metadata sync completes, if there are messages and replies to download from the server, the client shows a message "Retrieving messages" for 2.5 seconds before adding a job per message / reply to a queue.
- Due to the Guardian's volume of sources, messages, and replies, processing all message and reply download jobs after a metadata sync has completed can take a long time (around 20 minutes). 
- We would like to provide an easy way for the user to track download progress.
   - Note: as messages are downloaded, the user can see the text being populated (i.e.`<Message not yet available>` being replaced by the decrypted message text) allowing the user to approximate overall download progress.

- This change adds message to the left side of the top nav bar showing the number of message and reply download jobs in the queue when the queue is non-empty, updating every time a job is queued or dequeued (e.g. "Retrieving 23 messages").

### Example

https://user-images.githubusercontent.com/17057932/205993457-551796fa-f1b1-43de-813f-fc303445cc59.mov

## Test Plan

- [ ] Confirm that CI is green :green_apple: 
- [ ] The count of messages is displayed when message download is in progress
- [ ] The count of messages is not displayed once downloading finishes
- [x] Signals are tested without mocking the object under test :dancers: 

We plan to merge https://github.com/guardian/securedrop-client/pull/1 and deploy our fork of the project to production.

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations