### PR TITLE
Install debian package requirements via sdw-config

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -41,7 +41,7 @@ Description: This is securedrop Qubes proxy service
 
 Package: securedrop-workstation-config
 Architecture: all
-Depends: nautilus, securedrop-keyring
+Depends: qubes-core-passwordless-root, rsyslog, mailcap, apparmor, nautilus, securedrop-keyring
 Description: This is the SecureDrop workstation template configuration package.
  This package provides dependencies and configuration for the Qubes SecureDrop workstation VM Templates.
 


### PR DESCRIPTION
## Status

Ready for review 
## Description

Fixes #1956

## Test Plan

- [x] CI is passing
- [x] `DEBIAN_VERSION='bookworm' make build-debs` succeeds
- [ ] Installing resultant securedrop-workstation-config package on a debian-12-minimal template pulls in qubes-core-passwordless-root, rsyslog, mailcap, apparmor, apparmor-utils, nautilus.
- [x] Visual review looks good.


## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
