### PR TITLE
Remove Qubes-specific package from securedrop-workstation-config dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -41,7 +41,7 @@ Description: This is securedrop Qubes proxy service
 
 Package: securedrop-workstation-config
 Architecture: all
-Depends: qubes-core-passwordless-root, rsyslog, mailcap, apparmor, nautilus, securedrop-keyring
+Depends: rsyslog, mailcap, apparmor, nautilus, securedrop-keyring
 Description: This is the SecureDrop workstation template configuration package.
  This package provides dependencies and configuration for the Qubes SecureDrop workstation VM Templates.
 


### PR DESCRIPTION
## Status

Ready for review 
## Description

Fixes #1956 for real this time.

Qubes `qubes-core-agent-passwordless-root` is installed separately in template via the `qubes-vm-recommended` metapackage, so it's removed from here.

## Test Plan
- [ ] visual review

