### PR TITLE
Show full timestamp of last source activity

### DIFF
--- a/securedrop_client/gui/datetime_helpers.py
+++ b/securedrop_client/gui/datetime_helpers.py
@@ -9,11 +9,11 @@ from dateutil import tz
 from PyQt5.QtCore import QTimeZone
 
 
-def format_datetime_month_day(date: datetime.datetime) -> str:
+def format_datetime_month_day_time(date: datetime.datetime) -> str:
     """
-    Formats date as e.g. Sep 16
+    Formats datetime as e.g. Sep 16, 23:35
     """
-    return arrow.get(date).format("MMM D")
+    return arrow.get(date).format("MMM D, HH:mm")
 
 
 def localise_datetime(date: datetime.datetime) -> datetime.datetime:
@@ -21,11 +21,10 @@ def localise_datetime(date: datetime.datetime) -> datetime.datetime:
     Localise the datetime object to system timezone
     """
     local_timezone = str(QTimeZone.systemTimeZoneId(), encoding="utf-8")
-    return arrow.get(date).to(tz.gettz(local_timezone)).datetime
-
+    return arrow.get(date).to(tz.gettz(local_timezone))
 
 def format_datetime_local(date: datetime.datetime) -> str:
     """
-    Localise date and return as a string in the format e.g. Sep 16
+    Localise date and return as a string in the format e.g. Sep 16 10:15
     """
-    return format_datetime_month_day(localise_datetime(date))
+    return format_datetime_month_day_time(localise_datetime(date))

--- a/securedrop_client/gui/datetime_helpers.py
+++ b/securedrop_client/gui/datetime_helpers.py
@@ -1,0 +1,31 @@
+"""
+Helper functions for formatting information in the UI
+
+"""
+import datetime
+
+import arrow
+from dateutil import tz
+from PyQt5.QtCore import QTimeZone
+
+
+def format_datetime_month_day(date: datetime.datetime) -> str:
+    """
+    Formats date as e.g. Sep 16
+    """
+    return arrow.get(date).format("MMM D")
+
+
+def localise_datetime(date: datetime.datetime) -> datetime.datetime:
+    """
+    Localise the datetime object to the timezone specified, otherwise use the system timezone
+    """
+    local_timezone = str(QTimeZone.systemTimeZoneId(), encoding="utf-8")
+    return arrow.get(date).to(tz.gettz(local_timezone)).datetime
+
+
+def format_datetime_local(date: datetime.datetime) -> str:
+    """
+    Localise date and return as a string in the format e.g. Sep 16
+    """
+    return format_datetime_month_day(localise_datetime(date))

--- a/securedrop_client/gui/datetime_helpers.py
+++ b/securedrop_client/gui/datetime_helpers.py
@@ -18,7 +18,7 @@ def format_datetime_month_day(date: datetime.datetime) -> str:
 
 def localise_datetime(date: datetime.datetime) -> datetime.datetime:
     """
-    Localise the datetime object to the timezone specified, otherwise use the system timezone
+    Localise the datetime object to system timezone
     """
     local_timezone = str(QTimeZone.systemTimeZoneId(), encoding="utf-8")
     return arrow.get(date).to(tz.gettz(local_timezone)).datetime

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -80,6 +80,7 @@ from securedrop_client.gui.actions import (
 )
 from securedrop_client.gui.base import SecureQLabel, SvgLabel, SvgPushButton, SvgToggleButton
 from securedrop_client.gui.conversation import DeleteConversationDialog
+from securedrop_client.gui.datetime_helpers import format_datetime_local
 from securedrop_client.gui.source import DeleteSourceDialog
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_css, load_icon, load_image, load_movie
@@ -1330,7 +1331,7 @@ class SourceWidget(QWidget):
         try:
             self.controller.session.refresh(self.source)
             self.last_updated = self.source.last_updated
-            self.timestamp.setText(_(arrow.get(self.source.last_updated).format("MMM D")))
+            self.timestamp.setText(_(format_datetime_local(self.source.last_updated)))
             self.name.setText(self.source.journalist_designation)
 
             self.set_snippet(self.source_uuid)
@@ -3481,7 +3482,7 @@ class SourceProfileShortWidget(QWidget):
             self.MARGIN_LEFT, self.VERTICAL_MARGIN, self.MARGIN_RIGHT, self.VERTICAL_MARGIN
         )
         title = TitleLabel(self.source.journalist_designation)
-        self.updated = LastUpdatedLabel(_(arrow.get(self.source.last_updated).format("MMM D")))
+        self.updated = LastUpdatedLabel(_(format_datetime_local(self.source.last_updated)))
         menu = SourceMenuButton(self.source, self.controller, app_state)
         header_layout.addWidget(title, alignment=Qt.AlignLeft)
         header_layout.addStretch()
@@ -3502,4 +3503,4 @@ class SourceProfileShortWidget(QWidget):
         Ensure the timestamp is always kept up to date with the latest activity
         from the source.
         """
-        self.updated.setText(_(arrow.get(self.source.last_updated).format("MMM D")))
+        self.updated.setText(_(format_datetime_local(self.source.last_updated)))

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -92,6 +92,7 @@ logger = logging.getLogger(__name__)
 
 MINIMUM_ANIMATION_DURATION_IN_MILLISECONDS = 300
 NO_DELAY = 1
+LAST_UPDATED_LABEL_TOOLTIP = "Time of last activity from source"
 
 
 class TopPane(QWidget):
@@ -1204,7 +1205,7 @@ class SourceWidget(QWidget):
     SPACER = 14
     BOTTOM_SPACER = 11
     STAR_WIDTH = 20
-    TIMESTAMP_WIDTH = 60
+    TIMESTAMP_WIDTH = 70
 
     SOURCE_NAME_CSS = load_css("source_name.css")
     SOURCE_PREVIEW_CSS = load_css("source_preview.css")
@@ -1273,6 +1274,7 @@ class SourceWidget(QWidget):
         self.timestamp.setSizePolicy(retain_space)
         self.timestamp.setFixedWidth(self.TIMESTAMP_WIDTH)
         self.timestamp.setObjectName("SourceWidget_timestamp")
+        self.timestamp.setToolTip(LAST_UPDATED_LABEL_TOOLTIP)
 
         # Create source_widget:
         # -------------------------------------------------------------------
@@ -1295,11 +1297,11 @@ class SourceWidget(QWidget):
         self.spacer.setFixedWidth(self.SPACER)
         source_widget_layout.addWidget(self.spacer, 0, 1, 1, 1)
         source_widget_layout.addWidget(self.name, 0, 2, 1, 1)
-        source_widget_layout.addWidget(self.paperclip, 0, 3, 1, 1)
+        source_widget_layout.addWidget(self.paperclip, 0, 3, 1, 1, alignment=Qt.AlignRight)
         source_widget_layout.addWidget(self.paperclip_disabled, 0, 3, 1, 1)
         source_widget_layout.addWidget(self.preview, 1, 2, 1, 1, alignment=Qt.AlignLeft)
         source_widget_layout.addWidget(self.deletion_indicator, 1, 2, 1, 1)
-        source_widget_layout.addWidget(self.timestamp, 1, 3, 1, 1)
+        source_widget_layout.addWidget(self.timestamp, 1, 3, 1, 1, alignment=Qt.AlignRight)
         source_widget_layout.addItem(QSpacerItem(self.BOTTOM_SPACER, self.BOTTOM_SPACER))
         self.source_widget.setLayout(source_widget_layout)
         layout = QHBoxLayout(self)
@@ -3442,6 +3444,7 @@ class LastUpdatedLabel(QLabel):
 
         # Set CSS id
         self.setObjectName("LastUpdatedLabel")
+        self.setToolTip(LAST_UPDATED_LABEL_TOOLTIP)
 
 
 class SourceProfileShortWidget(QWidget):

--- a/securedrop_client/resources/css/source_timestamp.css
+++ b/securedrop_client/resources/css/source_timestamp.css
@@ -1,14 +1,14 @@
 #SourceWidget_timestamp {
     font-family: 'Montserrat';
     font-weight: 500;
-    font-size: 13px;
+    font-size: 11px;
     color: #383838;
 }
 
 #SourceWidget_timestamp_unread {
     font-family: 'Montserrat';
     font-weight: 600;
-    font-size: 13px;
+    font-size: 11px;
     color: #000;
 }
 

--- a/tests/gui/test_datetime_helpers.py
+++ b/tests/gui/test_datetime_helpers.py
@@ -1,14 +1,18 @@
 import datetime
-import pytz
 from dateutil import tz
 
-from securedrop_client.gui.datetime_helpers import localise_datetime, format_datetime_local, format_datetime_month_day_time
+from PyQt5.QtCore import QByteArray
+
+from securedrop_client.gui.datetime_helpers import (
+    localise_datetime,
+    format_datetime_local,
+    format_datetime_month_day_time
+)
 
 
-
-def test_format_datetime_month_day():
-    # Dates are shown in the source list as well as the conversation view. Changing the date format may result in UI
-    # issues - this test is a reminder to check both views!
+def test_format_datetime_month_day_time():
+    # Dates are shown in the source list as well as the conversation view. Changing the date format
+    # may result in UI issues - this test is a reminder to check both views!
     midnight_january_london = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
     assert format_datetime_month_day_time(midnight_january_london) == "Jan 1, 00:00"
 
@@ -25,6 +29,7 @@ def test_format_datetime_local(mocker):
     mocker.patch("securedrop_client.gui.datetime_helpers.QTimeZone.systemTimeZoneId",
                  return_value=QByteArray(b"Pacific/Auckland"))
     evening_january_1_london = datetime.datetime(2023, 1, 1, 18, 0, 0, tzinfo=datetime.timezone.utc)
-    assert format_datetime_local(evening_january_1_london) == "Jan 2"
+    assert format_datetime_local(evening_january_1_london) == "Jan 2, 07:00"
+
 
 

--- a/tests/gui/test_datetime_helpers.py
+++ b/tests/gui/test_datetime_helpers.py
@@ -1,11 +1,34 @@
 import datetime
+from dateutil import tz
 
-from securedrop_client.gui.datetime_helpers import format_datetime_month_day
+from PyQt5.QtCore import QByteArray
+
+from securedrop_client.gui.datetime_helpers import (
+    localise_datetime,
+    format_datetime_local,
+    format_datetime_month_day
+)
 
 
 def test_format_datetime_month_day():
-    # Dates are shown in the source list as well as the conversation view. Changing the date format may result in UI
-    # issues - this test is a reminder to check both views!
+    # Dates are shown in the source list as well as the conversation view. Changing the date format
+    # may result in UI issues - this test is a reminder to check both views!
     midnight_january_london = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
 
     assert format_datetime_month_day(midnight_january_london) == "Jan 1"
+
+
+def test_localise_datetime(mocker):
+    mocker.patch("securedrop_client.gui.datetime_helpers.QTimeZone.systemTimeZoneId",
+                 return_value=QByteArray(b"Pacific/Auckland"))
+    evening_january_1_london = datetime.datetime(2023, 1, 1, 18, 0, 0, tzinfo=datetime.timezone.utc)
+    morning_january_2_auckland = datetime.datetime(2023, 1, 2, 7, 0, 0,
+                                                   tzinfo=tz.gettz("Pacific/Auckland"))
+    assert localise_datetime(evening_january_1_london) == morning_january_2_auckland
+
+
+def test_format_datetime_local(mocker):
+    mocker.patch("securedrop_client.gui.datetime_helpers.QTimeZone.systemTimeZoneId",
+                 return_value=QByteArray(b"Pacific/Auckland"))
+    evening_january_1_london = datetime.datetime(2023, 1, 1, 18, 0, 0, tzinfo=datetime.timezone.utc)
+    assert format_datetime_local(evening_january_1_london) == "Jan 2"

--- a/tests/gui/test_datetime_helpers.py
+++ b/tests/gui/test_datetime_helpers.py
@@ -1,0 +1,11 @@
+import datetime
+
+from securedrop_client.gui.datetime_helpers import format_datetime_month_day
+
+
+def test_format_datetime_month_day():
+    # Dates are shown in the source list as well as the conversation view. Changing the date format may result in UI issues -
+    # this test is a reminder to check both views!
+    midnight_january_london = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+
+    assert format_datetime_month_day(midnight_january_london) == "Jan 1"

--- a/tests/gui/test_datetime_helpers.py
+++ b/tests/gui/test_datetime_helpers.py
@@ -4,8 +4,8 @@ from securedrop_client.gui.datetime_helpers import format_datetime_month_day
 
 
 def test_format_datetime_month_day():
-    # Dates are shown in the source list as well as the conversation view. Changing the date format may result in UI issues -
-    # this test is a reminder to check both views!
+    # Dates are shown in the source list as well as the conversation view. Changing the date format may result in UI
+    # issues - this test is a reminder to check both views!
     midnight_january_london = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
 
     assert format_datetime_month_day(midnight_january_london) == "Jan 1"

--- a/tests/gui/test_datetime_helpers.py
+++ b/tests/gui/test_datetime_helpers.py
@@ -1,29 +1,23 @@
 import datetime
+import pytz
 from dateutil import tz
 
-from PyQt5.QtCore import QByteArray
+from securedrop_client.gui.datetime_helpers import localise_datetime, format_datetime_local, format_datetime_month_day_time
 
-from securedrop_client.gui.datetime_helpers import (
-    localise_datetime,
-    format_datetime_local,
-    format_datetime_month_day
-)
 
 
 def test_format_datetime_month_day():
-    # Dates are shown in the source list as well as the conversation view. Changing the date format
-    # may result in UI issues - this test is a reminder to check both views!
+    # Dates are shown in the source list as well as the conversation view. Changing the date format may result in UI
+    # issues - this test is a reminder to check both views!
     midnight_january_london = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-
-    assert format_datetime_month_day(midnight_january_london) == "Jan 1"
+    assert format_datetime_month_day_time(midnight_january_london) == "Jan 1, 00:00"
 
 
 def test_localise_datetime(mocker):
     mocker.patch("securedrop_client.gui.datetime_helpers.QTimeZone.systemTimeZoneId",
                  return_value=QByteArray(b"Pacific/Auckland"))
     evening_january_1_london = datetime.datetime(2023, 1, 1, 18, 0, 0, tzinfo=datetime.timezone.utc)
-    morning_january_2_auckland = datetime.datetime(2023, 1, 2, 7, 0, 0,
-                                                   tzinfo=tz.gettz("Pacific/Auckland"))
+    morning_january_2_auckland = datetime.datetime(2023, 1, 2, 7, 0, 0, tzinfo=tz.gettz("Pacific/Auckland"))
     assert localise_datetime(evening_january_1_london) == morning_january_2_auckland
 
 
@@ -32,3 +26,5 @@ def test_format_datetime_local(mocker):
                  return_value=QByteArray(b"Pacific/Auckland"))
     evening_january_1_london = datetime.datetime(2023, 1, 1, 18, 0, 0, tzinfo=datetime.timezone.utc)
     assert format_datetime_local(evening_january_1_london) == "Jan 2"
+
+

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from gettext import gettext as _
 from unittest.mock import Mock, PropertyMock
 
-import arrow
 import sqlalchemy
 import sqlalchemy.orm.exc
 from PyQt5.QtCore import QEvent, QPointF, QSize, Qt
@@ -18,6 +17,7 @@ from sqlalchemy.orm import attributes, scoped_session, sessionmaker
 
 from securedrop_client import db, logic, storage
 from securedrop_client.app import threads
+from securedrop_client.gui.format_helpers import format_datetime_local
 from securedrop_client.gui.source import DeleteSourceDialog
 from securedrop_client.gui.widgets import (
     ActivityStatusBar,
@@ -3749,7 +3749,7 @@ def test_SourceConversationWrapper_on_conversation_updated(mocker, qtbot):
 
     scw.conversation_view.add_file(file=file, index=1)
 
-    expected_timestamp = arrow.get(source.last_updated).format("MMM D")
+    expected_timestamp = format_datetime_local(source.last_updated)
 
     def check_timestamp():
         assert scw.conversation_title_bar.updated.text() == expected_timestamp
@@ -5223,9 +5223,7 @@ def test_SourceProfileShortWidget_update_timestamp(mocker):
     spsw = SourceProfileShortWidget(mock_source, mock_controller, None)
     spsw.updated = mocker.MagicMock()
     spsw.update_timestamp()
-    spsw.updated.setText.assert_called_once_with(
-        arrow.get(mock_source.last_updated).format("MMM D")
-    )
+    spsw.updated.setText.assert_called_once_with(format_datetime_local(mock_source.last_updated))
 
 
 def test_SenderIcon_for_deleted_user(mocker):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import attributes, scoped_session, sessionmaker
 
 from securedrop_client import db, logic, storage
 from securedrop_client.app import threads
-from securedrop_client.gui.format_helpers import format_datetime_local
+from securedrop_client.gui.datetime_helpers import format_datetime_local
 from securedrop_client.gui.source import DeleteSourceDialog
 from securedrop_client.gui.widgets import (
     ActivityStatusBar,


### PR DESCRIPTION
# Description
Fixes https://github.com/freedomofpress/securedrop-client/issues/1563

Building on https://github.com/freedomofpress/securedrop-client/pull/1626 this change modifies securedrop-client so that it shows the full timestamp rather than just the date of the last source activity. 

Once concern noted elsewhere about this date is that it is not the last updated (as the user would expect) - it's the last source activity time. I've added a tooltip to this effect but I don't think that's sufficient. However, we're already showing the date, adding the time doesn't make it any more 'wrong' so this feels like a helpful improvement.

I've got two other date/time related PRs stacked up:
 - https://github.com/freedomofpress/securedrop-client/pull/1626 (has been partly reviewed)
 - https://github.com/guardian/securedrop-client/pull/8 (currently against our fork whilst waiting on the above)

With that in mind, I think we could merge this to our fork potentially and bundle with our next release, whilst separately proposing changes to the main freedomofpress repo once those other changes have been discussed/approved.

# Test Plan
I've tested this on qubes and macos
Qubes:

![20230215_121511](https://user-images.githubusercontent.com/3606555/219025747-d1111453-57e4-4b9a-ad8f-4d4a78a8ff2d.jpg)

Macos:

<img width="1455" alt="Screenshot 2023-02-15 at 12 20 17" src="https://user-images.githubusercontent.com/3606555/219025933-bdc71fa6-743c-41bc-895f-682d5023a5e9.png">


# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
