### PR TITLE
Backport unicode transcript fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,16 @@ common-steps:
         set -e
         apt update && apt install -y git gnupg libqt5x11extras5 make python3-tk python3-dev gnupg python3-venv sqlite3 xvfb
 
+  - &configure_locales
+    run:
+      name: Configure locales
+      command: |
+        set -e
+        apt update && apt install -y locales
+        echo "en_US ISO-8859-1" >> /etc/locale.gen
+        echo "en_US UTF-8" >> /etc/locale.gen
+        locale-gen
+
   - &install_build_dependencies
     run:
       name: Install build dependencies
@@ -152,6 +162,7 @@ jobs:
     docker: *docker
     steps:
       - *install_testing_dependencies
+      - *configure_locales
       - checkout
       - *run_unit_tests
       - store_test_results:

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -177,7 +177,7 @@ class PrintConversationAction(QAction):  # pragma: nocover
         transcript = ConversationTranscript(self._source)
         safe_mkdir(file_path.parent)
 
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             f.write(str(transcript))
             # Let this context lapse to ensure the file contents
             # are written to disk.

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -229,7 +229,7 @@ class ExportConversationTranscriptAction(QAction):  # pragma: nocover
         transcript = ConversationTranscript(self._source)
         safe_mkdir(file_path.parent)
 
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             f.write(str(transcript))
             # Let this context lapse to ensure the file contents
             # are written to disk.

--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -311,7 +311,7 @@ class ExportConversationAction(QAction):  # pragma: nocover
         transcript = ConversationTranscript(self._source)
         safe_mkdir(transcript_location.parent)
 
-        with open(transcript_location, "w") as f:
+        with open(transcript_location, "w", encoding="utf-8") as f:
             f.write(str(transcript))
             # Let this context lapse to ensure the file contents
             # are written to disk.


### PR DESCRIPTION
# Description

Backports #1648 

# Test Plan
- [ ] CI is passing
- [ ] base is `release/0.9.0`
- [ ] PR contains only all commits from #1648


