### PR TITLE
Restore non-freedesktopped desktop entry file

### DIFF
--- a/files/securedrop-client.desktop
+++ b/files/securedrop-client.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=SecureDrop Client
+Exec=securedrop-client
+Icon=utilities-terminal
+Type=Application


### PR DESCRIPTION
## Description

Fixes #1638 .
This reverts commit 10225d775226df0f9d7c2e2e03502582c5177741.

Both the new and old-style desktop files are required until a version of securedrop-workstation is available with Salt changes referencing the new file name.

Temporary reverts https://github.com/freedomofpress/securedrop-client/pull/1601

## Test Plan

- [x] CI is passing
- [ ] both `files/securedrop-client.desktop` and `files/press.freedom.SecureDropClient.desktop` are present in the repo.