### PR TITLE
Copy the backport.py script from securedrop server

### DIFF
--- a/scripts/backport.py
+++ b/scripts/backport.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+Automatically backport a PR to a release branch
+
+./scripts/backport.py PR_ID 2.x.x
+
+The `gh` CLI must be set up and already authenticated.
+"""
+import argparse
+import json
+import subprocess
+import sys
+
+parser = argparse.ArgumentParser(description="Backport a PR")
+parser.add_argument("pr", type=int, help="the # of the PR to backport")
+parser.add_argument("version", help="the release version to target with the backport")
+parser.add_argument("--remote", default="origin", help="the git remote to use (defaults to origin)")
+args = parser.parse_args()
+
+title = json.loads(
+    subprocess.check_output(["gh", "pr", "view", str(args.pr), "--json", "title"], text=True)
+)["title"]
+commits = json.loads(
+    subprocess.check_output(
+        ["gh", "api", f"repos/{{owner}}/{{repo}}/pulls/{args.pr}/commits"], text=True
+    )
+)
+print(f'Backporting {len(commits)} commits from "{title}"')
+branch = f"backport-{args.pr}"
+base = f"release/{args.version}"
+remote = args.remote
+subprocess.check_call(["git", "fetch", remote])
+subprocess.check_call(["git", "checkout", "-b", branch, f"{remote}/{base}"])
+subprocess.check_call(["git", "cherry-pick", "-x"] + [commit["sha"] for commit in commits])
+if input("OK to push and create PR? [y/N]").lower() != "y":
+    sys.exit()
+subprocess.check_call(["git", "push", "-u", remote, branch])
+body = f"""\
+## Status
+
+Ready for review
+
+## Description of Changes
+
+Backport of #{args.pr}.
+
+## Testing
+
+* [ ] CI is passing
+* [ ] base is `{base}`
+* [ ] Only contains changes from #{args.pr}.
+"""
+print(body)
+
+subprocess.check_call(
+    [
+        "gh",
+        "pr",
+        "create",
+        "--base",
+        base,
+        "--body",
+        body,
+        "--title",
+        f'[{args.version}] Backport "{title}"',
+    ]
+)


### PR DESCRIPTION
## Status

Ready for review

## Description

Introduced in <https://github.com/freedomofpress/securedrop/pull/6875>, makes creating backport PRs much easier.

## Test Plan

* [ ] Visual review
* [ ] I created https://github.com/freedomofpress/securedrop-client/pull/1911 using the script

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
