### PR TITLE
Appease shellcheck (run-piuparts.sh, securedrop-export.postrm)

### DIFF
--- a/.github/workflows/piuparts/run-piuparts.sh
+++ b/.github/workflows/piuparts/run-piuparts.sh
@@ -6,14 +6,14 @@ apt-get update && apt-get install --yes piuparts docker.io
 cd /piuparts
 
 cp /keyring/securedrop-keyring.gpg .
-docker build . --build-arg DISTRO=$DISTRO -t ourimage
+docker build . --build-arg DISTRO="$DISTRO" -t ourimage
 
 # TODO: Our currently released packages don't install with piuparts, so we pass
 # --no-upgrade-test to avoid installing them and testing the upgrade path. Once
 # they do we can remove that line.
 piuparts --docker-image ourimage \
-    --distribution $DISTRO \
+    --distribution "$DISTRO" \
     --extra-repo 'deb [signed-by=/usr/share/keyrings/securedrop-keyring.gpg] https://apt.freedom.press bullseye main' \
     --warn-on-leftovers-after-purge \
     --no-upgrade-test \
-    /build/securedrop-${PACKAGE}*.deb
+    /build/securedrop-"${PACKAGE}"*.deb

--- a/debian/securedrop-export.postrm
+++ b/debian/securedrop-export.postrm
@@ -2,6 +2,7 @@
 # postrm script for securedrop-export
 #
 # see: dh_installdeb(1)
+# shellcheck disable=SC3010
 
 set -e
 


### PR DESCRIPTION
## Status

Ready for review

## Description

Fixes CI failures that shellcheck picked up:
- `run-piuparts.sh` (addressed)
- `securedrop-export.postrm` (suppressed)

## Test Plan
- [x] CI passing
- [x] Visual review

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
