### PR TITLE
Push "nightly" after each merged PR

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -2,6 +2,14 @@ name: Nightlies
 on:
   schedule:
     - cron: "0 6 * * *"
+  push:
+    branches:
+      - main
+
+# Only allow one job to run at a time because we're pushing to git repos;
+# the string value doesn't matter, just that it's a fixed string.
+concurrency:
+  group: "just-one-please"
 
 defaults:
   run:


### PR DESCRIPTION
## Status

Ready for review

## Description

Instead of needing to wait up to 24 hours for nightly packages to be built, just do it instantly. This will allow for faster development cycles because securedrop-apt-test will now reflect what is in "main", making securedrop-workstation CI more useful too.

The only thing we need to add after the push trigger is a concurrency limiter so multiple jobs aren't pulling/pushing to the build-logs and securedrop-apt-test repositories at the same time.

Fixes #1959.

## Test Plan

* [ ] Visual review

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
