### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,21 +12,33 @@ updates:
       interval: "weekly"
     allow:
       - dependency-type: "development"
+    groups:
+      dev-dependencies:
+        patterns: ["*"]
   - package-ecosystem: "pip"
     directory: "/export"
     schedule:
       interval: "weekly"
     allow:
       - dependency-type: "development"
+    groups:
+      dev-dependencies:
+        patterns: ["*"]
   - package-ecosystem: "pip"
     directory: "/log"
     schedule:
       interval: "weekly"
     allow:
       - dependency-type: "development"
+    groups:
+      dev-dependencies:
+        patterns: ["*"]
   - package-ecosystem: "pip"
     directory: "/proxy"
     schedule:
       interval: "weekly"
     allow:
       - dependency-type: "development"
+    groups:
+      dev-dependencies:
+        patterns: ["*"]


### PR DESCRIPTION
## Status

Ready for review 

## Description

To cut down on the number of PRs opened, have dependabot group all the updates for a component in a single pull request.

Refs #1823.

## Test Plan

* [x] visual review, can compare with https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#example-2

