### PR TITLE
Automatically collect package build log with `script`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,16 @@
 all: help
 
 .PHONY: build-debs
+build-debs: OUT:=build/securedrop-client-$(shell date +%Y%m%d).log
 build-debs: ## Build Debian packages
-	./scripts/build-debs.sh
+	@echo "Building SecureDrop Client Debian packages..."
+	@export TERM=dumb
+	@script \
+		--command scripts/build-debs.sh --return \
+		$(OUT)
+	@echo
+	@echo "You can now examine or commit the log at:"
+	@echo "$(OUT)"
 
 .PHONY: lint-desktop
 lint-desktop: ## Lint .desktop files


### PR DESCRIPTION
## Status

Ready for review

## Description

This port's @cfm's <https://github.com/freedomofpress/securedrop/pull/6787> with a little less abstraction.

Fixes #1789.

## Test Plan

* [ ] Run `make build-debs`, look at the log and it is comprehensible (i.e. not a ton of ASCII escape codes, etc.)

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
