### PR TITLE
[0.10.0] Backport "Support unlocked unpartitioned VeraCrypt block device for export"

### DIFF
--- a/client/securedrop_client/gui/conversation/export/export_wizard_constants.py
+++ b/client/securedrop_client/gui/conversation/export/export_wizard_constants.py
@@ -31,7 +31,8 @@ STATUS_MESSAGES = {
     ExportStatus.INVALID_DEVICE_DETECTED: _(
         "Either the drive is not encrypted or there is something else wrong with it."
         "<br />"
-        "If this is a VeraCrypt drive, please unlock it from within `sd-devices`, then try again."
+        "If this is a VeraCrypt drive, please unlock it from within "
+        "the sd-devices VM, then try again."
     ),
     ExportStatus.DEVICE_WRITABLE: _("The device is ready for export."),
     ExportStatus.DEVICE_LOCKED: _("The device is locked."),

--- a/client/securedrop_client/locale/messages.pot
+++ b/client/securedrop_client/locale/messages.pot
@@ -282,7 +282,7 @@ msgstr ""
 msgid "Too many USB devices detected; please insert one supported device."
 msgstr ""
 
-msgid "Either the drive is not encrypted or there is something else wrong with it.<br />If this is a VeraCrypt drive, please unlock it from within `sd-devices`, then try again."
+msgid "Either the drive is not encrypted or there is something else wrong with it.<br />If this is a VeraCrypt drive, please unlock it from within the sd-devices VM, then try again."
 msgstr ""
 
 msgid "The device is ready for export."

--- a/export/tests/disk/test_cli.py
+++ b/export/tests/disk/test_cli.py
@@ -28,6 +28,7 @@ from ..lsblk_sample import (
     UDISKS_STATUS_MULTI_CONNECTED,
     UDISKS_STATUS_NOTHING_CONNECTED,
     UDISKS_STATUS_ONE_DEVICE_CONNECTED,
+    WHOLE_DEVICE_VC_WRITABLE,
 )
 
 _PRETEND_LUKS_ID = "/dev/mapper/luks-dbfb85f2-77c4-4b1f-99a9-2dd3c6789094"
@@ -41,6 +42,7 @@ supported_volumes_no_mount_required = [
     SINGLE_DEVICE_LOCKED,
     SINGLE_PART_LUKS_WRITABLE,
     SINGLE_PART_VC_WRITABLE,
+    WHOLE_DEVICE_VC_WRITABLE,
 ]
 
 # Volume, expected device name, expected mapped device name

--- a/export/tests/lsblk_sample.py
+++ b/export/tests/lsblk_sample.py
@@ -84,6 +84,25 @@ SINGLE_PART_VC_WRITABLE = {
     ],
 }
 
+WHOLE_DEVICE_VC_WRITABLE = {
+    "name": "sda",
+    "rm": True,
+    "ro": False,
+    "type": "disk",
+    "mountpoint": None,
+    "fstype": None,
+    "children": [
+        {
+            "name": "tcrypt-2049",
+            "rm": False,
+            "ro": False,
+            "type": "crypt",
+            "mountpoint": "/media/usb/tcrypt-1234",
+            "fstype": "vfat",
+        }
+    ],
+}
+
 SINGLE_PART_LUKS_UNLOCKED_UNMOUNTED = {
     "name": "sda1",
     "type": "part",


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #1908.

## Testing

* [ ] CI is passing
* [ ] base is `release/0.10.0`
* [ ] Only contains changes from #1908.
