### PR TITLE
Revert "Remove unnecessary work around segmentation faults :)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,10 +121,7 @@ test-integration: ## Run the integration tests
 
 .PHONY: test-functional
 test-functional: ## Run the functional tests
-	@TEST_CMD="python -m pytest -v -n 4 --random-order-bucket global --random-order-seed=$(RANDOM_SEED) $(FTESTS)" ; \
-		if command -v xvfb-run > /dev/null; then \
-		xvfb-run --server-args="-screen 0, 1680x1050x24" -a $$TEST_CMD ; else \
-		$$TEST_CMD ; fi
+	@./test-functional.sh
 
 .PHONY: lint
 lint: ## Run the linters

--- a/test-functional.sh
+++ b/test-functional.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# A script to run each functional test module (randomly ordered) in their own
+# pytest process. Why? Because not all random combinations of these tests
+# result in a passing suite (instead you get a core dump).
+
+TESTFILES=$(find tests/functional/test_*.py -print | sort -R)
+for f in $TESTFILES
+do
+    TEST_CMD=(python -m pytest -v --random-order-bucket global "$f")
+    echo "${TEST_CMD[@]}"
+    if command -v xvfb-run > /dev/null; then
+        xvfb-run  --server-args="-screen 0, 1680x1050x24" -a "${TEST_CMD[@]}"
+    else
+        "${TEST_CMD[@]}"
+    fi
+    if test $? -ne 0
+    then
+        exit 1
+    fi
+done


### PR DESCRIPTION
## Description

Run the functional tests in isolation (one by one) [again](https://github.com/freedomofpress/securedrop-client/pull/1525), to work around frequent timeouts that don't happen that way.
Details in the commit message! :speech_balloon: 

## Test Plan

- [x] CI is green, stays green if you re-build a few times (the occasional segfault is acceptable, but it should be a lot less frequent than we currently observe).
