### PR TITLE
Decrease estimation of Tor network speeds when calculating timeout

### DIFF
--- a/securedrop_client/api_jobs/base.py
+++ b/securedrop_client/api_jobs/base.py
@@ -81,6 +81,9 @@ class ApiJob(QueueJob):
                 if self.remaining_attempts == 0:
                     self.failure_signal.emit(e)
                     raise
+                # Timeout errors may mean the user should try changing Tor circuits
+                elif isinstance(e, RequestTimeoutError):
+                    logger.info("Encountered RequestTimeoutError, retrying API call")
             except Exception as e:
                 self.failure_signal.emit(e)
                 raise

--- a/securedrop_client/api_jobs/downloads.py
+++ b/securedrop_client/api_jobs/downloads.py
@@ -68,22 +68,22 @@ class DownloadJob(SingleObjectApiJob):
           os.stat.ST_SIZE).
 
         * The following times are reasonable estimations for how long it should take to fetch a
-          file over Tor according to Tor metrics given a recent three month period in 2019:
+          file over Tor according to Tor metrics given a recent three month period in 2022-2023:
 
-          50 KiB  (51200 bytes)   =  4   seconds  (  12800 bytes/second)
-          1  MiB  (1049000 bytes) =  7.5 seconds  (~139867 bytes/second)
+          50 KiB  (51200 bytes)   =  6   seconds  (8,533 bytes/second)
+          1  MiB  (1049000 bytes) =  15 seconds  (~ 69,905 bytes/second)
 
           For more information, see:
-          https://metrics.torproject.org/torperf.html?start=2019-05-02&end=2019-07-31&server=onion
+          https://metrics.torproject.org/torperf.html?start=2022-12-06&end=2023-03-06&server=onion
 
         * As you might expect, this method returns timeouts that are larger than the expected
           download time, which is why the rates below are slower than what you see above with the
-          Tor metrics, e.g. instead of setting TIMEOUT_BYTES_PER_SECOND to 139867 bytes/second, we
-          set it to 100000 bytes/second.
+          Tor metrics, e.g. instead of setting TIMEOUT_BYTES_PER_SECOND to 69905 bytes/second, we
+          set it to 50000 bytes/second.
 
         * Minimum timeout allowed is 25 seconds
         """
-        TIMEOUT_BYTES_PER_SECOND = 100_000.0
+        TIMEOUT_BYTES_PER_SECOND = 50_000.0
         TIMEOUT_ADJUSTMENT_FACTOR = 1.5
         TIMEOUT_BASE = 25
         timeout = math.ceil((size_in_bytes / TIMEOUT_BYTES_PER_SECOND) * TIMEOUT_ADJUSTMENT_FACTOR)


### PR DESCRIPTION
# Description

Towards #1633, but let's keep it open 
- Re-estimate file download speeds on Tor and link to updated metrics URL. Conservative estimate of speed is now 50000B/s (~0.4Mbit/s), down from 100000B/s. This will allow for longer intervals before file downloads time out. 
- Log API retry attempt in client logs if Timeout error is encountered
 
# Test Plan
No logic changes, so pretty light test plan.
- [ ] CI passes and visual review looks sane
- [x] Forcing a timeout exception (eg by stopping tor service in a staging environment: see developer wiki) yields new error msg in logs
 
# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
