### PR TITLE
chore: remove unnecessary mypy `ignore` pragma

### DIFF
--- a/securedrop_client/queue.py
+++ b/securedrop_client/queue.py
@@ -220,7 +220,7 @@ class RunnableQueue(QObject):
                 self._clear()
                 return
 
-            if isinstance(self.current_job, PauseQueueJob):  # type: ignore
+            if isinstance(self.current_job, PauseQueueJob):
                 self.paused.emit()
                 with self.condition_add_or_remove_job:
                     self.current_job = None


### PR DESCRIPTION
# Description

Fixes failing CI `lint-*` ([e.g.](https://app.circleci.com/pipelines/github/freedomofpress/securedrop-client/3053/workflows/50a49db6-3d9e-4842-a562-8920451e1206/jobs/18422)).  After #1611, specifically 64293d1, this `ignore` pragma is unnecessary and therefore invalid in strict mode.  It was introduced in #1486, which was reviewed and merged while #1611 was still in review.

# Test Plan

- [ ] CI passes.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - I have tested these changes in the appropriate Qubes environment
 - I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations