### PR TITLE
Build and push nightly packages

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -1,0 +1,79 @@
+name: Nightlies
+on:
+  schedule:
+    - cron: "0 6 * * *"
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-debs:
+    strategy:
+      matrix:
+        debian_version:
+          - bullseye
+          - bookworm
+    runs-on: ubuntu-latest
+    outputs:
+      artifact_id: ${{ steps.upload.outputs.artifact-id }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: "freedomofpress/securedrop-builder"
+          path: "securedrop-builder"
+          lfs: true
+      - name: Build packages
+        run: |
+          git config --global --add safe.directory '*'
+          NIGHTLY=1 DEBIAN_VERSION=${{ matrix.debian_version }} BUILDER=securedrop-builder \
+            ./scripts/build-debs.sh
+      - uses: actions/upload-artifact@v4
+        id: upload
+        with:
+          name: build-${{ matrix.debian_version }}
+          path: build
+          if-no-files-found: error
+
+  commit-and-push:
+    runs-on: ubuntu-latest
+    container: debian:bookworm
+    needs:
+      - build-debs
+    steps:
+      - name: Install dependencies
+        run: |
+          apt-get update && apt-get install --yes git git-lfs
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "*${{ matrix.debian_version }}"
+      - uses: actions/checkout@v4
+        with:
+          repository: "freedomofpress/securedrop-apt-test"
+          path: "securedrop-apt-test"
+          lfs: true
+          token: ${{ secrets.PUSH_TOKEN }}
+      - uses: actions/checkout@v4
+        with:
+          repository: "freedomofpress/build-logs"
+          path: "build-logs"
+          token: ${{ secrets.PUSH_TOKEN }}
+      - name: Commit and push
+        run: |
+          git config --global user.email "securedrop@freedom.press"
+          git config --global user.name "sdcibot"
+          # First publish buildinfo files
+          cd build-logs
+          mkdir -p "buildinfo/$(date +%Y)"
+          cp -v ../build-*/*.buildinfo "buildinfo/$(date +%Y)"
+          git add .
+          git diff-index --quiet HEAD || git commit -m "Publishing buildinfo files for workstation nightlies"
+          git push origin main
+          # Now the packages themselves
+          cd ../securedrop-apt-test
+          cp -v ../build-bullseye/*.deb workstation/bullseye-nightlies/
+          cp -v ../build-bookworm/*.deb workstation/bookworm-nightlies/
+          git add .
+          git diff-index --quiet HEAD || git commit -m "Automated SecureDrop workstation build"
+          git push origin main

--- a/scripts/build-debs.sh
+++ b/scripts/build-debs.sh
@@ -38,5 +38,6 @@ $OCI_BIN pull debian:${DEBIAN_VERSION}
 
 $OCI_BIN run --rm $OCI_RUN_ARGUMENTS \
     -v "${BUILDER}:/builder:Z" \
+    --env NIGHTLY="${NIGHTLY:-}" \
     --entrypoint "/src/scripts/build-debs-real.sh" \
     debian:${DEBIAN_VERSION}

--- a/scripts/fixup-changelog.sh
+++ b/scripts/fixup-changelog.sh
@@ -10,5 +10,14 @@ if [[ "$VERSION_CODENAME" == "" ]]; then
     VERSION_CODENAME=$(echo $PRETTY_NAME | awk '{split($0, a, "[ /]"); print a[4]}')
 fi
 
-version=$(dpkg-parsechangelog -S Version)
-sed -i "0,/${version}/ s//${version}+${VERSION_CODENAME}/" debian/changelog
+VERSION=$(dpkg-parsechangelog -S Version)
+
+NIGHTLY="${NIGHTLY:-}"
+if [[ ! -z $NIGHTLY ]]; then
+    NEW_VERSION="${VERSION}.dev$(date +%Y%m%d%H%M%S)"
+else
+    NEW_VERSION=$VERSION
+fi
+
+# Ideally we'd use `dch` here but then we'd to install all of devscripts
+sed -i "0,/${VERSION}/ s//${NEW_VERSION}+${VERSION_CODENAME}/" debian/changelog


### PR DESCRIPTION
# Status

Ready for review

# Description

As part of our monorepo consolidation, we're moving the nightly package building from the securedrop-builder repository to here. The overall process is the same, we build the packages for bullseye and bookworm, then push buildinfo files and then push debs.

Some changes:
* nightlies will not be pushed if the bookworm job fails. This is largely to simplify the configuration and also because we're going to move to bookworm pretty soon.
* Authentication will be done via a GitHub token, which will be configured by infra.
* Running `clean-old-packages` will happen via the securedrop-apt-test repository itself instead of during nightly builds.

Fixes #1776.

# Test Plan

* [ ] Visual review
* [ ] See successful test run at https://github.com/freedomofpress/securedrop-client/actions/runs/7800588879/job/21273810560 -> https://github.com/freedomofpress/securedrop-apt-test/commit/3b5de7603b0b0ecbd71eb56d6435a9b512ff0328 + https://github.com/freedomofpress/build-logs/commit/6520c9b7d72ee3bf91efd140849af086a6e6c661

![Screenshot 2024-02-06 at 08-56-45 DNM Try running nightlies now · freedomofpress_securedrop-client@82d75f8](https://github.com/freedomofpress/securedrop-client/assets/81392/2a954f51-53ee-4277-8ed4-2bde54668526)

