### PR TITLE
build(dev-requirements): `pip-compile` bookworm dependencies in container if necessary; don't cross-check in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ common-steps:
         export VERSION_CODENAME=$(~/project/scripts/codename)
         make venv
         source .venv/bin/activate
-        make requirements
+        make requirements/requirements.txt requirements/dev-${VERSION_CODENAME}-requirements.txt
         git diff --exit-code requirements/dev-${VERSION_CODENAME}-requirements.txt
 
   - &build_debian_package

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,19 @@ check: clean check-black check-isort semgrep bandit lint mypy test-random test-i
 .PHONY: dev-requirements
 dev-requirements:  ## Update dev-*requirements.txt files if pinned versions do not comply with the dependency specifications in dev-*requirements.in
 	pip-compile --allow-unsafe --generate-hashes --output-file requirements/dev-bullseye-requirements.txt requirements/dev-bullseye-requirements.in
+ifneq ($(VERSION_CODENAME), bookworm)
+	docker run \
+		--interactive \
+		--name dev-requirements \
+		--rm \
+		--tty \
+		--volume "${PWD}":/srv \
+		--workdir /srv \
+		python:3.11-bookworm \
+		bash -c "pip install pip-tools && pip-compile --allow-unsafe --generate-hashes --output-file requirements/dev-bookworm-requirements.txt requirements/dev-bookworm-requirements.in"
+else
 	pip-compile --allow-unsafe --generate-hashes --output-file requirements/dev-bookworm-requirements.txt requirements/dev-bookworm-requirements.in
+endif
 	pip-compile --allow-unsafe --generate-hashes --output-file requirements/dev-sdw-requirements.txt requirements/dev-sdw-requirements.in
 
 .PHONY: update-dev-dependencies


### PR DESCRIPTION
# Description

This pull request suggests two opinionated changes:

1. Since we still officially target Python 3.9 on Debian bullseye, Python 3.11 dependencies on Debian bookworm are diffed by the `check-testing-requirements` job but not easily updated in the development environment.  This lets you update "next" dependencies in a "current" development environment.

2. Test bullseye and bookworm dependencies on bullseye and bookworm, respectively; don't cross-check both on both.  (That's what CI parameterization is for!)

# Test Plan

- On Debian bullseye, run `make update-dev-dependencies`.
- Push to a testing branch.
- [ ] CI passes.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - I have tested these changes in the appropriate Qubes environment
 - I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
