### PR TITLE
Add sections to conversation menu, download files prior to conversation export

### DIFF
--- a/securedrop_client/export.py
+++ b/securedrop_client/export.py
@@ -230,7 +230,7 @@ class Export(QObject):
             grand_parent_path, parent_name = os.path.split(parent_path)
             grand_parent_name = os.path.split(grand_parent_path)[1]
             arcname = os.path.join("export_data", grand_parent_name, parent_name, filename)
-            if filename == "conversation.txt":
+            if filename == "transcript.txt":
                 arcname = os.path.join("export_data", parent_name, filename)
 
         archive.add(filepath, arcname=arcname, recursive=False)

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -276,28 +276,25 @@ class ExportConversationAction(QAction):  # pragma: nocover
         alongside all the (attached) files that are downloaded, in the manner
         of the existing ExportFileDialog.
         """
-        if self.controller.api is None:
-            self.controller.on_action_requiring_login()
-        else:
-            if self._state is not None:
-                id = self._state.selected_conversation
-                if id is None:
-                    return
-                if self._state.selected_conversation_has_downloadable_files:
-                    dialog = ModalDialog(show_header=False)
-                    message = _(
-                        "<h2>Some files will not be exported</h2>"
-                        "Some files from this source have not yet been downloaded, and will not be exported."  # noqa: E501
-                        "<br /><br />"
-                        'To export the currently-downloaded files, click "Continue."'
-                    )
-                    dialog.body.setText(message)
-                    dialog.rejected.connect(self._on_confirmation_dialog_rejected)
-                    dialog.accepted.connect(self._on_confirmation_dialog_accepted)
-                    dialog.continue_button.setFocus()
-                    dialog.exec()
-                else:
-                    self._prepare_to_export()
+        if self._state is not None:
+            id = self._state.selected_conversation
+            if id is None:
+                return
+            if self._state.selected_conversation_has_downloadable_files:
+                dialog = ModalDialog(show_header=False)
+                message = _(
+                    "<h2>Some files will not be exported</h2>"
+                    "Some files from this source have not yet been downloaded, and will not be exported."  # noqa: E501
+                    "<br /><br />"
+                    'To export the currently-downloaded files, click "Continue."'
+                )
+                dialog.body.setText(message)
+                dialog.rejected.connect(self._on_confirmation_dialog_rejected)
+                dialog.accepted.connect(self._on_confirmation_dialog_accepted)
+                dialog.continue_button.setFocus()
+                dialog.exec()
+            else:
+                self._prepare_to_export()
 
     def _prepare_to_export(self) -> None:
         """

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -167,9 +167,6 @@ class PrintConversationAction(QAction):  # pragma: nocover
         (Re-)generates the conversation transcript and opens a confirmation dialog to print it,
         in the manner of the existing PrintDialog.
         """
-        if self.controller.api is None:
-            self.controller.on_action_requiring_login()
-
         file_path = (
             Path(self.controller.data_dir)
             .joinpath(self._source.journalist_filename)
@@ -222,9 +219,6 @@ class ExportConversationTranscriptAction(QAction):  # pragma: nocover
         (Re-)generates the conversation transcript and opens a confirmation dialog to export it,
         in the manner of the existing ExportFileDialog.
         """
-        if self.controller.api is None:
-            self.controller.on_action_requiring_login()
-
         file_path = (
             Path(self.controller.data_dir)
             .joinpath(self._source.journalist_filename)

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -319,7 +319,7 @@ class ExportConversationAction(QAction):  # pragma: nocover
             if file_count == 1:
                 summary = "conversation.txt"
             else:
-                summary = _("{file_count} files").format(file_count=file_count)
+                summary = _("all files and transcript")
 
             dialog = ExportConversationDialog(
                 self._export_device,

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -256,6 +256,7 @@ class ExportConversationAction(QAction):  # pragma: nocover
         parent: QMenu,
         controller: Controller,
         source: Source,
+        app_state: Optional[state.State] = None,
     ) -> None:
         """
         Allows export of a conversation transcript and all is files. Will download any file
@@ -267,6 +268,7 @@ class ExportConversationAction(QAction):  # pragma: nocover
 
         self.controller = controller
         self._source = source
+        self._state = app_state
 
         self._export_device = ConversationExportDevice(controller)
 
@@ -281,6 +283,12 @@ class ExportConversationAction(QAction):  # pragma: nocover
         """
         if self.controller.api is None:
             self.controller.on_action_requiring_login()
+        else:
+            if self._state is not None:
+                id = self._state.selected_conversation
+                if id is None:
+                    return
+                self.controller.download_conversation(id)
 
         transcript_location = (
             Path(self.controller.data_dir)

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -150,7 +150,7 @@ class PrintConversationAction(QAction):  # pragma: nocover
         """
         Allows printing of a conversation transcript.
         """
-        text = _("Print Conversation Transcript")
+        text = _("Print All Messages")
 
         super().__init__(text, parent)
 
@@ -202,7 +202,7 @@ class ExportConversationTranscriptAction(QAction):  # pragma: nocover
         """
         Allows export of a conversation transcript.
         """
-        text = _("Export Conversation Transcript")
+        text = _("Export All Messages")
 
         super().__init__(text, parent)
 
@@ -254,7 +254,7 @@ class ExportConversationAction(QAction):  # pragma: nocover
         """
         Allows export of a conversation transcript.
         """
-        text = _("Export Conversation")
+        text = _("Export All Files and Messages")
 
         super().__init__(text, parent)
 

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -35,7 +35,7 @@ class DownloadConversation(QAction):
     ) -> None:
         self._controller = controller
         self._state = app_state
-        self._text = _("Download All Files")
+        self._text = _("Download All")
         super().__init__(self._text, parent)
         self.setShortcut(Qt.CTRL + Qt.Key_D)
         self.triggered.connect(self.on_triggered)
@@ -150,7 +150,7 @@ class PrintConversationAction(QAction):  # pragma: nocover
         """
         Allows printing of a conversation transcript.
         """
-        text = _("Print All Messages")
+        text = _("Print Transcript")
 
         super().__init__(text, parent)
 
@@ -205,7 +205,7 @@ class ExportConversationTranscriptAction(QAction):  # pragma: nocover
         """
         Allows export of a conversation transcript.
         """
-        text = _("Export All Messages")
+        text = _("Export Transcript")
 
         super().__init__(text, parent)
 
@@ -262,7 +262,7 @@ class ExportConversationAction(QAction):  # pragma: nocover
         Allows export of a conversation transcript and all is files. Will download any file
         that wasn't already downloaded.
         """
-        text = _("Export All Files and Messages")
+        text = _("Export All")
 
         super().__init__(text, parent)
 

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -167,6 +167,9 @@ class PrintConversationAction(QAction):  # pragma: nocover
         (Re-)generates the conversation transcript and opens a confirmation dialog to print it,
         in the manner of the existing PrintDialog.
         """
+        if self.controller.api is None:
+            self.controller.on_action_requiring_login()
+
         file_path = (
             Path(self.controller.data_dir)
             .joinpath(self._source.journalist_filename)
@@ -219,6 +222,9 @@ class ExportConversationTranscriptAction(QAction):  # pragma: nocover
         (Re-)generates the conversation transcript and opens a confirmation dialog to export it,
         in the manner of the existing ExportFileDialog.
         """
+        if self.controller.api is None:
+            self.controller.on_action_requiring_login()
+
         file_path = (
             Path(self.controller.data_dir)
             .joinpath(self._source.journalist_filename)
@@ -252,7 +258,8 @@ class ExportConversationAction(QAction):  # pragma: nocover
         source: Source,
     ) -> None:
         """
-        Allows export of a conversation transcript.
+        Allows export of a conversation transcript and all is files. Will download any file
+        that wasn't already downloaded.
         """
         text = _("Export All Files and Messages")
 
@@ -272,6 +279,9 @@ class ExportConversationAction(QAction):  # pragma: nocover
         alongside all the (attached) files that are downloaded, in the manner
         of the existing ExportFileDialog.
         """
+        if self.controller.api is None:
+            self.controller.on_action_requiring_login()
+
         transcript_location = (
             Path(self.controller.data_dir)
             .joinpath(self._source.journalist_filename)

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -170,7 +170,7 @@ class PrintConversationAction(QAction):  # pragma: nocover
         file_path = (
             Path(self.controller.data_dir)
             .joinpath(self._source.journalist_filename)
-            .joinpath("conversation.txt")
+            .joinpath("transcript.txt")
         )
 
         transcript = ConversationTranscript(self._source)
@@ -187,7 +187,7 @@ class PrintConversationAction(QAction):  # pragma: nocover
         # by the operating system.
         with open(file_path, "r") as f:
             dialog = PrintConversationTranscriptDialog(
-                self._export_device, "conversation.txt", str(file_path)
+                self._export_device, "transcript.txt", str(file_path)
             )
             dialog.exec()
 
@@ -222,7 +222,7 @@ class ExportConversationTranscriptAction(QAction):  # pragma: nocover
         file_path = (
             Path(self.controller.data_dir)
             .joinpath(self._source.journalist_filename)
-            .joinpath("conversation.txt")
+            .joinpath("transcript.txt")
         )
 
         transcript = ConversationTranscript(self._source)
@@ -239,7 +239,7 @@ class ExportConversationTranscriptAction(QAction):  # pragma: nocover
         # by the operating system.
         with open(file_path, "r") as f:
             dialog = ExportConversationTranscriptDialog(
-                self._export_device, "conversation.txt", str(file_path)
+                self._export_device, "transcript.txt", str(file_path)
             )
             dialog.exec()
 
@@ -287,7 +287,7 @@ class ExportConversationAction(QAction):  # pragma: nocover
         transcript_location = (
             Path(self.controller.data_dir)
             .joinpath(self._source.journalist_filename)
-            .joinpath("conversation.txt")
+            .joinpath("transcript.txt")
         )
 
         transcript = ConversationTranscript(self._source)
@@ -317,7 +317,7 @@ class ExportConversationAction(QAction):  # pragma: nocover
 
             file_count = len(files)
             if file_count == 1:
-                summary = "conversation.txt"
+                summary = "transcript.txt"
             else:
                 summary = _("all files and transcript")
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3383,16 +3383,34 @@ class SourceMenu(QMenu):
         self.controller = controller
 
         self.setStyleSheet(self.SOURCE_MENU_CSS)
+        separator_font = QFont()
+        separator_font.setLetterSpacing(QFont.AbsoluteSpacing, 2)
+        separator_font.setBold(True)
+
+        messages_section = self.addSection(_("MESSAGES"))
+        messages_section.setFont(separator_font)
+
+        self.addAction(ExportConversationTranscriptAction(self, self.controller, self.source))
+        self.addAction(PrintConversationAction(self, self.controller, self.source))
+
+        files_section = self.addSection(_("FILES"))
+        files_section.setFont(separator_font)
 
         self.addAction(DownloadConversation(self, self.controller, app_state))
-        self.addAction(ExportConversationTranscriptAction(self, self.controller, self.source))
+
+        conversation_section = self.addSection(_("MESSAGES AND FILES"))
+        conversation_section.setFont(separator_font)
+
         self.addAction(ExportConversationAction(self, self.controller, self.source))
-        self.addAction(PrintConversationAction(self, self.controller, self.source))
         self.addAction(
             DeleteConversationAction(
                 self.source, self, self.controller, DeleteConversationDialog, app_state
             )
         )
+
+        source_section = self.addSection(_("SOURCE ACCOUNT"))
+        source_section.setFont(separator_font)
+
         self.addAction(DeleteSourceAction(self.source, self, self.controller, DeleteSourceDialog))
 
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3387,30 +3387,22 @@ class SourceMenu(QMenu):
         separator_font.setLetterSpacing(QFont.AbsoluteSpacing, 2)
         separator_font.setBold(True)
 
-        messages_section = self.addSection(_("MESSAGES"))
+        messages_section = self.addSection(_("FILES AND MESSAGES"))
         messages_section.setFont(separator_font)
 
+        self.addAction(DownloadConversation(self, self.controller, app_state))
+        self.addAction(ExportConversationAction(self, self.controller, self.source, app_state))
         self.addAction(ExportConversationTranscriptAction(self, self.controller, self.source))
         self.addAction(PrintConversationAction(self, self.controller, self.source))
 
-        files_section = self.addSection(_("FILES"))
-        files_section.setFont(separator_font)
+        source_section = self.addSection(_("SOURCE ACCOUNT"))
+        source_section.setFont(separator_font)
 
-        self.addAction(DownloadConversation(self, self.controller, app_state))
-
-        conversation_section = self.addSection(_("MESSAGES AND FILES"))
-        conversation_section.setFont(separator_font)
-
-        self.addAction(ExportConversationAction(self, self.controller, self.source, app_state))
         self.addAction(
             DeleteConversationAction(
                 self.source, self, self.controller, DeleteConversationDialog, app_state
             )
         )
-
-        source_section = self.addSection(_("SOURCE ACCOUNT"))
-        source_section.setFont(separator_font)
-
         self.addAction(DeleteSourceAction(self.source, self, self.controller, DeleteSourceDialog))
 
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -3401,7 +3401,7 @@ class SourceMenu(QMenu):
         conversation_section = self.addSection(_("MESSAGES AND FILES"))
         conversation_section.setFont(separator_font)
 
-        self.addAction(ExportConversationAction(self, self.controller, self.source))
+        self.addAction(ExportConversationAction(self, self.controller, self.source, app_state))
         self.addAction(
             DeleteConversationAction(
                 self.source, self, self.controller, DeleteConversationDialog, app_state

--- a/securedrop_client/locale/messages.pot
+++ b/securedrop_client/locale/messages.pot
@@ -94,7 +94,7 @@ msgstr ""
 msgid "Export All"
 msgstr ""
 
-msgid "{file_count} files"
+msgid "all files and transcript"
 msgstr ""
 
 msgid "SecureDrop Client {}"

--- a/securedrop_client/locale/messages.pot
+++ b/securedrop_client/locale/messages.pot
@@ -76,7 +76,7 @@ msgstr ""
 msgid "File: %(filename)s"
 msgstr ""
 
-msgid "Download All Files"
+msgid "Download All"
 msgstr ""
 
 msgid "Delete Source Account"
@@ -85,13 +85,13 @@ msgstr ""
 msgid "Delete All Files and Messages"
 msgstr ""
 
-msgid "Print All Messages"
+msgid "Print Transcript"
 msgstr ""
 
-msgid "Export All Messages"
+msgid "Export Transcript"
 msgstr ""
 
-msgid "Export All Files and Messages"
+msgid "Export All"
 msgstr ""
 
 msgid "{file_count} files"
@@ -192,13 +192,7 @@ msgstr ""
 msgid " to compose or send a reply"
 msgstr ""
 
-msgid "MESSAGES"
-msgstr ""
-
-msgid "FILES"
-msgstr ""
-
-msgid "MESSAGES AND FILES"
+msgid "FILES AND MESSAGES"
 msgstr ""
 
 msgid "SOURCE ACCOUNT"

--- a/securedrop_client/locale/messages.pot
+++ b/securedrop_client/locale/messages.pot
@@ -85,13 +85,13 @@ msgstr ""
 msgid "Delete All Files and Messages"
 msgstr ""
 
-msgid "Print Conversation Transcript"
+msgid "Print All Messages"
 msgstr ""
 
-msgid "Export Conversation Transcript"
+msgid "Export All Messages"
 msgstr ""
 
-msgid "Export Conversation"
+msgid "Export All Files and Messages"
 msgstr ""
 
 msgid "{file_count} files"
@@ -190,6 +190,18 @@ msgid "Sign in"
 msgstr ""
 
 msgid " to compose or send a reply"
+msgstr ""
+
+msgid "MESSAGES"
+msgstr ""
+
+msgid "FILES"
+msgstr ""
+
+msgid "MESSAGES AND FILES"
+msgstr ""
+
+msgid "SOURCE ACCOUNT"
 msgstr ""
 
 msgid "Username"

--- a/securedrop_client/locale/messages.pot
+++ b/securedrop_client/locale/messages.pot
@@ -94,6 +94,9 @@ msgstr ""
 msgid "Export All"
 msgstr ""
 
+msgid "<h2>Some files will not be exported</h2>Some files from this source have not yet been downloaded, and will not be exported.<br /><br />To export the currently-downloaded files, click \"Continue.\""
+msgstr ""
+
 msgid "all files and transcript"
 msgstr ""
 

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -1066,13 +1066,19 @@ class Controller(QObject):
     @login_required
     def download_conversation(self, id: state.ConversationId) -> None:
         files = self._state.conversation_files(id)
+        file_count = len(files)
+        download_count = 0
         for file in files:
             if not file.is_downloaded:
+                download_count += 1
                 job = FileDownloadJob(str(file.id), self.data_dir, self.gpg)
                 job.success_signal.connect(self.on_file_download_success)
                 job.failure_signal.connect(self.on_file_download_failure)
                 self.add_job.emit(job)
                 self.file_download_started.emit(file.id)
+        logger.debug(
+            f"Downloaded {download_count} files, {file_count - download_count} were already downloaded (total: {file_count} files)"  # noqa: E501
+        )
 
     @login_required
     def send_reply(self, source_uuid: str, reply_uuid: str, message: str) -> None:

--- a/securedrop_client/resources/css/source_menu.css
+++ b/securedrop_client/resources/css/source_menu.css
@@ -1,7 +1,14 @@
 QMenu {
     font-family: 'Source Sans Pro';
-    padding: 0.5em 0;
+    padding: 0.5em 0 0.5em;
     font-size: 16px;
+}
+
+QMenu::separator {
+    margin: 0.75em 1.75em 0.5em 1.675em;
+    height: 1em;
+    font-weight: 900;
+    color: #b8c0de;
 }
 
 QMenu::item {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,7 @@ def print_transcript_dialog(mocker, homedir):
     export_device = mocker.MagicMock(spec=conversation.ExportDevice)
 
     dialog = conversation.PrintTranscriptDialog(
-        export_device, "conversation.txt", "some/path/conversation.txt"
+        export_device, "transcript.txt", "some/path/transcript.txt"
     )
 
     yield dialog
@@ -105,7 +105,7 @@ def export_dialog(mocker, homedir):
     dialog = conversation.ExportDialog(
         export_device,
         "3 files",
-        ["/some/path/file123.jpg", "/some/path/memo.txt", "/some/path/conversation.txt"],
+        ["/some/path/file123.jpg", "/some/path/memo.txt", "/some/path/transcript.txt"],
     )
 
     yield dialog
@@ -129,7 +129,7 @@ def export_transcript_dialog(mocker, homedir):
     export_device = mocker.MagicMock(spec=conversation.ExportDevice)
 
     dialog = conversation.ExportTranscriptDialog(
-        export_device, "conversation.txt", "/some/path/conversation.txt"
+        export_device, "transcript.txt", "/some/path/transcript.txt"
     )
 
     yield dialog

--- a/tests/gui/conversation/export/test_dialog.py
+++ b/tests/gui/conversation/export/test_dialog.py
@@ -9,7 +9,7 @@ def test_ExportDialog_init(mocker):
     )
 
     export_dialog = ExportDialog(
-        mocker.MagicMock(), "3 files", ["mock.jpg", "memo.txt", "conversation.txt"]
+        mocker.MagicMock(), "3 files", ["mock.jpg", "memo.txt", "transcript.txt"]
     )
 
     _show_starting_instructions_fn.assert_called_once_with()
@@ -162,7 +162,7 @@ def test_ExportDialog__export_files(mocker, export_dialog):
     export_dialog._export_files()
 
     device.export_files.assert_called_once_with(
-        ["/some/path/file123.jpg", "/some/path/memo.txt", "/some/path/conversation.txt"],
+        ["/some/path/file123.jpg", "/some/path/memo.txt", "/some/path/transcript.txt"],
         "mock_passphrase",
     )
 

--- a/tests/gui/conversation/export/test_print_transcript_dialog.py
+++ b/tests/gui/conversation/export/test_print_transcript_dialog.py
@@ -8,7 +8,7 @@ def test_PrintTranscriptDialog_init(mocker):
         "securedrop_client.gui.conversation.PrintTranscriptDialog._show_starting_instructions"
     )
 
-    PrintTranscriptDialog(mocker.MagicMock(), "conversation.txt", "/some/path/conversation.txt")
+    PrintTranscriptDialog(mocker.MagicMock(), "transcript.txt", "/some/path/transcript.txt")
 
     _show_starting_instructions_fn.assert_called_once_with()
 
@@ -19,7 +19,7 @@ def test_PrintTranscriptDialog_init_sanitizes_filename(mocker):
     )
     filename = '<script>alert("boom!");</script>'
 
-    PrintTranscriptDialog(mocker.MagicMock(), filename, "/some/path/conversation.txt")
+    PrintTranscriptDialog(mocker.MagicMock(), filename, "/some/path/transcript.txt")
 
     secure_qlabel.assert_any_call(filename, wordwrap=False, max_length=260)
 
@@ -27,11 +27,11 @@ def test_PrintTranscriptDialog_init_sanitizes_filename(mocker):
 def test_PrintTranscriptDialog__show_starting_instructions(mocker, print_transcript_dialog):
     print_transcript_dialog._show_starting_instructions()
 
-    # conversation.txt comes from the print_transcript_dialog fixture
+    # transcript.txt comes from the print_transcript_dialog fixture
     assert (
         print_transcript_dialog.header.text() == "Preparing to print:"
         "<br />"
-        '<span style="font-weight:normal">conversation.txt</span>'
+        '<span style="font-weight:normal">transcript.txt</span>'
     )
     assert (
         print_transcript_dialog.body.text() == "<h2>Managing printout risks</h2>"

--- a/tests/gui/conversation/export/test_transcript_dialog.py
+++ b/tests/gui/conversation/export/test_transcript_dialog.py
@@ -9,7 +9,7 @@ def test_TranscriptDialog_init(mocker):
     )
 
     export_transcript_dialog = ExportTranscriptDialog(
-        mocker.MagicMock(), "conversation.txt", "/some/path/conversation.txt"
+        mocker.MagicMock(), "transcript.txt", "/some/path/transcript.txt"
     )
 
     _show_starting_instructions_fn.assert_called_once_with()
@@ -23,7 +23,7 @@ def test_TranscriptDialog_init_sanitizes_filename(mocker):
     mocker.patch("securedrop_client.gui.widgets.QVBoxLayout.addWidget")
     filename = '<script>alert("boom!");</script>'
 
-    ExportTranscriptDialog(mocker.MagicMock(), filename, "/some/path/conversation.txt")
+    ExportTranscriptDialog(mocker.MagicMock(), filename, "/some/path/transcript.txt")
 
     secure_qlabel.assert_any_call(filename, wordwrap=False, max_length=260)
 
@@ -31,11 +31,11 @@ def test_TranscriptDialog_init_sanitizes_filename(mocker):
 def test_TranscriptDialog__show_starting_instructions(mocker, export_transcript_dialog):
     export_transcript_dialog._show_starting_instructions()
 
-    # conversation.txt comes from the export_transcript_dialog fixture
+    # transcript.txt comes from the export_transcript_dialog fixture
     assert (
         export_transcript_dialog.header.text() == "Preparing to export:"
         "<br />"
-        '<span style="font-weight:normal">conversation.txt</span>'
+        '<span style="font-weight:normal">transcript.txt</span>'
     )
     assert (
         export_transcript_dialog.body.text()
@@ -179,9 +179,7 @@ def test_TranscriptDialog__export_transcript(mocker, export_transcript_dialog):
 
     export_transcript_dialog._export_transcript()
 
-    device.export_transcript.assert_called_once_with(
-        "/some/path/conversation.txt", "mock_passphrase"
-    )
+    device.export_transcript.assert_called_once_with("/some/path/transcript.txt", "mock_passphrase")
 
 
 def test_TranscriptDialog__on_export_preflight_check_succeeded(mocker, export_transcript_dialog):

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -4351,7 +4351,7 @@ def test_DeleteSource_from_source_menu_when_user_is_loggedout(mocker):
 
     mocker.patch("securedrop_client.gui.source.DeleteSourceDialog", mock_delete_source_dialog)
     source_menu = SourceMenu(mock_source, mock_controller, None)
-    source_menu.actions()[4].trigger()
+    source_menu.actions()[5].trigger()
     mock_delete_source_dialog_instance.exec.assert_not_called()
 
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -395,7 +395,7 @@ def test__create_archive_with_multiple_export_files(mocker):
     export = Export()
     archive_path = None
     with TemporaryDirectory() as temp_dir, NamedTemporaryFile() as export_file_one, NamedTemporaryFile() as export_file_two:  # noqa
-        transcript_path = os.path.join(temp_dir, "conversation.txt")
+        transcript_path = os.path.join(temp_dir, "transcript.txt")
         with open(transcript_path, "a+") as transcript:
             archive_path = export._create_archive(
                 temp_dir,


### PR DESCRIPTION
## Description

Fixes #1629

Please refer to the issue for context on the design decisions.

## Test Plan

- [ ] Confirm that actions are easier to distinguish in the conversation menu  (i.e. the menu is more readable)
- Confirm that "Export All Files and Messages":
  - [ ] Does download any files that weren't downloaded in a given conversation
  - [ ] Does export all the conversation files

## Preview

![conversation-menu-36](https://user-images.githubusercontent.com/1619067/222008395-c6dbd226-20bb-4427-a579-e0be33a7cfb2.png)

The following confirmation dialog is shown if (and only if) there are files pending download:

![export-conversation-dialog-6](https://user-images.githubusercontent.com/1619067/223578821-f3ee57d3-0442-4575-b87f-d7897d88b2b0.png)


<details>
<summary>Obsolete screenshots</summary>
<img src="https://user-images.githubusercontent.com/1619067/221716123-82a48e4a-56ea-4651-8add-346c03151179.png" alt="A preview of the conversation menu"/>

</details>

