### PR TITLE
Fix typos in user-facing copy

### DIFF
--- a/securedrop_client/gui/actions.py
+++ b/securedrop_client/gui/actions.py
@@ -286,7 +286,7 @@ class ExportConversationAction(QAction):  # pragma: nocover
                     "<h2>Some files will not be exported</h2>"
                     "Some files from this source have not yet been downloaded, and will not be exported."  # noqa: E501
                     "<br /><br />"
-                    'To export the currently-downloaded files, click "Continue."'
+                    'To export the currently downloaded files, click "Continue."'
                 )
                 dialog.body.setText(message)
                 dialog.rejected.connect(self._on_confirmation_dialog_rejected)

--- a/securedrop_client/gui/base/misc.py
+++ b/securedrop_client/gui/base/misc.py
@@ -197,7 +197,7 @@ class SecureQLabel(QLabel):
             elided_text = ""
             for c in full_text:
                 if fm.horizontalAdvance(elided_text) > self.max_length:
-                    elided_text = elided_text[:-3] + "..."
+                    elided_text = elided_text[:-3] + "…"
                     return elided_text
                 elided_text = elided_text + c
 

--- a/securedrop_client/gui/widgets.py
+++ b/securedrop_client/gui/widgets.py
@@ -1128,7 +1128,7 @@ class ConversationDeletionIndicator(QWidget):
         self.setPalette(palette)
         self.setAutoFillBackground(True)
 
-        deletion_message = QLabel(_("Deleting files and messages..."))
+        deletion_message = QLabel(_("Deleting files and messages…"))
         deletion_message.setWordWrap(False)
 
         self.animation = load_movie("loading-cubes.gif")
@@ -1174,7 +1174,7 @@ class SourceDeletionIndicator(QWidget):
         self.setPalette(palette)
         self.setAutoFillBackground(True)
 
-        self.deletion_message = QLabel(_("Deleting source account..."))
+        self.deletion_message = QLabel(_("Deleting source account…"))
         self.deletion_message.setWordWrap(False)
 
         self.animation = load_movie("loading-cubes.gif")
@@ -3390,7 +3390,7 @@ class ReplyTextEditPlaceholder(QWidget):
 
     def update_label_width(self, width: int) -> None:
         if width > self.RESERVED_WIDTH:
-            # Ensure source designations are elided with "..." if needed per
+            # Ensure source designations are elided with "…" if needed per
             # current container size
             self.source_name_label.max_length = width - self.RESERVED_WIDTH
             self.source_name_label.setText(self.source_name)

--- a/securedrop_client/locale/messages.pot
+++ b/securedrop_client/locale/messages.pot
@@ -94,7 +94,7 @@ msgstr ""
 msgid "Export All"
 msgstr ""
 
-msgid "<h2>Some files will not be exported</h2>Some files from this source have not yet been downloaded, and will not be exported.<br /><br />To export the currently-downloaded files, click \"Continue.\""
+msgid "<h2>Some files will not be exported</h2>Some files from this source have not yet been downloaded, and will not be exported.<br /><br />To export the currently downloaded files, click \"Continue.\""
 msgstr ""
 
 msgid "all files and transcript"
@@ -142,10 +142,10 @@ msgstr ""
 msgid "Send a response"
 msgstr ""
 
-msgid "Deleting files and messages..."
+msgid "Deleting files and messages…"
 msgstr ""
 
-msgid "Deleting source account..."
+msgid "Deleting source account…"
 msgstr ""
 
 msgid "— All files and messages deleted for this source —"

--- a/tests/gui/base/test_misc.py
+++ b/tests/gui/base/test_misc.py
@@ -154,7 +154,7 @@ def test_SecureQLabel_get_elided_text(mocker):
     sl = SecureQLabel(long_string, wordwrap=False, max_length=100)
     elided_text = sl.get_elided_text(long_string)
     assert sl.text() == elided_text
-    assert "..." in elided_text
+    assert "…" in elided_text
 
 
 def test_SecureQLabel_get_elided_text_short_string(mocker):
@@ -181,7 +181,7 @@ def test_SecureQLabel_get_elided_text_only_returns_oneline_elided(mocker):
     sl = SecureQLabel(string_with_newline, wordwrap=False, max_length=38)
     elided_text = sl.get_elided_text(string_with_newline)
     assert sl.text() == elided_text
-    assert "..." in elided_text
+    assert "…" in elided_text
 
 
 def test_SecureQLabel_quotes_not_escaped_for_readability():

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -1940,7 +1940,7 @@ def test_SourceWidget_set_snippet(mocker, session_maker, session, homedir):
 def test_SourceWidget_update_truncate_latest_msg(mocker):
     """
     If the latest message in the conversation is longer than 150 characters,
-    truncate and add "..." to the end.
+    truncate and add "…" to the end.
     """
     controller = mocker.MagicMock()
     source = mocker.MagicMock()
@@ -1951,7 +1951,7 @@ def test_SourceWidget_update_truncate_latest_msg(mocker):
     sw = SourceWidget(controller, source, mark_seen_signal, mocker.MagicMock())
 
     sw.reload()
-    assert sw.preview.text().endswith("...")
+    assert sw.preview.text().endswith("…")
 
 
 def test_SourceWidget__on_source_deleted(mocker, session, source):
@@ -3471,7 +3471,7 @@ def test_FileWidget_filename_truncation(mocker, source, session):
 
     fw._on_file_downloaded(file.source.uuid, file.uuid, str(file))
 
-    assert fw.file_name.text().endswith("...")
+    assert fw.file_name.text().endswith("…")
     assert fw.file_name.toolTip() == filename
 
 


### PR DESCRIPTION
## Description

Fixes a few typos that were flagged by AO_Localization_Lab in Weblate.

## Test Plan

- [x] CI is green
- [x] A visual check should suffice
