### PR TITLE
Parameterize sender_is_current_user in test instead of randomization

### DIFF
--- a/client/tests/gui/test_widgets.py
+++ b/client/tests/gui/test_widgets.py
@@ -3,11 +3,11 @@ Make sure the UI widgets are configured correctly and work as expected.
 """
 
 import math
-import random
 from datetime import datetime
 from gettext import gettext as _
 from unittest.mock import Mock, PropertyMock
 
+import pytest
 import sqlalchemy
 import sqlalchemy.orm.exc
 from PyQt5.QtCore import QEvent, QPointF, QSize, Qt
@@ -2863,12 +2863,14 @@ def test_ReplyBoxWidget__on_authentication_changed_updates_badge_when_switched_t
     reply_widget._update_styles.assert_called_once_with()
 
 
-def test_ReplyBoxWidget__on_authentication_changed_does_nothing_when_authenticated(mocker):
+@pytest.mark.parametrize("sender_is_current_user", [True, False])
+def test_ReplyBoxWidget__on_authentication_changed_does_nothing_when_authenticated(
+    mocker, sender_is_current_user
+):
     authenticated_user = factory.User()
     controller = mocker.MagicMock(authenticated_user=authenticated_user)
 
     sender = factory.User()
-    sender_is_current_user = random.choice([True, False])
     reply_widget = ReplyWidget(
         controller=controller,
         message_uuid="mock_uuid",


### PR DESCRIPTION
## Status

Ready for review

## Description

Instead of randomizing whether we're testing sender_is_current_user or not, just parameterize the test to properly test both cases, which increases coverage and reduces variance.

I noticed this because of ruff in a roundabout way, as it flagged the use of insecure randomization.

## Test Plan

* [ ] CI passes

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
