### PR TITLE
Ignore SQLAlchemy vulnerabitity without released mitigation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,12 +125,14 @@ test-functional: ## Run the functional tests
 lint: ## Run the linters
 	@flake8 securedrop_client tests
 
+IGNORED_VULNERABILITIES ?= "51668"
+
 .PHONY: safety
 safety: ## Runs `safety check` to check python dependencies for vulnerabilities
 	pip install --upgrade safety && \
 		for req_file in `find . -type f -wholename '*requirements.txt'`; do \
 			echo "Checking file $$req_file" \
-			&& safety check --full-report -r $$req_file \
+			&& safety check --full-report --ignore $(IGNORED_VULNERABILITIES) -r $$req_file \
 			&& echo -e '\n' \
 			|| exit 1; \
 		done


### PR DESCRIPTION
## Description

The vulnerability is fixed in `sqlalchemy>=2.0.0b1`, and the most recent version in the 2.x series is currently `2.0.0b4`.

Unblocks: https://github.com/freedomofpress/securedrop-client/pull/1609 and every other PR currently being reviewed.

## Test Plan

- [ ] Confirm that ignoring this vulnerability is reasonable considering that we're not releasing a new version of the SecureDrop Client immediately.