### PR TITLE
Enable PyQt5 type checking

### DIFF
--- a/.semgrep/custom-rules.yml
+++ b/.semgrep/custom-rules.yml
@@ -166,3 +166,17 @@ rules:
             _\(\s*".*"\s*\.format\(
         - pattern-regex: |-
             _\(\s*f"(.*)
+
+- id: unsafe-assert
+  languages:
+    - python
+  severity: ERROR
+  message: Assert is unsafe unless used for type narrowing - see https://mypy.readthedocs.io/en/stable/type_narrowing.html
+  patterns:
+    # Exempt assertions that are used for type narrowing
+    - pattern-not-regex: |
+        assert isinstance\(.*\)
+
+    # Forbid any other use of assert
+    - pattern-regex: |
+        assert.*

--- a/requirements/dev-bookworm-requirements.txt
+++ b/requirements/dev-bookworm-requirements.txt
@@ -501,6 +501,10 @@ pyqt5-sip==12.9.0 \
     # via
     #   -r requirements/dev-bookworm-requirements.in
     #   pyqt5
+pyqt5-stubs==5.15.6.0 \
+    --hash=sha256:7fb8177c72489a8911f021b7bd7c33f12c87f6dba92dcef3fdcdb5d9400f0f3f \
+    --hash=sha256:91270ac23ebf38a1dc04cd97aa852cd08af82dc839100e5395af1447e3e99707
+    # via -r requirements/dev-sdw-requirements.in
 pyrect==0.2.0 \
     --hash=sha256:f65155f6df9b929b67caffbd57c0947c5ae5449d3b580d178074bffb47a09b78
     # via pygetwindow

--- a/requirements/dev-bullseye-requirements.txt
+++ b/requirements/dev-bullseye-requirements.txt
@@ -501,6 +501,10 @@ pyqt5-sip==12.8.1 \
     # via
     #   -r requirements/dev-bullseye-requirements.in
     #   pyqt5
+pyqt5-stubs==5.15.6.0 \
+    --hash=sha256:7fb8177c72489a8911f021b7bd7c33f12c87f6dba92dcef3fdcdb5d9400f0f3f \
+    --hash=sha256:91270ac23ebf38a1dc04cd97aa852cd08af82dc839100e5395af1447e3e99707
+    # via -r requirements/dev-sdw-requirements.in
 pyrect==0.2.0 \
     --hash=sha256:f65155f6df9b929b67caffbd57c0947c5ae5449d3b580d178074bffb47a09b78
     # via pygetwindow

--- a/requirements/dev-sdw-requirements.in
+++ b/requirements/dev-sdw-requirements.in
@@ -11,6 +11,7 @@ pip-tools>=6.8.0  # for jazzband/piptools#1617
 PyAutoGUI
 pyobjc-core;platform_system=="Darwin"
 pyobjc;platform_system=="Darwin"
+pyqt5-stubs
 pytest>=7.2.0  # CVE-2022-42969
 pytest-cov
 pytest-mock

--- a/requirements/dev-sdw-requirements.txt
+++ b/requirements/dev-sdw-requirements.txt
@@ -469,6 +469,10 @@ pyparsing==3.0.9 \
 pyperclip==1.8.2 \
     --hash=sha256:105254a8b04934f0bc84e9c24eb360a591aaf6535c9def5f29d92af107a9bf57
     # via mouseinfo
+pyqt5-stubs==5.15.6.0 \
+    --hash=sha256:7fb8177c72489a8911f021b7bd7c33f12c87f6dba92dcef3fdcdb5d9400f0f3f \
+    --hash=sha256:91270ac23ebf38a1dc04cd97aa852cd08af82dc839100e5395af1447e3e99707
+    # via -r requirements/dev-sdw-requirements.in
 pyrect==0.2.0 \
     --hash=sha256:f65155f6df9b929b67caffbd57c0947c5ae5449d3b580d178074bffb47a09b78
     # via pygetwindow

--- a/securedrop_client/api_jobs/base.py
+++ b/securedrop_client/api_jobs/base.py
@@ -23,9 +23,10 @@ class ApiInaccessibleError(Exception):
 
 
 class QueueJob(QObject):
-    def __init__(self) -> None:
+    def __init__(self, remaining_attempts: int = DEFAULT_NUM_ATTEMPTS) -> None:
         super().__init__()
         self.order_number = None  # type: Optional[int]
+        self.remaining_attempts = remaining_attempts
 
     def __lt__(self, other: QueueJobType) -> bool:
         """
@@ -60,8 +61,7 @@ class ApiJob(QueueJob):
     failure_signal = pyqtSignal(Exception)
 
     def __init__(self, remaining_attempts: int = DEFAULT_NUM_ATTEMPTS) -> None:
-        super().__init__()
-        self.remaining_attempts = remaining_attempts
+        super().__init__(remaining_attempts)
 
     def _do_call_api(self, api_client: API, session: Session) -> None:
         if not api_client:

--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -170,9 +170,11 @@ def prevent_second_instance(app: QApplication, unique_name: str) -> None:
     IDENTIFIER = "\0" + app.applicationName() + unique_name
     ALREADY_BOUND_ERRNO = 98
 
-    app.instance_binding = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    app.instance_binding = socket.socket(  # type: ignore [attr-defined]
+        socket.AF_UNIX, socket.SOCK_DGRAM
+    )
     try:
-        app.instance_binding.bind(IDENTIFIER)
+        app.instance_binding.bind(IDENTIFIER)  # type: ignore [attr-defined]
     except OSError as e:
         if e.errno == ALREADY_BOUND_ERRNO:
             err_dialog = QMessageBox()

--- a/securedrop_client/export.py
+++ b/securedrop_client/export.py
@@ -10,7 +10,7 @@ from shlex import quote
 from tempfile import TemporaryDirectory
 from typing import List, Optional
 
-from PyQt5.QtCore import QObject, Qt, pyqtSignal, pyqtSlot
+from PyQt5.QtCore import QObject, Qt, pyqtBoundSignal, pyqtSignal, pyqtSlot
 
 logger = logging.getLogger(__name__)
 
@@ -80,10 +80,10 @@ class Export(QObject):
 
     def __init__(
         self,
-        export_preflight_check_requested: Optional[pyqtSignal] = None,
-        export_requested: Optional[pyqtSignal] = None,
-        print_preflight_check_requested: Optional[pyqtSignal] = None,
-        print_requested: Optional[pyqtSignal] = None,
+        export_preflight_check_requested: Optional[pyqtBoundSignal] = None,
+        export_requested: Optional[pyqtBoundSignal] = None,
+        print_preflight_check_requested: Optional[pyqtBoundSignal] = None,
+        print_requested: Optional[pyqtBoundSignal] = None,
     ) -> None:
         super().__init__()
 
@@ -96,10 +96,10 @@ class Export(QObject):
 
     def connect_signals(
         self,
-        export_preflight_check_requested: Optional[pyqtSignal] = None,
-        export_requested: Optional[pyqtSignal] = None,
-        print_preflight_check_requested: Optional[pyqtSignal] = None,
-        print_requested: Optional[pyqtSignal] = None,
+        export_preflight_check_requested: Optional[pyqtBoundSignal] = None,
+        export_requested: Optional[pyqtBoundSignal] = None,
+        print_preflight_check_requested: Optional[pyqtBoundSignal] = None,
+        print_requested: Optional[pyqtBoundSignal] = None,
     ) -> None:
 
         # This instance can optionally react to events to prevent

--- a/securedrop_client/export.py
+++ b/securedrop_client/export.py
@@ -10,7 +10,7 @@ from shlex import quote
 from tempfile import TemporaryDirectory
 from typing import List, Optional
 
-from PyQt5.QtCore import QObject, Qt, pyqtBoundSignal, pyqtSignal, pyqtSlot
+from PyQt5.QtCore import QObject, pyqtBoundSignal, pyqtSignal, pyqtSlot
 
 logger = logging.getLogger(__name__)
 
@@ -105,17 +105,13 @@ class Export(QObject):
         # This instance can optionally react to events to prevent
         # coupling it to dependent code.
         if export_preflight_check_requested is not None:
-            export_preflight_check_requested.connect(
-                self.run_preflight_checks, type=Qt.QueuedConnection
-            )
+            export_preflight_check_requested.connect(self.run_preflight_checks)
         if export_requested is not None:
-            export_requested.connect(self.send_file_to_usb_device, type=Qt.QueuedConnection)
+            export_requested.connect(self.send_file_to_usb_device)
         if print_requested is not None:
-            print_requested.connect(self.print, type=Qt.QueuedConnection)
+            print_requested.connect(self.print)
         if print_preflight_check_requested is not None:
-            print_preflight_check_requested.connect(
-                self.run_printer_preflight, type=Qt.QueuedConnection
-            )
+            print_preflight_check_requested.connect(self.run_printer_preflight)
 
     def _export_archive(cls, archive_path: str) -> Optional[ExportStatus]:
         """

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -74,9 +74,9 @@ class DeleteSourceAction(QAction):
     ) -> None:
         self.source = source
         self.controller = controller
-        self.text = _("Delete Source Account")
+        text = _("Delete Source Account")
 
-        super().__init__(self.text, parent)
+        super().__init__(text, parent)
 
         self._confirmation_dialog = confirmation_dialog(self.source)
         self._confirmation_dialog.accepted.connect(
@@ -105,9 +105,9 @@ class DeleteConversationAction(QAction):
         self.source = source
         self.controller = controller
         self._state = app_state
-        self.text = _("Delete All Files and Messages")
+        text = _("Delete All Files and Messages")
 
-        super().__init__(self.text, parent)
+        super().__init__(text, parent)
 
         self._confirmation_dialog = confirmation_dialog(self.source)
         self._confirmation_dialog.accepted.connect(lambda: self._on_confirmation_dialog_accepted())

--- a/securedrop_client/gui/base/checkbox.py
+++ b/securedrop_client/gui/base/checkbox.py
@@ -26,10 +26,10 @@ class SDCheckBox(QWidget):
         font = QFont()
         font.setLetterSpacing(QFont.AbsoluteSpacing, self.PASSPHRASE_LABEL_SPACING)
 
-        self.layout = QHBoxLayout()
-        self.layout.setContentsMargins(0, 0, 0, 0)
-        self.layout.setSpacing(0)
-        self.setLayout(self.layout)
+        self._layout = QHBoxLayout()
+        self._layout.setContentsMargins(0, 0, 0, 0)
+        self._layout.setSpacing(0)
+        self.setLayout(self._layout)
 
         self.frame = QFrame()
         self.frame.setLayout(QHBoxLayout())
@@ -40,7 +40,7 @@ class SDCheckBox(QWidget):
         self.label = QLabel(_("Show Passphrase"))
         self.label.setFont(font)
 
-        self.layout.addWidget(self.frame)
+        self._layout.addWidget(self.frame)
         self.frame.layout().addWidget(self.checkbox)
         self.frame.layout().addWidget(self.label)
         self.frame.setCursor(QCursor(Qt.PointingHandCursor))

--- a/securedrop_client/gui/base/inputs.py
+++ b/securedrop_client/gui/base/inputs.py
@@ -25,8 +25,7 @@ class PasswordEdit(QLineEdit):
     """
 
     def __init__(self, parent: QDialog) -> None:
-        self.parent = parent
-        super().__init__(self.parent)
+        super().__init__(parent)
 
         self.setEchoMode(QLineEdit.Password)
         self.password_shown = False

--- a/securedrop_client/gui/base/misc.py
+++ b/securedrop_client/gui/base/misc.py
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from typing import Optional, Union
 
 from PyQt5.QtCore import QSize, Qt
+from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QHBoxLayout, QLabel, QPushButton, QWidget
 
 from securedrop_client.resources import load_icon, load_svg
@@ -99,8 +100,6 @@ class SvgPushButton(QPushButton):
         # Remove margins and spacing
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
-
-        from PyQt5.QtGui import QIcon
 
         # Add SVG icon and set its size
         self._icon: QIcon = load_icon(

--- a/securedrop_client/gui/base/misc.py
+++ b/securedrop_client/gui/base/misc.py
@@ -39,7 +39,7 @@ class SvgToggleButton(QPushButton):
         The display size of the SVG, defaults to filling the entire size of the widget.
     """
 
-    def __init__(self, on: str, off: str, svg_size: Optional[str] = None):
+    def __init__(self, on: str, off: str, svg_size: Optional[QSize] = None):
         super().__init__()
 
         # Set layout
@@ -88,7 +88,7 @@ class SvgPushButton(QPushButton):
         disabled: Optional[str] = None,
         active: Optional[str] = None,
         selected: Optional[str] = None,
-        svg_size: Optional[str] = None,
+        svg_size: Optional[QSize] = None,
     ) -> None:
         super().__init__()
 
@@ -126,7 +126,7 @@ class SvgLabel(QLabel):
         The display size of the SVG, defaults to filling the entire size of the widget.
     """
 
-    def __init__(self, filename: str, svg_size: Optional[str] = None) -> None:
+    def __init__(self, filename: str, svg_size: Optional[QSize] = None) -> None:
         super().__init__()
 
         # Remove margins and spacing
@@ -140,7 +140,7 @@ class SvgLabel(QLabel):
         self.svg.setFixedSize(svg_size) if svg_size else self.svg.setFixedSize(QSize())
         layout.addWidget(self.svg)
 
-    def update_image(self, filename: str, svg_size: Optional[str] = None) -> None:
+    def update_image(self, filename: str, svg_size: Optional[QSize] = None) -> None:
         self.svg = load_svg(filename)
         self.svg.setFixedSize(svg_size) if svg_size else self.svg.setFixedSize(QSize())
         child = self.layout().takeAt(0)

--- a/securedrop_client/gui/base/misc.py
+++ b/securedrop_client/gui/base/misc.py
@@ -51,16 +51,16 @@ class SvgToggleButton(QPushButton):
         layout.setSpacing(0)
 
         # Add SVG icon and set its size
-        self.icon = load_icon(normal=on, normal_off=off)
-        self.setIcon(self.icon)
+        self._icon = load_icon(normal=on, normal_off=off)
+        self.setIcon(self._icon)
         self.setIconSize(svg_size) if svg_size else self.setIconSize(QSize())
 
         # Make this a toggle button
         self.setCheckable(True)
 
     def set_icon(self, on: str, off: str) -> None:
-        self.icon = load_icon(normal=on, normal_off=off)
-        self.setIcon(self.icon)
+        self._icon = load_icon(normal=on, normal_off=off)
+        self.setIcon(self._icon)
 
 
 class SvgPushButton(QPushButton):
@@ -100,8 +100,10 @@ class SvgPushButton(QPushButton):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
+        from PyQt5.QtGui import QIcon
+
         # Add SVG icon and set its size
-        self._icon = load_icon(
+        self._icon: QIcon = load_icon(
             normal=normal,
             disabled=disabled,
             active=active,

--- a/securedrop_client/gui/conversation/delete/dialog.py
+++ b/securedrop_client/gui/conversation/delete/dialog.py
@@ -87,7 +87,7 @@ class DeleteConversationDialog(ModalDialog):
             source=source,
         )
 
-    def exec(self) -> None:
+    def exec(self) -> int:
         # Refresh counters
         self.body.setText(self.make_body_text())
-        super().exec()
+        return super().exec()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2760,6 +2760,9 @@ class ConversationView(QWidget):
         for index, conversation_item in enumerate(collection):
             item_widget = current_conversation.get(conversation_item.uuid)
             if item_widget:
+                # FIXME: Item types cannot be defines as (FileWidget, MessageWidget, ReplyWidget)
+                # because one test mocks MessageWidget.
+                assert isinstance(item_widget, (FileWidget, SpeechBubble))
                 current_conversation.pop(conversation_item.uuid)
                 if item_widget.index != index:
                     # The existing widget is out of order.

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2526,8 +2526,8 @@ class ConversationScrollArea(QScrollArea):
         super().resizeEvent(event)
         self.widget().setFixedWidth(event.size().width())
 
-        for widget in self.findChildren(FileWidget):
-            widget.adjust_width(self.widget().width())
+        for file_widget in self.findChildren(FileWidget):
+            file_widget.adjust_width(self.widget().width())
 
         for widget in self.findChildren(SpeechBubble):
             widget.adjust_width(self.widget().width())

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1006,19 +1006,22 @@ class SourceList(QListWidget):
             return source_widget.source
         return None  # pragma: nocover
 
-    def get_source_widget(self, source_uuid: str) -> Optional[QListWidget]:
+    def get_source_widget(self, source_uuid: str) -> Optional["SourceWidget"]:
         """
         First try to get the source widget from the cache, then look for it in the SourceList.
         """
         try:
             source_item = self.source_items[source_uuid]
-            return self.itemWidget(source_item)
+            source_widget = self.itemWidget(source_item)
+            assert isinstance(source_widget, SourceWidget)
+            return source_widget
         except KeyError:
             pass
 
         for i in range(self.count()):
             list_item = self.item(i)
             source_widget = self.itemWidget(list_item)
+            assert isinstance(source_widget, SourceWidget)
             if source_widget and source_widget.source_uuid == source_uuid:
                 return source_widget
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1201,8 +1201,8 @@ class SourceWidget(QWidget):
         self,
         controller: Controller,
         source: Source,
-        source_selected_signal: pyqtSignal,
-        adjust_preview: pyqtSignal,
+        source_selected_signal: pyqtBoundSignal,
+        adjust_preview: pyqtBoundSignal,
     ):
         super().__init__()
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -668,7 +668,9 @@ class MainView(QWidget):
             # Get or create the SourceConversationWrapper
             if source.uuid in self.source_conversations:
                 conversation_wrapper = self.source_conversations[source.uuid]
-                conversation_wrapper.conversation_view.update_conversation(source.collection)
+                conversation_wrapper.conversation_view.update_conversation(  # type: ignore [has-type]  # noqa: E501
+                    source.collection
+                )
             else:
                 conversation_wrapper = SourceConversationWrapper(
                     source, self.controller, self._state, self._export_service
@@ -694,7 +696,9 @@ class MainView(QWidget):
             self.controller.session.refresh(source)
             self.controller.mark_seen(source)
             conversation_wrapper = self.source_conversations[source.uuid]
-            conversation_wrapper.conversation_view.update_conversation(source.collection)
+            conversation_wrapper.conversation_view.update_conversation(  # type: ignore [has-type]
+                source.collection
+            )
         except sqlalchemy.exc.InvalidRequestError as e:
             logger.debug("Error refreshing source conversations: %s", e)
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -566,7 +566,7 @@ class MainView(QWidget):
 
     def __init__(
         self,
-        parent: QObject,
+        parent: Optional[QWidget],
         app_state: Optional[state.State] = None,
         export_service: Optional[export.Service] = None,
     ) -> None:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1001,6 +1001,7 @@ class SourceList(QListWidget):
 
         source_item = self.selectedItems()[0]
         source_widget = self.itemWidget(source_item)
+        assert isinstance(source_widget, SourceWidget)
         if source_widget and source_exists(self.controller.session, source_widget.source_uuid):
             return source_widget.source
         return None  # pragma: nocover
@@ -1226,7 +1227,7 @@ class SourceWidget(QWidget):
         source_selected_signal.connect(self._on_source_selected)
         adjust_preview.connect(self._on_adjust_preview)
 
-        self.source = source
+        self.source: Source = source
         self.seen = self.source.seen
         self.source_uuid: str = self.source.uuid
         self.last_updated: sqlalchemy.DateTime = self.source.last_updated

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -485,14 +485,14 @@ class UserButton(SvgPushButton):
 
         self.setLayoutDirection(Qt.RightToLeft)
 
-        self.menu = UserMenu()
-        self.setMenu(self.menu)
+        self._menu = UserMenu()
+        self.setMenu(self._menu)
 
         # Set cursor.
         self.setCursor(QCursor(Qt.PointingHandCursor))
 
     def setup(self, controller: Controller) -> None:
-        self.menu.setup(controller)
+        self._menu.setup(controller)
 
     def set_username(self, username: str) -> None:
         formatted_name = _("{}").format(html.escape(username))
@@ -549,13 +549,13 @@ class LoginButton(QPushButton):
         """
         Store a reference to the GUI window object.
         """
-        self.window = window
+        self._window = window
 
     def _on_clicked(self) -> None:
         """
         Called when the login button is clicked.
         """
-        self.window.show_login()
+        self._window.show_login()
 
 
 class MainView(QWidget):
@@ -579,12 +579,12 @@ class MainView(QWidget):
         self.setObjectName("MainView")
 
         # Set layout
-        self.layout = QHBoxLayout(self)
-        self.setLayout(self.layout)
+        self._layout = QHBoxLayout(self)
+        self.setLayout(self._layout)
 
         # Set margins and spacing
-        self.layout.setContentsMargins(0, 0, 0, 0)
-        self.layout.setSpacing(0)
+        self._layout.setContentsMargins(0, 0, 0, 0)
+        self._layout.setSpacing(0)
 
         # Create SourceList widget
         self.source_list = SourceList()
@@ -606,8 +606,8 @@ class MainView(QWidget):
         self.view_layout.addWidget(self.empty_conversation_view)
 
         # Add widgets to layout
-        self.layout.addWidget(self.source_list, stretch=1)
-        self.layout.addWidget(self.view_holder, stretch=2)
+        self._layout.addWidget(self.source_list, stretch=1)
+        self._layout.addWidget(self.view_holder, stretch=2)
 
         # Note: We should not delete SourceConversationWrapper when its source is unselected. This
         # is a temporary solution to keep copies of our objects since we do delete them.
@@ -2658,16 +2658,16 @@ class ConversationView(QWidget):
         main_layout.addWidget(self.deleted_conversation_items_marker)
         main_layout.addWidget(self.deleted_conversation_marker)
 
-        self.scroll = ConversationScrollArea()
+        self._scroll = ConversationScrollArea()
 
         # Flag to show if the current user has sent a reply. See issue #61.
         self.reply_flag = False
 
         # Completely unintuitive way to ensure the view remains scrolled to the bottom.
-        sb = self.scroll.verticalScrollBar()
+        sb = self._scroll.verticalScrollBar()
         sb.rangeChanged.connect(self.update_conversation_position)
 
-        main_layout.addWidget(self.scroll)
+        main_layout.addWidget(self._scroll)
 
         try:
             self.update_conversation(self.source.collection)
@@ -2700,11 +2700,11 @@ class ConversationView(QWidget):
             # If a draft reply exists then show the tear pattern above the draft replies.
             # Otherwise, show that the entire conversation is deleted.
             if draft_reply_exists:
-                self.scroll.show()
+                self._scroll.show()
                 self.deleted_conversation_items_marker.show()
                 self.deleted_conversation_marker.hide()
             else:
-                self.scroll.hide()
+                self._scroll.hide()
                 self.deleted_conversation_items_marker.hide()
                 self.deleted_conversation_marker.show()
         except sqlalchemy.exc.InvalidRequestError as e:
@@ -2712,12 +2712,12 @@ class ConversationView(QWidget):
 
     def update_deletion_markers(self) -> None:
         if self.source.collection:
-            self.scroll.show()
+            self._scroll.show()
             if self.source.collection[0].file_counter > 1:
                 self.deleted_conversation_marker.hide()
                 self.deleted_conversation_items_marker.show()
         elif self.source.interaction_count > 0:
-            self.scroll.hide()
+            self._scroll.hide()
             self.deleted_conversation_items_marker.hide()
             self.deleted_conversation_marker.show()
 
@@ -2753,12 +2753,12 @@ class ConversationView(QWidget):
                 if item_widget.index != index:
                     # The existing widget is out of order.
                     # Remove / re-add it and update index details.
-                    self.scroll.remove_widget_from_conversation(item_widget)
+                    self._scroll.remove_widget_from_conversation(item_widget)
                     item_widget.index = index
                     if isinstance(item_widget, ReplyWidget):
-                        self.scroll.add_widget_to_conversation(index, item_widget, Qt.AlignRight)
+                        self._scroll.add_widget_to_conversation(index, item_widget, Qt.AlignRight)
                     else:
-                        self.scroll.add_widget_to_conversation(index, item_widget, Qt.AlignLeft)
+                        self._scroll.add_widget_to_conversation(index, item_widget, Qt.AlignLeft)
                 # Check if text in item has changed, then update the
                 # widget to reflect this change.
                 if not isinstance(item_widget, FileWidget):
@@ -2795,7 +2795,7 @@ class ConversationView(QWidget):
             logger.debug("Deleting item: {}".format(item_widget.uuid))
             self.current_messages.pop(item_widget.uuid)
             item_widget.deleteLater()
-            self.scroll.remove_widget_from_conversation(item_widget)
+            self._scroll.remove_widget_from_conversation(item_widget)
 
         self.update_deletion_markers()
         self.conversation_updated.emit()
@@ -2812,10 +2812,10 @@ class ConversationView(QWidget):
             self.controller.file_ready,
             self.controller.file_missing,
             index,
-            self.scroll.widget().width(),
+            self._scroll.widget().width(),
             self._export_service,
         )
-        self.scroll.add_widget_to_conversation(index, conversation_item, Qt.AlignLeft)
+        self._scroll.add_widget_to_conversation(index, conversation_item, Qt.AlignLeft)
         self.current_messages[file.uuid] = conversation_item
         self.conversation_updated.emit()
 
@@ -2825,7 +2825,7 @@ class ConversationView(QWidget):
         it's scrolled to the bottom and thus visible.
         """
         if self.reply_flag and max_val > 0:
-            self.scroll.verticalScrollBar().setValue(max_val)
+            self._scroll.verticalScrollBar().setValue(max_val)
             self.reply_flag = False
 
     def add_message(self, message: Message, index: int) -> None:
@@ -2838,7 +2838,7 @@ class ConversationView(QWidget):
             self.controller.message_ready,
             self.controller.message_download_failed,
             index,
-            self.scroll.widget().width(),
+            self._scroll.widget().width(),
             self.controller.authenticated_user,
             message.download_error is not None,
         )
@@ -2849,7 +2849,7 @@ class ConversationView(QWidget):
         )
         # Retrieve the list of usernames of the users who have seen the message.
         conversation_item.update_seen_by_list(message.seen_by_list)
-        self.scroll.add_widget_to_conversation(index, conversation_item, Qt.AlignLeft)
+        self._scroll.add_widget_to_conversation(index, conversation_item, Qt.AlignLeft)
         self.current_messages[message.uuid] = conversation_item
         self.conversation_updated.emit()
 
@@ -2880,7 +2880,7 @@ class ConversationView(QWidget):
             self.controller.reply_succeeded,
             self.controller.reply_failed,
             index,
-            self.scroll.widget().width(),
+            self._scroll.widget().width(),
             sender,
             sender_is_current_user,
             self.controller.authenticated_user,
@@ -2892,7 +2892,7 @@ class ConversationView(QWidget):
         )
         # Retrieve the list of usernames of the users who have seen the reply.
         conversation_item.update_seen_by_list(reply.seen_by_list)
-        self.scroll.add_widget_to_conversation(index, conversation_item, Qt.AlignRight)
+        self._scroll.add_widget_to_conversation(index, conversation_item, Qt.AlignRight)
         self.current_messages[reply.uuid] = conversation_item
 
     def on_reply_sent(self, source_uuid: str) -> None:
@@ -3400,8 +3400,8 @@ class SourceMenuButton(QToolButton):
         self.setIcon(load_icon("ellipsis.svg"))
         self.setIconSize(QSize(22, 33))  # Make it taller than the svg viewBox to increase hitbox
 
-        self.menu = SourceMenu(self.source, self.controller, app_state)
-        self.setMenu(self.menu)
+        menu = SourceMenu(self.source, self.controller, app_state)
+        self.setMenu(menu)
 
         self.setPopupMode(QToolButton.InstantPopup)
         # Set cursor.

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2335,6 +2335,7 @@ class FileWidget(QWidget):
     def eventFilter(self, obj: QObject, event: QEvent) -> bool:
         t = event.type()
         if t == QEvent.MouseButtonPress:
+            assert isinstance(event, QMouseEvent)
             if event.button() == Qt.LeftButton:
                 self._on_left_click()
         elif t == QEvent.HoverEnter and not self.downloading:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -16,6 +16,8 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+from __future__ import annotations
+
 import html
 import logging
 from datetime import datetime
@@ -1007,7 +1009,7 @@ class SourceList(QListWidget):
             return source_widget.source
         return None  # pragma: nocover
 
-    def get_source_widget(self, source_uuid: str) -> Optional["SourceWidget"]:
+    def get_source_widget(self, source_uuid: str) -> Optional[SourceWidget]:
         """
         First try to get the source widget from the cache, then look for it in the SourceList.
         """

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2307,9 +2307,9 @@ class FileWidget(QWidget):
         layout.addWidget(self.file_size)
 
         # Connect signals to slots
-        file_download_started.connect(self._on_file_download_started, type=Qt.QueuedConnection)
-        file_ready_signal.connect(self._on_file_downloaded, type=Qt.QueuedConnection)
-        file_missing.connect(self._on_file_missing, type=Qt.QueuedConnection)
+        file_download_started.connect(self._on_file_download_started)
+        file_ready_signal.connect(self._on_file_downloaded)
+        file_missing.connect(self._on_file_missing)
 
     def adjust_width(self, container_width: int) -> None:
         """

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -829,6 +829,8 @@ class SourceListWidgetItem(QListWidgetItem):
         me = lw.itemWidget(self)
         them = lw.itemWidget(other)
         if me and them:
+            assert isinstance(me, SourceWidget)
+            assert isinstance(them, SourceWidget)
             my_ts = arrow.get(me.last_updated)
             other_ts = arrow.get(them.last_updated)
             return my_ts < other_ts
@@ -1226,7 +1228,7 @@ class SourceWidget(QWidget):
         self.source = source
         self.seen = self.source.seen
         self.source_uuid = self.source.uuid
-        self.last_updated = self.source.last_updated
+        self.last_updated: sqlalchemy.DateTime = self.source.last_updated
         self.selected = False
         self.deletion_scheduled_timestamp = datetime.utcnow()
         self.sync_started_timestamp = datetime.utcnow()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1567,7 +1567,7 @@ class StarToggleButton(SvgToggleButton):
         self.setCheckable(True)
         self.set_icon(on="star_on.svg", off="star_off.svg")  # Undo icon change from disable_toggle
 
-    def eventFilter(self, obj: QObject, event: QEvent) -> None:
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:
         """
         If the button is checkable then we show a hover state.
         """
@@ -1912,7 +1912,7 @@ class SpeechBubble(QWidget):
 
         self.check_mark.setToolTip(",\n".join(username for username in self.seen_by.keys()))
 
-    def eventFilter(self, obj: QObject, event: QEvent) -> None:
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:
         t = event.type()
         if t == QEvent.HoverEnter:
             self.check_mark.setIcon(load_icon("checkmark_hover.svg"))
@@ -2325,7 +2325,7 @@ class FileWidget(QWidget):
         else:
             self.setFixedWidth(int(container_width * self.WIDTH_TO_CONTAINER_WIDTH_RATIO))
 
-    def eventFilter(self, obj: QObject, event: QEvent) -> None:
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:
         t = event.type()
         if t == QEvent.MouseButtonPress:
             if event.button() == Qt.LeftButton:

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -2649,7 +2649,7 @@ class ConversationView(QWidget):
         )
 
         # To hold currently displayed messages.
-        self.current_messages = {}  # type: Dict[str, QWidget]
+        self.current_messages = {}  # type: Dict[str, Union[FileWidget, MessageWidget, ReplyWidget]]
 
         self.deletion_scheduled_timestamp = datetime.utcnow()
         self.sync_started_timestamp = datetime.utcnow()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -913,6 +913,7 @@ class SourceList(QListWidget):
 
             source_widget = self.itemWidget(source_item)
             self.takeItem(self.row(source_item))
+            assert isinstance(source_widget, SourceWidget)
             if source_widget.source_uuid in self.source_items:
                 del self.source_items[source_widget.source_uuid]
 
@@ -1227,7 +1228,7 @@ class SourceWidget(QWidget):
 
         self.source = source
         self.seen = self.source.seen
-        self.source_uuid = self.source.uuid
+        self.source_uuid: str = self.source.uuid
         self.last_updated: sqlalchemy.DateTime = self.source.last_updated
         self.selected = False
         self.deletion_scheduled_timestamp = datetime.utcnow()

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -644,7 +644,7 @@ class MainView(QWidget):
         if not self.source_list.source_items:
             self.source_list.initial_update(sources)
         else:
-            deleted_sources = self.source_list.update(sources)
+            deleted_sources = self.source_list.update_sources(sources)
             for source_uuid in deleted_sources:
                 # Then call the function to remove the wrapper and its children.
                 self.delete_conversation(source_uuid)
@@ -886,7 +886,7 @@ class SourceList(QListWidget):
         self.controller.message_download_failed.connect(self.set_snippet)
         self.controller.reply_download_failed.connect(self.set_snippet)
 
-    def update(self, sources: List[Source]) -> List[str]:
+    def update_sources(self, sources: List[Source]) -> List[str]:
         """
         Update the list with the passed in list of sources.
         """

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -927,7 +927,8 @@ class SourceList(QListWidget):
             if not source_widget:
                 continue
 
-            source_widget.update()
+            assert isinstance(source_widget, SourceWidget)
+            source_widget.reload()
 
         # Add widgets for new sources
         for uuid in sources_to_add:
@@ -1304,14 +1305,14 @@ class SourceWidget(QWidget):
         layout.setSpacing(0)
         layout.addWidget(self.source_widget)
 
-        self.update()
+        self.reload()
 
     @pyqtSlot(int)
     def _on_adjust_preview(self, width: int) -> None:
         self.setFixedWidth(width)
         self.preview.adjust_preview(width)
 
-    def update(self) -> None:
+    def reload(self) -> None:
         """
         Updates the displayed values with the current values from self.source.
         """

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -29,7 +29,7 @@ from typing import Dict, List, Optional, Type, Union
 import arrow
 import sdclientapi
 import sqlalchemy.orm.exc
-from PyQt5.QtCore import QObject, QProcess, Qt, QThread, QTimer, pyqtSignal, pyqtSlot
+from PyQt5.QtCore import QObject, QProcess, QThread, QTimer, pyqtSignal, pyqtSlot
 from sdclientapi import AuthError, RequestTimeoutError, ServerConnectionError
 from sqlalchemy.orm.session import sessionmaker
 
@@ -398,9 +398,9 @@ class Controller(QObject):
         self.api_sync = ApiSync(
             self.api, self.session_maker, self.gpg, self.data_dir, self.sync_thread, state
         )
-        self.api_sync.sync_started.connect(self.on_sync_started, type=Qt.QueuedConnection)
-        self.api_sync.sync_success.connect(self.on_sync_success, type=Qt.QueuedConnection)
-        self.api_sync.sync_failure.connect(self.on_sync_failure, type=Qt.QueuedConnection)
+        self.api_sync.sync_started.connect(self.on_sync_started)
+        self.api_sync.sync_success.connect(self.on_sync_success)
+        self.api_sync.sync_failure.connect(self.on_sync_failure)
 
         # Create a timer to show the time since the last sync
         self.show_last_sync_timer = QTimer()
@@ -755,8 +755,8 @@ class Controller(QObject):
                 return
 
             job = SeenJob(files, messages, replies)
-            job.success_signal.connect(self.on_seen_success, type=Qt.QueuedConnection)
-            job.failure_signal.connect(self.on_seen_failure, type=Qt.QueuedConnection)
+            job.success_signal.connect(self.on_seen_success)
+            job.failure_signal.connect(self.on_seen_failure)
             self.add_job.emit(job)
         except sqlalchemy.exc.InvalidRequestError as e:
             logger.debug(e)
@@ -784,8 +784,8 @@ class Controller(QObject):
         Star or unstar.
         """
         job = UpdateStarJob(source_uuid, is_starred)
-        job.success_signal.connect(self.on_update_star_success, type=Qt.QueuedConnection)
-        job.failure_signal.connect(self.on_update_star_failure, type=Qt.QueuedConnection)
+        job.success_signal.connect(self.on_update_star_success)
+        job.failure_signal.connect(self.on_update_star_failure)
         self.add_job.emit(job)
 
     def logout(self) -> None:
@@ -835,16 +835,16 @@ class Controller(QObject):
             job = ReplyDownloadJob(
                 uuid, self.data_dir, self.gpg
             )  # type: Union[ReplyDownloadJob, MessageDownloadJob, FileDownloadJob]
-            job.success_signal.connect(self.on_reply_download_success, type=Qt.QueuedConnection)
-            job.failure_signal.connect(self.on_reply_download_failure, type=Qt.QueuedConnection)
+            job.success_signal.connect(self.on_reply_download_success)
+            job.failure_signal.connect(self.on_reply_download_failure)
         elif object_type == db.Message:
             job = MessageDownloadJob(uuid, self.data_dir, self.gpg)
-            job.success_signal.connect(self.on_message_download_success, type=Qt.QueuedConnection)
-            job.failure_signal.connect(self.on_message_download_failure, type=Qt.QueuedConnection)
+            job.success_signal.connect(self.on_message_download_success)
+            job.failure_signal.connect(self.on_message_download_failure)
         elif object_type == db.File:
             job = FileDownloadJob(uuid, self.data_dir, self.gpg)
-            job.success_signal.connect(self.on_file_download_success, type=Qt.QueuedConnection)
-            job.failure_signal.connect(self.on_file_download_failure, type=Qt.QueuedConnection)
+            job.success_signal.connect(self.on_file_download_success)
+            job.failure_signal.connect(self.on_file_download_failure)
 
         self.add_job.emit(job)
 
@@ -1037,8 +1037,8 @@ class Controller(QObject):
         the failure handler will display an error.
         """
         job = DeleteSourceJob(source.uuid)
-        job.success_signal.connect(self.on_delete_source_success, type=Qt.QueuedConnection)
-        job.failure_signal.connect(self.on_delete_source_failure, type=Qt.QueuedConnection)
+        job.success_signal.connect(self.on_delete_source_success)
+        job.failure_signal.connect(self.on_delete_source_failure)
 
         self.add_job.emit(job)
         self.source_deleted.emit(source.uuid)
@@ -1054,8 +1054,8 @@ class Controller(QObject):
         handler will display an error.
         """
         job = DeleteConversationJob(source.uuid)
-        job.success_signal.connect(self.on_delete_conversation_success, type=Qt.QueuedConnection)
-        job.failure_signal.connect(self.on_delete_conversation_failure, type=Qt.QueuedConnection)
+        job.success_signal.connect(self.on_delete_conversation_success)
+        job.failure_signal.connect(self.on_delete_conversation_failure)
 
         self.add_job.emit(job)
         self.conversation_deleted.emit(source.uuid)
@@ -1066,8 +1066,8 @@ class Controller(QObject):
         for file in files:
             if not file.is_downloaded:
                 job = FileDownloadJob(str(file.id), self.data_dir, self.gpg)
-                job.success_signal.connect(self.on_file_download_success, type=Qt.QueuedConnection)
-                job.failure_signal.connect(self.on_file_download_failure, type=Qt.QueuedConnection)
+                job.success_signal.connect(self.on_file_download_success)
+                job.failure_signal.connect(self.on_file_download_failure)
                 self.add_job.emit(job)
                 self.file_download_started.emit(file.id)
 
@@ -1107,8 +1107,8 @@ class Controller(QObject):
         self.session.commit()
 
         job = SendReplyJob(source_uuid, reply_uuid, message, self.gpg)
-        job.success_signal.connect(self.on_reply_success, type=Qt.QueuedConnection)
-        job.failure_signal.connect(self.on_reply_failure, type=Qt.QueuedConnection)
+        job.success_signal.connect(self.on_reply_success)
+        job.failure_signal.connect(self.on_reply_failure)
 
         self.add_job.emit(job)
 

--- a/securedrop_client/sync.py
+++ b/securedrop_client/sync.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from PyQt5.QtCore import QObject, Qt, QThread, QTimer, pyqtBoundSignal, pyqtSignal
+from PyQt5.QtCore import QObject, QThread, QTimer, pyqtBoundSignal, pyqtSignal
 from sdclientapi import API
 from sqlalchemy.orm import scoped_session
 
@@ -126,8 +126,8 @@ class ApiSyncBackgroundTask(QObject):
         self.on_sync_failure = on_sync_failure
 
         self.job = MetadataSyncJob(self.data_dir, app_state)
-        self.job.success_signal.connect(self.on_sync_success, type=Qt.QueuedConnection)
-        self.job.failure_signal.connect(self.on_sync_failure, type=Qt.QueuedConnection)
+        self.job.success_signal.connect(self.on_sync_success)
+        self.job.failure_signal.connect(self.on_sync_failure)
 
     def sync(self) -> None:
         """

--- a/securedrop_client/sync.py
+++ b/securedrop_client/sync.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from PyQt5.QtCore import QObject, Qt, QThread, QTimer, pyqtSignal
+from PyQt5.QtCore import QObject, Qt, QThread, QTimer, pyqtBoundSignal, pyqtSignal
 from sdclientapi import API
 from sqlalchemy.orm import scoped_session
 
@@ -110,7 +110,7 @@ class ApiSyncBackgroundTask(QObject):
         session_maker: scoped_session,
         gpg: GpgHelper,
         data_dir: str,
-        sync_started: pyqtSignal,
+        sync_started: pyqtBoundSignal,
         on_sync_success,
         on_sync_failure,
         app_state: Optional[state.State] = None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,7 +203,7 @@ def functional_test_offline_context(functional_test_logged_in_context, qtbot):
     # Trigger log out
     # Note: The qtbot object cannot interact with QAction items (as used in the logout button/menu),
     # so we programatically logout rather than using the GUI via qtbot
-    gui.left_pane.user_profile.user_button.menu.logout.trigger()
+    gui.left_pane.user_profile.user_button._menu.logout.trigger()
 
     def check_login_button():
         assert gui.left_pane.user_profile.login_button.isVisible()

--- a/tests/functional/test_logout.py
+++ b/tests/functional/test_logout.py
@@ -22,7 +22,7 @@ def test_logout_as_journalist(functional_test_logged_in_context, qtbot, mocker):
     # Trigger log out
     # Note: The qtbot object cannot interact with QAction items (as used in the logout button/menu),
     # so we programatically logout rather than using the GUI via qtbot
-    gui.left_pane.user_profile.user_button.menu.logout.trigger()
+    gui.left_pane.user_profile.user_button._menu.logout.trigger()
 
     def login_button_is_visible():
         assert gui.left_pane.user_profile.login_button.isVisible()

--- a/tests/functional/test_user_profile_menu.py
+++ b/tests/functional/test_user_profile_menu.py
@@ -27,7 +27,7 @@ def test_user_icon_click(qtbot, mocker, functional_test_logged_in_context):
     pyautogui.click(cursor_x, cursor_y)
 
     def user_menu_is_visible():
-        assert gui.left_pane.user_profile.user_button.menu.logout.isVisible()
+        assert gui.left_pane.user_profile.user_button._menu.logout.isVisible()
 
     # Ensure user menu is visible after clicking on the user icon
     qtbot.waitUntil(user_menu_is_visible, timeout=TIME_CLICK_ACTION)

--- a/tests/gui/base/test_misc.py
+++ b/tests/gui/base/test_misc.py
@@ -52,7 +52,7 @@ def test_SvgToggleButton_set_icon(mocker):
 
     load_icon_fn.assert_called_with(normal="mock_on", normal_off="mock_off")
     setIcon_fn.assert_called_with(icon)
-    assert stb.icon == icon
+    assert stb._icon == icon
 
 
 def test_SvgPushButton_init(mocker):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1638,7 +1638,7 @@ def test_SourceWidget_html_init(mocker):
     sw.summary_layout = mocker.MagicMock()
 
     mocker.patch("securedrop_client.gui.base.SvgLabel")
-    sw.update()
+    sw.reload()
 
     sw.name.setText.assert_called_once_with("foo <b>bar</b> baz")
 
@@ -1828,12 +1828,12 @@ def test_SourceWidget_update_attachment_icon(mocker):
     mark_seen_signal = mocker.MagicMock()
     sw = SourceWidget(controller, source, mark_seen_signal, mocker.MagicMock())
 
-    sw.update()
+    sw.reload()
     assert not sw.paperclip.isHidden()
 
     source.document_count = 0
 
-    sw.update()
+    sw.reload()
     assert sw.paperclip.isHidden()
 
 
@@ -1850,7 +1850,7 @@ def test_SourceWidget_update_does_not_raise_exception(mocker):
     controller.session.refresh.side_effect = ex
     mock_logger = mocker.MagicMock()
     mocker.patch("securedrop_client.gui.widgets.logger", mock_logger)
-    sw.update()
+    sw.reload()
     assert mock_logger.debug.call_count == 1
 
 
@@ -1861,7 +1861,7 @@ def test_SourceWidget_update_skips_setting_snippet_if_deletion_in_progress(mocke
     sw = SourceWidget(mocker.MagicMock(), factory.Source(), mocker.MagicMock(), mocker.MagicMock())
     sw.deleting = True
     sw.set_snippet = mocker.MagicMock()
-    sw.update()
+    sw.reload()
     sw.set_snippet.assert_not_called()
 
 
@@ -1873,7 +1873,7 @@ def test_SourceWidget_update_skips_setting_snippet_if_sync_is_stale(mocker):
     sw.sync_started_timestamp = datetime.now()
     sw.deletion_scheduled_timestamp = datetime.now()
     sw.set_snippet = mocker.MagicMock()
-    sw.update()
+    sw.reload()
     sw.set_snippet.assert_not_called()
 
 
@@ -1884,7 +1884,7 @@ def test_SourceWidget_update_skips_setting_snippet_if_conversation_deletion_in_p
     sw = SourceWidget(mocker.MagicMock(), factory.Source(), mocker.MagicMock(), mocker.MagicMock())
     sw.deleting_conversation = True
     sw.set_snippet = mocker.MagicMock()
-    sw.update()
+    sw.reload()
     sw.set_snippet.assert_not_called()
 
 
@@ -1950,7 +1950,7 @@ def test_SourceWidget_update_truncate_latest_msg(mocker):
     mark_seen_signal = mocker.MagicMock()
     sw = SourceWidget(controller, source, mark_seen_signal, mocker.MagicMock())
 
-    sw.update()
+    sw.reload()
     assert sw.preview.text().endswith("...")
 
 
@@ -2076,7 +2076,7 @@ def test_SourceWidget_preview_after_conversation_deleted(mocker, session, i18n):
 
     controller = mocker.MagicMock()
     sw = SourceWidget(controller, source, mocker.MagicMock(), mocker.MagicMock())
-    sw.update()
+    sw.reload()
     assert sw.preview.property("class") == "conversation_deleted"
     assert sw.preview.text() == _("\u2014 All files and messages deleted for this source \u2014")
 
@@ -2139,12 +2139,12 @@ def test_SourceWidget_uses_SecureQLabel(mocker):
     mark_seen_signal = mocker.MagicMock()
     sw = SourceWidget(controller, source, mark_seen_signal, mocker.MagicMock())
 
-    sw.update()
+    sw.reload()
     assert isinstance(sw.preview, SecureQLabel)
 
     sw.preview.setTextFormat = mocker.MagicMock()
     sw.preview.setText("<b>bad text</b>")
-    sw.update()
+    sw.reload()
     sw.preview.setTextFormat.assert_called_with(Qt.PlainText)
 
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -438,12 +438,12 @@ def test_UserIconLabel_clicks(mocker):
 
 def test_UserButton_setup(mocker):
     ub = UserButton()
-    ub.menu = mocker.MagicMock()
+    ub._menu = mocker.MagicMock()
     controller = mocker.MagicMock()
 
     ub.setup(controller)
 
-    ub.menu.setup.assert_called_once_with(controller)
+    ub._menu.setup.assert_called_once_with(controller)
 
 
 def test_UserButton_set_username():
@@ -498,11 +498,11 @@ def test_LoginButton_setup(mocker):
     lb.window = window
 
 
-def test_Loginbutton_on_clicked(mocker):
+def test_LoginButton_on_clicked(mocker):
     lb = LoginButton()
-    lb.window = mocker.MagicMock()
+    lb._window = mocker.MagicMock()
     lb._on_clicked()
-    lb.window.show_login.assert_called_once_with()
+    lb._window.show_login.assert_called_once_with()
 
 
 def test_MainView_init():
@@ -3894,7 +3894,7 @@ def test_ConversationView_init(mocker, homedir):
     user = factory.User()
     mocked_controller = mocker.MagicMock(authenticated_user=user)
     cv = ConversationView(mocked_source, mocked_controller)
-    assert isinstance(cv.scroll.conversation_layout, QVBoxLayout)
+    assert isinstance(cv._scroll.conversation_layout, QVBoxLayout)
 
 
 def test_ConversationView_init_with_deleted_source(mocker, homedir, session):
@@ -3941,12 +3941,12 @@ def test_ConversationView_ConversationScrollArea_resize(mocker):
     file_widget_adjust_width = mocker.patch("securedrop_client.gui.widgets.FileWidget.adjust_width")
 
     cv.setFixedWidth(800)
-    event = QResizeEvent(cv.scroll.size(), QSize(123_456_789, 123_456_789))
-    cv.scroll.resizeEvent(event)
+    event = QResizeEvent(cv._scroll.size(), QSize(123_456_789, 123_456_789))
+    cv._scroll.resizeEvent(event)
 
-    assert cv.scroll.widget().width() == cv.scroll.width()
-    speech_bubble_adjust_width.assert_called_with(cv.scroll.widget().width())
-    file_widget_adjust_width.assert_called_with(cv.scroll.widget().width())
+    assert cv._scroll.widget().width() == cv._scroll.width()
+    speech_bubble_adjust_width.assert_called_with(cv._scroll.widget().width())
+    file_widget_adjust_width.assert_called_with(cv._scroll.widget().width())
 
 
 def test_ConversationView__on_sync_started(mocker, session):
@@ -3969,7 +3969,7 @@ def test_ConversationView__on_conversation_deletion_successful(mocker, session):
     cv._on_conversation_deletion_successful(cv.source.uuid, timestamp)
 
     assert cv.deletion_scheduled_timestamp == timestamp
-    assert cv.scroll.isHidden()
+    assert cv._scroll.isHidden()
     assert cv.deleted_conversation_items_marker.isHidden()
     assert not cv.deleted_conversation_marker.isHidden()
     assert cv.current_messages[message.uuid].isHidden()
@@ -3983,13 +3983,13 @@ def test_ConversationView__on_conversation_deletion_successful_with_mismatched_s
     source = factory.Source(uuid="abc123")
     cv = ConversationView(source, mocker.MagicMock())
 
-    assert not cv.scroll.isHidden()
+    assert not cv._scroll.isHidden()
     assert cv.deleted_conversation_items_marker.isHidden()
     assert cv.deleted_conversation_marker.isHidden()
 
     cv._on_conversation_deletion_successful("notabc123", datetime.now())
 
-    assert not cv.scroll.isHidden()
+    assert not cv._scroll.isHidden()
     assert cv.deleted_conversation_items_marker.isHidden()
     assert cv.deleted_conversation_marker.isHidden()
 
@@ -4013,7 +4013,7 @@ def test_ConversationView__on_conversation_deletion_successful_does_not_hide_dra
 
     cv._on_conversation_deletion_successful(cv.source.uuid, datetime.now())
 
-    assert not cv.scroll.isHidden()
+    assert not cv._scroll.isHidden()
     assert not cv.deleted_conversation_items_marker.isHidden()
     assert cv.deleted_conversation_marker.isHidden()
     assert cv.current_messages[message.uuid].isHidden()
@@ -4039,13 +4039,13 @@ def test_ConversationView_update_conversation_position_follow(mocker, homedir):
     # Flag to denote a reply was sent by the user.
     cv.reply_flag = True
 
-    cv.scroll.verticalScrollBar().value = mocker.MagicMock(return_value=5900)
-    cv.scroll.viewport().height = mocker.MagicMock(return_value=500)
-    cv.scroll.verticalScrollBar().setValue = mocker.MagicMock()
+    cv._scroll.verticalScrollBar().value = mocker.MagicMock(return_value=5900)
+    cv._scroll.viewport().height = mocker.MagicMock(return_value=500)
+    cv._scroll.verticalScrollBar().setValue = mocker.MagicMock()
 
     cv.update_conversation_position(0, 6000)
 
-    cv.scroll.verticalScrollBar().setValue.assert_called_once_with(6000)
+    cv._scroll.verticalScrollBar().setValue.assert_called_once_with(6000)
 
 
 def test_ConversationView_update_conversation_position_stay_fixed(mocker, homedir):
@@ -4062,13 +4062,13 @@ def test_ConversationView_update_conversation_position_stay_fixed(mocker, homedi
 
     cv = ConversationView(mocked_source, mocked_controller)
 
-    cv.scroll.verticalScrollBar().value = mocker.MagicMock(return_value=5500)
-    cv.scroll.viewport().height = mocker.MagicMock(return_value=500)
-    cv.scroll.verticalScrollBar().setValue = mocker.MagicMock()
+    cv._scroll.verticalScrollBar().value = mocker.MagicMock(return_value=5500)
+    cv._scroll.viewport().height = mocker.MagicMock(return_value=500)
+    cv._scroll.verticalScrollBar().setValue = mocker.MagicMock()
 
     cv.update_conversation_position(0, 6000)
 
-    cv.scroll.verticalScrollBar().setValue.assert_not_called()
+    cv._scroll.verticalScrollBar().setValue.assert_not_called()
 
 
 def test_ConversationView_add_message(mocker, session, session_maker, homedir):
@@ -4088,7 +4088,7 @@ def test_ConversationView_add_message(mocker, session, session_maker, homedir):
     cv.add_message(message=message, index=0)
 
     # Check that we added the correct widget to the layout
-    message_widget = cv.scroll.conversation_layout.itemAt(1).widget()
+    message_widget = cv._scroll.conversation_layout.itemAt(1).widget()
     assert isinstance(message_widget, MessageWidget)
 
     assert message_widget.message.text() == ">^..^<"
@@ -4116,7 +4116,7 @@ def test_ConversationView_add_message_no_content(mocker, session, session_maker,
     cv.add_message(message=message, index=0)
 
     # Check that we added the correct widget to the layout
-    message_widget = cv.scroll.conversation_layout.itemAt(1).widget()
+    message_widget = cv._scroll.conversation_layout.itemAt(1).widget()
     assert isinstance(message_widget, MessageWidget)
 
     assert message_widget.message.text() == "<Message not yet available>"
@@ -4197,7 +4197,7 @@ def test_ConversationView_add_reply(mocker, homedir, session, session_maker):
     cv.add_reply(reply=reply, sender=sender, index=0)
 
     # Check that we added the correct widget to the layout
-    reply_widget = cv.scroll.conversation_layout.itemAt(1).widget()
+    reply_widget = cv._scroll.conversation_layout.itemAt(1).widget()
     assert isinstance(reply_widget, ReplyWidget)
 
     assert reply_widget.uuid == "abc123"
@@ -4232,7 +4232,7 @@ def test_ConversationView_add_reply_no_content(mocker, homedir, session_maker, s
     cv.add_reply(reply=reply, sender=sender, index=0)
 
     # Check that we added the correct widget to the layout
-    reply_widget = cv.scroll.conversation_layout.itemAt(1).widget()
+    reply_widget = cv._scroll.conversation_layout.itemAt(1).widget()
     assert isinstance(reply_widget, ReplyWidget)
 
     assert reply_widget.uuid == "abc123"
@@ -4267,7 +4267,7 @@ def test_ConversationView_add_reply_that_has_current_user_as_sender(
     cv.add_reply(reply=reply, sender=authenticated_user, index=0)
 
     # Check that we added the correct widget to the layout
-    reply_widget = cv.scroll.conversation_layout.itemAt(1).widget()
+    reply_widget = cv._scroll.conversation_layout.itemAt(1).widget()
     assert isinstance(reply_widget, ReplyWidget)
 
     assert reply_widget.uuid == "abc123"
@@ -4306,7 +4306,7 @@ def test_ConversationView_add_downloaded_file(mocker, homedir, source, session):
     mock_label.assert_called_with("123B")  # default factory filesize
     assert cv.conversation_updated.emit.call_count == 1
 
-    file_widget = cv.scroll.conversation_layout.itemAt(1).widget()
+    file_widget = cv._scroll.conversation_layout.itemAt(1).widget()
     assert isinstance(file_widget, FileWidget)
 
 
@@ -4334,7 +4334,7 @@ def test_ConversationView_add_not_downloaded_file(mocker, homedir, source, sessi
     mock_label.assert_called_with("123B")  # default factory filesize
     assert cv.conversation_updated.emit.call_count == 1
 
-    file_widget = cv.scroll.conversation_layout.itemAt(1).widget()
+    file_widget = cv._scroll.conversation_layout.itemAt(1).widget()
     assert isinstance(file_widget, FileWidget)
 
 
@@ -4850,11 +4850,11 @@ def test_update_conversation_maintains_old_items(mocker, session):
     controller = mocker.MagicMock(get_file=get_file, authenticated_user=user)
 
     cv = ConversationView(source, controller)
-    assert cv.scroll.conversation_layout.count() == 3
+    assert cv._scroll.conversation_layout.count() == 3
 
     cv.update_conversation(cv.source.collection)
 
-    assert cv.scroll.conversation_layout.count() == 3
+    assert cv._scroll.conversation_layout.count() == 3
 
 
 def test_update_conversation_does_not_remove_pending_draft_items(mocker, session):
@@ -4881,7 +4881,7 @@ def test_update_conversation_does_not_remove_pending_draft_items(mocker, session
     controller = mocker.MagicMock(get_file=get_file, authenticated_user=user)
 
     cv = ConversationView(source, controller)
-    assert cv.scroll.conversation_layout.count() == 3  # precondition with draft
+    assert cv._scroll.conversation_layout.count() == 3  # precondition with draft
 
     # add the new message and persist
     new_message = factory.Message(filename="4-source-msg.gpg", source=source)
@@ -4890,7 +4890,7 @@ def test_update_conversation_does_not_remove_pending_draft_items(mocker, session
 
     # New message added, draft message persists.
     cv.update_conversation(cv.source.collection)
-    assert cv.scroll.conversation_layout.count() == 4
+    assert cv._scroll.conversation_layout.count() == 4
 
 
 def test_update_conversation_does_remove_successful_draft_items(mocker, session):
@@ -4917,7 +4917,7 @@ def test_update_conversation_does_remove_successful_draft_items(mocker, session)
     controller = mocker.MagicMock(get_file=get_file, authenticated_user=user)
 
     cv = ConversationView(source, controller)
-    assert cv.scroll.conversation_layout.count() == 3  # precondition with draft
+    assert cv._scroll.conversation_layout.count() == 3  # precondition with draft
 
     # add the new message and persist
     new_message = factory.Message(filename="4-source-msg.gpg", source=source)
@@ -4930,7 +4930,7 @@ def test_update_conversation_does_remove_successful_draft_items(mocker, session)
 
     # New message added, draft message is gone.
     cv.update_conversation(cv.source.collection)
-    assert cv.scroll.conversation_layout.count() == 3
+    assert cv._scroll.conversation_layout.count() == 3
 
 
 def test_update_conversation_keeps_failed_draft_items(mocker, session):
@@ -4957,7 +4957,7 @@ def test_update_conversation_keeps_failed_draft_items(mocker, session):
     controller = mocker.MagicMock(get_file=get_file, authenticated_user=user)
 
     cv = ConversationView(source, controller)
-    assert cv.scroll.conversation_layout.count() == 3  # precondition with draft
+    assert cv._scroll.conversation_layout.count() == 3  # precondition with draft
 
     # add the new message and persist
     new_message = factory.Message(filename="4-source-msg.gpg", source=source)
@@ -4966,7 +4966,7 @@ def test_update_conversation_keeps_failed_draft_items(mocker, session):
 
     # New message added, draft message retained.
     cv.update_conversation(cv.source.collection)
-    assert cv.scroll.conversation_layout.count() == 4
+    assert cv._scroll.conversation_layout.count() == 4
 
 
 def test_update_conversation_adds_new_items(mocker, session):
@@ -4990,7 +4990,7 @@ def test_update_conversation_adds_new_items(mocker, session):
     controller = mocker.MagicMock(get_file=get_file, authenticated_user=user)
 
     cv = ConversationView(source, controller)
-    assert cv.scroll.conversation_layout.count() == 3  # precondition
+    assert cv._scroll.conversation_layout.count() == 3  # precondition
 
     # add the new message and persist
     new_message = factory.Message(filename="4-source-msg.gpg", source=source)
@@ -4998,7 +4998,7 @@ def test_update_conversation_adds_new_items(mocker, session):
     session.commit()
 
     cv.update_conversation(cv.source.collection)
-    assert cv.scroll.conversation_layout.count() == 4
+    assert cv._scroll.conversation_layout.count() == 4
 
 
 def test_update_conversation_position_updates(mocker, session):
@@ -5022,7 +5022,7 @@ def test_update_conversation_position_updates(mocker, session):
     controller = mocker.MagicMock(get_file=get_file, authenticated_user=user)
 
     cv = ConversationView(source, controller)
-    assert cv.scroll.conversation_layout.count() == 3  # precondition
+    assert cv._scroll.conversation_layout.count() == 3  # precondition
 
     # Change the position of the Reply.
     reply_widget = cv.current_messages[reply.uuid]
@@ -5034,7 +5034,7 @@ def test_update_conversation_position_updates(mocker, session):
     session.commit()
 
     cv.update_conversation(cv.source.collection)
-    assert cv.scroll.conversation_layout.count() == 4
+    assert cv._scroll.conversation_layout.count() == 4
     assert reply_widget.index == 2  # re-ordered.
 
 
@@ -5059,8 +5059,8 @@ def test_update_conversation_content_updates(mocker, session):
     cv.update_deletion_markers = mocker.MagicMock()
     cv.current_messages = {}
 
-    cv.scroll.conversation_layout.removeWidget = mocker.MagicMock()
-    mocker.patch.object(cv.scroll, "add_widget_to_conversation")
+    cv._scroll.conversation_layout.removeWidget = mocker.MagicMock()
+    mocker.patch.object(cv._scroll, "add_widget_to_conversation")
 
     # this is the MessageWidget that __init__() would return
     mock_msg_widget_res = mocker.MagicMock()

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -5065,7 +5065,11 @@ def test_update_conversation_content_updates(mocker, session):
     mocker.patch.object(cv._scroll, "add_widget_to_conversation")
 
     # this is the MessageWidget that __init__() would return
-    mock_msg_widget_res = mocker.MagicMock()
+    # FIXME: It is a sign that something isn't quite right that index and message must
+    # be manually added to the MessageWidget spec.
+    mock_msg_widget_res = mocker.MagicMock(
+        spec=MessageWidget, index=None, message=mocker.MagicMock(text=lambda: None)
+    )
     # mock MessageWidget so we can inspect the __init__ call to see what content
     # is in the widget.
     mock_msg_widget = mocker.patch(

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -10,8 +10,8 @@ from unittest.mock import Mock, PropertyMock
 import arrow
 import sqlalchemy
 import sqlalchemy.orm.exc
-from PyQt5.QtCore import QEvent, QSize, Qt
-from PyQt5.QtGui import QFocusEvent, QMovie, QResizeEvent
+from PyQt5.QtCore import QEvent, QPointF, QSize, Qt
+from PyQt5.QtGui import QFocusEvent, QMouseEvent, QMovie, QResizeEvent
 from PyQt5.QtTest import QTest
 from PyQt5.QtWidgets import QVBoxLayout, QWidget
 from sqlalchemy.orm import attributes, scoped_session, sessionmaker
@@ -3162,8 +3162,9 @@ def test_FileWidget_event_handler_left_click(mocker, session, source):
     get_file = mocker.MagicMock(return_value=file_)
     controller = mocker.MagicMock(get_file=get_file)
 
-    test_event = QEvent(QEvent.MouseButtonPress)
-    test_event.button = mocker.MagicMock(return_value=Qt.LeftButton)
+    test_event = QMouseEvent(
+        QEvent.MouseButtonPress, QPointF(), Qt.LeftButton, Qt.NoButton, Qt.NoModifier
+    )
 
     fw = FileWidget(
         file_.uuid,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -36,7 +36,7 @@ def main_window(mocker, homedir):
         # Create a source widget
         source_list = gui.main_view.source_list
         source = factory.Source()
-        source_list.update([source])
+        source_list.update_sources([source])
 
         # Create a file widget, message widget, and reply widget
         mocker.patch("securedrop_client.gui.widgets.humanize_filesize", return_value="100")
@@ -88,7 +88,7 @@ def main_window_no_key(mocker, homedir):
         # Create a source widget
         source_list = gui.main_view.source_list
         source = factory.Source(public_key=None)
-        source_list.update([source])
+        source_list.update_sources([source])
 
         # Create a file widget, message widget, and reply widget
         mocker.patch("securedrop_client.gui.widgets.humanize_filesize", return_value="100")

--- a/tests/integration/test_styles_file_download_button.py
+++ b/tests/integration/test_styles_file_download_button.py
@@ -6,7 +6,7 @@ from securedrop_client.resources import load_icon
 
 def test_styles(mocker, main_window):
     wrapper = main_window.main_view.view_layout.itemAt(0).widget()
-    conversation_scrollarea = wrapper.conversation_view.scroll
+    conversation_scrollarea = wrapper.conversation_view._scroll
     file_widget = conversation_scrollarea.widget().layout().itemAt(0).widget()
     download_button = file_widget.download_button
 
@@ -29,7 +29,7 @@ def test_styles(mocker, main_window):
 
 def test_styles_animated(mocker, main_window):
     wrapper = main_window.main_view.view_layout.itemAt(0).widget()
-    conversation_scrollarea = wrapper.conversation_view.scroll
+    conversation_scrollarea = wrapper.conversation_view._scroll
     file_widget = conversation_scrollarea.widget().layout().itemAt(0).widget()
     download_button = file_widget.download_button
 

--- a/tests/integration/test_styles_reply_status_bar.py
+++ b/tests/integration/test_styles_reply_status_bar.py
@@ -3,7 +3,7 @@ from PyQt5.QtGui import QPalette
 
 def test_styles(mocker, main_window):
     wrapper = main_window.main_view.view_layout.itemAt(0).widget()
-    conversation_scrollarea = wrapper.conversation_view.scroll
+    conversation_scrollarea = wrapper.conversation_view._scroll
     reply_widget = conversation_scrollarea.widget().layout().itemAt(2).widget()
     reply_widget.sender_is_current_user = False
 
@@ -26,7 +26,7 @@ def test_styles(mocker, main_window):
 
 def test_styles_for_replies_from_authenticated_user(mocker, main_window):
     wrapper = main_window.main_view.view_layout.itemAt(0).widget()
-    conversation_scrollarea = wrapper.conversation_view.scroll
+    conversation_scrollarea = wrapper.conversation_view._scroll
     reply_widget = conversation_scrollarea.widget().layout().itemAt(2).widget()
     reply_widget.sender_is_current_user = True
 

--- a/tests/integration/test_styles_sdclient.py
+++ b/tests/integration/test_styles_sdclient.py
@@ -112,7 +112,7 @@ def test_class_name_matches_css_object_name(mocker, main_window):
     assert "LastUpdatedLabel" in last_updated_label.objectName()
     title = conversation_title_bar.layout().itemAt(0).widget().layout().itemAt(0).widget()
     assert "TitleLabel" in title.objectName()
-    conversation_scroll_area = wrapper.conversation_view.scroll
+    conversation_scroll_area = wrapper.conversation_view._scroll
     assert "ConversationScrollArea" == conversation_scroll_area.__class__.__name__
     assert "ConversationScrollArea" in conversation_scroll_area.widget().objectName()
     file_widget = conversation_scroll_area.widget().layout().itemAt(0).widget()
@@ -365,7 +365,7 @@ def test_styles_for_conversation_view(mocker, main_window):
     assert 24 == title.font().pixelSize()
     assert "#2a319d" == title.palette().color(QPalette.Foreground).name()
 
-    conversation_scrollarea = wrapper.conversation_view.scroll
+    conversation_scrollarea = wrapper.conversation_view._scroll
     assert "#f9f9ff" == conversation_scrollarea.palette().color(QPalette.Background).name()
     assert "#f9f9ff" == conversation_scrollarea.widget().palette().color(QPalette.Background).name()
     file_widget = conversation_scrollarea.widget().layout().itemAt(0).widget()

--- a/tests/integration/test_styles_speech_bubble_message.py
+++ b/tests/integration/test_styles_speech_bubble_message.py
@@ -3,7 +3,7 @@ from PyQt5.QtGui import QFont, QPalette
 
 def test_styles(mocker, main_window):
     wrapper = main_window.main_view.view_layout.itemAt(0).widget()
-    conversation_scrollarea = wrapper.conversation_view.scroll
+    conversation_scrollarea = wrapper.conversation_view._scroll
     speech_bubble = conversation_scrollarea.widget().layout().itemAt(1).widget()
 
     assert 400 == speech_bubble.speech_bubble.minimumSize().width()

--- a/tests/integration/test_styles_speech_bubble_status_bar.py
+++ b/tests/integration/test_styles_speech_bubble_status_bar.py
@@ -3,7 +3,7 @@ from PyQt5.QtGui import QPalette
 
 def test_styles(mocker, main_window):
     wrapper = main_window.main_view.view_layout.itemAt(0).widget()
-    conversation_scrollarea = wrapper.conversation_view.scroll
+    conversation_scrollarea = wrapper.conversation_view._scroll
     speech_bubble = conversation_scrollarea.widget().layout().itemAt(1).widget()
 
     assert 5 == speech_bubble.color_bar.minimumSize().height()

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -12,7 +12,6 @@ from unittest.mock import Mock, call
 import arrow
 import pytest
 import sqlalchemy.orm.exc
-from PyQt5.QtCore import Qt
 from PyQt5.QtTest import QSignalSpy
 from sdclientapi import AuthError, RequestTimeoutError, ServerConnectionError
 from sqlalchemy.orm import attributes
@@ -710,8 +709,8 @@ def test_Controller_mark_seen(homedir, config, mocker, session, session_maker):
 
     assert len(add_job_emissions) == 1
     assert add_job_emissions[0] == [job]
-    job.success_signal.connect.assert_called_once_with(co.on_seen_success, type=Qt.QueuedConnection)
-    job.failure_signal.connect.assert_called_once_with(co.on_seen_failure, type=Qt.QueuedConnection)
+    job.success_signal.connect.assert_called_once_with(co.on_seen_success)
+    job.failure_signal.connect.assert_called_once_with(co.on_seen_failure)
 
 
 def test_Controller_mark_seen_with_unseen_item_of_each_type(
@@ -1236,13 +1235,13 @@ def test_Controller_download_conversation(homedir, config, session, mocker, sess
     assert add_job_emissions[0] == [job]
     assert add_job_emissions[1] == [job]
     expected = [
-        call(co.on_file_download_success, type=Qt.QueuedConnection),
-        call(co.on_file_download_success, type=Qt.QueuedConnection),
+        call(co.on_file_download_success),
+        call(co.on_file_download_success),
     ]
     assert job_success_signal.connect.mock_calls == expected
     expected = [
-        call(co.on_file_download_failure, type=Qt.QueuedConnection),
-        call(co.on_file_download_failure, type=Qt.QueuedConnection),
+        call(co.on_file_download_failure),
+        call(co.on_file_download_failure),
     ]
     assert job_failure_signal.connect.mock_calls == expected
 
@@ -1319,12 +1318,8 @@ def test_Controller_on_file_download_Submission(homedir, config, session, mocker
     mock_job_cls.assert_called_once_with(file_.uuid, co.data_dir, co.gpg)
     assert len(add_job_emissions) == 1
     assert add_job_emissions[0] == [mock_job]
-    mock_success_signal.connect.assert_called_once_with(
-        co.on_file_download_success, type=Qt.QueuedConnection
-    )
-    mock_failure_signal.connect.assert_called_once_with(
-        co.on_file_download_failure, type=Qt.QueuedConnection
-    )
+    mock_success_signal.connect.assert_called_once_with(co.on_file_download_success)
+    mock_failure_signal.connect.assert_called_once_with(co.on_file_download_failure)
 
 
 def test_Controller_on_file_download_Submission_no_auth(
@@ -1644,12 +1639,8 @@ def test_Controller_download_new_replies_with_new_reply(mocker, session, session
 
     assert len(add_job_emissions) == 1
     assert add_job_emissions[0] == [job]
-    success_signal.connect.assert_called_once_with(
-        co.on_reply_download_success, type=Qt.QueuedConnection
-    )
-    failure_signal.connect.assert_called_once_with(
-        co.on_reply_download_failure, type=Qt.QueuedConnection
-    )
+    success_signal.connect.assert_called_once_with(co.on_reply_download_success)
+    failure_signal.connect.assert_called_once_with(co.on_reply_download_failure)
 
 
 def test_Controller_download_new_replies_without_replies(mocker, session, session_maker, homedir):
@@ -1770,12 +1761,8 @@ def test_Controller_download_new_messages_with_new_message(mocker, session, sess
 
     assert len(add_job_emissions) == 1
     assert add_job_emissions[0] == [job]
-    success_signal.connect.assert_called_once_with(
-        co.on_message_download_success, type=Qt.QueuedConnection
-    )
-    failure_signal.connect.assert_called_once_with(
-        co.on_message_download_failure, type=Qt.QueuedConnection
-    )
+    success_signal.connect.assert_called_once_with(co.on_message_download_success)
+    failure_signal.connect.assert_called_once_with(co.on_message_download_failure)
 
     # fake APIJobQueue's emitting main_queue_updated when the job is queued and dequeued
     co.api_job_queue.main_queue_updated.emit(1)
@@ -2020,12 +2007,8 @@ def test_Controller_delete_source(homedir, config, mocker, session_maker, sessio
     mock_job_cls.assert_called_once_with(source.uuid)
     assert len(add_job_emissions) == 1
     assert add_job_emissions[0] == [mock_job]
-    mock_success_signal.connect.assert_called_once_with(
-        co.on_delete_source_success, type=Qt.QueuedConnection
-    )
-    mock_failure_signal.connect.assert_called_once_with(
-        co.on_delete_source_failure, type=Qt.QueuedConnection
-    )
+    mock_success_signal.connect.assert_called_once_with(co.on_delete_source_success)
+    mock_failure_signal.connect.assert_called_once_with(co.on_delete_source_failure)
 
 
 def test_Controller_on_delete_conversation_success(mocker, homedir):
@@ -2100,12 +2083,8 @@ def test_Controller_delete_conversation(homedir, config, mocker, session_maker, 
     mock_job_cls.assert_called_once_with(source.uuid)
     assert len(add_job_emissions) == 1
     assert add_job_emissions[0] == [mock_job]
-    mock_success_signal.connect.assert_called_once_with(
-        co.on_delete_conversation_success, type=Qt.QueuedConnection
-    )
-    mock_failure_signal.connect.assert_called_once_with(
-        co.on_delete_conversation_failure, type=Qt.QueuedConnection
-    )
+    mock_success_signal.connect.assert_called_once_with(co.on_delete_conversation_success)
+    mock_failure_signal.connect.assert_called_once_with(co.on_delete_conversation_failure)
 
 
 def test_Controller_send_reply_success(
@@ -2141,12 +2120,8 @@ def test_Controller_send_reply_success(
 
     assert len(add_job_emissions) == 1
     assert add_job_emissions[0] == [mock_job]
-    mock_success_signal.connect.assert_called_once_with(
-        co.on_reply_success, type=Qt.QueuedConnection
-    )
-    mock_failure_signal.connect.assert_called_once_with(
-        co.on_reply_failure, type=Qt.QueuedConnection
-    )
+    mock_success_signal.connect.assert_called_once_with(co.on_reply_success)
+    mock_failure_signal.connect.assert_called_once_with(co.on_reply_failure)
 
 
 def test_Controller_send_reply_does_not_send_if_not_authenticated(
@@ -2392,12 +2367,8 @@ def test_Controller_call_update_star_success(homedir, config, mocker, session_ma
     assert len(add_job_emissions) == 1
     assert add_job_emissions[0] == [mock_job]
     assert star_update_successful.connect.call_count == 1
-    star_update_failed.connect.assert_called_once_with(
-        co.on_update_star_failure, type=Qt.QueuedConnection
-    )
-    star_update_successful.connect.assert_called_once_with(
-        co.on_update_star_success, type=Qt.QueuedConnection
-    )
+    star_update_failed.connect.assert_called_once_with(co.on_update_star_failure)
+    star_update_successful.connect.assert_called_once_with(co.on_update_star_success)
 
 
 def test_get_file(mocker, session, homedir):


### PR DESCRIPTION
## Description

We are currently not providing PyQt5 stubs to **mypy**. As a result, Qt types are not checked. Since half of the repo is a Qt GUI, we should fix that.

@zekehuntergreen wrote  ([source](https://github.com/freedomofpress/securedrop-client/pull/1604#discussion_r1047368531)):

> After reading the section in the docs on [None and Optional handling](https://mypy.readthedocs.io/en/stable/command_line.html#none-and-optional-handling) [the fact that **mypy** didn't identify the implicit `Optional[pyqtSignal]`] surprised me too! It sounds like the default behavior changed as of version 0.980 so that parameters with `None` as a default value are no longer treated as `Optional` be default.
>
> I think what's going on is that mypy can't find a library stub for `PyQt5.QtCore` so in the absence of a type for `pyqtSignal`, it's being treated as `Any`. Since `None` is a subtype of `Any`, mypy doesn't raise an "incompatible default for argument" error.
> It looks like there is a [stub library for PyQt5](https://pypi.org/project/PyQt5-stubs/) which it might be worth looking into adding to the project!

This PR adds the library to the development requirements and fixes the issues highlighted by `make mypy`.

Towards https://github.com/freedomofpress/securedrop-client/issues/1614

## Test Plan

:crystal_ball: **Reviewers**: _It makes a lot of sense to review this PR commit by commit. They're independent form each other, and I've added to the commit message when making the most significant decisions._

The gist of it is:
- [x] Confirm that the tests haven't changed significantly
- [x] Confirm that the type checks that were ignored can reasonably be ignored
- Confirm that there are no regressions in:
  - [x] The export flow
  - [x] ... please add any feature that seems relevant to the files that have been touched.
