### PR TITLE
Remove __pycache__ folders from packages

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -13,6 +13,7 @@ override_dh_auto_install:
 
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete
+	find ./debian/ -type d -name '__pycache__' -delete
 	find ./debian/ -type f -name 'pip-selfcheck.json' -delete
 	find ./debian/ -type f -name 'direct_url.json' -delete
 	find ./debian/ -type f -name 'RECORD' -delete


### PR DESCRIPTION
## Status

Ready for review

## Description

We already delete the individual .pyc files because they're not reproducible, but leave behind empty `__pycache__` folders. This can be annoying if people are doing builds out of a development checkout that has these folders that won't be present on a pristine build.

So remove the empty folders right after deleting the .pyc files.

Fixes #1907.

## Test Plan

* [ ] On main, run `FAST=1 make build-debs`
* [ ] Run `dpkg -c build/securedrop-client_0.9.0+bullseye_all.deb | grep pycache`, observe that you see a number of folders in the package, especially under `/opt/venvs`
* [ ] Check out this patch, run `FAST=1 make build-debs` again
* [ ] Re-run `dpkg -c build/securedrop-client_0.9.0+bullseye_all.deb | grep pycache`, you should get nothing. Yay!

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
