### PR TITLE
Run lintian on Debian packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
           lfs: true
       - name: Build packages
         run: |
-          DEBIAN_VERSION=${{ matrix.debian_version }} BUILDER=securedrop-builder ./scripts/build-debs.sh
+          DEBIAN_VERSION=${{ matrix.debian_version }} BUILDER=securedrop-builder FAST=1 ./scripts/build-debs.sh
       - uses: actions/upload-artifact@v4
         id: upload
         with:
@@ -68,8 +68,9 @@ jobs:
           path: build
           if-no-files-found: error
 
-  # Second round of builds (in parallel) for diffoscoping
-  build-debs2:
+  # Another set of builds for lintian checks and also so we can diffoscope
+  # for reproducibility issues with the first set
+  lintian:
     strategy:
       matrix:
         debian_version:
@@ -105,7 +106,7 @@ jobs:
     container: debian:bookworm
     needs:
       - build-debs
-      - build-debs2
+      - lintian
     steps:
       - name: Install dependencies
         run: |

--- a/debian/securedrop-client.lintian-overrides
+++ b/debian/securedrop-client.lintian-overrides
@@ -1,0 +1,32 @@
+securedrop-client: arch-independent-package-contains-binary-or-object
+
+# This is intentional
+securedrop-client: dir-or-file-in-opt
+
+# FIXME
+securedrop-client: extended-description-is-empty
+
+# FIXME: fix by switching to arch: any
+securedrop-client: missing-dependency-on-libc
+
+# FIXME: remove __pycache__ directories
+securedrop-client: package-installs-python-pycache-dir
+
+# FIXME: section shouldn't be "unknown"
+securedrop-client: section-is-dh_make-template
+
+# FIXME: fix by switching to arch: any
+securedrop-client: unstripped-binary-or-object [opt/venvs/securedrop-client/lib/python3.*/site-packages/markupsafe/*]
+securedrop-client: unstripped-binary-or-object [opt/venvs/securedrop-client/lib/python3.*/site-packages/sqlalchemy/*]
+
+# We don't care
+securedrop-client: no-manual-page
+
+# FIXME
+securedrop-client: package-contains-vcs-control-file [opt/venvs/securedrop-client/.gitignore]
+
+# We don't care about these
+securedrop-client: script-not-executable
+
+# This is our virtualenv's interpreter
+securedrop-client: unusual-interpreter

--- a/debian/securedrop-export.lintian-overrides
+++ b/debian/securedrop-export.lintian-overrides
@@ -1,0 +1,29 @@
+# Yes, we ship stuff in /opt
+securedrop-export: dir-or-file-in-opt [opt/venvs/*]
+
+# FIXME: don't install __pycache__
+securedrop-export: package-installs-python-pycache-dir
+
+# FIXME: section shouldn't be "unknown"
+securedrop-export: section-is-dh_make-template
+
+# TODO: "does not provide a code like %f, %F, %u or %U in the Exec key."
+securedrop-export: desktop-mime-but-no-exec-code [usr/share/applications/send-to-usb.desktop]
+
+# We don't care about man pages
+securedrop-export: no-manual-page
+
+# FIXME: don't ship gitignore
+securedrop-export: package-contains-vcs-control-file [opt/venvs/securedrop-export/.gitignore]
+
+# Doesn't matter
+securedrop-export: script-not-executable
+
+# This is our virtualenv's interpreter
+securedrop-export: unusual-interpreter
+
+# This is intentional
+securedrop-export: file-in-etc-not-marked-as-conffile [etc/udisks2/tcrypt.conf]
+
+# This is intentional
+securedrop-export: control-file-is-empty [conffiles]

--- a/debian/securedrop-keyring.lintian-overrides
+++ b/debian/securedrop-keyring.lintian-overrides
@@ -1,0 +1,20 @@
+# FIXME
+securedrop-keyring: extended-description-is-empty
+
+# This is intentional
+securedrop-keyring: file-in-etc-not-marked-as-conffile [etc/apt/trusted.gpg.d/securedrop-keyring.gpg]
+
+# This is intentional
+securedrop-keyring: package-installs-apt-keyring [etc/apt/trusted.gpg.d/securedrop-keyring.gpg]
+
+# FIXME: section shouldn't be "unknown"
+securedrop-keyring: section-is-dh_make-template
+
+# This is intentional
+securedrop-keyring: control-file-is-empty [conffiles]
+
+# FIXME: abbreviate
+securedrop-keyring: synopsis-too-long
+
+# TODO: this probably isn't an issue, double check our kernels have fs.protected_hardlinks=1.
+securedrop-keyring: recursive-privilege-change

--- a/debian/securedrop-log.lintian-overrides
+++ b/debian/securedrop-log.lintian-overrides
@@ -1,0 +1,33 @@
+# This is intentional
+securedrop-log: dir-or-file-in-opt
+
+# FIXME: remove __pycache__ directories
+securedrop-log: package-installs-python-pycache-dir
+
+# FIXME: missing a python3 dependency
+securedrop-log: python3-script-but-no-python3-dep
+
+# FIXME: section shouldn't be "unknown"
+securedrop-log: section-is-dh_make-template
+
+# TODO: we should ship this in /lib instead
+securedrop-log: systemd-service-in-odd-location [etc/systemd/system/securedrop-log.service]
+
+# This is fine
+securedrop-log: executable-not-elf-or-script [etc/qubes-rpc/*]
+
+# FIXME: abbreviate
+securedrop-log: extended-description-line-too-long
+
+# We don't care
+securedrop-log: no-manual-page
+
+# FIXME
+securedrop-log: package-contains-vcs-control-file [opt/venvs/securedrop-log/.gitignore]
+
+# We don't care about these
+securedrop-log: script-not-executable
+
+# This is our virtualenv's interpreter
+securedrop-log: unusual-interpreter
+securedrop-log: wrong-path-for-interpreter

--- a/debian/securedrop-proxy.lintian-overrides
+++ b/debian/securedrop-proxy.lintian-overrides
@@ -1,0 +1,35 @@
+# FIXME: fix by switching to arch: any
+securedrop-proxy: arch-independent-package-contains-binary-or-object
+
+# This is intentional
+securedrop-proxy: dir-or-file-in-opt
+
+# FIXME: fix by switching to arch: any
+securedrop-proxy: missing-dependency-on-libc
+
+# FIXME: remove __pycache__ directories
+securedrop-proxy: package-installs-python-pycache-dir
+
+# FIXME: section shouldn't be "unknown"
+securedrop-proxy: section-is-dh_make-template
+
+# FIXME: fix by switching to arch: any
+securedrop-proxy: unstripped-binary-or-object [opt/venvs/securedrop-proxy/lib/python3.*/site-packages/yaml/*]
+
+# This is fine
+securedrop-proxy: executable-not-elf-or-script [etc/qubes-rpc/*]
+
+# FIXME: abbreviate
+securedrop-proxy: extended-description-line-too-long
+
+# We don't care
+securedrop-proxy: no-manual-page
+
+# FIXME
+securedrop-proxy: package-contains-vcs-control-file [opt/venvs/securedrop-proxy/.gitignore]
+
+# We don't care about these
+securedrop-proxy: script-not-executable
+
+# This is our virtualenv's interpreter
+securedrop-proxy: unusual-interpreter

--- a/debian/securedrop-workstation-config.lintian-overrides
+++ b/debian/securedrop-workstation-config.lintian-overrides
@@ -1,0 +1,11 @@
+# This is intentional
+securedrop-workstation-config: dir-or-file-in-opt
+
+# FIXME: section shouldn't be "unknown"
+securedrop-workstation-config: section-is-dh_make-template
+
+# FIXME: abbreviate
+securedrop-workstation-config: extended-description-line-too-long
+
+# We're just restarting paxctld, it's fine
+securedrop-workstation-config: maintainer-script-calls-systemctl [postinst:28]

--- a/debian/securedrop-workstation-viewer.lintian-overrides
+++ b/debian/securedrop-workstation-viewer.lintian-overrides
@@ -1,0 +1,11 @@
+# FIXME
+securedrop-workstation-viewer: extended-description-is-empty
+
+# FIXME: section shouldn't be "unknown"
+securedrop-workstation-viewer: section-is-dh_make-template
+
+# FIXME: Needs "metapackage" in the description
+securedrop-workstation-viewer: empty-binary-package
+
+# FIXME: abbreviate
+securedrop-workstation-viewer: synopsis-too-long

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,0 +1,5 @@
+securedrop-client source: python3-depends-but-no-python3-helper
+securedrop-client source: ancient-python-version-field
+securedrop-client source: custom-compression-in-debian-source-options
+securedrop-client source: debhelper-but-no-misc-depends
+securedrop-client source: missing-license-paragraph-in-dep5-copyright

--- a/debian/source/options
+++ b/debian/source/options
@@ -2,3 +2,9 @@
 compression = "gzip"
 # ignore the build/ directory, that contains our artifacts
 tar-ignore = "build"
+# ignore all dotfiles + hidden directories
+tar-ignore = ".*"
+# and some more generated directories
+tar-ignore = "__pycache__"
+tar-ignore = "htmlcov"
+tar-ignore = "target"

--- a/scripts/build-debs-real.sh
+++ b/scripts/build-debs-real.sh
@@ -22,7 +22,6 @@ apt-get build-dep . --yes
 dpkg-buildpackage --no-sign
 ls ../
 # Copy the built artifacts back and print checksums
-mkdir -p /src/build/
-mv -v ../*.{buildinfo,changes,deb,dsc,tar.gz} /src/build/
-cd /src/build/
+mv -v ../*.{buildinfo,changes,deb,dsc,tar.gz} /build/
+cd /build/
 sha256sum ./*

--- a/scripts/lintian/Dockerfile
+++ b/scripts/lintian/Dockerfile
@@ -1,0 +1,3 @@
+FROM debian:bookworm
+
+RUN apt-get update && apt-get --yes upgrade && apt-get install --yes lintian


### PR DESCRIPTION
## Status

Ready for review

## Description

lintian is the Debian package linter and catches a number of things we can improve in our packages. For now I've suppressed everything and annotated them with TODO/FIXME for others to take on or address incrementally.

lintian is run at the end of `make build-debs` unless the "FAST" environment variable is set. Any warning or error causes the build to fail, but it can be suppressed in the corresponding lintian-overrides file.

Internally there's a bit of work so we can identify the *.changes file that we just built, so we first build into a temporary directory, copy the files into our repository's build, then run lintian in the temporary directory.

Refs #1785.

## Test Plan

* [x] `make build-debs` passes locally
* [x] `DEBIAN_VERSION=bookworm make build-debs` passes locally too
* [x] `FAST=1 make build-debs` doesn't run lintian
* [x] CI passes
* [x] Infra moving the "Required" label from the now-renamed build-debs2/bullseye job to lintian/bullseye.

