### PR TITLE
Enable dependabot for Python dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,29 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  # Python development dependencies
+  - package-ecosystem: "pip"
+    directory: "/client"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "development"
+  - package-ecosystem: "pip"
+    directory: "/export"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "development"
+  - package-ecosystem: "pip"
+    directory: "/log"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "development"
+  - package-ecosystem: "pip"
+    directory: "/proxy"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "development"


### PR DESCRIPTION
# Status

Ready for review

# Description

prod dependencies require manual work (building wheels), but we should be fine for dependabot doing dev updates. Unfortunately we have to configure each component manually, oh well.

Fixes #1774.

# Test Plan

* [ ] Visual review, cross-reference with https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file as needed