### PR TITLE
Exclude root project .venv from bandit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ safety = "*"
 shellcheck-py = "*"
 
 [tool.bandit]
-exclude_dirs = ["client/tests", "export/tests", "log/tests", "proxy/tests"]
+exclude_dirs = ["client/tests", "export/tests", "log/tests", "proxy/tests", ".venv/"]
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
## Status

Ready for review

## Description

`make bandit` reports results from the root project venv, if it's located in the project root.  Filing this as a draft - if we want to instead instruct people to use a cache dir outside of the project root for poetry environment, we should add setup notes to the readme

## Test Plan
- [ ] CI passing
- [ ] Agreement on this change

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
