### PR TITLE
Use find_packages in securedrop-client setup.py; use bash in securedrop-export postrm 

### DIFF
--- a/client/setup.py
+++ b/client/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     install_requires=["SQLAlchemy", "alembic", "securedrop-sdk", "python-dateutil", "arrow"],
     python_requires=">=3.5",
     url="https://github.com/freedomofpress/securedrop-client",
-    packages=["securedrop_client", "securedrop_client.gui", "securedrop_client.resources"],
+    packages=setuptools.find_packages(include=["securedrop_client", "securedrop_client.*"]),
     include_package_data=True,
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/debian/securedrop-export.postrm
+++ b/debian/securedrop-export.postrm
@@ -1,8 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 # postrm script for securedrop-export
 #
 # see: dh_installdeb(1)
-# shellcheck disable=SC3010
 
 set -e
 


### PR DESCRIPTION
## Status

WIP 
Fixes #1874 

## Description

After #1854 and #1844, there were two issues with building packages.  
- `securedrop-export` built successfully, but when installing, postrm generated an error due to not being POSIX compliant
- `securedrop-client` built "successfully" but a number of packages were missing. This was confusing until @cfm pointed me at setup.py, noticing that it specifies packages by name, and does not include all the packages. `MANIFEST.in` was filling that gap for us, which probably wasn't intentional.   

## Test Plan
- [x] Visual review
- [x] CI passing
- [ ] `.scripts/build-deb.sh` and smoketest (packages install and launch successfully)
- [ ] After installing freshly built package, venv in sd-app does not contain unnecessary files or directories

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
