### PR TITLE
chore: make `verify-mo.py` compatible with `securedrop`

### DIFF
--- a/scripts/verify-mo.py
+++ b/scripts/verify-mo.py
@@ -20,10 +20,8 @@ import argparse
 import os
 import shlex
 import subprocess
-from collections.abc import Iterator
 from pathlib import Path
-from types import TracebackType
-from typing import Optional, Set
+from typing import Any, Iterator, Optional, Set
 
 import polib
 from translate.tools.pocompile import convertmo
@@ -61,9 +59,9 @@ class CatalogVerifier:
 
     def __exit__(
         self,
-        exc_type: Optional[type[BaseException]],
-        exc_value: Optional[BaseException],
-        traceback: Optional[TracebackType],
+        exc_type: Optional[Any],
+        exc_value: Optional[Any],
+        traceback: Optional[Any],
     ) -> None:
         """Clean up."""
 

--- a/scripts/verify-mo.py
+++ b/scripts/verify-mo.py
@@ -34,7 +34,8 @@ parser = argparse.ArgumentParser(
 parser.add_argument(
     "locale",
     nargs="+",
-    help="""one or more locale directories, each of which must contain an "LC_MESSAGES" directory""",
+    help="""one or more locale directories, each of which must contain an
+    "LC_MESSAGES" directory""",
 )
 parser.add_argument(
     "--domain", default="messages", help="""the gettext domain to load (defaults to "messages")"""
@@ -99,7 +100,7 @@ class CatalogVerifier:
         for stray in self.strays:
             yield f"--diff-mask {shlex.quote(stray)}"  # tell diffoscope to mask strays
         yield "| grep -Fv '[masked]'"  # ignore things we've masked
-        yield "| grep -E '│ (-|\+)msg(id|str)'"  # ignore context; we only care about real diffs
+        yield "| grep -E '│ (-|\\+)msg(id|str)'"  # ignore context; we only care about real diffs
 
     def diffoscope_call(
         self, a: Path, b: Path, filtered: bool = True
@@ -113,7 +114,8 @@ class CatalogVerifier:
         # We silence Bandit and Semgrep warnings on `shell=True`
         # because we want to inherit the Python virtual environment
         # in which we're invoked.
-        return subprocess.run(  # nosec B602 nosemgrep: python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
+        # nosemgrep: python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
+        return subprocess.run(  # nosec B602
             cmd,
             capture_output=True,
             env=os.environ,


### PR DESCRIPTION
# Description

`freedomofpress/securedrop` has stricter linting (ruff) and older typing (Python 3.8) than I tested with in #1666.  This makes `verify-mo.py` compatible with both, after freedomofpress/securedrop#6953.

# Test Plan

CI passes.

# Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - I have tested these changes in the appropriate Qubes environment
 - I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - No update to the AppArmor profile is required for these changes
 - [x] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations