### PR TITLE
Support unlocked unpartitioned VeraCrypt block device for export

### DIFF
--- a/client/securedrop_client/gui/conversation/export/export_wizard_constants.py
+++ b/client/securedrop_client/gui/conversation/export/export_wizard_constants.py
@@ -31,7 +31,8 @@ STATUS_MESSAGES = {
     ExportStatus.INVALID_DEVICE_DETECTED: _(
         "Either the drive is not encrypted or there is something else wrong with it."
         "<br />"
-        "If this is a VeraCrypt drive, please unlock it from within `sd-devices`, then try again."
+        "If this is a VeraCrypt drive, please unlock it from within "
+        "the sd-devices VM, then try again."
     ),
     ExportStatus.DEVICE_WRITABLE: _("The device is ready for export."),
     ExportStatus.DEVICE_LOCKED: _("The device is locked."),

--- a/client/securedrop_client/locale/messages.pot
+++ b/client/securedrop_client/locale/messages.pot
@@ -282,7 +282,7 @@ msgstr ""
 msgid "Too many USB devices detected; please insert one supported device."
 msgstr ""
 
-msgid "Either the drive is not encrypted or there is something else wrong with it.<br />If this is a VeraCrypt drive, please unlock it from within `sd-devices`, then try again."
+msgid "Either the drive is not encrypted or there is something else wrong with it.<br />If this is a VeraCrypt drive, please unlock it from within the sd-devices VM, then try again."
 msgstr ""
 
 msgid "The device is ready for export."

--- a/export/tests/disk/test_cli.py
+++ b/export/tests/disk/test_cli.py
@@ -28,6 +28,7 @@ from ..lsblk_sample import (
     UDISKS_STATUS_MULTI_CONNECTED,
     UDISKS_STATUS_NOTHING_CONNECTED,
     UDISKS_STATUS_ONE_DEVICE_CONNECTED,
+    WHOLE_DEVICE_VC_WRITABLE,
 )
 
 _PRETEND_LUKS_ID = "/dev/mapper/luks-dbfb85f2-77c4-4b1f-99a9-2dd3c6789094"
@@ -41,6 +42,7 @@ supported_volumes_no_mount_required = [
     SINGLE_DEVICE_LOCKED,
     SINGLE_PART_LUKS_WRITABLE,
     SINGLE_PART_VC_WRITABLE,
+    WHOLE_DEVICE_VC_WRITABLE,
 ]
 
 # Volume, expected device name, expected mapped device name

--- a/export/tests/lsblk_sample.py
+++ b/export/tests/lsblk_sample.py
@@ -84,6 +84,25 @@ SINGLE_PART_VC_WRITABLE = {
     ],
 }
 
+WHOLE_DEVICE_VC_WRITABLE = {
+    "name": "sda",
+    "rm": True,
+    "ro": False,
+    "type": "disk",
+    "mountpoint": None,
+    "fstype": None,
+    "children": [
+        {
+            "name": "tcrypt-2049",
+            "rm": False,
+            "ro": False,
+            "type": "crypt",
+            "mountpoint": "/media/usb/tcrypt-1234",
+            "fstype": "vfat",
+        }
+    ],
+}
+
 SINGLE_PART_LUKS_UNLOCKED_UNMOUNTED = {
     "name": "sda1",
     "type": "part",


### PR DESCRIPTION
## Status

Ready for review

## Description

Addresses QA feedback in https://github.com/freedomofpress/securedrop-client/issues/1867#issuecomment-1991887267

* Remove backticks on the word "sd-devices" in a user-facing error message (note: I looked into monospaced fonts and formatting alternatives, but didn't want to introduce a new UI/font style that we don't use elsewhere in the client, for consistency. Open to revisiting this later though)
* Support export to an unlocked unpartitioned drive (scenario: the whole block device has been encrypted and is already unlocked when the user launches the wizard)  

## Test Plan
- [ ] Visual review
- [ ] CI passing
- [x] base is `main` (backport forthcoming on approval)

Note: I have already built debs and run through the following, but would include basic functionality testing in the test plan.
- [x] Export to LUKS drive works (locked, unlocked)
- [x] Export to unlocked  Veracrypt-encrypted device (no partitions, i.e. /dev/sdX is encrypted) works
- [x] Export to unlocked vc device with one encrypted partition (/dev/sdX1 , or /dev/sdx2, etc is encrypted) works. (Note for testers: you can have multiple partitions on the drive as long as only one is encrypted with LUKS or Veracrypt. I suggest creating a small veracrypt partition to test this since it takes a long time to encrypt an entire storage device if it's large).

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
