### PR TITLE
Skip CI jobs for proxy on bookworm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -441,13 +441,19 @@ workflows:
   securedrop_proxy_ci:
     jobs: &proxy_jobs
       - proxy_unit-test:
-          matrix: *matrix
+          # bookworm jobs are failing and will be
+          # replaced with proxy v2 shortly, so skip
+          # https://github.com/freedomofpress/securedrop-client/issues/1681
+          matrix: &proxy_matrix
+            parameters:
+              image:
+                - bullseye
       - proxy_lint:
-          matrix: *matrix
+          matrix: *proxy_matrix
       - proxy_check-security:
-          matrix: *matrix
+          matrix: *proxy_matrix
       - proxy_check-python-security:
-          matrix: *matrix
+          matrix: *proxy_matrix
 
   client_nightly:
     triggers:


### PR DESCRIPTION
## Status

Ready for review

## Description

These are failing because of <https://github.com/freedomofpress/securedrop-client/issues/1681>.

Our plan is to just replace them entirely with proxy v2, so just skip these jobs for now so commits can at least get a green check again.

## Test Plan

* [ ] This commit gets a green check

