### PR TITLE
Add readme index for readability and fix numbering typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,32 @@ To learn more about architecture and our rationale behind our Qubes OS approach,
 
 **IMPORTANT:** This project is currently undergoing a pilot study and should not be used in production environments.
 
+## Index
+
+* [Getting Started](#getting-started)
+    * [Running against a test server](#running-against-a-test-server)
+    * [Developer environment](#developer-environment)
+    * [Developer environment on a Linux-based non-Qubes OS](#developer-environment-on-a-linux-based-non-qubes-os)
+    * [Developer environment on macOS](#developer-environment-on-macos)
+        * [Set up the server](#set-up-the-server)
+        * [Set up the SecureDrop Client](#set-up-the-securedrop-client)
+    * [Staging environment](#staging-environment)
+    * [Production environment](#production-environment)
+* [Updating dependencies](#updating-dependencies)
+    * [Production](#production)
+    * [Development](#development)
+    * [Build dependencies](#build-dependencies)
+* [Generating and running database migrations](#generating-and-running-database-migrations)
+* [AppArmor support](#apparmor-support)
+    * [Requirements](#Requirements)
+    * [Enabling AppArmor](#enabling-apparmor)
+    * [Testing and updating the AppArmor profile](#testing-and-updating-the-apparmor-profile)
+* [Running tests and checks](#running-tests-and-checks)
+    * [Functional Tests](#functional-tests)
+        * [Generating new cassettes](#generating-new-cassettes)
+* [Making a Release](#making-a-release)
+* [Debugging](#debugging)
+
 ## Getting Started
 
 The quickest way to get started with running the client is to use the [developer environment](#developer-environment) that [runs against a test server running in a local docker container](#running-against-a-test-server). This differs from a staging or production environment where the client receives and sends requests over Tor. Things are a lot snappier in the developer environment and can sometimes lead to a much different user experience, which is why it is important to do end-to-end testing in Qubes using the [staging environment](#staging-environment), especially if you are modifying code paths involving how we handle server requests and responses.
@@ -261,27 +287,29 @@ securedrop-client
 If you're adding or updating a production dependency, you need to:
 
 1. Modify `requirements.in`
-1. Activate a Python 3.9 virtual environment (default version on Debian Bullseye, used in production)
-1. Run `make requirements`. This will generate `requirements.txt`. Review and commit the changes.
+2. Activate a Python 3.9 virtual environment (default version on Debian Bullseye, used in production)
+3. Run `make requirements`. This will generate `requirements.txt`. Review and commit the changes.
 
 ### Development
 
 In addition to supporting Debian Bullseye, we keep track of changes in the next version of Debian (Bookworm). In order to do that we need to maintain requirement files for both. If you're adding or updating a development dependency, you need to:
 
 1. Modify `dev-sdw-requirements.in` when possible. If needed modify `dev-bullseye-requirements.in` or `dev-bookworm-requirements.in`.
-1. Activate a Python 3.9 virtual environment (default version on Debian Bullseye, used in production)
-1. Run `make dev-requirements`. This will generate `dev-*-requirements.txt`. Only commit `dev-bullseye-requirements.txt` and `dev-sdw-requirements.txt`.
-1. Discard the other changes.
-1. Activate a Python 3.10 virtual environment (default version on Debian Bookworm).
+2. Activate a Python 3.9 virtual environment (default version on Debian Bullseye, used in production)
+3. Run `make dev-requirements`. This will generate `dev-*-requirements.txt`. Only commit `dev-bullseye-requirements.txt` and `dev-sdw-requirements.txt`.
+4. Discard the other changes.
+5. Activate a Python 3.10 virtual environment (default version on Debian Bookworm).
    If needed you can create one and activate it by running `python3.10 -m venv .venv310 && source .venv310/bin/activate`.
-1. Run `make dev-requirements`. This will generate `dev-*-requirements.txt`. Only commit `dev-bookworm-requirements.txt`.
-1. Discard the other changes.
+6. Run `make dev-requirements`. This will generate `dev-*-requirements.txt`. Only commit `dev-bookworm-requirements.txt`.
+7. Discard the other changes.
 
 ### Build dependencies
 
-For building a debian package from this project, we use the requirements in
+1. For building a debian package from this project, we use the requirements in
 `build-requirements.txt` which uses our pip mirror, i.e. the hashes in that file point to
-wheels on our pip mirror. A maintainer will need to add
+wheels on our pip mirror. 
+
+2. A maintainer will need to add
 the updated dependency to our pip mirror (you can request this in the PR).
 
 3. Once the pip mirror is updated, you should checkout the [securedrop-builder repo](https://github.com/freedomofpress/securedrop-builder) and run `make requirements`. Commit the `build-requirements.txt` that results and add it to your PR.


### PR DESCRIPTION
# Description

Add an index to the README since it is quite long and IMHO having an index improves readability for new comers like me.

# Test Plan

No code was touched so no test plan is required.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
