### PR TITLE
Ensure files on USB have read permissions, not just enclosing directory.

### DIFF
--- a/export/securedrop_export/disk/cli.py
+++ b/export/securedrop_export/disk/cli.py
@@ -424,13 +424,16 @@ class CLI:
             is_error = False
 
             target_path = os.path.join(device.mountpoint, archive_target_dirname)
-            subprocess.check_call(["mkdir", target_path], preexec_fn=self._set_umask_usb)
+            subprocess.check_call(["mkdir", target_path])
 
             export_data = os.path.join(archive_tmpdir, "export_data/")
             logger.debug("Copying file to {}".format(archive_target_dirname))
 
             subprocess.check_call(["cp", "-r", export_data, target_path])
-            logger.info("File copied successfully to {}".format(archive_target_dirname))
+            logger.info("File copied successfully to {}".format(target_path))
+
+            subprocess.check_call(["chmod", "-R", "ugo+r", target_path])
+            logger.info("Read permissions granted on {}".format(target_path))
 
         except (subprocess.CalledProcessError, OSError) as ex:
             logger.error(ex)
@@ -441,14 +444,6 @@ class CLI:
 
         finally:
             self.cleanup(device, archive_tmpdir, is_error)
-
-    def _set_umask_usb(self) -> None:
-        """
-        Set umask to 0o22 before writing to USB, to facilitate reading exported
-        files on other computers.
-        """
-        os.setpgrp()
-        os.umask(0o22)
 
     def cleanup(
         self,


### PR DESCRIPTION
## Status

Ready for review

## Description

Fixes file permissions on USB export drive (ref #1726 and adds test case. The initial change (in #1777) correctly changed the permission on the export directory, but not on the files being copied into that directory.

## Test Plan
- [x] CI passing (looks like there are some issues to iron out, for tomorrow..)
- [x] visual review makes sense
- [x] Export succeeds and files have desired permissions (For quick testing that avoids building a deb, this can also be tested at the commandline. Check out this branch, activate venv, open a terminal, attach a supported USB drive to the VM and unlock it).
```
$ mkdir -p /tmp/export/export_data/
$ echo "foo" > /tmp/export/export_data/test.txt
$ python3
>> from securedrop_export.disk.cli import CLI
>> cli = CLI()
>> usb = cli.get_volume()  # will show you have a MountedVolume object attached
>> cli.write_data_to_device(usb, "/tmp/export", "test")
>> # Command succeeds, usb is locked/unmounted, and contains a folder called "test" with `export_data/test.txt` in it, with 644 permissions
```

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
