### PR TITLE
Cancel old GHA builds if new commits are pushed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: Package builds
 on: [push, pull_request]
+# Only build for latest push/PR unless it's main or release/
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith( github.ref, 'refs/heads/release/' ) }}
 
 defaults:
   run:
@@ -36,7 +40,7 @@ jobs:
           PKG_DIR=../proxy make -C securedrop-builder requirements
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git diff --ignore-matching-lines=# --exit-code
-          
+
 
   build-debs:
     strategy:

--- a/.github/workflows/cargo-vet.yml
+++ b/.github/workflows/cargo-vet.yml
@@ -3,6 +3,10 @@
 name: cargo vet
 
 on: [push, pull_request]
+# Only build for latest push/PR unless it's main or release/
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith( github.ref, 'refs/heads/release/' ) }}
 
 jobs:
   cargo-vet:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 on: [push, pull_request]
+# Only build for latest push/PR unless it's main or release/
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith( github.ref, 'refs/heads/release/' ) }}
 
 defaults:
   run:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -1,5 +1,9 @@
 name: SDK
 on: [push, pull_request]
+# Only build for latest push/PR unless it's main or release/
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith( github.ref, 'refs/heads/release/' ) }}
 
 defaults:
   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: Tests
 on: [push, pull_request]
+# Only build for latest push/PR unless it's main or release/
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith( github.ref, 'refs/heads/release/' ) }}
 
 defaults:
   run:


### PR DESCRIPTION
## Status

Ready for review

## Description

If the branch is not main and not a release branch, then cancel old in-progress jobs.

Reduces the queue size when refactoring or quickly pushing new things.
This is roughly the same behavior CircleCI had.
    
Inspired by <https://stackoverflow.com/questions/68418857/how-to-cancel-existing-runs-when-a-new-push-happens-on-github-actions-but-only>.
    
Fixes #1858.

## Test Plan

* [ ] When I force pushed onto this branch, it cancelled the in-progress jobs (see screenshot)
* [ ] Feel free to amend/push to this PR for further testing
![Screenshot 2024-02-22 at 17-07-27 Workflow runs · freedomofpress_securedrop-client](https://github.com/freedomofpress/securedrop-client/assets/81392/ff946ad4-c85c-40b0-ba4f-c08a06103bbb)
