### PR TITLE
[0.10.0] Backport "Remove __pycache__ folders from packages"

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -13,6 +13,7 @@ override_dh_auto_install:
 
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete
+	find ./debian/ -type d -name '__pycache__' -delete
 	find ./debian/ -type f -name 'pip-selfcheck.json' -delete
 	find ./debian/ -type f -name 'direct_url.json' -delete
 	find ./debian/ -type f -name 'RECORD' -delete


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #1909.

## Testing

* [ ] CI is passing
* [ ] base is `release/0.10.0`
* [ ] Only contains changes from #1909.
