### PR TITLE
Use dh_apparmor for installing profile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,10 +124,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: client sets up apparmor, which doesn't work in our CI setup
         # TODO: workstation-config pulls in systemd, which doesn't work
         # TODO: workstation-viewer pulls in grsec and qubes packages
         package:
+          - client
           - export
           - keyring
           - log

--- a/debian/control
+++ b/debian/control
@@ -2,14 +2,14 @@ Source: securedrop-client
 Section: unknown
 Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Build-Depends: debhelper-compat (= 11), python3-virtualenv
+Build-Depends: debhelper-compat (= 11), dh-apparmor, python3-virtualenv
 Standards-Version: 3.9.8
 Homepage: https://github.com/freedomofpress/securedrop-client
 X-Python3-Version: >= 3.5
 
 Package: securedrop-client
 Architecture: all
-Depends: ${python3:Depends},${misc:Depends}, python3-pyqt5, python3-pyqt5.qtsvg, apparmor-utils, desktop-file-utils
+Depends: ${python3:Depends},${misc:Depends}, python3-pyqt5, python3-pyqt5.qtsvg, desktop-file-utils
 Description: securedrop client for qubes workstation
 
 Package: securedrop-export

--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,7 @@ override_dh_auto_install:
 	bash ./debian/setup-venv.sh log
 	bash ./debian/setup-venv.sh proxy
 	dh_auto_install
+	dh_apparmor --profile-name=usr.bin.securedrop-client -psecuredrop-client
 
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete

--- a/debian/securedrop-client.postinst
+++ b/debian/securedrop-client.postinst
@@ -22,7 +22,6 @@ case "$1" in
     configure)
 
     update-desktop-database /usr/share/applications
-    aa-enforce /usr/bin/securedrop-client
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
## Status

Ready for review

## Description

dh_apparmor generates the appropriate postinst and postrm snippets for (re)loading apparmor profiles in a way that seems more robust than our current usage of `aa-enforce`.

If apparmor isn't enabled, then it gracefully skips instead of aborting the installation. This allows for installing the client package in contexts where apparmor isn't available, like containers. Notably we can now enable piuparts testing for the client.

Fixes #1853.

## Test Plan

* [x] Build package, install in a qubes VM. Start client (just the login screen is fine), run `sudo aa-status`, see output like:
```
17 profiles are in enforce mode.
   ...
   /usr/bin/securedrop-client <-- this
...
4 processes are in enforce mode.
   /usr/bin/dash (10941) /usr/bin/securedrop-client <-- and
   /usr/bin/python3.9 (10944) /usr/bin/securedrop-client <-- this
```
* [x] Spin up a podman/docker container, install the package and it succeeds. Run `sudo aa-status` to verify apparmor is *not* enabled.

