### PR TITLE
Localise dates shown in UI using QTimeZone

### DIFF
--- a/securedrop_client/config.py
+++ b/securedrop_client/config.py
@@ -6,7 +6,6 @@ logger = logging.getLogger(__name__)
 
 
 class Config:
-
     CONFIG_NAME = "config.json"
 
     def __init__(self, journalist_key_fingerprint: str) -> None:

--- a/securedrop_client/crypto.py
+++ b/securedrop_client/crypto.py
@@ -32,7 +32,6 @@ logger = logging.getLogger(__name__)
 
 
 class CryptoError(Exception):
-
     pass
 
 
@@ -208,7 +207,6 @@ class GpgHelper:
         with tempfile.NamedTemporaryFile("w+") as content, tempfile.NamedTemporaryFile(
             "w+"
         ) as stdout, tempfile.NamedTemporaryFile("w+") as stderr:
-
             content.write(data)
             content.seek(0)
 

--- a/securedrop_client/db.py
+++ b/securedrop_client/db.py
@@ -45,7 +45,6 @@ def make_session_maker(home: str) -> scoped_session:
 
 
 class User(Base):
-
     __tablename__ = "users"
 
     id = Column(Integer, primary_key=True)
@@ -94,7 +93,6 @@ class DeletedUser(User):
 
 
 class Source(Base):
-
     __tablename__ = "sources"
 
     id = Column(Integer, primary_key=True)
@@ -200,7 +198,6 @@ class DeletedSource(Base):
 
 
 class Message(Base):
-
     __tablename__ = "messages"
     __table_args__ = (
         UniqueConstraint("source_id", "file_counter", name="uq_messages_source_id_file_counter"),
@@ -321,7 +318,6 @@ class Message(Base):
 
 
 class File(Base):
-
     __tablename__ = "files"
     __table_args__ = (
         UniqueConstraint("source_id", "file_counter", name="uq_messages_source_id_file_counter"),
@@ -425,7 +421,6 @@ class File(Base):
 
 
 class Reply(Base):
-
     __tablename__ = "replies"
     __table_args__ = (
         UniqueConstraint("source_id", "file_counter", name="uq_messages_source_id_file_counter"),
@@ -574,7 +569,6 @@ class DownloadError(Base):
 
 
 class DraftReply(Base):
-
     __tablename__ = "draftreplies"
 
     id = Column(Integer, primary_key=True)
@@ -646,7 +640,6 @@ class DraftReply(Base):
 
 
 class ReplySendStatus(Base):
-
     __tablename__ = "replysendstatuses"
 
     id = Column(Integer, primary_key=True)

--- a/securedrop_client/export.py
+++ b/securedrop_client/export.py
@@ -101,7 +101,6 @@ class Export(QObject):
         print_preflight_check_requested: Optional[pyqtBoundSignal] = None,
         print_requested: Optional[pyqtBoundSignal] = None,
     ) -> None:
-
         # This instance can optionally react to events to prevent
         # coupling it to dependent code.
         if export_preflight_check_requested is not None:

--- a/securedrop_client/gui/base/dialogs.py
+++ b/securedrop_client/gui/base/dialogs.py
@@ -37,7 +37,6 @@ from securedrop_client.resources import load_movie
 
 
 class ModalDialog(QDialog):
-
     DIALOG_CSS = resource_string(__name__, "dialogs.css").decode("utf-8")
     BUTTON_CSS = resource_string(__name__, "dialog_button.css").decode("utf-8")
     ERROR_DETAILS_CSS = resource_string(__name__, "dialog_message.css").decode("utf-8")

--- a/securedrop_client/gui/base/misc.py
+++ b/securedrop_client/gui/base/misc.py
@@ -149,7 +149,6 @@ class SvgLabel(QLabel):
 
 
 class SecureQLabel(QLabel):
-
     MAX_PREVIEW_LENGTH = 200
 
     def __init__(

--- a/securedrop_client/gui/conversation/export/dialog.py
+++ b/securedrop_client/gui/conversation/export/dialog.py
@@ -7,13 +7,8 @@ from .device import Device
 from .file_dialog import FileDialog
 
 
-class Dialog(FileDialog):
-    """Adapts the dialog used to export files to allow exporting a conversation.
-
-    - Adjust the init arguments to export multiple files.
-    - Adds a method to allow all those files to be exported.
-    - Overrides the two slots that handles the export action to call said method.
-    """
+class ExportDialog(ModalDialog):
+    DIALOG_CSS = resource_string(__name__, "dialog.css").decode("utf-8")
 
     def __init__(self, device: Device, summary: str, file_locations: List[str]) -> None:
         super().__init__(device, "", summary)

--- a/securedrop_client/gui/conversation/export/dialog.py
+++ b/securedrop_client/gui/conversation/export/dialog.py
@@ -7,8 +7,12 @@ from .device import Device
 from .file_dialog import FileDialog
 
 
-class ExportDialog(ModalDialog):
-    DIALOG_CSS = resource_string(__name__, "dialog.css").decode("utf-8")
+class Dialog(FileDialog):
+    """Adapts the dialog used to export files to allow exporting a conversation.
+    - Adjust the init arguments to export multiple files.
+    - Adds a method to allow all those files to be exported.
+    - Overrides the two slots that handles the export action to call said method.
+    """
 
     def __init__(self, device: Device, summary: str, file_locations: List[str]) -> None:
         super().__init__(device, "", summary)

--- a/securedrop_client/gui/conversation/export/print_dialog.py
+++ b/securedrop_client/gui/conversation/export/print_dialog.py
@@ -10,7 +10,6 @@ from .device import Device
 
 
 class PrintDialog(ModalDialog):
-
     FILENAME_WIDTH_PX = 260
 
     def __init__(self, device: Device, file_uuid: str, file_name: str) -> None:

--- a/securedrop_client/gui/datetime_helpers.py
+++ b/securedrop_client/gui/datetime_helpers.py
@@ -1,0 +1,31 @@
+"""
+Helper functions for formatting information in the UI
+
+"""
+import datetime
+
+import arrow
+from dateutil import tz
+from PyQt5.QtCore import QTimeZone
+
+
+def format_datetime_month_day(date: datetime.datetime) -> str:
+    """
+    Formats date as e.g. Sep 16
+    """
+    return arrow.get(date).format("MMM D")
+
+
+def localise_datetime(date: datetime.datetime) -> datetime.datetime:
+    """
+    Localise the datetime object to the timezone specified, otherwise use the system timezone
+    """
+    local_timezone = str(QTimeZone.systemTimeZoneId(), encoding="utf-8")
+    return arrow.get(date).to(tz.gettz(local_timezone)).datetime
+
+
+def format_datetime_local(date: datetime.datetime) -> str:
+    """
+    Localise date and return as a string in the format e.g. Sep 16
+    """
+    return format_datetime_month_day(localise_datetime(date))

--- a/securedrop_client/gui/datetime_helpers.py
+++ b/securedrop_client/gui/datetime_helpers.py
@@ -18,7 +18,7 @@ def format_datetime_month_day(date: datetime.datetime) -> str:
 
 def localise_datetime(date: datetime.datetime) -> datetime.datetime:
     """
-    Localise the datetime object to the timezone specified, otherwise use the system timezone
+    Localise the datetime object to system timezone
     """
     local_timezone = str(QTimeZone.systemTimeZoneId(), encoding="utf-8")
     return arrow.get(date).to(tz.gettz(local_timezone)).datetime

--- a/securedrop_client/gui/datetime_helpers.py
+++ b/securedrop_client/gui/datetime_helpers.py
@@ -20,7 +20,7 @@ def localise_datetime(date: datetime.datetime) -> datetime.datetime:
     """
     Localise the datetime object to system timezone
     """
-    local_timezone = str(QTimeZone.systemTimeZoneId(), encoding="utf-8")
+    local_timezone = QTimeZone.systemTimeZoneId().data().decode("utf-8")
     return arrow.get(date).to(tz.gettz(local_timezone)).datetime
 
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -734,7 +734,6 @@ class MainView(QWidget):
 
 
 class EmptyConversationView(QWidget):
-
     MARGIN = 30
     NEWLINE_HEIGHT_PX = 35
 
@@ -2488,7 +2487,6 @@ class FileWidget(QWidget):
 
 
 class ConversationScrollArea(QScrollArea):
-
     MARGIN_BOTTOM = 28
     MARGIN_LEFT = 38
     MARGIN_RIGHT = 20
@@ -3269,7 +3267,6 @@ class ReplyTextEdit(QPlainTextEdit):
 
 
 class ReplyTextEditPlaceholder(QWidget):
-
     # These values are used to determine the width that can be taken up by
     # the source designation as the widget is initialized or the window is
     # resized.

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -81,6 +81,7 @@ from securedrop_client.gui.actions import (
 )
 from securedrop_client.gui.base import SecureQLabel, SvgLabel, SvgPushButton, SvgToggleButton
 from securedrop_client.gui.conversation import DeleteConversationDialog
+from securedrop_client.gui.datetime_helpers import format_datetime_local
 from securedrop_client.gui.source import DeleteSourceDialog
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_css, load_icon, load_image, load_movie
@@ -1331,7 +1332,7 @@ class SourceWidget(QWidget):
         try:
             self.controller.session.refresh(self.source)
             self.last_updated = self.source.last_updated
-            self.timestamp.setText(_(arrow.get(self.source.last_updated).format("MMM D")))
+            self.timestamp.setText(_(format_datetime_local(self.source.last_updated)))
             self.name.setText(self.source.journalist_designation)
 
             self.set_snippet(self.source_uuid)
@@ -3483,7 +3484,7 @@ class SourceProfileShortWidget(QWidget):
             self.MARGIN_LEFT, self.VERTICAL_MARGIN, self.MARGIN_RIGHT, self.VERTICAL_MARGIN
         )
         title = TitleLabel(self.source.journalist_designation)
-        self.updated = LastUpdatedLabel(_(arrow.get(self.source.last_updated).format("MMM D")))
+        self.updated = LastUpdatedLabel(_(format_datetime_local(self.source.last_updated)))
         menu = SourceMenuButton(self.source, self.controller, app_state)
         header_layout.addWidget(title, alignment=Qt.AlignLeft)
         header_layout.addStretch()
@@ -3504,4 +3505,4 @@ class SourceProfileShortWidget(QWidget):
         Ensure the timestamp is always kept up to date with the latest activity
         from the source.
         """
-        self.updated.setText(_(arrow.get(self.source.last_updated).format("MMM D")))
+        self.updated.setText(_(format_datetime_local(self.source.last_updated)))

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -829,7 +829,6 @@ class Controller(QObject):
     def _submit_download_job(
         self, object_type: Union[Type[db.Reply], Type[db.Message], Type[db.File]], uuid: str
     ) -> None:
-
         if object_type == db.Reply:
             job = ReplyDownloadJob(
                 uuid, self.data_dir, self.gpg

--- a/securedrop_client/storage.py
+++ b/securedrop_client/storage.py
@@ -442,7 +442,6 @@ def __update_submissions(
     source_cache = SourceCache(session)
 
     for submission in remote_submissions:
-
         # If submission belongs to a locally-deleted source, skip it
         if submission.source_uuid in skip_uuids_deleted_source:
             logger.debug(
@@ -497,7 +496,6 @@ def __update_submissions(
     # check if we have left empty directories behind after deletion.
     deleted_submission_directory_names = set()
     for deleted_submission in local_submissions_by_uuid.values():
-
         deleted_submission_directory_names.add(deleted_submission.source.journalist_filename)
 
         # The local method could have deleted these files and submissions already
@@ -609,7 +607,6 @@ def update_replies(
     user_cache: Dict[str, User] = {}
     source_cache = SourceCache(session)
     for reply in remote_replies:
-
         # If the source account was just deleted locally (and is either deleted or scheduled
         # for deletion on the server), we don't want this reply
         if reply.source_uuid in skip_uuids_deleted_source:
@@ -991,7 +988,6 @@ def delete_local_conversation_by_source_uuid(session: Session, uuid: str, data_d
     """
     source = session.query(Source).filter_by(uuid=uuid).one_or_none()
     if source:
-
         # Delete all source files on disk
         logger.debug("Delete files on disk for source {} from local database.".format(uuid))
         delete_source_collection(source.journalist_filename, data_dir)

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -40,7 +40,6 @@ def User(**attrs):
 
 
 def Source(**attrs):
-
     with open(os.path.join(os.path.dirname(__file__), "files", "test-key.gpg.pub.asc")) as f:
         pub_key = f.read()
 

--- a/tests/gui/test_datetime_helpers.py
+++ b/tests/gui/test_datetime_helpers.py
@@ -1,11 +1,39 @@
 import datetime
 
-from securedrop_client.gui.datetime_helpers import format_datetime_month_day
+from dateutil import tz
+from PyQt5.QtCore import QByteArray
+
+from securedrop_client.gui.datetime_helpers import (
+    format_datetime_local,
+    format_datetime_month_day,
+    localise_datetime,
+)
 
 
 def test_format_datetime_month_day():
-    # Dates are shown in the source list as well as the conversation view. Changing the date format may result in UI
-    # issues - this test is a reminder to check both views!
+    # Dates are shown in the source list as well as the conversation view. Changing the date format
+    # may result in UI issues - this test is a reminder to check both views!
     midnight_january_london = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
 
     assert format_datetime_month_day(midnight_january_london) == "Jan 1"
+
+
+def test_localise_datetime(mocker):
+    mocker.patch(
+        "securedrop_client.gui.datetime_helpers.QTimeZone.systemTimeZoneId",
+        return_value=QByteArray(b"Pacific/Auckland"),
+    )
+    evening_january_1_london = datetime.datetime(2023, 1, 1, 18, 0, 0, tzinfo=datetime.timezone.utc)
+    morning_january_2_auckland = datetime.datetime(
+        2023, 1, 2, 7, 0, 0, tzinfo=tz.gettz("Pacific/Auckland")
+    )
+    assert localise_datetime(evening_january_1_london) == morning_january_2_auckland
+
+
+def test_format_datetime_local(mocker):
+    mocker.patch(
+        "securedrop_client.gui.datetime_helpers.QTimeZone.systemTimeZoneId",
+        return_value=QByteArray(b"Pacific/Auckland"),
+    )
+    evening_january_1_london = datetime.datetime(2023, 1, 1, 18, 0, 0, tzinfo=datetime.timezone.utc)
+    assert format_datetime_local(evening_january_1_london) == "Jan 2"

--- a/tests/gui/test_datetime_helpers.py
+++ b/tests/gui/test_datetime_helpers.py
@@ -1,0 +1,11 @@
+import datetime
+
+from securedrop_client.gui.datetime_helpers import format_datetime_month_day
+
+
+def test_format_datetime_month_day():
+    # Dates are shown in the source list as well as the conversation view. Changing the date format may result in UI issues -
+    # this test is a reminder to check both views!
+    midnight_january_london = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+
+    assert format_datetime_month_day(midnight_january_london) == "Jan 1"

--- a/tests/gui/test_datetime_helpers.py
+++ b/tests/gui/test_datetime_helpers.py
@@ -4,8 +4,8 @@ from securedrop_client.gui.datetime_helpers import format_datetime_month_day
 
 
 def test_format_datetime_month_day():
-    # Dates are shown in the source list as well as the conversation view. Changing the date format may result in UI issues -
-    # this test is a reminder to check both views!
+    # Dates are shown in the source list as well as the conversation view. Changing the date format may result in UI
+    # issues - this test is a reminder to check both views!
     midnight_january_london = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
 
     assert format_datetime_month_day(midnight_january_london) == "Jan 1"

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from gettext import gettext as _
 from unittest.mock import Mock, PropertyMock
 
-import arrow
 import sqlalchemy
 import sqlalchemy.orm.exc
 from PyQt5.QtCore import QEvent, QPointF, QSize, Qt
@@ -18,6 +17,7 @@ from sqlalchemy.orm import attributes, scoped_session, sessionmaker
 
 from securedrop_client import db, logic, storage
 from securedrop_client.app import threads
+from securedrop_client.gui.format_helpers import format_datetime_local
 from securedrop_client.gui.source import DeleteSourceDialog
 from securedrop_client.gui.widgets import (
     ActivityStatusBar,
@@ -3749,7 +3749,7 @@ def test_SourceConversationWrapper_on_conversation_updated(mocker, qtbot):
 
     scw.conversation_view.add_file(file=file, index=1)
 
-    expected_timestamp = arrow.get(source.last_updated).format("MMM D")
+    expected_timestamp = format_datetime_local(source.last_updated)
 
     def check_timestamp():
         assert scw.conversation_title_bar.updated.text() == expected_timestamp
@@ -5223,9 +5223,7 @@ def test_SourceProfileShortWidget_update_timestamp(mocker):
     spsw = SourceProfileShortWidget(mock_source, mock_controller, None)
     spsw.updated = mocker.MagicMock()
     spsw.update_timestamp()
-    spsw.updated.setText.assert_called_once_with(
-        arrow.get(mock_source.last_updated).format("MMM D")
-    )
+    spsw.updated.setText.assert_called_once_with(format_datetime_local(mock_source.last_updated))
 
 
 def test_SenderIcon_for_deleted_user(mocker):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import attributes, scoped_session, sessionmaker
 
 from securedrop_client import db, logic, storage
 from securedrop_client.app import threads
-from securedrop_client.gui.format_helpers import format_datetime_local
+from securedrop_client.gui.datetime_helpers import format_datetime_local
 from securedrop_client.gui.source import DeleteSourceDialog
 from securedrop_client.gui.widgets import (
     ActivityStatusBar,

--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -70,7 +70,7 @@ def get_schema(session):
 
 
 def assert_schemas_equal(left, right):
-    for (k, v) in left.items():
+    for k, v in left.items():
         if k not in right:
             raise AssertionError("Left contained {} but right did not".format(k))
         if not ddl_equal(v, right[k]):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -178,7 +178,6 @@ PERMISSIONS_CASES = [
 
 
 def test_create_app_dir_permissions(tmpdir, mocker):
-
     for idx, case in enumerate(PERMISSIONS_CASES):
         mock_session_maker = mocker.MagicMock()
         mock_args = mocker.MagicMock()

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -8,7 +8,6 @@ from securedrop_client import db as database
 
 class TestConversationTranscript(unittest.TestCase):
     def setUp(self):
-
         source = database.Source(
             journalist_designation="happy-bird",
         )

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1158,7 +1158,6 @@ def test_create_client_dir_permissions(tmpdir, mocker, session_maker):
 
 
 def test_Controller_download_conversation(homedir, config, session, mocker, session_maker):
-
     app_state = state.State()
     gui = mocker.MagicMock()
     co = Controller("http://localhost", gui, session_maker, homedir, app_state)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1812,7 +1812,7 @@ def test_mark_pending_replies_as_failed(mocker, session, reply_status_codes):
 
     mark_all_pending_drafts_as_failed(session)
 
-    for (i, draft) in enumerate(session.query(db.DraftReply).all()):
+    for i, draft in enumerate(session.query(db.DraftReply).all()):
         if i == 0:
             assert draft.send_status == pending_status
         else:
@@ -2377,7 +2377,6 @@ def test__delete_source_collection_from_db_uuid_not_found(mocker, homedir):
 
 
 def test__delete_source_collection_from_db_query_error(mocker, session):
-
     mock_session = mocker.MagicMock()
     mock_session.query().filter_by().all.return_value = [mocker.MagicMock()]
     mock_session.query().filter_by().one_or_none.side_effect = SQLAlchemyError()
@@ -2402,7 +2401,6 @@ def test__delete_source_collection_from_db_query_error(mocker, session):
 
 
 def test__delete_source_collection_from_db_commit_error(mocker, session):
-
     mock_session = mocker.MagicMock()
     mock_session.commit.return_value = [mocker.MagicMock()]
     mock_session.commit.side_effect = SQLAlchemyError()


### PR DESCRIPTION
# Description
Currently dates are shown in securedrop-client in UTC. This change localises them. 

The motivation for this came out of working on https://github.com/freedomofpress/securedrop-client/issues/1563 - after adding timestamps I noticed that they were in UTC. This change doesn't add timestamps - it keeps the existing date format, just localised. 

I've just added a single unit test for this the 'datetime to MMM DD' bit - happy to add some tests for the other functions too if desirable (I'd either need to mock out QTimeZone or pass in timezone as an optional argument)

# Test Plan
I tested these changes on my qubes workstation by manually changing the timezone of `sd-app`:

`sudo timedatectl set-timezone 'Pacific/Auckland'`

These are the dates in the UI I expect to update:

<img width="1454" alt="Screenshot 2023-02-13 at 16 08 30" src="https://user-images.githubusercontent.com/3606555/218510825-d004388f-804d-4b19-b39d-67d612a322e1.png">


# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
