### PR TITLE
Add action to (re-)generate and export conversation transcript

### DIFF
--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -246,11 +246,11 @@ def start_app(args, qt_args) -> NoReturn:  # type: ignore [no-untyped-def]
         main_queue_thread,
         file_download_queue_thread,
     ]:
-        export_service = export.Service()
+        export_service = export.getService()
         export_service.moveToThread(export_service_thread)
         export_service_thread.start()
 
-        gui = Window(app_state, export_service)
+        gui = Window(app_state)
 
         controller = Controller(
             "http://localhost:8081/",

--- a/securedrop_client/export.py
+++ b/securedrop_client/export.py
@@ -378,3 +378,22 @@ class Export(QObject):
 
 
 Service = Export
+
+# Store a singleton service instance.
+_service = Service()
+
+
+def resetService() -> None:
+    """Replaces the existing sngleton service instance by a new one.
+
+    Get the instance by using getService().
+    """
+    global _service
+    _service = Service()
+
+
+def getService() -> Service:
+    """All calls to this function return the same singleton service instance.
+
+    Use resetService() to replace it by a new one."""
+    return _service

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -11,7 +11,7 @@ from typing import Callable, Optional
 from PyQt5.QtCore import Qt, pyqtSlot
 from PyQt5.QtWidgets import QAction, QDialog, QMenu
 
-from securedrop_client import export, state
+from securedrop_client import state
 from securedrop_client.conversation import Transcript as ConversationTranscript
 from securedrop_client.db import Source
 from securedrop_client.gui.conversation import ExportDevice as ConversationExportDevice
@@ -144,7 +144,6 @@ class PrintConversationAction(QAction):  # pragma: nocover
         parent: QMenu,
         controller: Controller,
         source: Source,
-        export_service: Optional[export.Service] = None,
     ) -> None:
         """
         Allows printing of a conversation transcript.
@@ -156,13 +155,7 @@ class PrintConversationAction(QAction):  # pragma: nocover
         self.controller = controller
         self._source = source
 
-        if export_service is None:
-            # Note that injecting an export service that runs in a separate
-            # thread is greatly encouraged! But it is optional because strictly
-            # speaking it is not a dependency of this FileWidget.
-            export_service = export.Service()
-
-        self._export_device = ConversationExportDevice(controller, export_service)
+        self._export_device = ConversationExportDevice(controller)
 
         self.triggered.connect(self._on_triggered)
 
@@ -203,7 +196,6 @@ class ExportConversationAction(QAction):  # pragma: nocover
         parent: QMenu,
         controller: Controller,
         source: Source,
-        export_service: Optional[export.Service] = None,
     ) -> None:
         """
         Allows export of a conversation transcript.
@@ -215,13 +207,7 @@ class ExportConversationAction(QAction):  # pragma: nocover
         self.controller = controller
         self._source = source
 
-        if export_service is None:
-            # Note that injecting an export service that runs in a separate
-            # thread is greatly encouraged! But it is optional because strictly
-            # speaking it is not a dependency of this FileWidget.
-            export_service = export.Service()
-
-        self._export_device = ConversationExportDevice(controller, export_service)
+        self._export_device = ConversationExportDevice(controller)
 
         self.triggered.connect(self._on_triggered)
 

--- a/securedrop_client/gui/conversation/__init__.py
+++ b/securedrop_client/gui/conversation/__init__.py
@@ -7,3 +7,4 @@ from .export import Device as ExportDevice  # noqa: F401
 from .export import Dialog as ExportFileDialog  # noqa: F401
 from .export import PrintDialog as PrintFileDialog  # noqa: F401
 from .export import PrintTranscriptDialog  # noqa: F401
+from .export import TranscriptDialog as ExportTranscriptDialog  # noqa: F401

--- a/securedrop_client/gui/conversation/export/__init__.py
+++ b/securedrop_client/gui/conversation/export/__init__.py
@@ -2,3 +2,4 @@ from .device import Device  # noqa: F401
 from .dialog import ExportDialog as Dialog  # noqa: F401
 from .print_dialog import PrintDialog  # noqa: F401
 from .print_transcript_dialog import PrintTranscriptDialog  # noqa: F401
+from .transcript_dialog import TranscriptDialog  # noqa: F401

--- a/securedrop_client/gui/conversation/export/device.py
+++ b/securedrop_client/gui/conversation/export/device.py
@@ -79,6 +79,12 @@ class Device(QObject):
         logger.info("Running export preflight check")
         self.export_preflight_check_requested.emit()
 
+    def export_transcript(self, file_location: str, passphrase: str) -> None:
+        """
+        Send the transcript specified by file_location to the Export VM.
+        """
+        self.export_requested.emit([file_location], passphrase)
+
     def export_file_to_usb_drive(self, file_uuid: str, passphrase: str) -> None:
         """
         Send the file specified by file_uuid to the Export VM with the user-provided passphrase for

--- a/securedrop_client/gui/conversation/export/device.py
+++ b/securedrop_client/gui/conversation/export/device.py
@@ -34,11 +34,11 @@ class Device(QObject):
     print_succeeded = pyqtSignal()
     print_failed = pyqtSignal(object)
 
-    def __init__(self, controller: Controller, export_service: export.Service) -> None:
+    def __init__(self, controller: Controller) -> None:
         super().__init__()
 
         self._controller = controller
-        self._export_service = export_service
+        self._export_service = export.getService()
 
         self._export_service.connect_signals(
             self.export_preflight_check_requested,

--- a/securedrop_client/gui/conversation/export/transcript_dialog.py
+++ b/securedrop_client/gui/conversation/export/transcript_dialog.py
@@ -1,0 +1,56 @@
+"""
+A dialog that allows journalists to export sensitive files to a USB drive.
+"""
+from gettext import gettext as _
+
+from PyQt5.QtCore import pyqtSlot
+
+from .device import Device
+from .dialog import ExportDialog as FileDialog
+
+
+class TranscriptDialog(FileDialog):
+    """Adapts the dialog used to export files to allow exporting a conversation transcript.
+
+    - Adjust the init arguments to the needs of conversation transcript export.
+    - Adds a method to allow a transcript to be exported.
+    - Overrides the two slots that handles the export action to call said method.
+    """
+
+    def __init__(self, device: Device, file_name: str, transcript_location: str) -> None:
+        super().__init__(device, "", file_name)
+
+        self.transcript_location = transcript_location
+
+    def _export_transcript(self, checked: bool = False) -> None:
+        self.start_animate_activestate()
+        self.cancel_button.setEnabled(False)
+        self.passphrase_field.setDisabled(True)
+        self._device.export_transcript(self.transcript_location, self.passphrase_field.text())
+
+    @pyqtSlot()
+    def _show_passphrase_request_message(self) -> None:
+        self.continue_button.clicked.disconnect()
+        self.continue_button.clicked.connect(self._export_transcript)
+        self.header.setText(self.passphrase_header)
+        self.continue_button.setText(_("SUBMIT"))
+        self.header_line.hide()
+        self.error_details.hide()
+        self.body.hide()
+        self.passphrase_field.setFocus()
+        self.passphrase_form.show()
+        self.adjustSize()
+
+    @pyqtSlot()
+    def _show_passphrase_request_message_again(self) -> None:
+        self.continue_button.clicked.disconnect()
+        self.continue_button.clicked.connect(self._export_transcript)
+        self.header.setText(self.passphrase_header)
+        self.error_details.setText(self.passphrase_error_message)
+        self.continue_button.setText(_("SUBMIT"))
+        self.header_line.hide()
+        self.body.hide()
+        self.error_details.show()
+        self.passphrase_field.setFocus()
+        self.passphrase_form.show()
+        self.adjustSize()

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -27,7 +27,7 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QClipboard, QGuiApplication, QIcon, QKeySequence
 from PyQt5.QtWidgets import QAction, QApplication, QHBoxLayout, QMainWindow, QVBoxLayout, QWidget
 
-from securedrop_client import __version__, export, state
+from securedrop_client import __version__, state
 from securedrop_client.db import Source, User
 from securedrop_client.gui.auth import LoginDialog
 from securedrop_client.gui.widgets import LeftPane, MainView, TopPane
@@ -48,7 +48,6 @@ class Window(QMainWindow):
     def __init__(
         self,
         app_state: Optional[state.State] = None,
-        export_service: Optional[export.Service] = None,
     ) -> None:
         """
         Create the default start state. The window contains a root widget into
@@ -77,7 +76,7 @@ class Window(QMainWindow):
         layout.setSpacing(0)
         self.main_pane.setLayout(layout)
         self.left_pane = LeftPane()
-        self.main_view = MainView(self.main_pane, app_state, export_service)
+        self.main_view = MainView(self.main_pane, app_state)
         layout.addWidget(self.left_pane)
         layout.addWidget(self.main_view)
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -75,6 +75,7 @@ from securedrop_client.gui.actions import (
     DeleteConversationAction,
     DeleteSourceAction,
     DownloadConversation,
+    ExportConversationAction,
     PrintConversationAction,
 )
 from securedrop_client.gui.base import SecureQLabel, SvgLabel, SvgPushButton, SvgToggleButton
@@ -3400,6 +3401,7 @@ class SourceMenu(QMenu):
         self.setStyleSheet(self.SOURCE_MENU_CSS)
 
         self.addAction(DownloadConversation(self, self.controller, app_state))
+        self.addAction(ExportConversationAction(self, self.controller, self.source, export_service))
         self.addAction(PrintConversationAction(self, self.controller, self.source, export_service))
         self.addAction(
             DeleteConversationAction(

--- a/securedrop_client/locale/messages.pot
+++ b/securedrop_client/locale/messages.pot
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Print Conversation Transcript"
 msgstr ""
 
+msgid "Export Conversation Transcript"
+msgstr ""
+
 msgid "SecureDrop Client {}"
 msgstr ""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,6 +108,19 @@ def export_dialog(mocker, homedir):
 
 
 @pytest.fixture(scope="function")
+def export_transcript_dialog(mocker, homedir):
+    mocker.patch("PyQt5.QtWidgets.QApplication.activeWindow", return_value=QMainWindow())
+
+    export_device = mocker.MagicMock(spec=conversation.ExportDevice)
+
+    dialog = conversation.ExportTranscriptDialog(
+        export_device, "conversation.txt", "/some/path/conversation.txt"
+    )
+
+    yield dialog
+
+
+@pytest.fixture(scope="function")
 def i18n():
     """
     Set up locale/language/gettext functions. This enables the use of _().

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,7 +153,7 @@ def homedir(i18n):
 
 
 @pytest.fixture(scope="function")
-def export_service():
+def mock_export_service():
     """An export service that assumes the Qubes RPC calls are successful and skips them."""
     export_service = export.Service()
     # Ensure the export_service doesn't rely on Qubes OS:
@@ -166,16 +166,14 @@ def export_service():
 
 
 @pytest.fixture(scope="function")
-def functional_test_app_started_context(
-    homedir, reply_status_codes, session, config, qtbot, export_service
-):
+def functional_test_app_started_context(homedir, reply_status_codes, session, config, qtbot):
     """
     Returns a tuple containing the gui window and controller of a configured client. This should be
     used to for tests that need to start from the login dialog before the main application window
     is visible.
     """
     app_state = state.State()
-    gui = Window(app_state, export_service)
+    gui = Window(app_state)
     create_gpg_test_context(homedir)  # Configure test keys
     session_maker = make_session_maker(homedir)  # Configure and create the database
     controller = Controller(HOSTNAME, gui, session_maker, homedir, app_state, False, False)

--- a/tests/functional/test_export_dialog.py
+++ b/tests/functional/test_export_dialog.py
@@ -20,11 +20,15 @@ from tests.conftest import (
 
 @flaky
 @pytest.mark.vcr()
-def test_export_dialog(functional_test_logged_in_context, qtbot, mocker):
+def test_export_dialog(functional_test_logged_in_context, qtbot, mocker, mock_export_service):
     """
     Download a file, export it, and verify that the export is complete by checking that the label of
     the export dialog's continue button is "DONE".
     """
+    mocker.patch(
+        "securedrop_client.gui.conversation.export.device.export.getService",
+        return_value=mock_export_service,
+    )
     gui, controller = functional_test_logged_in_context
 
     def check_for_sources():

--- a/tests/gui/conversation/export/test_device.py
+++ b/tests/gui/conversation/export/test_device.py
@@ -13,7 +13,11 @@ def no_session():
     pass
 
 
-def test_Device_run_printer_preflight_checks(homedir, mocker, source, export_service):
+def test_Device_run_printer_preflight_checks(homedir, mocker, source, mock_export_service):
+    mocker.patch(
+        "securedrop_client.gui.conversation.export.device.export.getService",
+        return_value=mock_export_service,
+    )
     gui = mocker.MagicMock(spec=Window)
     with threads(3) as [sync_thread, main_queue_thread, file_download_queue_thread]:
         controller = Controller(
@@ -26,7 +30,7 @@ def test_Device_run_printer_preflight_checks(homedir, mocker, source, export_ser
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service)
+        device = Device(controller)
         print_preflight_check_requested_emissions = QSignalSpy(
             device.print_preflight_check_requested
         )
@@ -36,7 +40,11 @@ def test_Device_run_printer_preflight_checks(homedir, mocker, source, export_ser
         assert len(print_preflight_check_requested_emissions) == 1
 
 
-def test_Device_run_print_file(mocker, homedir, export_service):
+def test_Device_run_print_file(mocker, homedir, mock_export_service):
+    mocker.patch(
+        "securedrop_client.gui.conversation.export.device.export.getService",
+        return_value=mock_export_service,
+    )
     gui = mocker.MagicMock(spec=Window)
     with threads(3) as [sync_thread, main_queue_thread, file_download_queue_thread]:
         controller = Controller(
@@ -49,7 +57,7 @@ def test_Device_run_print_file(mocker, homedir, export_service):
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service)
+        device = Device(controller)
         print_requested_emissions = QSignalSpy(device.print_requested)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
@@ -64,7 +72,11 @@ def test_Device_run_print_file(mocker, homedir, export_service):
         assert len(print_requested_emissions) == 1
 
 
-def test_Device_print_transcript(mocker, homedir, export_service):
+def test_Device_print_transcript(mocker, homedir, mock_export_service):
+    mocker.patch(
+        "securedrop_client.gui.conversation.export.device.export.getService",
+        return_value=mock_export_service,
+    )
     gui = mocker.MagicMock(spec=Window)
     with threads(3) as [sync_thread, main_queue_thread, file_download_queue_thread]:
         controller = Controller(
@@ -77,7 +89,7 @@ def test_Device_print_transcript(mocker, homedir, export_service):
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service)
+        device = Device(controller)
         print_requested_emissions = QSignalSpy(device.print_requested)
 
         filepath = "some/file/path"
@@ -88,7 +100,11 @@ def test_Device_print_transcript(mocker, homedir, export_service):
         assert print_requested_emissions[0] == [["some/file/path"]]
 
 
-def test_Device_print_file_file_missing(homedir, mocker, session, export_service):
+def test_Device_print_file_file_missing(homedir, mocker, session, mock_export_service):
+    mocker.patch(
+        "securedrop_client.gui.conversation.export.device.export.getService",
+        return_value=mock_export_service,
+    )
     """
     If the file is missing from the data dir, is_downloaded should be set to False and the failure
     should be communicated to the user.
@@ -105,7 +121,7 @@ def test_Device_print_file_file_missing(homedir, mocker, session, export_service
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service)
+        device = Device(controller)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
         warning_logger = mocker.patch("securedrop_client.logic.logger.warning")
@@ -119,8 +135,12 @@ def test_Device_print_file_file_missing(homedir, mocker, session, export_service
 
 
 def test_Device_print_file_when_orig_file_already_exists(
-    homedir, config, mocker, source, export_service
+    homedir, config, mocker, source, mock_export_service
 ):
+    mocker.patch(
+        "securedrop_client.gui.conversation.export.device.export.getService",
+        return_value=mock_export_service,
+    )
     """
     The signal `print_requested` should still be emitted if the original file already exists.
     """
@@ -136,7 +156,7 @@ def test_Device_print_file_when_orig_file_already_exists(
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service)
+        device = Device(controller)
         file = factory.File(source=factory.Source())
         print_requested_emissions = QSignalSpy(device.print_requested)
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
@@ -148,7 +168,11 @@ def test_Device_print_file_when_orig_file_already_exists(
         controller.get_file.assert_called_with(file.uuid)
 
 
-def test_Device_run_export_preflight_checks(homedir, mocker, source, export_service):
+def test_Device_run_export_preflight_checks(homedir, mocker, source, mock_export_service):
+    mocker.patch(
+        "securedrop_client.gui.conversation.export.device.export.getService",
+        return_value=mock_export_service,
+    )
     gui = mocker.MagicMock(spec=Window)
     with threads(3) as [sync_thread, main_queue_thread, file_download_queue_thread]:
         controller = Controller(
@@ -161,7 +185,7 @@ def test_Device_run_export_preflight_checks(homedir, mocker, source, export_serv
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service)
+        device = Device(controller)
         export_preflight_check_requested_emissions = QSignalSpy(
             device.export_preflight_check_requested
         )
@@ -173,7 +197,11 @@ def test_Device_run_export_preflight_checks(homedir, mocker, source, export_serv
         assert len(export_preflight_check_requested_emissions) == 1
 
 
-def test_Device_export_file_to_usb_drive(homedir, mocker, export_service):
+def test_Device_export_file_to_usb_drive(homedir, mocker, mock_export_service):
+    mocker.patch(
+        "securedrop_client.gui.conversation.export.device.export.getService",
+        return_value=mock_export_service,
+    )
     """
     The signal `export_requested` should be emitted during export_file_to_usb_drive.
     """
@@ -189,7 +217,7 @@ def test_Device_export_file_to_usb_drive(homedir, mocker, export_service):
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service)
+        device = Device(controller)
         export_requested_emissions = QSignalSpy(device.export_requested)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
@@ -204,7 +232,13 @@ def test_Device_export_file_to_usb_drive(homedir, mocker, export_service):
         assert len(export_requested_emissions) == 1
 
 
-def test_Device_export_file_to_usb_drive_file_missing(homedir, mocker, session, export_service):
+def test_Device_export_file_to_usb_drive_file_missing(
+    homedir, mocker, session, mock_export_service
+):
+    mocker.patch(
+        "securedrop_client.gui.conversation.export.device.export.getService",
+        return_value=mock_export_service,
+    )
     """
     If the file is missing from the data dir, is_downloaded should be set to False and the failure
     should be communicated to the user.
@@ -221,7 +255,7 @@ def test_Device_export_file_to_usb_drive_file_missing(homedir, mocker, session, 
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service)
+        device = Device(controller)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
         warning_logger = mocker.patch("securedrop_client.logic.logger.warning")
@@ -235,8 +269,12 @@ def test_Device_export_file_to_usb_drive_file_missing(homedir, mocker, session, 
 
 
 def test_Device_export_file_to_usb_drive_when_orig_file_already_exists(
-    homedir, config, mocker, source, export_service
+    homedir, config, mocker, source, mock_export_service
 ):
+    mocker.patch(
+        "securedrop_client.gui.conversation.export.device.export.getService",
+        return_value=mock_export_service,
+    )
     """
     The signal `export_requested` should still be emitted if the original file already exists.
     """
@@ -252,7 +290,7 @@ def test_Device_export_file_to_usb_drive_when_orig_file_already_exists(
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service)
+        device = Device(controller)
         export_requested_emissions = QSignalSpy(device.export_requested)
         file = factory.File(source=factory.Source())
         mocker.patch("securedrop_client.logic.Controller.get_file", return_value=file)
@@ -264,7 +302,11 @@ def test_Device_export_file_to_usb_drive_when_orig_file_already_exists(
         controller.get_file.assert_called_with(file.uuid)
 
 
-def test_Device_export_transcript(mocker, homedir, export_service):
+def test_Device_export_transcript(mocker, homedir, mock_export_service):
+    mocker.patch(
+        "securedrop_client.gui.conversation.export.device.export.getService",
+        return_value=mock_export_service,
+    )
     gui = mocker.MagicMock(spec=Window)
     with threads(3) as [sync_thread, main_queue_thread, file_download_queue_thread]:
         controller = Controller(
@@ -277,7 +319,7 @@ def test_Device_export_transcript(mocker, homedir, export_service):
             main_queue_thread=main_queue_thread,
             file_download_queue_thread=file_download_queue_thread,
         )
-        device = Device(controller, export_service)
+        device = Device(controller)
         export_requested_emissions = QSignalSpy(device.export_requested)
 
         filepath = "some/file/path"

--- a/tests/gui/conversation/export/test_device.py
+++ b/tests/gui/conversation/export/test_device.py
@@ -262,3 +262,27 @@ def test_Device_export_file_to_usb_drive_when_orig_file_already_exists(
 
         assert len(export_requested_emissions) == 1
         controller.get_file.assert_called_with(file.uuid)
+
+
+def test_Device_export_transcript(mocker, homedir, export_service):
+    gui = mocker.MagicMock(spec=Window)
+    with threads(3) as [sync_thread, main_queue_thread, file_download_queue_thread]:
+        controller = Controller(
+            "http://localhost",
+            gui,
+            no_session,
+            homedir,
+            None,
+            sync_thread=sync_thread,
+            main_queue_thread=main_queue_thread,
+            file_download_queue_thread=file_download_queue_thread,
+        )
+        device = Device(controller, export_service)
+        export_requested_emissions = QSignalSpy(device.export_requested)
+
+        filepath = "some/file/path"
+
+        device.export_transcript(filepath, "passphrase")
+
+        assert len(export_requested_emissions) == 1
+        assert export_requested_emissions[0] == [["some/file/path"], "passphrase"]

--- a/tests/gui/conversation/export/test_transcript_dialog.py
+++ b/tests/gui/conversation/export/test_transcript_dialog.py
@@ -1,0 +1,351 @@
+from securedrop_client.export import ExportError, ExportStatus
+from securedrop_client.gui.conversation import ExportTranscriptDialog
+from tests.helper import app  # noqa: F401
+
+
+def test_TranscriptDialog_init(mocker):
+    _show_starting_instructions_fn = mocker.patch(
+        "securedrop_client.gui.conversation.ExportTranscriptDialog._show_starting_instructions"
+    )
+
+    export_transcript_dialog = ExportTranscriptDialog(
+        mocker.MagicMock(), "conversation.txt", "/some/path/conversation.txt"
+    )
+
+    _show_starting_instructions_fn.assert_called_once_with()
+    assert export_transcript_dialog.passphrase_form.isHidden()
+
+
+def test_TranscriptDialog_init_sanitizes_filename(mocker):
+    secure_qlabel = mocker.patch("securedrop_client.gui.conversation.export.dialog.SecureQLabel")
+    mocker.patch("securedrop_client.gui.widgets.QVBoxLayout.addWidget")
+    filename = '<script>alert("boom!");</script>'
+
+    ExportTranscriptDialog(mocker.MagicMock(), filename, "/some/path/conversation.txt")
+
+    secure_qlabel.assert_any_call(filename, wordwrap=False, max_length=260)
+
+
+def test_TranscriptDialog__show_starting_instructions(mocker, export_transcript_dialog):
+    export_transcript_dialog._show_starting_instructions()
+
+    # conversation.txt comes from the export_transcript_dialog fixture
+    assert (
+        export_transcript_dialog.header.text() == "Preparing to export:"
+        "<br />"
+        '<span style="font-weight:normal">conversation.txt</span>'
+    )
+    assert (
+        export_transcript_dialog.body.text()
+        == "<h2>Understand the risks before exporting files</h2>"
+        "<b>Malware</b>"
+        "<br />"
+        "This workstation lets you open files securely. If you open files on another "
+        "computer, any embedded malware may spread to your computer or network. If you are "
+        "unsure how to manage this risk, please print the file, or contact your "
+        "administrator."
+        "<br /><br />"
+        "<b>Anonymity</b>"
+        "<br />"
+        "Files submitted by sources may contain information or hidden metadata that "
+        "identifies who they are. To protect your sources, please consider redacting files "
+        "before working with them on network-connected computers."
+    )
+    assert not export_transcript_dialog.header.isHidden()
+    assert not export_transcript_dialog.header_line.isHidden()
+    assert export_transcript_dialog.error_details.isHidden()
+    assert not export_transcript_dialog.body.isHidden()
+    assert export_transcript_dialog.passphrase_form.isHidden()
+    assert not export_transcript_dialog.continue_button.isHidden()
+    assert not export_transcript_dialog.cancel_button.isHidden()
+
+
+def test_TranscriptDialog___show_passphrase_request_message(mocker, export_transcript_dialog):
+    export_transcript_dialog._show_passphrase_request_message()
+
+    assert export_transcript_dialog.header.text() == "Enter passphrase for USB drive"
+    assert not export_transcript_dialog.header.isHidden()
+    assert export_transcript_dialog.header_line.isHidden()
+    assert export_transcript_dialog.error_details.isHidden()
+    assert export_transcript_dialog.body.isHidden()
+    assert not export_transcript_dialog.passphrase_form.isHidden()
+    assert not export_transcript_dialog.continue_button.isHidden()
+    assert not export_transcript_dialog.cancel_button.isHidden()
+
+
+def test_TranscriptDialog__show_passphrase_request_message_again(mocker, export_transcript_dialog):
+    export_transcript_dialog._show_passphrase_request_message_again()
+
+    assert export_transcript_dialog.header.text() == "Enter passphrase for USB drive"
+    assert (
+        export_transcript_dialog.error_details.text()
+        == "The passphrase provided did not work. Please try again."
+    )
+    assert export_transcript_dialog.body.isHidden()
+    assert not export_transcript_dialog.header.isHidden()
+    assert export_transcript_dialog.header_line.isHidden()
+    assert not export_transcript_dialog.error_details.isHidden()
+    assert export_transcript_dialog.body.isHidden()
+    assert not export_transcript_dialog.passphrase_form.isHidden()
+    assert not export_transcript_dialog.continue_button.isHidden()
+    assert not export_transcript_dialog.cancel_button.isHidden()
+
+
+def test_TranscriptDialog__show_success_message(mocker, export_transcript_dialog):
+    export_transcript_dialog._show_success_message()
+
+    assert export_transcript_dialog.header.text() == "Export successful"
+    assert (
+        export_transcript_dialog.body.text()
+        == "Remember to be careful when working with files outside of your Workstation machine."
+    )
+    assert not export_transcript_dialog.header.isHidden()
+    assert not export_transcript_dialog.header_line.isHidden()
+    assert export_transcript_dialog.error_details.isHidden()
+    assert not export_transcript_dialog.body.isHidden()
+    assert export_transcript_dialog.passphrase_form.isHidden()
+    assert not export_transcript_dialog.continue_button.isHidden()
+    assert export_transcript_dialog.cancel_button.isHidden()
+
+
+def test_TranscriptDialog__show_insert_usb_message(mocker, export_transcript_dialog):
+    export_transcript_dialog._show_insert_usb_message()
+
+    assert export_transcript_dialog.header.text() == "Insert encrypted USB drive"
+    assert (
+        export_transcript_dialog.body.text()
+        == "Please insert one of the export drives provisioned specifically "
+        "for the SecureDrop Workstation."
+    )
+    assert not export_transcript_dialog.header.isHidden()
+    assert not export_transcript_dialog.header_line.isHidden()
+    assert export_transcript_dialog.error_details.isHidden()
+    assert not export_transcript_dialog.body.isHidden()
+    assert export_transcript_dialog.passphrase_form.isHidden()
+    assert not export_transcript_dialog.continue_button.isHidden()
+    assert not export_transcript_dialog.cancel_button.isHidden()
+
+
+def test_TranscriptDialog__show_insert_encrypted_usb_message(mocker, export_transcript_dialog):
+    export_transcript_dialog._show_insert_encrypted_usb_message()
+
+    assert export_transcript_dialog.header.text() == "Insert encrypted USB drive"
+    assert (
+        export_transcript_dialog.error_details.text()
+        == "Either the drive is not encrypted or there is something else wrong with it."
+    )
+    assert (
+        export_transcript_dialog.body.text()
+        == "Please insert one of the export drives provisioned specifically for the SecureDrop "
+        "Workstation."
+    )
+    assert not export_transcript_dialog.header.isHidden()
+    assert not export_transcript_dialog.header_line.isHidden()
+    assert not export_transcript_dialog.error_details.isHidden()
+    assert not export_transcript_dialog.body.isHidden()
+    assert export_transcript_dialog.passphrase_form.isHidden()
+    assert not export_transcript_dialog.continue_button.isHidden()
+    assert not export_transcript_dialog.cancel_button.isHidden()
+
+
+def test_TranscriptDialog__show_generic_error_message(mocker, export_transcript_dialog):
+    export_transcript_dialog.error_status = "mock_error_status"
+
+    export_transcript_dialog._show_generic_error_message()
+
+    assert export_transcript_dialog.header.text() == "Export failed"
+    assert (
+        export_transcript_dialog.body.text()
+        == "mock_error_status: See your administrator for help."
+    )
+    assert not export_transcript_dialog.header.isHidden()
+    assert not export_transcript_dialog.header_line.isHidden()
+    assert export_transcript_dialog.error_details.isHidden()
+    assert not export_transcript_dialog.body.isHidden()
+    assert export_transcript_dialog.passphrase_form.isHidden()
+    assert not export_transcript_dialog.continue_button.isHidden()
+    assert not export_transcript_dialog.cancel_button.isHidden()
+
+
+def test_TranscriptDialog__export_transcript(mocker, export_transcript_dialog):
+    device = mocker.MagicMock()
+    device.export_transcript = mocker.MagicMock()
+    export_transcript_dialog._device = device
+    export_transcript_dialog.passphrase_field.text = mocker.MagicMock(
+        return_value="mock_passphrase"
+    )
+
+    export_transcript_dialog._export_transcript()
+
+    device.export_transcript.assert_called_once_with(
+        "/some/path/conversation.txt", "mock_passphrase"
+    )
+
+
+def test_TranscriptDialog__on_export_preflight_check_succeeded(mocker, export_transcript_dialog):
+    export_transcript_dialog._show_passphrase_request_message = mocker.MagicMock()
+    export_transcript_dialog.continue_button = mocker.MagicMock()
+    export_transcript_dialog.continue_button.clicked = mocker.MagicMock()
+    mocker.patch.object(export_transcript_dialog.continue_button, "isEnabled", return_value=False)
+
+    export_transcript_dialog._on_export_preflight_check_succeeded()
+
+    export_transcript_dialog._show_passphrase_request_message.assert_not_called()
+    export_transcript_dialog.continue_button.clicked.connect.assert_called_once_with(
+        export_transcript_dialog._show_passphrase_request_message
+    )
+
+
+def test_TranscriptDialog__on_export_preflight_check_succeeded_when_continue_enabled(
+    mocker, export_transcript_dialog
+):
+    export_transcript_dialog._show_passphrase_request_message = mocker.MagicMock()
+    export_transcript_dialog.continue_button.setEnabled(True)
+
+    export_transcript_dialog._on_export_preflight_check_succeeded()
+
+    export_transcript_dialog._show_passphrase_request_message.assert_called_once_with()
+
+
+def test_TranscriptDialog__on_export_preflight_check_succeeded_enabled_after_preflight_success(
+    mocker, export_transcript_dialog
+):
+    assert not export_transcript_dialog.continue_button.isEnabled()
+    export_transcript_dialog._on_export_preflight_check_succeeded()
+    assert export_transcript_dialog.continue_button.isEnabled()
+
+
+def test_TranscriptDialog__on_export_preflight_check_succeeded_enabled_after_preflight_failure(
+    mocker, export_transcript_dialog
+):
+    assert not export_transcript_dialog.continue_button.isEnabled()
+    export_transcript_dialog._on_export_preflight_check_failed(mocker.MagicMock())
+    assert export_transcript_dialog.continue_button.isEnabled()
+
+
+def test_TranscriptDialog__on_export_preflight_check_failed(mocker, export_transcript_dialog):
+    export_transcript_dialog._update_dialog = mocker.MagicMock()
+
+    error = ExportError("mock_error_status")
+    export_transcript_dialog._on_export_preflight_check_failed(error)
+
+    export_transcript_dialog._update_dialog.assert_called_with("mock_error_status")
+
+
+def test_TranscriptDialog__on_export_succeeded(mocker, export_transcript_dialog):
+    export_transcript_dialog._show_success_message = mocker.MagicMock()
+
+    export_transcript_dialog._on_export_succeeded()
+
+    export_transcript_dialog._show_success_message.assert_called_once_with()
+
+
+def test_TranscriptDialog__on_export_failed(mocker, export_transcript_dialog):
+    export_transcript_dialog._update_dialog = mocker.MagicMock()
+
+    error = ExportError("mock_error_status")
+    export_transcript_dialog._on_export_failed(error)
+
+    export_transcript_dialog._update_dialog.assert_called_with("mock_error_status")
+
+
+def test_TranscriptDialog__update_dialog_when_status_is_USB_NOT_CONNECTED(
+    mocker, export_transcript_dialog
+):
+    export_transcript_dialog._show_insert_usb_message = mocker.MagicMock()
+    export_transcript_dialog.continue_button = mocker.MagicMock()
+    export_transcript_dialog.continue_button.clicked = mocker.MagicMock()
+    mocker.patch.object(export_transcript_dialog.continue_button, "isEnabled", return_value=False)
+
+    # When the continue button is enabled, ensure clicking continue will show next instructions
+    export_transcript_dialog._update_dialog(ExportStatus.USB_NOT_CONNECTED)
+    export_transcript_dialog.continue_button.clicked.connect.assert_called_once_with(
+        export_transcript_dialog._show_insert_usb_message
+    )
+
+    # When the continue button is enabled, ensure next instructions are shown
+    mocker.patch.object(export_transcript_dialog.continue_button, "isEnabled", return_value=True)
+    export_transcript_dialog._update_dialog(ExportStatus.USB_NOT_CONNECTED)
+    export_transcript_dialog._show_insert_usb_message.assert_called_once_with()
+
+
+def test_TranscriptDialog__update_dialog_when_status_is_BAD_PASSPHRASE(
+    mocker, export_transcript_dialog
+):
+    export_transcript_dialog._show_passphrase_request_message_again = mocker.MagicMock()
+    export_transcript_dialog.continue_button = mocker.MagicMock()
+    export_transcript_dialog.continue_button.clicked = mocker.MagicMock()
+    mocker.patch.object(export_transcript_dialog.continue_button, "isEnabled", return_value=False)
+
+    # When the continue button is enabled, ensure clicking continue will show next instructions
+    export_transcript_dialog._update_dialog(ExportStatus.BAD_PASSPHRASE)
+    export_transcript_dialog.continue_button.clicked.connect.assert_called_once_with(
+        export_transcript_dialog._show_passphrase_request_message_again
+    )
+
+    # When the continue button is enabled, ensure next instructions are shown
+    mocker.patch.object(export_transcript_dialog.continue_button, "isEnabled", return_value=True)
+    export_transcript_dialog._update_dialog(ExportStatus.BAD_PASSPHRASE)
+    export_transcript_dialog._show_passphrase_request_message_again.assert_called_once_with()
+
+
+def test_TranscriptDialog__update_dialog_when_status_DISK_ENCRYPTION_NOT_SUPPORTED_ERROR(
+    mocker, export_transcript_dialog
+):
+    export_transcript_dialog._show_insert_encrypted_usb_message = mocker.MagicMock()
+    export_transcript_dialog.continue_button = mocker.MagicMock()
+    export_transcript_dialog.continue_button.clicked = mocker.MagicMock()
+    mocker.patch.object(export_transcript_dialog.continue_button, "isEnabled", return_value=False)
+
+    # When the continue button is enabled, ensure clicking continue will show next instructions
+    export_transcript_dialog._update_dialog(ExportStatus.DISK_ENCRYPTION_NOT_SUPPORTED_ERROR)
+    export_transcript_dialog.continue_button.clicked.connect.assert_called_once_with(
+        export_transcript_dialog._show_insert_encrypted_usb_message
+    )
+
+    # When the continue button is enabled, ensure next instructions are shown
+    mocker.patch.object(export_transcript_dialog.continue_button, "isEnabled", return_value=True)
+    export_transcript_dialog._update_dialog(ExportStatus.DISK_ENCRYPTION_NOT_SUPPORTED_ERROR)
+    export_transcript_dialog._show_insert_encrypted_usb_message.assert_called_once_with()
+
+
+def test_TranscriptDialog__update_dialog_when_status_is_CALLED_PROCESS_ERROR(
+    mocker, export_transcript_dialog
+):
+    export_transcript_dialog._show_generic_error_message = mocker.MagicMock()
+    export_transcript_dialog.continue_button = mocker.MagicMock()
+    export_transcript_dialog.continue_button.clicked = mocker.MagicMock()
+    mocker.patch.object(export_transcript_dialog.continue_button, "isEnabled", return_value=False)
+
+    # When the continue button is enabled, ensure clicking continue will show next instructions
+    export_transcript_dialog._update_dialog(ExportStatus.CALLED_PROCESS_ERROR)
+    export_transcript_dialog.continue_button.clicked.connect.assert_called_once_with(
+        export_transcript_dialog._show_generic_error_message
+    )
+    assert export_transcript_dialog.error_status == ExportStatus.CALLED_PROCESS_ERROR
+
+    # When the continue button is enabled, ensure next instructions are shown
+    mocker.patch.object(export_transcript_dialog.continue_button, "isEnabled", return_value=True)
+    export_transcript_dialog._update_dialog(ExportStatus.CALLED_PROCESS_ERROR)
+    export_transcript_dialog._show_generic_error_message.assert_called_once_with()
+    assert export_transcript_dialog.error_status == ExportStatus.CALLED_PROCESS_ERROR
+
+
+def test_TranscriptDialog__update_dialog_when_status_is_unknown(mocker, export_transcript_dialog):
+    export_transcript_dialog._show_generic_error_message = mocker.MagicMock()
+    export_transcript_dialog.continue_button = mocker.MagicMock()
+    export_transcript_dialog.continue_button.clicked = mocker.MagicMock()
+    mocker.patch.object(export_transcript_dialog.continue_button, "isEnabled", return_value=False)
+
+    # When the continue button is enabled, ensure clicking continue will show next instructions
+    export_transcript_dialog._update_dialog("Some Unknown Error Status")
+    export_transcript_dialog.continue_button.clicked.connect.assert_called_once_with(
+        export_transcript_dialog._show_generic_error_message
+    )
+    assert export_transcript_dialog.error_status == "Some Unknown Error Status"
+
+    # When the continue button is enabled, ensure next instructions are shown
+    mocker.patch.object(export_transcript_dialog.continue_button, "isEnabled", return_value=True)
+    export_transcript_dialog._update_dialog("Some Unknown Error Status")
+    export_transcript_dialog._show_generic_error_message.assert_called_once_with()
+    assert export_transcript_dialog.error_status == "Some Unknown Error Status"

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -5,7 +5,7 @@ import unittest
 
 from PyQt5.QtWidgets import QHBoxLayout
 
-from securedrop_client import export, state
+from securedrop_client import state
 from securedrop_client.gui.main import Window
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_icon
@@ -38,12 +38,11 @@ def test_init(mocker):
     load_css = mocker.patch("securedrop_client.gui.main.load_css")
 
     app_state = state.State()
-    export_service = export.Service()
-    w = Window(app_state, export_service)
+    w = Window(app_state)
 
     mock_li.assert_called_once_with(w.icon)
     mock_lp.assert_called_once_with()
-    mock_mv.assert_called_once_with(w.main_pane, app_state, export_service)
+    mock_mv.assert_called_once_with(w.main_pane, app_state)
     assert mock_lo().addWidget.call_count == 2
     load_css.assert_called_once_with("sdclient.css")
 

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -4351,7 +4351,7 @@ def test_DeleteSource_from_source_menu_when_user_is_loggedout(mocker):
 
     mocker.patch("securedrop_client.gui.source.DeleteSourceDialog", mock_delete_source_dialog)
     source_menu = SourceMenu(mock_source, mock_controller, None)
-    source_menu.actions()[2].trigger()
+    source_menu.actions()[3].trigger()
     mock_delete_source_dialog_instance.exec.assert_not_called()
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,7 +11,11 @@ from tests import factory
 
 
 @pytest.fixture(scope="function")
-def main_window(mocker, homedir):
+def main_window(mocker, homedir, mock_export_service):
+    mocker.patch(
+        "securedrop_client.gui.conversation.export.device.export.getService",
+        return_value=mock_export_service,
+    )
     # Setup
     app = QApplication([])
     gui = Window()
@@ -63,7 +67,11 @@ def main_window(mocker, homedir):
 
 
 @pytest.fixture(scope="function")
-def main_window_no_key(mocker, homedir):
+def main_window_no_key(mocker, homedir, mock_export_service):
+    mocker.patch(
+        "securedrop_client.gui.conversation.export.device.export.getService",
+        return_value=mock_export_service,
+    )
     # Setup
     app = QApplication([])
     gui = Window()
@@ -146,7 +154,7 @@ def modal_dialog(mocker, homedir):
 
 
 @pytest.fixture(scope="function")
-def export_service():
+def mock_export_service():
     """An export service that assumes the Qubes RPC calls are successful and skips them."""
     export_service = export.Service()
     # Ensure the export_service doesn't rely on Qubes OS:
@@ -159,9 +167,13 @@ def export_service():
 
 
 @pytest.fixture(scope="function")
-def print_dialog(mocker, homedir, export_service):
+def print_dialog(mocker, homedir, mock_export_service):
+    mocker.patch(
+        "securedrop_client.gui.conversation.export.device.export.getService",
+        return_value=mock_export_service,
+    )
     app = QApplication([])
-    gui = Window(export_service=export_service)
+    gui = Window()
     app.setActiveWindow(gui)
     gui.show()
     with threads(3) as [sync_thread, main_queue_thread, file_download_thread]:
@@ -181,7 +193,7 @@ def print_dialog(mocker, homedir, export_service):
         )
         controller.authenticated_user = factory.User()
         controller.qubes = False
-        export_device = conversation.ExportDevice(controller, export_service)
+        export_device = conversation.ExportDevice(controller)
         gui.setup(controller)
         gui.login_dialog.close()
         dialog = conversation.PrintFileDialog(export_device, "file_uuid", "file_name")
@@ -194,9 +206,13 @@ def print_dialog(mocker, homedir, export_service):
 
 
 @pytest.fixture(scope="function")
-def export_dialog(mocker, homedir, export_service):
+def export_dialog(mocker, homedir, mock_export_service):
+    mocker.patch(
+        "securedrop_client.gui.conversation.export.device.export.getService",
+        return_value=mock_export_service,
+    )
     app = QApplication([])
-    gui = Window(export_service=export_service)
+    gui = Window()
     app.setActiveWindow(gui)
     gui.show()
     with threads(3) as [sync_thread, main_queue_thread, file_download_thread]:
@@ -213,7 +229,7 @@ def export_dialog(mocker, homedir, export_service):
         )
         controller.authenticated_user = factory.User()
         controller.qubes = False
-        export_device = conversation.ExportDevice(controller, export_service)
+        export_device = conversation.ExportDevice(controller)
         gui.setup(controller)
         gui.login_dialog.close()
         dialog = conversation.ExportFileDialog(export_device, "file_uuid", "file_name")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,7 +7,7 @@ import sys
 
 import pytest
 
-from securedrop_client import export, state
+from securedrop_client import state
 from securedrop_client.app import (
     DEFAULT_SDC_HOME,
     ENCODING,
@@ -139,8 +139,6 @@ def test_start_app(homedir, mocker):
     mock_args.proxy = False
     app_state = state.State()
     mocker.patch("securedrop_client.state.State", return_value=app_state)
-    export_service = export.Service()
-    mocker.patch("securedrop_client.export.Service", return_value=export_service)
 
     mocker.patch("securedrop_client.app.configure_logging")
     mock_app = mocker.patch("securedrop_client.app.QApplication")
@@ -154,7 +152,7 @@ def test_start_app(homedir, mocker):
     start_app(mock_args, mock_qt_args)
 
     mock_app.assert_called_once_with(mock_qt_args)
-    mock_win.assert_called_once_with(app_state, export_service)
+    mock_win.assert_called_once_with(app_state)
     mock_controller.assert_called_once_with(
         "http://localhost:8081/",
         mock_win(),

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,10 +1,38 @@
 import os
 import subprocess
+import unittest
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 import pytest
 
+from securedrop_client import export
 from securedrop_client.export import Export, ExportError, ExportStatus
+
+
+class TestService(unittest.TestCase):
+    def tearDown(self):
+        # ensure any changes to the export.Service instance are reset
+        # export.resetService()
+        pass
+
+    def test_service_is_unique(self):
+        service = export.getService()
+        same_service = export.getService()  # Act.
+
+        self.assertTrue(
+            service is same_service,
+            "expected successive calls to getService to return the same service, got different services",  # noqa: E501
+        )
+
+    def test_service_can_be_reset(self):
+        service = export.getService()
+        export.resetService()  # Act.
+        different_service = export.getService()
+
+        self.assertTrue(
+            different_service is not service,
+            "expected resetService to reset the service, got same service after reset",
+        )
 
 
 def test_run_printer_preflight(mocker):


### PR DESCRIPTION
## Description

The shortest path to providing an option to export a conversation transcript to journalists.

## Context

This is a direct continuation of #1621, the same context applies.

## Implementation

- Takes the existing _export dialog_ as a reference
- Follows the existing patterns for testing it

## Test plan

1. Start the app
2. Select a conversation
3. For good measure download a file or two
4. Trigger "Export Conversation Transcript" in the _conversation menu_ (a.k.a source menu, kebab menu...)
- [ ] Confirm that the dialog says it will export `conversation.txt`
- [ ] Confirm the file is exported as expected
- [ ] Confirm that error messages are shown in the same ways as in the existing export dialog

(I can provide guidance for a lightweight tests like I did for #1621, but since exporting doesn't depend on hard to get hardware, I think we should eventually test the feature using an actual USB drive. **Edit**: here is the [patch](https://github.com/freedomofpress/securedrop-client/commit/c3f6f80394b5567163747a094227469e88791a9a).)
