### PR TITLE
Export improvements + documentation

### DIFF
--- a/client/securedrop_client/gui/conversation/export/export_wizard_page.py
+++ b/client/securedrop_client/gui/conversation/export/export_wizard_page.py
@@ -402,6 +402,10 @@ class FinalPage(ExportWizardPage):
             header = _("Export sucessful, but drive was not locked")
             body = STATUS_MESSAGES.get(status)
 
+        elif status in self.UNRECOVERABLE_ERRORS:
+            header = _("Export Failed")
+            body = STATUS_MESSAGES.get(status)
+
         else:
             header = _("Working...")
 
@@ -411,9 +415,9 @@ class FinalPage(ExportWizardPage):
 
     def isComplete(self) -> bool:
         """
-        Override the default isComplete() implementation in order to disable the "Finish"
+        Override the default isComplete() implementation in order to disable the "Done"
         button while an export is taking place. (If the "Working...." header is being shown,
-        the export is still in progress and "Finish" should not be clickable.)
+        the export is still in progress and "Done" should not be clickable.)
         """
         if self.status:
             return self.status not in (

--- a/export/README.md
+++ b/export/README.md
@@ -9,13 +9,25 @@ Code for exporting and printing files from the SecureDrop Qubes Workstation.
 
 ## Supported Printers
 
-TBD
+Printer support is currently limited to a subset of Brother and HP printers that offer USB
+(non-wireless) connectivity, such as:
+
+- HP LaserJet Pro 4001dn
+- Brother HL-L2320D
 
 ## Supported Export Devices
 
-We support luks-encrypted drives that are either MBR/DOS partitioned or GPT partitioned. If you use `Disks` in Linux to partition your drive, you can [follow these instructions](https://docs.securedrop.org/en/stable/set_up_transfer_and_export_device.html#create-usb-transfer-device) to create a new export device. You can also use [cryptsetup](https://linux.die.net/man/8/cryptsetup) to create a luks-encrypted device with full-disk encryption, for example:
+Export to LUKS-encrypted or VeraCrypt-encrypted USB devices is supported.
 
-1. `sudo cryptsetup luksFormat --hash=sha512 --key-size=512 DEVICE` where `DEVICE` is the name of your removable drive, which you can find via `lsblk -p`.
+### LUKS
+Partition a drive (either the MBR/DOS or the GPT partition scheme is fine)
+and encrypt exactly one partition with LUKS.  On Linux, you can
+[follow these instructions](https://docs.securedrop.org/en/stable/set_up_transfer_and_export_device.html#create-usb-transfer-device)
+to use GNOME Disks to set up your drive.  You can also use
+[cryptsetup](https://linux.die.net/man/8/cryptsetup):
+
+1. `sudo cryptsetup luksFormat --hash=sha512 --key-size=512 DEVICE` where `DEVICE`
+   is the name of your removable drive, which you can find via `lsblk -p`.
 
    Make sure `DEVICE` is correct because you will be overwriting its data irrevocably.
 
@@ -25,7 +37,17 @@ We support luks-encrypted drives that are either MBR/DOS partitioned or GPT part
 
 4. `sudo cryptsetup luksClose /dev/mapper/encrypted_device`
 
-We do not yet support drives that use full-disk encryption with VeraCrypt.
+### VeraCrypt
+[Download and verify](https://www.veracrypt.fr/) VeraCrypt or VeraCrypt CLI and follow the
+documentation to provision a USB drive. When provisioning VeraCrypt drives, ensure that the
+filesystem is Linux-compatible. (FAT32 is suggested for cross-platform compatibility).
+
+VeraCrypt devices must be manually unlocked in order to be detected for export. Users
+will be prompted during the export workflow.
+
+Unlock a VeraCrypt device using the commandline in `sd-devices` by typing
+`udisksctl unlock -b /dev/sdXX`, where `/dev/sdXX` is the device as identified in
+the Devices widget (for example, `/dev/sda1`) or as identified by `lsblk -p`.
 
 ## Export Archive Format
 

--- a/export/securedrop_export/archive.py
+++ b/export/securedrop_export/archive.py
@@ -38,7 +38,6 @@ class Metadata(object):
                 json_config = json.loads(f.read())
                 self.export_method = json_config.get("device", None)
                 self.encryption_key = json_config.get("encryption_key", None)
-                self.encryption_method = json_config.get("encryption_method", None)
                 logger.info("Command: {}".format(self.export_method))
 
         except Exception as ex:

--- a/export/securedrop_export/disk/cli.py
+++ b/export/securedrop_export/disk/cli.py
@@ -416,7 +416,7 @@ class CLI:
             is_error = False
 
             target_path = os.path.join(device.mountpoint, archive_target_dirname)
-            subprocess.check_call(["mkdir", target_path])
+            subprocess.check_call(["mkdir", target_path], preexec_fn=self._set_umask_usb)
 
             export_data = os.path.join(archive_tmpdir, "export_data/")
             logger.debug("Copying file to {}".format(archive_target_dirname))
@@ -433,6 +433,14 @@ class CLI:
 
         finally:
             self.cleanup(device, archive_tmpdir, is_error)
+
+    def _set_umask_usb(self) -> None:
+        """
+        Set umask to 0o22 before writing to USB, to facilitate reading exported
+        files on other computers.
+        """
+        os.setpgrp()
+        os.umask(0o22)
 
     def cleanup(
         self,


### PR DESCRIPTION
## Status

Ready for review
- Blocked by #1873

## Description

Some stragglers:

- Remove `encryption_method` from archive.py (looks like a regression maybe based on rebasing/squashing - was meant to be fully removed during VeraCrypt work)
- Fix UI issue where `EXPORT_ERROR` did not update the UI (Seen once in testing by cfm:  https://github.com/freedomofpress/securedrop-client/pull/1777#pullrequestreview-1894631155) 
- Update export README to include veracrypt instructions and note about compatible printers

And one new change:
- Adjust umask only before writing to the export USB (Fixes #1726) - Per [sec eng approval ](https://github.com/freedomofpress/securedrop-client/issues/1726#issuecomment-1932771841) and discussion with previous sec eng. 

## Test Plan
- [x] CI passes
- [x] Visual review
- [x] Rapid testing: export to USB works on LUKS and VeraCrypt
- [x] Files on export USB have permission `644` (#1726)
- [x] Export still succeeds on drives unlocked with `sudo`

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
