### PR TITLE
Use bash for all Debian packaging scripts

### DIFF
--- a/client/files/securedrop-client
+++ b/client/files/securedrop-client
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 mkdir -p ~/.securedrop_client
 chmod 0700 ~/.securedrop_client

--- a/debian/securedrop-client.postinst
+++ b/debian/securedrop-client.postinst
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # postinst script for securedrop-client
 #
 # see: dh_installdeb(1)

--- a/debian/securedrop-export.postinst
+++ b/debian/securedrop-export.postinst
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # postinst script for securedrop-export
 #
 # see: dh_installdeb(1)

--- a/debian/securedrop-keyring.postinst
+++ b/debian/securedrop-keyring.postinst
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # postinst script for securedrop-keyring
 #
 # see: dh_installdeb(1)

--- a/debian/securedrop-workstation-config.postinst
+++ b/debian/securedrop-workstation-config.postinst
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # postinst script for securedrop-workstation-config
 #
 # see: dh_installdeb(1)


### PR DESCRIPTION
## Status

Ready for review

## Description

Just use bash unconditionally for its nicer features, there's very little advantage to using dash at our scale.

Fixes #1878.

## Test Plan

* [ ] Visual review
* [ ] CI passes, verifying shellcheck and also package installation

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
