### PR TITLE
Update safety alerts: 51668 (sqlalchemy)

### DIFF
--- a/project.json
+++ b/project.json
@@ -1,0 +1,7 @@
+{
+    "variables": {
+        "SAFETY_IGNORE_IDS": [
+        "51668"
+    ]
+    }
+}


### PR DESCRIPTION
Relevant upstream PR: https://github.com/sqlalchemy/sqlalchemy/pull/8563

Does not affect us because we only use it with local SQLite databases. [We also ignore this in `securedrop`](https://github.com/freedomofpress/securedrop/blob/develop/project.json).

Just a configuration file for internal infrastructure, no testing required.
