### PR TITLE
Auto-detect Wayland in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -58,6 +58,11 @@ else
     qubes_flag="--no-qubes"
 fi
 
+if [[ $XDG_SESSION_TYPE = "wayland" ]]; then
+    echo "Detected Wayland, will run with QT_QPA_PLATFORM variable..."
+    export QT_QPA_PLATFORM=wayland
+fi
+
 wait
 
 echo "Starting client, log available at: $SDC_HOME/logs/client.log"


### PR DESCRIPTION
# Description

Optionally can replace #1652.  Check XDG_SESSION_TYPE and if wayland, set QT_QPA_PLATFORM var when running the client.

Annoyingly, the warning ("Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway") is displayed even when the QT_QPA_PLATFORM environment variable is set.

# Test Plan

Activate venv, `run.sh`:
- [x] Client launches successfully in both Xorg and Wayland environments
- [x] Visual review ok and CI passing

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
