### PR TITLE
Have CI run piuparts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           PKG_DIR=../proxy make -C securedrop-builder requirements
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git diff --ignore-matching-lines=# --exit-code
-          
+
 
   build-debs:
     strategy:
@@ -119,3 +119,39 @@ jobs:
             echo "Diffoscoping $deb"
             diffoscope build-${{ matrix.debian_version }}/$deb build2-${{ matrix.debian_version }}/$deb
           done;
+
+  piuparts:
+    strategy:
+      fail-fast: false
+      matrix:
+        # TODO: client sets up apparmor, which doesn't work in our CI setup
+        # TODO: workstation-config pulls in systemd, which doesn't work
+        # TODO: workstation-viewer pulls in grsec and qubes packages
+        package:
+          - export
+          - keyring
+          - log
+          - proxy
+        debian_version:
+          - bullseye
+          - bookworm
+    runs-on: ubuntu-latest
+    needs:
+      - build-debs
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "build-${{ matrix.debian_version }}"
+      - name: Run piuparts
+        run: |
+          # We need to run it as docker-in-docker
+          docker run \
+            -v "/var/lib/docker:/var/lib/docker" \
+            -v "/var/run/docker.sock:/var/run/docker.sock" \
+            -v "/$(pwd)/keyring:/keyring" \
+            -v "/$(pwd)/build-${{ matrix.debian_version }}:/build" \
+            -v "/$(pwd)/.github/workflows/piuparts:/piuparts" \
+            -e DISTRO=${{ matrix.debian_version }} \
+            -e PACKAGE=${{ matrix.package }} \
+            debian:${{ matrix.debian_version }} bash /piuparts/run-piuparts.sh

--- a/.github/workflows/piuparts/Dockerfile
+++ b/.github/workflows/piuparts/Dockerfile
@@ -1,0 +1,9 @@
+ARG DISTRO=bullseye
+FROM debian:$DISTRO
+
+RUN apt-get update && apt-get upgrade --yes && apt-get install -y ca-certificates
+# FIXME: Do this to fool piuparts into thinking we didn't remove /opt during
+# the package purge. Why does purging our packages not work properly?
+RUN rm -rf /opt
+# CI manifest will copy keyring into the build directory
+COPY securedrop-keyring.gpg /usr/share/keyrings

--- a/.github/workflows/piuparts/run-piuparts.sh
+++ b/.github/workflows/piuparts/run-piuparts.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euxo pipefail
+# Runs inside the container
+apt-get update && apt-get install --yes piuparts docker.io
+
+cd /piuparts
+
+cp /keyring/securedrop-keyring.gpg .
+docker build . --build-arg DISTRO=$DISTRO -t ourimage
+
+# TODO: Our currently released packages don't install with piuparts, so we pass
+# --no-upgrade-test to avoid installing them and testing the upgrade path. Once
+# they do we can remove that line.
+piuparts --docker-image ourimage \
+    --distribution $DISTRO \
+    --extra-repo 'deb [signed-by=/usr/share/keyrings/securedrop-keyring.gpg] https://apt.freedom.press bullseye main' \
+    --warn-on-leftovers-after-purge \
+    --no-upgrade-test \
+    /build/securedrop-${PACKAGE}*.deb

--- a/debian/control
+++ b/debian/control
@@ -40,7 +40,7 @@ Description: This is securedrop Qubes proxy service
 
 Package: securedrop-workstation-config
 Architecture: all
-Depends: nautilus, gvfs-bin, securedrop-keyring
+Depends: nautilus, securedrop-keyring
 Description: This is the SecureDrop workstation template configuration package.
  This package provides dependencies and configuration for the Qubes SecureDrop workstation VM Templates.
 

--- a/debian/control
+++ b/debian/control
@@ -9,12 +9,13 @@ X-Python3-Version: >= 3.5
 
 Package: securedrop-client
 Architecture: all
-Depends: ${python3:Depends},${misc:Depends}, python3-pyqt5, python3-pyqt5.qtsvg, apparmor-utils
+Depends: ${python3:Depends},${misc:Depends}, python3-pyqt5, python3-pyqt5.qtsvg, apparmor-utils, desktop-file-utils
 Description: securedrop client for qubes workstation
 
 Package: securedrop-export
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, udisks2, cups, printer-driver-brlaser, printer-driver-hpcups, system-config-printer, xpp, libcups2-dev, python3-dev, libtool-bin, unoconv, gnome-disk-utility
+Depends: ${python3:Depends}, ${misc:Depends}, udisks2, cups, printer-driver-brlaser, printer-driver-hpcups, system-config-printer, xpp, libcups2, unoconv, gnome-disk-utility,
+ desktop-file-utils, shared-mime-info
 Description: Submission export scripts for SecureDrop Workstation
  This package provides scripts used by the SecureDrop Qubes Workstation to
  export submissions from the client to external storage, via the sd-export

--- a/debian/securedrop-export.postrm
+++ b/debian/securedrop-export.postrm
@@ -22,8 +22,14 @@ set -e
 case "$1" in
     purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
 
-    update-desktop-database /usr/share/applications
-    update-mime-database /usr/share/mime
+    # There is no guarantees dependencies are available in postrm, so
+    # conditionally issue these updates.
+    if [[ -x "/usr/bin/update-desktop-database" ]]; then
+        update-desktop-database /usr/share/applications
+    fi
+    if [[ -x "/usr/bin/update-mime-database" ]]; then
+        update-mime-database /usr/share/mime
+    fi
     ;;
 
     *)


### PR DESCRIPTION
## Status

Ready for review, depends on #1842 first.

I'm mostly posting this because it works and is better than the status quo, but I'm a bit disappointed that we had to exempt nearly half of our packages to the point where this wouldn't have caught, e.g. #1787. I'm also going to play with using a chroot to see if that fixes workstation-config and workstation-viewer, but I don't want to block this on that. 

## Description

piuparts tests package installation, upgrade and removal. We don't care
that much about the last one so it's just a warning for now.

For each package, piuparts will install the package CI just built and
ensure that goes smoothly, making sure all the dependencies are present
and the postinst works. Issues that were found are being fixed in the
next commit.

At a later stage, once the released packages are passing piuparts too,
we can have it automatically grab the latest package from
apt.freedom.press, install that, and then test the upgrade path to the
new CI-built packages.

This CI setup relies on running docker-in-docker, which is hacky but
seems to work. Unfortunately it doesn't work for the client (starts
apparmor), workstation-config (starts systemd) and workstation-viewer
(pulls in grsec kernel). In the future we can look at switching into a
chrooted setup that might fix the last two.

Getting this to work in GitHub Actions was inspired by
<https://github.com/evgeni/action-piuparts/> but I didn't really copy
any code.

Refs #1785.

#### Fix issues caught by piuparts

Both -client and -export were missing dependencies on
desktop-file-utils, which is needed for the `update-desktop-database`
call in the postinst. -export also needed shared-mime-info.

As far as I can tell, the -dev and libtool-bin dependencies in -export
are unnecessary; we aren't compiling any C/C++ code at runtime that
should need them.

Finally, make the postrm commands optional per
<https://www.debian.org/doc/debian-policy/ch-relationships.html#binary-dependencies-depends-recommends-suggests-enhances-pre-depends>,
which states that "There is no guarantee that package dependencies will
be available when postrm is run".


## Test Plan

 * [x] CI passes
 * [x] Visual review
