### PR TITLE
Use --require-hashes when installing requirements.txt

### DIFF
--- a/debian/setup-venv.sh
+++ b/debian/setup-venv.sh
@@ -11,7 +11,8 @@ WHEELS_DIR="/builder/securedrop-${NAME}/wheels"
 PIP_ARGS="--ignore-installed --no-index --find-links ${WHEELS_DIR} --no-deps --no-cache-dir --no-use-pep517"
 
 /usr/bin/python3 -m virtualenv $VENV_ARGS ./debian/securedrop-${NAME}/opt/venvs/securedrop-${NAME}
-./debian/securedrop-${NAME}/opt/venvs/securedrop-${NAME}/bin/pip install $PIP_ARGS -r ${NAME}/build-requirements.txt
+./debian/securedrop-${NAME}/opt/venvs/securedrop-${NAME}/bin/pip install $PIP_ARGS --require-hashes \
+    -r ${NAME}/build-requirements.txt
 ./debian/securedrop-${NAME}/opt/venvs/securedrop-${NAME}/bin/pip install $PIP_ARGS ./${NAME}
 
 # Adjust paths to reflect installed paths


### PR DESCRIPTION
# Status

Ready for review

# Description

This is mostly a safety measure, as pip will automatically enable require hashes mode when it sees hashes in the requirements.txt file.

Previously we couldn't do this because dh-virtualenv wasn't flexible enough, but we've now dropped that and can do it directly!

Fixes #1791.

# Test Plan

* [ ] CI passes
* [ ] Run `./scripts/build-debs.sh`, see `--require-hashes` in the output and no errors
