### PR TITLE
Run tests as not-root

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,12 @@ jobs:
     container: debian:${{ matrix.debian_version }}
     steps:
       - run: |
-          apt-get update && apt-get install --yes git make gnupg
+          apt-get update && apt-get install --yes git make gnupg sudo
       - uses: actions/checkout@v4
+      - name: Setup user
+        run: |
+          # We want to run tests as a regular user, similar to Qubes VMs
+          useradd --create-home --shell /bin/bash user
       - name: Install dependencies
         run: |
           source /etc/os-release
@@ -48,10 +52,11 @@ jobs:
               echo "Unsupported Debian version: $VERSION_CODENAME"
               exit 1
           fi
-          poetry -C ${{ matrix.component }} install
+          sudo -u user poetry -C ${{ matrix.component }} install
       - name: Run test
         run: |
-          make -C ${{ matrix.component }} test
+          sudo chown -R user:user .
+          sudo -u user make -C ${{ matrix.component }} test
 
   # Run the various `make test-...` commands for the client.
   # TODO: these should be consolidated into one when feasible
@@ -70,8 +75,12 @@ jobs:
     container: debian:${{ matrix.debian_version }}
     steps:
       - run: |
-          apt-get update && apt-get install --yes git make gnupg
+          apt-get update && apt-get install --yes git make gnupg sudo
       - uses: actions/checkout@v4
+      - name: Setup user
+        run: |
+          # We want to run tests as a regular user, similar to Qubes VMs
+          useradd --create-home --shell /bin/bash user
       - name: Install dependencies
         run: |
           source /etc/os-release
@@ -86,11 +95,12 @@ jobs:
               echo "Unsupported Debian version: $VERSION_CODENAME"
               exit 1
           fi
-          poetry -C client install
           make -C client ci-install-deps
+          sudo -u user poetry -C client install
       - name: Run test
         run: |
-          make -C client ${{ matrix.command }}
+          sudo chown -R user:user .
+          sudo -u user make -C client ${{ matrix.command }}
 
   # Run the client i18n/l10n checks.
   internationalization:


### PR DESCRIPTION
## Status

Ready for review

## Description

Better mimics the Qubes VM environment. I didn't set up passwordless-sudo (like Qubes) since it isn't needed right now.

## Test Plan

* [ ] CI passes

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
