### PR TITLE
chore: remove pre-commit hooks

### DIFF
--- a/client/.githooks/pre-commit
+++ b/client/.githooks/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-TOP=$(git rev-parse --show-toplevel)
-
-make -C "$TOP" check-strings

--- a/client/Makefile
+++ b/client/Makefile
@@ -7,12 +7,6 @@ all: help
 PYTHON := $(if $(shell bash -c "command -v python3.9"), python3.9, python3)
 VERSION_CODENAME ?= bullseye
 
-HOOKS_DIR=.githooks
-
-.PHONY: hooks
-hooks:  ## Configure Git to use the hooks provided by this repository.
-	git config core.hooksPath "$(HOOKS_DIR)"
-
 SEMGREP_FLAGS := --exclude "tests/" --error --strict --verbose
 
 .PHONY: semgrep

--- a/client/README.md
+++ b/client/README.md
@@ -78,7 +78,6 @@ poetry install
 ```
 
    * You will need Python 3.9 to run the client. If it's not the default `python3` on your installation, you can set `poetry env use python3.9`.
-   * You may also want to run `make hooks`, which will configure Git to use the hooks found in `.githooks/` to check certain code-quality standards on new commits in this repository.  These checks are also enforced in CI.
 
 4. Run SecureDrop Client
 
@@ -113,8 +112,6 @@ git clone git@github.com:freedomofpress/securedrop-client.git
 cd securedrop-client
 poetry install
 ```
-
-   * You may also want to run `make hooks`, which will configure Git to use the hooks found in `.githooks/` to check certain code-quality standards on new commits in this repository.  These checks are also enforced in CI.
 
 4. Run SecureDrop Client
 
@@ -169,7 +166,6 @@ socat TCP4-LISTEN:8081,fork,reuseaddr TCP4:A.B.C.D:8081
    cd securedrop-client
    poetry install
    ```
-   * You may also want to run `make hooks`, which will configure Git to use the hooks found in `.githooks/` to check certain code-quality standards on new commits in this repository.  These checks are also enforced in CI.
 
 5. Run SecureDrop Client
    ```


### PR DESCRIPTION
## Status

Ready for review

## Description

Closes #1673 by removing the pre-commit hook for `make check-strings`, which will now be enforced by CI.

## Test Plan

Visual review.