### PR TITLE
Run `make extract-strings` to update copyright year

### DIFF
--- a/client/securedrop_client/locale/messages.pot
+++ b/client/securedrop_client/locale/messages.pot
@@ -1,7 +1,7 @@
 # Translations template for SecureDrop Client.
-# Copyright (C) 2023 Freedom of the Press Foundation
+# Copyright (C) 2024 Freedom of the Press Foundation
 # This file is distributed under the same license as the SecureDrop Client project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
 #
 #, fuzzy
 msgid ""


### PR DESCRIPTION
Fixes CI failure caused by rotation of the Earth around the Sun by running `make extract-strings`.