### PR TITLE
[0.10.1] Backport "Let parent handle PrintTranscriptDialog dialog close "

### DIFF
--- a/client/securedrop_client/gui/conversation/export/print_transcript_dialog.py
+++ b/client/securedrop_client/gui/conversation/export/print_transcript_dialog.py
@@ -24,7 +24,6 @@ class PrintTranscriptDialog(PrintDialog):
 
     def _print_transcript(self) -> None:
         self._device.print(self.transcript_location)
-        self.close()
 
     @pyqtSlot()
     def _on_print_preflight_check_succeeded(self) -> None:
@@ -35,7 +34,6 @@ class PrintTranscriptDialog(PrintDialog):
         if not self.continue_button.isEnabled():
             self.continue_button.clicked.disconnect()
             self.continue_button.clicked.connect(self._print_transcript)
-
             self.continue_button.setEnabled(True)
             self.continue_button.setFocus()
             return

--- a/client/tests/gui/conversation/export/test_print_transcript_dialog.py
+++ b/client/tests/gui/conversation/export/test_print_transcript_dialog.py
@@ -90,7 +90,9 @@ def test_PrintTranscriptDialog__print_transcript(mocker, print_transcript_dialog
 
     print_transcript_dialog._print_transcript()
 
-    print_transcript_dialog.close.assert_called_once_with()
+    # Dialog.close() should not be called directly; it is closed only
+    # after receiving the completed signal from the QProcess
+    print_transcript_dialog.close.assert_not_called()
 
 
 def test_PrintTranscriptDialog__on_print_preflight_check_succeeded(mocker, print_transcript_dialog):


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #1936.

## Testing

* [ ] CI is passing
* [ ] base is `release/0.10.1`
* [ ] Only contains changes from #1936.
