### PR TITLE
Exclude client version string from Project-Id-Version of .pot files

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -124,7 +124,6 @@ docs:  ## Generate browsable documentation and call/caller graphs (requires Doxy
 
 LOCALE_DIR=securedrop_client/locale
 POT=${LOCALE_DIR}/messages.pot
-VERSION=$(shell poetry run python -c "import securedrop_client; print(securedrop_client.__version__)")
 
 .PHONY: check-strings
 check-strings: ## Check that the translation catalog is up to date with source code
@@ -144,7 +143,6 @@ $(POT): securedrop_client
 		--charset=utf-8 \
 		--output=${POT} \
 		--project="SecureDrop Client" \
-		--version=${VERSION} \
 		--msgid-bugs-address=securedrop@freedom.press \
 		--copyright-holder="Freedom of the Press Foundation" \
 		--add-comments="Translators:" \

--- a/client/securedrop_client/locale/messages.pot
+++ b/client/securedrop_client/locale/messages.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: SecureDrop Client 0.9.0\n"
+"Project-Id-Version: SecureDrop Client VERSION\n"
 "Report-Msgid-Bugs-To: securedrop@freedom.press\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"


### PR DESCRIPTION
## Status

Ready for review

## Description

leave `VERSION` constant in a header in .pot files rather than the actual version string, since that header isn't in use. 
See https://github.com/freedomofpress/securedrop/pull/7034 for prior context 

## Test Plan
- [ ] CI passing
- [x] Visual review
- [x] Comparison with https://github.com/freedomofpress/securedrop/pull/7034

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
