### PR TITLE
Ignore urllib3 and pip alerts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,7 @@ safety: ## Runs `safety check` to check python dependencies for vulnerabilities
 			--ignore 51668 \
 			--ignore 61601 \
 			--ignore 61893 \
+			--ignore 62044 \
 			-r $$req_file \
 			&& echo -e '\n' \
 			|| exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,7 @@ safety: ## Runs `safety check` to check python dependencies for vulnerabilities
 			&& safety check --full-report \
 			--ignore 51668 \
 			--ignore 61601 \
+			--ignore 61893 \
 			-r $$req_file \
 			&& echo -e '\n' \
 			|| exit 1; \


### PR DESCRIPTION
# Description

* urllib3: Same as the last one, we're not concerned with malicious redirects.
* pip: We don't install dependencies from mercurial repositories
