### PR TITLE
Let parent handle PrintTranscriptDialog dialog close 

### DIFF
--- a/client/securedrop_client/gui/conversation/export/print_transcript_dialog.py
+++ b/client/securedrop_client/gui/conversation/export/print_transcript_dialog.py
@@ -24,7 +24,6 @@ class PrintTranscriptDialog(PrintDialog):
 
     def _print_transcript(self) -> None:
         self._device.print(self.transcript_location)
-        self.close()
 
     @pyqtSlot()
     def _on_print_preflight_check_succeeded(self) -> None:
@@ -35,7 +34,6 @@ class PrintTranscriptDialog(PrintDialog):
         if not self.continue_button.isEnabled():
             self.continue_button.clicked.disconnect()
             self.continue_button.clicked.connect(self._print_transcript)
-
             self.continue_button.setEnabled(True)
             self.continue_button.setFocus()
             return

--- a/client/tests/gui/conversation/export/test_print_transcript_dialog.py
+++ b/client/tests/gui/conversation/export/test_print_transcript_dialog.py
@@ -90,7 +90,9 @@ def test_PrintTranscriptDialog__print_transcript(mocker, print_transcript_dialog
 
     print_transcript_dialog._print_transcript()
 
-    print_transcript_dialog.close.assert_called_once_with()
+    # Dialog.close() should not be called directly; it is closed only
+    # after receiving the completed signal from the QProcess
+    print_transcript_dialog.close.assert_not_called()
 
 
 def test_PrintTranscriptDialog__on_print_preflight_check_succeeded(mocker, print_transcript_dialog):


### PR DESCRIPTION
## Status

Ready for review

## Description

Fixes Print Transcript failure (0.10.0)

Fixes https://github.com/freedomofpress/securedrop-client/issues/1937

## Test Plan

- [ ] CI passing
- [x] Transcript can be printed

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
