### PR TITLE
Add shellcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     container: debian:${{ matrix.debian_version }}
     steps:
       - run: |
-          apt-get update && apt-get install --yes git make
+          apt-get update && apt-get install --yes git make file
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ lint-desktop: ## Lint .desktop files
 	find . -name *.desktop -type f -not -path '*/\.git/*' | xargs desktop-file-validate
 
 .PHONY: lint
-lint: check-black check-isort bandit ## Run linters and formatters
+lint: check-black check-isort bandit shellcheck ## Run linters and formatters
 
 .PHONY: fix
 fix: black isort ## Fix lint and formatting issues
@@ -42,6 +42,10 @@ safety:  ## Run safety dependency checks on build dependencies
 		--ignore 61893 \
 		--ignore 62044 \
  		-r
+
+.PHONY: shellcheck
+shellcheck:  ## Lint shell scripts
+	@poetry run ./scripts/shellcheck.sh
 
 .PHONY: rust-lint
 rust-lint: ## Lint Rust code

--- a/client/.githooks/pre-commit
+++ b/client/.githooks/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
-TOP=`git rev-parse --show-toplevel`
+TOP=$(git rev-parse --show-toplevel)
 
 make -C "$TOP" check-strings

--- a/debian/securedrop-keyring.preinst
+++ b/debian/securedrop-keyring.preinst
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+# shellcheck disable=SC2064
 set -e
 
 # Solution adapted from DKG's work on `deb.torproject.org-keyring` and
@@ -31,4 +31,3 @@ if [ -e /etc/apt/trusted.gpg ] && which gpg >/dev/null; then
 fi
 
 #DEBHELPER#
-

--- a/debian/setup-venv.sh
+++ b/debian/setup-venv.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2086
 set -euxo pipefail
 
 NAME=$1

--- a/poetry.lock
+++ b/poetry.lock
@@ -904,6 +904,19 @@ testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[l
 testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
+name = "shellcheck-py"
+version = "0.9.0.6"
+description = "Python wrapper around invoking shellcheck (https://www.shellcheck.net/)"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "shellcheck_py-0.9.0.6-py2.py3-none-macosx_11_0_x86_64.whl", hash = "sha256:38d48a4e2279f5deac374574e7625cd53b7f615301f36b1b1fffd22105dc066d"},
+    {file = "shellcheck_py-0.9.0.6-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:730235c4f92657884f8b343d5426e4dc28e9a6ba9ad54d469cd038e340ea5be0"},
+    {file = "shellcheck_py-0.9.0.6-py2.py3-none-win_amd64.whl", hash = "sha256:d1d0c285e2c094813659e0920559a2892da598c1176da59cb4eb9e2f505e5ee8"},
+    {file = "shellcheck_py-0.9.0.6.tar.gz", hash = "sha256:f83a0ee1e9762f787ab52e8a906e553b9583586c44e3f9730b6e635f296a69e8"},
+]
+
+[[package]]
 name = "stevedore"
 version = "5.1.0"
 description = "Manage dynamic plugins for Python applications"
@@ -980,4 +993,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "a4319256f0a3818846eddef054452e7a568f61ef60273239934f9708abe94b7e"
+content-hash = "cf9ebf9eb3a2f8942a0dbfcf47f699439e19b0f7e9aceb990e609eae35720e13"

--- a/proxy/entrypoint.sh
+++ b/proxy/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 cd /home/user/projects/securedrop-proxy
 virtualenv .venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ bandit = "*"
 black = "*"
 isort = "*"
 safety = "*"
+shellcheck-py = "*"
 
 [tool.bandit]
 exclude_dirs = ["client/tests", "export/tests", "log/tests", "proxy/tests"]

--- a/scripts/build-debs.sh
+++ b/scripts/build-debs.sh
@@ -29,13 +29,14 @@ if test -t 0; then
 fi
 
 # Look for the builder repo with our local wheels
-export BUILDER=$(realpath "${BUILDER:-../securedrop-builder}")
+BUILDER=$(realpath "${BUILDER:-../securedrop-builder}")
 if [[ ! -d $BUILDER ]]; then
     echo "Cannot find securedrop-builder repository, please check it out \
 to ${BUILDER} or set the BUILDER variable"
     exit 1
 fi
 
+export BUILDER
 export DEBIAN_VERSION="${DEBIAN_VERSION:-bullseye}"
 export OCI_RUN_ARGUMENTS
 export OCI_BIN

--- a/scripts/fixup-changelog.sh
+++ b/scripts/fixup-changelog.sh
@@ -7,13 +7,13 @@ source /etc/os-release
 if [[ "$VERSION_CODENAME" == "" ]]; then
     # PRETTY_NAME="Debian GNU/Linux bookworm/sid"
     # Use awk to split on spaces and /
-    VERSION_CODENAME=$(echo $PRETTY_NAME | awk '{split($0, a, "[ /]"); print a[4]}')
+    VERSION_CODENAME=$(echo "$PRETTY_NAME" | awk '{split($0, a, "[ /]"); print a[4]}')
 fi
 
 VERSION=$(dpkg-parsechangelog -S Version)
 
 NIGHTLY="${NIGHTLY:-}"
-if [[ ! -z $NIGHTLY ]]; then
+if [[ -n $NIGHTLY ]]; then
     NEW_VERSION="${VERSION}.dev$(date +%Y%m%d%H%M%S)"
 else
     NEW_VERSION=$VERSION

--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+EXCLUDE_RULES="SC1091,SC2001,SC2164"
+
+# Omitting:
+# - the `.git/` directory since its hooks won't pass # validation, and
+#   we don't maintain those scripts.
+# - Python, JavaScript, YAML, HTML, SASS, PNG files because they're not shell scripts.
+# - Cache directories
+# - test results
+FILES=$(find "." \
+     \( \
+        -path '*.mo' \
+        -o -path '*.po' \
+        -o -path '*.py' \
+        -o -path '*.yml' \
+        -o -path '*/.mypy_cache/*' \
+        -o -path './.git' \
+        -o -path './build/*' \
+        -o -path './target' \
+     \) -prune \
+     -o -type f \
+     -exec file --mime {} + \
+    | awk '$2 ~ /x-shellscript/ { print $1 }' \
+    | sed 's/://')
+# Turn the multiline find output into a single space-separated line
+FILES=$(echo "$FILES" | tr '\n' ' ')
+
+shellcheck --version
+# $FILES intentionally unquoted so each file is passed as its own argument
+# shellcheck disable=SC2086
+shellcheck -x --exclude="$EXCLUDE_RULES" $FILES

--- a/update_version.sh
+++ b/update_version.sh
@@ -18,7 +18,7 @@ sed -i'' -r -e "s/^__version__ = \"(.*?)\"/__version__ = \"${NEW_VERSION}\"/" cl
 sed -i'' -r -e "s/^__version__ = \"(.*?)\"/__version__ = \"${NEW_VERSION}\"/" export/securedrop_export/__init__.py
 
 # Normalize version, convert any - to ~, e.g. 0.9.0-rc1 to 0.9.0~rc1
-DEB_VERSION=$(echo $NEW_VERSION | sed 's/-/~/g')
+DEB_VERSION=$(echo "$NEW_VERSION" | sed 's/-/~/g')
 
 export DEBEMAIL="securedrop@freedom.press"
 export DEBFULLNAME="SecureDrop Team"


### PR DESCRIPTION
## Status

Ready for review

## Description

Copy the `shellcheck.sh` script from the SecureDrop server repository and add it to the central `make lint` target. I added SC2164 as a global exclusion since we don't really care about `cd` potentially failing.

The following fixes are being made:
* client/.githooks/pre-commit: Use $() instead of backticks.
* debian/setup-venv.sh: Ignore quoting words, all the variables are a single word only.
* proxy/entrypoint.sh: Adjust shebang since we use bashisms.
* scripts/build-debs.sh: Set variable and then export it
* scripts/fixup-changelog.sh: Quote our variables, don't use `! -z`.

Fixes #814.

## Test Plan

* [ ] CI passes
* [ ] Visual review

