### PR TITLE
Enable "merge_group" events for GitHub's merge queue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: Package builds
-on: [push, pull_request]
+on:
+  - merge_group
+  - push
+  - pull_request
+
 # Only build for latest push/PR unless it's main or release/
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/cargo-vet.yml
+++ b/.github/workflows/cargo-vet.yml
@@ -1,8 +1,11 @@
 # Roughly based off of https://mozilla.github.io/cargo-vet/configuring-ci.html
 
 name: cargo vet
+on:
+  - merge_group
+  - push
+  - pull_request
 
-on: [push, pull_request]
 # Only build for latest push/PR unless it's main or release/
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push, pull_request]
+on:
+  - merge_group
+  - push
+  - pull_request
+
 # Only build for latest push/PR unless it's main or release/
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -1,5 +1,9 @@
 name: SDK
-on: [push, pull_request]
+on:
+  - merge_group
+  - push
+  - pull_request
+
 # Only build for latest push/PR unless it's main or release/
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: Tests
-on: [push, pull_request]
+on:
+  - merge_group
+  - push
+  - pull_request
+
 # Only build for latest push/PR unless it's main or release/
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Status

Ready for review, needs discussion

## Description

We need to also trigger on the "merge_group" event for GitHub's merge queue to work. This is the same as <https://github.com/freedomofpress/securedrop-dev-docs/pull/130>.

## Test Plan

* [ ] Visual review

