### PR TITLE
Always show "last refresh" sync status message

### DIFF
--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -176,9 +176,9 @@ class Window(QMainWindow):
         Display a message indicating the time of last sync with the server.
         """
         if updated_on:
-            self.update_activity_status(_("Last Refresh: {}").format(updated_on.humanize()))
+            self.update_sync_status(_("Last Refresh: {}").format(updated_on.humanize()))
         else:
-            self.update_activity_status(_("Last Refresh: never"))
+            self.update_sync_status(_("Last Refresh: never"))
 
     def set_logged_in_as(self, db_user: User) -> None:
         """
@@ -193,6 +193,13 @@ class Window(QMainWindow):
         """
         self.left_pane.set_logged_out()
         self.top_pane.set_logged_out()
+
+    def update_sync_status(self, message: str, duration: int = 0) -> None:
+        """
+        Display an activity status message to the user. Optionally, supply a duration
+        (in milliseconds), the default will continuously show the message.
+        """
+        self.top_pane.update_sync_status(message, duration)
 
     def update_activity_status(self, message: str, duration: int = 0) -> None:
         """

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -128,36 +128,43 @@ class TopPane(QWidget):
         layout.setContentsMargins(10, 0, 0, 0)
         layout.setSpacing(0)
 
+        status_layout = QHBoxLayout()
+        status_layout.setContentsMargins(0, 0, 0, 0)
+        status_layout.setSpacing(0)
+
         # Sync icon
         self.sync_icon = SyncIcon()
 
         # Activity status bar
         self.activity_status_bar = ActivityStatusBar()
 
+        self.sync_status_bar = SyncStatusBar()
+
         # Error status bar
         self.error_status_bar = ErrorStatusBar()
 
-        # Create space the size of the status bar to keep the error status bar centered
         spacer = QWidget()
-
-        # Create space ths size of the sync icon to keep the error status bar centered
         spacer2 = QWidget()
-        spacer2.setFixedWidth(42)
+
+        # Create space the size of the status bar to keep the error status bar centered
+        spacer3 = QWidget()
+        spacer3.setFixedWidth(42)
 
         # Set height of top pane to 42 pixels
         self.setFixedHeight(42)
         self.sync_icon.setFixedHeight(42)
         self.activity_status_bar.setFixedHeight(42)
         self.error_status_bar.setFixedHeight(42)
-        spacer.setFixedHeight(42)
-        spacer2.setFixedHeight(42)
 
         # Add widgets to layout
         layout.addWidget(self.sync_icon, 1)
-        layout.addWidget(self.activity_status_bar, 1)
+        status_layout.addWidget(self.sync_status_bar, 1)
+        status_layout.addWidget(self.activity_status_bar, 1)
+        status_layout.addWidget(spacer, 1)
+        layout.addLayout(status_layout, 1)
         layout.addWidget(self.error_status_bar, 1)
-        layout.addWidget(spacer, 1)
         layout.addWidget(spacer2, 1)
+        layout.addWidget(spacer3, 1)
 
     def setup(self, controller: Controller) -> None:
         self.sync_icon.setup(controller)
@@ -170,6 +177,9 @@ class TopPane(QWidget):
     def set_logged_out(self) -> None:
         self.sync_icon.disable()
         self.setPalette(self.offline_palette)
+
+    def update_sync_status(self, message: str, duration: int) -> None:
+        self.sync_status_bar.update_message(message, duration)
 
     def update_activity_status(self, message: str, duration: int) -> None:
         self.activity_status_bar.update_message(message, duration)
@@ -277,6 +287,28 @@ class SyncIcon(QLabel):
         self.sync_animation.setScaledSize(QSize(24, 20))
         self.setMovie(self.sync_animation)
         self.sync_animation.start()
+
+
+class SyncStatusBar(QStatusBar):
+    """
+    A status bar for displaying messages about metadata sync activity to the user. Messages will be
+    displayed for a given duration or until the message updated with a new message.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        # Set css id
+        self.setObjectName("SyncStatusBar")
+
+        # Remove grip image at bottom right-hand corner
+        self.setSizeGripEnabled(False)
+
+    def update_message(self, message: str, duration: int) -> None:
+        """
+        Display a status message to the user.
+        """
+        self.showMessage(message, duration)
 
 
 class ActivityStatusBar(QStatusBar):

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -135,20 +135,26 @@ class TopPane(QWidget):
         # Sync icon
         self.sync_icon = SyncIcon()
 
+        # Sync status bar with fixed width so that the left side of the
+        # activity status bar lines up with left pane
+        self.sync_status_bar = SyncStatusBar()
+        self.sync_status_bar.setFixedWidth(171)
+
         # Activity status bar
         self.activity_status_bar = ActivityStatusBar()
-
-        self.sync_status_bar = SyncStatusBar()
 
         # Error status bar
         self.error_status_bar = ErrorStatusBar()
 
-        spacer = QWidget()
-        spacer2 = QWidget()
+        # Create spacers the size of the sync icon and sync and activity status bars
+        # so that the error status bar is centered
+        sync_icon_spacer = QWidget()
+        sync_icon_spacer.setFixedWidth(42)
 
-        # Create space the size of the status bar to keep the error status bar centered
-        spacer3 = QWidget()
-        spacer3.setFixedWidth(42)
+        sync_status_bar_spacer = QWidget()
+        sync_status_bar_spacer.setFixedWidth(171)
+
+        activity_status_bar_spacer = QWidget()
 
         # Set height of top pane to 42 pixels
         self.setFixedHeight(42)
@@ -158,13 +164,14 @@ class TopPane(QWidget):
 
         # Add widgets to layout
         layout.addWidget(self.sync_icon, 1)
-        status_layout.addWidget(self.sync_status_bar, 1)
-        status_layout.addWidget(self.activity_status_bar, 1)
-        status_layout.addWidget(spacer, 1)
-        layout.addLayout(status_layout, 1)
+        layout.addWidget(self.sync_status_bar, 1)
+        layout.addWidget(self.activity_status_bar, 1)
+
         layout.addWidget(self.error_status_bar, 1)
-        layout.addWidget(spacer2, 1)
-        layout.addWidget(spacer3, 1)
+
+        layout.addWidget(activity_status_bar_spacer, 1)
+        layout.addWidget(sync_status_bar_spacer, 1)
+        layout.addWidget(sync_icon_spacer, 1)
 
     def setup(self, controller: Controller) -> None:
         self.sync_icon.setup(controller)

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -128,10 +128,6 @@ class TopPane(QWidget):
         layout.setContentsMargins(10, 0, 0, 0)
         layout.setSpacing(0)
 
-        status_layout = QHBoxLayout()
-        status_layout.setContentsMargins(0, 0, 0, 0)
-        status_layout.setSpacing(0)
-
         # Sync icon
         self.sync_icon = SyncIcon()
 

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -406,6 +406,7 @@ class Controller(QObject):
         # Create a timer to show the time since the last sync
         self.show_last_sync_timer = QTimer()
         self.show_last_sync_timer.timeout.connect(self.show_last_sync)
+        self.show_last_sync_timer.start(TIME_BETWEEN_SHOWING_LAST_SYNC_MS)
 
         # Path to the file containing the timestamp since the last sync with the server
         # TODO: Remove this code once the sync timestamp is tracked instead in svs.sqlite
@@ -500,11 +501,9 @@ class Controller(QObject):
         self.gui.update_error_status(
             _("The SecureDrop server cannot be reached. Trying to reconnect..."), duration=0
         )
-        self.show_last_sync_timer.start(TIME_BETWEEN_SHOWING_LAST_SYNC_MS)
 
     def resume_queues(self) -> None:
         self.api_job_queue.resume_queues()
-        self.show_last_sync_timer.stop()
 
         # clear error status in case queue was paused resulting in a permanent error message
         self.gui.clear_error_status()
@@ -547,8 +546,6 @@ class Controller(QObject):
         self.call_api(
             self.api.authenticate, self.on_authenticate_success, self.on_authenticate_failure
         )
-        self.show_last_sync_timer.stop()
-        self.set_status("")
 
     def on_authenticate_success(self, result):  # type: ignore [no-untyped-def]
         """
@@ -611,8 +608,6 @@ class Controller(QObject):
         self.gui.clear_clipboard()
         self.gui.show_main_window()
         self.update_sources()
-        self.show_last_sync()
-        self.show_last_sync_timer.start(TIME_BETWEEN_SHOWING_LAST_SYNC_MS)
 
     def on_action_requiring_login(self) -> None:
         """
@@ -810,8 +805,6 @@ class Controller(QObject):
         self.api_job_queue.stop()
         self.gui.logout()
 
-        self.show_last_sync_timer.start(TIME_BETWEEN_SHOWING_LAST_SYNC_MS)
-        self.show_last_sync()
         self.is_authenticated = False
 
     def invalidate_token(self) -> None:

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -68,7 +68,7 @@ from securedrop_client.utils import check_dir_permissions
 logger = logging.getLogger(__name__)
 
 # 30 seconds between showing the time since the last sync
-TIME_BETWEEN_SHOWING_LAST_SYNC_MS = 1000 * 30
+LAST_SYNC_REFRESH_INTERVAL_MS = 1000 * 30
 
 
 def login_required(f):  # type: ignore [no-untyped-def]
@@ -406,7 +406,7 @@ class Controller(QObject):
         # Create a timer to show the time since the last sync
         self.show_last_sync_timer = QTimer()
         self.show_last_sync_timer.timeout.connect(self.show_last_sync)
-        self.show_last_sync_timer.start(TIME_BETWEEN_SHOWING_LAST_SYNC_MS)
+        self.show_last_sync_timer.start(LAST_SYNC_REFRESH_INTERVAL_MS)
         self.show_last_sync()
 
         # Path to the file containing the timestamp since the last sync with the server

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -407,6 +407,7 @@ class Controller(QObject):
         self.show_last_sync_timer = QTimer()
         self.show_last_sync_timer.timeout.connect(self.show_last_sync)
         self.show_last_sync_timer.start(TIME_BETWEEN_SHOWING_LAST_SYNC_MS)
+        self.show_last_sync()
 
         # Path to the file containing the timestamp since the last sync with the server
         # TODO: Remove this code once the sync timestamp is tracked instead in svs.sqlite
@@ -649,6 +650,7 @@ class Controller(QObject):
         """
         with open(self.last_sync_filepath, "w") as f:
             f.write(arrow.now().format())
+        self.show_last_sync()
 
         missing_files = storage.update_missing_files(self.data_dir, self.session)
         for missed_file in missing_files:

--- a/securedrop_client/resources/css/sdclient.css
+++ b/securedrop_client/resources/css/sdclient.css
@@ -29,6 +29,7 @@ QWidget {
     font-weight: 600;
     font-size: 12px;
     color: #d3d8ea;
+    background: transparent;
 }
 
 #ErrorStatusBar_vertical_bar {

--- a/securedrop_client/resources/css/sdclient.css
+++ b/securedrop_client/resources/css/sdclient.css
@@ -16,6 +16,14 @@ QWidget {
     color: #fff;
 }
 
+#SyncStatusBar {
+    font-family: 'Source Sans Pro';
+    font-weight: 600;
+    font-size: 12px;
+    color: #d3d8ea;
+    background: transparent;
+}
+
 #ActivityStatusBar {
     font-family: 'Source Sans Pro';
     font-weight: 600;

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -328,12 +328,10 @@ def test_show_last_sync(mocker):
     If there's a value display the result of its "humanize" method.humanize
     """
     w = Window()
-    w.update_activity_status = mocker.MagicMock()
+    w.update_sync_status = mocker.MagicMock()
     updated_on = mocker.MagicMock()
     w.show_last_sync(updated_on)
-    w.update_activity_status.assert_called_once_with(
-        "Last Refresh: {}".format(updated_on.humanize())
-    )
+    w.update_sync_status.assert_called_once_with("Last Refresh: {}".format(updated_on.humanize()))
 
 
 def test_show_last_sync_no_sync(mocker):
@@ -341,9 +339,9 @@ def test_show_last_sync_no_sync(mocker):
     If there's no value to display, default to a "waiting" message.
     """
     w = Window()
-    w.update_activity_status = mocker.MagicMock()
+    w.update_sync_status = mocker.MagicMock()
     w.show_last_sync(None)
-    w.update_activity_status.assert_called_once_with("Last Refresh: never")
+    w.update_sync_status.assert_called_once_with("Last Refresh: never")
 
 
 def test_set_logged_in_as(mocker):

--- a/tests/integration/test_styles_sdclient.py
+++ b/tests/integration/test_styles_sdclient.py
@@ -190,7 +190,7 @@ def test_styles_for_top_pane(mocker, main_window):
     assert "Source Sans Pro" == activity_status_bar.font().family()
     assert QFont.Bold == activity_status_bar.font().weight()
     assert 12 == activity_status_bar.font().pixelSize()
-    assert "#ffffff" == activity_status_bar.palette().color(QPalette.Base).name()
+    assert "#000000" == activity_status_bar.palette().color(QPalette.Base).name()
     assert "#d3d8ea" == activity_status_bar.palette().color(QPalette.Foreground).name()
     error_status_bar = main_window.top_pane.error_status_bar
     assert "#ff3366" == error_status_bar.vertical_bar.palette().color(QPalette.Background).name()

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -179,7 +179,6 @@ def test_Controller_login(homedir, config, mocker, session_maker):
     co.call_api.assert_called_once_with(
         mock_api().authenticate, co.on_authenticate_success, co.on_authenticate_failure
     )
-    co.show_last_sync_timer.stop.assert_called_once_with()
 
 
 def test_Controller_login_offline_mode(homedir, config, mocker):
@@ -202,7 +201,6 @@ def test_Controller_login_offline_mode(homedir, config, mocker):
     co.gui.assert_has_calls([call.clear_clipboard(), call.show_main_window()])
     co.gui.hide_login.assert_called_once_with()
     co.update_sources.assert_called_once_with()
-    co.show_last_sync_timer.start.assert_called_once_with(TIME_BETWEEN_SHOWING_LAST_SYNC_MS)
 
 
 @pytest.mark.parametrize(
@@ -651,8 +649,6 @@ def test_Controller_show_last_sync(homedir, config, mocker, session_maker):
     """
     Ensure we get the last sync time when we show it.
     Using the `config` fixture to ensure the config is written to disk.
-    This should only happen if the user isn't logged in or the API queues are
-    paused (indicating network problems).
     """
     co = Controller("http://localhost", mocker.MagicMock(), session_maker, homedir, None)
     co.get_last_sync = mocker.MagicMock()
@@ -661,7 +657,9 @@ def test_Controller_show_last_sync(homedir, config, mocker, session_maker):
     co.show_last_sync()
 
     assert co.get_last_sync.call_count == 1
-    co.gui.show_last_sync.assert_called_once_with(co.get_last_sync())
+    # gui.show_last_sync also called in Controller.__init__
+    assert co.gui.show_last_sync.call_count == 2
+    co.gui.show_last_sync.assert_called_with(co.get_last_sync())
 
 
 def test_Controller_update_sources(homedir, config, mocker):
@@ -1074,7 +1072,6 @@ def test_Controller_logout_success(homedir, config, mocker, session_maker):
     co.gui.logout.assert_called_once_with()
     msg = "Client logout successful"
     info_logger.assert_called_once_with(msg)
-    co.show_last_sync_timer.start.assert_called_once_with(TIME_BETWEEN_SHOWING_LAST_SYNC_MS)
 
 
 def test_Controller_logout_failure(homedir, config, mocker, session_maker):
@@ -2258,7 +2255,6 @@ def test_Controller_resume_queues(homedir, mocker, session_maker):
     co.show_last_sync_timer = mocker.MagicMock()
     co.resume_queues()
     co.api_job_queue.resume_queues.assert_called_once_with()
-    co.show_last_sync_timer.stop.assert_called_once_with()
 
 
 @pytest.mark.parametrize("exception", [RequestTimeoutError, ServerConnectionError])
@@ -2310,7 +2306,6 @@ def test_Controller_on_queue_paused(homedir, config, mocker, session_maker):
     mock_gui.update_error_status.assert_called_once_with(
         "The SecureDrop server cannot be reached. Trying to reconnect...", duration=0
     )
-    co.show_last_sync_timer.start.assert_called_once_with(TIME_BETWEEN_SHOWING_LAST_SYNC_MS)
 
 
 def test_Controller_call_update_star_success(homedir, config, mocker, session_maker, session):

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -30,7 +30,7 @@ from securedrop_client.api_jobs.sources import (
 from securedrop_client.api_jobs.updatestar import UpdateStarJobError, UpdateStarJobTimeoutError
 from securedrop_client.api_jobs.uploads import SendReplyJobError, SendReplyJobTimeoutError
 from securedrop_client.app import threads
-from securedrop_client.logic import TIME_BETWEEN_SHOWING_LAST_SYNC_MS, APICallRunner, Controller
+from securedrop_client.logic import APICallRunner, Controller
 from tests import factory
 
 MAX_SIGNAL_WAITING_TIME = 50


### PR DESCRIPTION
# Description
Fixes #1608 

At our organization, the volume of data (sources, messages, replies, etc.) means that metadata syncs can take a very long time (around 10-20 minutes). While a sync is in progress, a user has very little information about how up-to-date the data that appears in the journalist's interface is. 

Before this change, the "last refresh" message only appears when the user is signed out or when they are disconnected from the network. After the change, the message is also displayed when the user is signed in with an active network connection. 

The sync status message moves from the "Activity status bar" to a new "Sync status bar" between the sync signal and the activity status bar. This is so that sync status can appear next to the retrieval progress message. 

## Example

https://user-images.githubusercontent.com/17057932/207862458-0d7c3c04-b25b-4de7-8115-2a60e8619728.mov


# Test Plan
- [ ] Confirm the error status bar appears in the correct place
- [ ] Confirm that no humanized last sync dates are wider than the sync status bar 
_fill this in_

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [x] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
