### PR TITLE
Fix user-facing copy mistake

### DIFF
--- a/securedrop_client/gui/conversation/delete/dialog.py
+++ b/securedrop_client/gui/conversation/delete/dialog.py
@@ -56,7 +56,7 @@ class DeleteConversationDialog(ModalDialog):
             "<style>li {{line-height: 150%;}}</li></style>",
             "<p>",
             _(
-                "You would like to delete {files_to_delete}, {replies_to_delete}, "
+                "Would you like to delete {files_to_delete}, {replies_to_delete}, "
                 "{messages_to_delete} from the source account for {source}?"
             ),
             "</p>",

--- a/securedrop_client/locale/messages.pot
+++ b/securedrop_client/locale/messages.pot
@@ -249,7 +249,7 @@ msgstr ""
 msgid "YES, DELETE FILES AND MESSAGES"
 msgstr ""
 
-msgid "You would like to delete {files_to_delete}, {replies_to_delete}, {messages_to_delete} from the source account for {source}?"
+msgid "Would you like to delete {files_to_delete}, {replies_to_delete}, {messages_to_delete} from the source account for {source}?"
 msgstr ""
 
 msgid "Preserving the account will retain its metadata, and the ability for {source} to log in to your SecureDrop again."


### PR DESCRIPTION
## Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/1575

## Test plan

- [ ] CI is green (means that the strings were extracted for translation)
- [ ] Visual proof-reading of the updated string looks good