### PR TITLE
Fix syntax of mypy ignore comments

### DIFF
--- a/securedrop_client/app.py
+++ b/securedrop_client/app.py
@@ -57,7 +57,7 @@ def init(sdc_home: Path) -> None:
     safe_mkdir(sdc_home, "data")
 
 
-def excepthook(*exc_args):  # type: ignore [no-untyped-def]
+def excepthook(*exc_args):  # type: ignore[no-untyped-def]
     """
     This function is called in the event of a catastrophic failure.
     Log exception and exit cleanly.
@@ -125,7 +125,7 @@ def configure_logging(sdc_home: Path) -> None:
 
 
 def configure_signal_handlers(app: QApplication) -> None:
-    def signal_handler(*nargs) -> None:  # type: ignore [no-untyped-def]
+    def signal_handler(*nargs) -> None:  # type: ignore[no-untyped-def]
         app.quit()
 
     for sig in [signal.SIGINT, signal.SIGTERM]:
@@ -170,11 +170,11 @@ def prevent_second_instance(app: QApplication, unique_name: str) -> None:
     IDENTIFIER = "\0" + app.applicationName() + unique_name
     ALREADY_BOUND_ERRNO = 98
 
-    app.instance_binding = socket.socket(  # type: ignore [attr-defined]
+    app.instance_binding = socket.socket(  # type: ignore[attr-defined]
         socket.AF_UNIX, socket.SOCK_DGRAM
     )
     try:
-        app.instance_binding.bind(IDENTIFIER)  # type: ignore [attr-defined]
+        app.instance_binding.bind(IDENTIFIER)  # type: ignore[attr-defined]
     except OSError as e:
         if e.errno == ALREADY_BOUND_ERRNO:
             err_dialog = QMessageBox()
@@ -206,7 +206,7 @@ def threads(count: int) -> Any:
         thread.wait(TWO_SECONDS_IN_MILLISECONDS)
 
 
-def start_app(args, qt_args) -> NoReturn:  # type: ignore [no-untyped-def]
+def start_app(args, qt_args) -> NoReturn:  # type: ignore[no-untyped-def]
     """
     Create all the top-level assets for the application, set things up and
     run the application. Specific tasks include:

--- a/securedrop_client/conversation/transcript/transcript.py
+++ b/securedrop_client/conversation/transcript/transcript.py
@@ -16,7 +16,7 @@ env = Environment(
     lstrip_blocks=True,
     trim_blocks=True,
 )
-env.install_gettext_translations(gettext)  # type: ignore [attr-defined]
+env.install_gettext_translations(gettext)  # type: ignore[attr-defined]
 
 
 def transcribe(record: database.Base) -> Optional[Item]:

--- a/securedrop_client/gui/main.py
+++ b/securedrop_client/gui/main.py
@@ -171,7 +171,7 @@ class Window(QMainWindow):
         """
         self.main_view.show_sources(sources)
 
-    def show_last_sync(self, updated_on):  # type: ignore [no-untyped-def]
+    def show_last_sync(self, updated_on):  # type: ignore[no-untyped-def]
         """
         Display a message indicating the time of last sync with the server.
         """

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -224,7 +224,7 @@ class LeftPane(QWidget):
         layout.addWidget(self.user_profile)
         layout.addWidget(self.branding_barre)
 
-    def setup(self, window, controller: Controller) -> None:  # type: ignore [no-untyped-def]
+    def setup(self, window, controller: Controller) -> None:  # type: ignore[no-untyped-def]
         self.user_profile.setup(window, controller)
 
     def set_logged_in_as(self, db_user: User) -> None:
@@ -474,7 +474,7 @@ class UserProfile(QLabel):
         layout.addWidget(self.user_icon, alignment=Qt.AlignTop)
         layout.addWidget(self.user_button, alignment=Qt.AlignTop)
 
-    def setup(self, window, controller: Controller) -> None:  # type: ignore [no-untyped-def]
+    def setup(self, window, controller: Controller) -> None:  # type: ignore[no-untyped-def]
         self.controller = controller
         self.controller.update_authenticated_user.connect(self._on_update_authenticated_user)
         self.user_button.setup(controller)
@@ -586,7 +586,7 @@ class LoginButton(QPushButton):
         # Set click handler
         self.clicked.connect(self._on_clicked)
 
-    def setup(self, window) -> None:  # type: ignore [no-untyped-def]
+    def setup(self, window) -> None:  # type: ignore[no-untyped-def]
         """
         Store a reference to the GUI window object.
         """
@@ -707,7 +707,7 @@ class MainView(QWidget):
             # Get or create the SourceConversationWrapper
             if source.uuid in self.source_conversations:
                 conversation_wrapper = self.source_conversations[source.uuid]
-                conversation_wrapper.conversation_view.update_conversation(  # type: ignore [has-type]  # noqa: E501
+                conversation_wrapper.conversation_view.update_conversation(  # type: ignore[has-type]  # noqa: E501
                     source.collection
                 )
             else:
@@ -735,7 +735,7 @@ class MainView(QWidget):
             self.controller.session.refresh(source)
             self.controller.mark_seen(source)
             conversation_wrapper = self.source_conversations[source.uuid]
-            conversation_wrapper.conversation_view.update_conversation(  # type: ignore [has-type]
+            conversation_wrapper.conversation_view.update_conversation(  # type: ignore[has-type]
                 source.collection
             )
         except sqlalchemy.exc.InvalidRequestError as e:
@@ -1793,7 +1793,7 @@ class SpeechBubble(QWidget):
     TOP_MARGIN = 28
     BOTTOM_MARGIN = 0
 
-    def __init__(  # type: ignore [no-untyped-def]
+    def __init__(  # type: ignore[no-untyped-def]
         self,
         message_uuid: str,
         text: str,
@@ -1993,7 +1993,7 @@ class MessageWidget(SpeechBubble):
     Represents an incoming message from the source.
     """
 
-    def __init__(  # type: ignore [no-untyped-def]
+    def __init__(  # type: ignore[no-untyped-def]
         self,
         message_uuid: str,
         message: str,
@@ -2032,7 +2032,7 @@ class ReplyWidget(SpeechBubble):
 
     ERROR_BOTTOM_MARGIN = 20
 
-    def __init__(  # type: ignore [no-untyped-def]
+    def __init__(  # type: ignore[no-untyped-def]
         self,
         controller: Controller,
         message_uuid: str,
@@ -3484,7 +3484,7 @@ class TitleLabel(QLabel):
 class LastUpdatedLabel(QLabel):
     """Time the conversation was last updated."""
 
-    def __init__(self, last_updated):  # type: ignore [no-untyped-def]
+    def __init__(self, last_updated):  # type: ignore[no-untyped-def]
         super().__init__(last_updated)
 
         # Set CSS id

--- a/securedrop_client/logic.py
+++ b/securedrop_client/logic.py
@@ -71,9 +71,9 @@ logger = logging.getLogger(__name__)
 LAST_SYNC_REFRESH_INTERVAL_MS = 1000 * 30
 
 
-def login_required(f):  # type: ignore [no-untyped-def]
+def login_required(f):  # type: ignore[no-untyped-def]
     @functools.wraps(f)
-    def decorated_function(self, *args, **kwargs):  # type: ignore [no-untyped-def]
+    def decorated_function(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         if not self.api:
             self.on_action_requiring_login()
             return
@@ -96,7 +96,7 @@ class APICallRunner(QObject):
     call_failed = pyqtSignal()
     call_timed_out = pyqtSignal()
 
-    def __init__(  # type: ignore [no-untyped-def]
+    def __init__(  # type: ignore[no-untyped-def]
         self, api_call, current_object=None, *args, **kwargs
     ):
         """
@@ -311,7 +311,7 @@ class Controller(QObject):
     """
     add_job = pyqtSignal("PyQt_PyObject")
 
-    def __init__(  # type: ignore [no-untyped-def]
+    def __init__(  # type: ignore[no-untyped-def]
         self,
         hostname: str,
         gui,
@@ -456,7 +456,7 @@ class Controller(QObject):
 
         storage.clear_download_errors(self.session)
 
-    def call_api(  # type: ignore [no-untyped-def]
+    def call_api(  # type: ignore[no-untyped-def]
         self,
         api_call_func,
         success_callback,
@@ -509,7 +509,7 @@ class Controller(QObject):
         # clear error status in case queue was paused resulting in a permanent error message
         self.gui.clear_error_status()
 
-    def completed_api_call(self, thread_id, user_callback):  # type: ignore [no-untyped-def]
+    def completed_api_call(self, thread_id, user_callback):  # type: ignore[no-untyped-def]
         """
         Manage a completed API call. The actual result *may* be an exception or
         error result from the API. It's up to the handler (user_callback) to
@@ -548,7 +548,7 @@ class Controller(QObject):
             self.api.authenticate, self.on_authenticate_success, self.on_authenticate_failure
         )
 
-    def on_authenticate_success(self, result):  # type: ignore [no-untyped-def]
+    def on_authenticate_success(self, result):  # type: ignore[no-untyped-def]
         """
         Handles a successful authentication call against the API.
         """
@@ -624,7 +624,7 @@ class Controller(QObject):
         """
         return bool(self.api and self.api.token is not None)
 
-    def get_last_sync(self):  # type: ignore [no-untyped-def]
+    def get_last_sync(self):  # type: ignore[no-untyped-def]
         """
         Returns the time of last synchronisation with the remote SD server.
         """

--- a/securedrop_client/sync.py
+++ b/securedrop_client/sync.py
@@ -104,7 +104,7 @@ class ApiSyncBackgroundTask(QObject):
     ApiSyncBackgroundTask provides a sync method that executes a MetadataSyncJob.
     """
 
-    def __init__(  # type: ignore [no-untyped-def]
+    def __init__(  # type: ignore[no-untyped-def]
         self,
         api_client: API,
         session_maker: scoped_session,


### PR DESCRIPTION
# Description

Per the mypy documentation[1], the syntax is:
`# type: ignore[error-code]`, with no space between ignore and [. It seems like mypy is fine with the space, but other tools (e.g. PyCharm) aren't, so use the non-spaced version.

[1] https://mypy.readthedocs.io/en/stable/type_inference_and_annotations.html#type-ignore-error-codes

# Test Plan

* [ ] CI passes

# Checklist

 - [x] These changes should not need testing in Qubes
 - [x] No update to the AppArmor profile is required for these changes
 - [x] No database schema changes are needed
