### PR TITLE
Fix support non-ASCII transcripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,16 @@ common-steps:
         set -e
         apt update && apt install -y git gnupg libqt5x11extras5 make python3-tk python3-dev gnupg python3-venv sqlite3 xvfb
 
+  - &configure_locales
+    run:
+      name: Configure locales
+      command: |
+        set -e
+        apt update && apt install -y locales
+        echo "en_US ISO-8859-1" >> /etc/locale.gen
+        echo "en_US UTF-8" >> /etc/locale.gen
+        locale-gen
+
   - &install_build_dependencies
     run:
       name: Install build dependencies
@@ -152,6 +162,7 @@ jobs:
     docker: *docker
     steps:
       - *install_testing_dependencies
+      - *configure_locales
       - checkout
       - *run_unit_tests
       - store_test_results:

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -177,7 +177,7 @@ class PrintConversationAction(QAction):  # pragma: nocover
         transcript = ConversationTranscript(self._source)
         safe_mkdir(file_path.parent)
 
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             f.write(str(transcript))
             # Let this context lapse to ensure the file contents
             # are written to disk.

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -229,7 +229,7 @@ class ExportConversationTranscriptAction(QAction):  # pragma: nocover
         transcript = ConversationTranscript(self._source)
         safe_mkdir(file_path.parent)
 
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             f.write(str(transcript))
             # Let this context lapse to ensure the file contents
             # are written to disk.

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -311,7 +311,7 @@ class ExportConversationAction(QAction):  # pragma: nocover
         transcript = ConversationTranscript(self._source)
         safe_mkdir(transcript_location.parent)
 
-        with open(transcript_location, "w") as f:
+        with open(transcript_location, "w", encoding="utf-8") as f:
             f.write(str(transcript))
             # Let this context lapse to ensure the file contents
             # are written to disk.


### PR DESCRIPTION
## Description

Even if the current locale specifies an encoding that doesn't support other languages (e.g. `ISO 5598-1` a.k.a "latin-1" doesn't support many Unicode characters), the conversation transcript generation MUST NOT fail.

In practice, there is no direct relationship between the language in which the SecureDrop Client UI is displayed and the languages that may be used y sources and journalists in their conversations, so the transcript will always be encoded to UTF-8.

Fixes #1643 

_Pardon the "pirate talk" in the commit message :grimacing: :pirate_flag: the sequence is long enough to run in CI that I didn't want to go back and edit it._

## Test Plan

- [ ] Confirm that you can "Export Transcript" with a broad range of Unicode characters, and that the content of the transcript is correct, under as many `LANG` settings as you want to try (e.g. `pt_PT`, `zh_Hans`).
- [ ] Confirm that you can "Export All Files and Transcript" with a broad range of Unicode characters, and that the content of the transcript is correct, under as many `LANG` settings as you want to try (e.g. `pt_PT`, `zh_Hans`).
- [ ] Confirm that you can "Print Transcript" with a broad range of Unicode characters, and that the content of the transcript is correct, under as many `LANG` settings as you want to try (e.g. `pt_PT`, `zh_Hans`).
- [ ] Confirming that you can make the tests fail with the expected error by removing the fix wouldn't hurt. (I've done that, but y'know, for thoroughness.)