### PR TITLE
More dependabot config tweaks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
       interval: "weekly"
     allow:
       - dependency-type: "development"
+    ignore:
+      - dependency-name: "pyqt*"
     groups:
       dev-dependencies:
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
     groups:
       dev-dependencies:
         patterns: ["*"]
+        dependency-type: "development"
   - package-ecosystem: "pip"
     directory: "/export"
     schedule:
@@ -24,6 +25,7 @@ updates:
     groups:
       dev-dependencies:
         patterns: ["*"]
+        dependency-type: "development"
   - package-ecosystem: "pip"
     directory: "/log"
     schedule:
@@ -33,6 +35,7 @@ updates:
     groups:
       dev-dependencies:
         patterns: ["*"]
+        dependency-type: "development"
   - package-ecosystem: "pip"
     directory: "/proxy"
     schedule:
@@ -42,3 +45,4 @@ updates:
     groups:
       dev-dependencies:
         patterns: ["*"]
+        dependency-type: "development"


### PR DESCRIPTION
## Status

Ready for review

## Description

Refs #1823

#### Have dependabot ignore pyqt*

These are pinned to the Debian versions and shouldn't be updated. Plus
dependabot errors on them anyways (e.g.
<https://github.com/freedomofpress/securedrop-client/network/updates/786279544>).

#### Tell dependabot a bit harder we only want dev updates

In <https://github.com/freedomofpress/securedrop-client/pull/1827#issuecomment-1941820767>
it updated a production dependency, which we don't want. I'm not sure
whether this will have an impact or whether it'll update it regardless
since a dev dependency wants the newer urllib, we'll see.

## Test Plan

* [ ] Visual review

