### PR TITLE
Revert "Remove obsolete MANIFEST.in files"

### DIFF
--- a/client/MANIFEST.in
+++ b/client/MANIFEST.in
@@ -1,0 +1,33 @@
+include requirements/build-requirements.txt
+include requirements/requirements.txt
+include README.md
+include LICENSE
+include changelog.md
+include setup.py
+include files/alembic.ini
+include files/client.ini
+include files/securedrop-client
+include files/securedrop-client.desktop
+include files/sd-app-qubes-gpg-domain.sh
+include files/usr.bin.securedrop-client
+
+recursive-include alembic *
+recursive-include securedrop_client *
+
+recursive-exclude alembic *.pyc
+recursive-exclude securedrop_client *.pyc
+
+
+# --- LOCALIZATION ---
+
+# Translations may appear in the tree before we consider them supported, so
+# don't include any by default.
+prune securedrop_client/locale
+
+# Explicitly include only supported translations, one line for each $LANG, like:
+#
+#     graft securedrop_client/locale/$LANG
+#
+# Please keep this list alphabetized.
+graft securedrop_client/locale/pt_PT
+graft securedrop_client/locale/zh_Hans

--- a/export/MANIFEST.in
+++ b/export/MANIFEST.in
@@ -1,0 +1,9 @@
+include LICENSE
+include README.md
+include changelog.md
+include build-requirements.txt
+include securedrop_export/*.py
+include setup.py
+include files/send-to-usb.desktop
+include files/application-x-sd-export.xml
+include files/sd-logo.png

--- a/log/MANIFEST.in
+++ b/log/MANIFEST.in
@@ -1,0 +1,9 @@
+include LICENSE
+include README.md
+include changelog.md
+include build-requirements.txt
+include securedrop-log*
+include securedrop-redis-log
+include securedrop.Log
+include sd-rsyslog*
+include sdlog.conf

--- a/proxy/MANIFEST.in
+++ b/proxy/MANIFEST.in
@@ -1,0 +1,8 @@
+include LICENSE
+include README.md
+include changelog.md
+include config-example.yaml
+include qubes/securedrop.Proxy
+include build-requirements.txt
+include securedrop_proxy/*.py
+include setup.py


### PR DESCRIPTION
## Status

Ready for review

## Description

These are in fact used, when the package is installed into the virtualenv. (Contrast with SecureDrop server, which installs an empty package into the virtualenv, just copies our file tree over and relies on sys.path modifications to import things.)

This reverts commit 785be31863260c872a48c7226cfc352579693c86.

Fixes #1874.

## Test Plan

* [ ] `make build-debs`, verify that non-Python files like CSS are correctly installed into the venv for securedrop-client

