### PR TITLE
Fix lintian errors on nightlies

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -10,6 +10,7 @@ defaults:
 jobs:
   build-debs:
     strategy:
+      fail-fast: false
       matrix:
         debian_version:
           - bullseye

--- a/debian/securedrop-workstation-config.lintian-overrides
+++ b/debian/securedrop-workstation-config.lintian-overrides
@@ -9,3 +9,6 @@ securedrop-workstation-config: extended-description-line-too-long
 
 # We're just restarting paxctld, it's fine
 securedrop-workstation-config: maintainer-script-calls-systemctl [postinst:28]
+
+# We're not shipping CDs, so this is fine
+securedrop-workstation-config: package-has-long-file-name

--- a/debian/securedrop-workstation-viewer.lintian-overrides
+++ b/debian/securedrop-workstation-viewer.lintian-overrides
@@ -9,3 +9,6 @@ securedrop-workstation-viewer: empty-binary-package
 
 # FIXME: abbreviate
 securedrop-workstation-viewer: synopsis-too-long
+
+# We're not shipping CDs, so this is fine
+securedrop-workstation-viewer: package-has-long-file-name


### PR DESCRIPTION
## Status

Ready for review

## Description

Because of the date-based version, we end up triggering the "package-has-long-file-name" check, which is only an issue for distributing them via CDs, so we can suppress them.

While we're at it, set fail-fast: false, so even if one distro fails we can still see if the other would have succeeded or has other errors.

## Test Plan

* [ ] Visual review
* [ ] Run `NIGHTLY=1 make build-debs` and it exits as 0 (aka lintian passes)
* [ ] Run `NIGHTLY=1 DEBIAN_VERSION=bookworm make build-debs` and same result

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
