### PR TITLE
Remove gvfs-bin dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -40,7 +40,7 @@ Description: This is securedrop Qubes proxy service
 
 Package: securedrop-workstation-config
 Architecture: all
-Depends: nautilus, gvfs-bin, securedrop-keyring
+Depends: nautilus, securedrop-keyring
 Description: This is the SecureDrop workstation template configuration package.
  This package provides dependencies and configuration for the Qubes SecureDrop workstation VM Templates.
 


### PR DESCRIPTION
## Status

Ready for review

## Description

This was deprecated in bullseye and removed in bookworm. It provided the `gvfs-copy` and `gvfs-rename` commands, which I couldn't find any usage of in our code.

Fixes #1787.

## Test Plan

* [ ] Visual review
* [ ] Smoke test on a 4.1/bullseye workstation?