### PR TITLE
Update readme to reference python3.11

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -77,7 +77,7 @@ cd securedrop-client
 poetry install
 ```
 
-   * You will need Python 3.9 to run the client. If it's not the default `python3` on your installation, you can set `poetry env use python3.9`.
+   * You will need Python 3.11 to run the client. If it's not the default `python3` on your installation, you can set `poetry env use python3.11`.
 
 4. Run SecureDrop Client
 
@@ -159,7 +159,7 @@ socat TCP4-LISTEN:8081,fork,reuseaddr TCP4:A.B.C.D:8081
     3. Enter a shell in `x86_64` mode with `arch -x86_64 bash`
     4. Install Homebrew via the instructions at https://brew.sh/
     5. Install the dependencies below in the same `x86_64` shell session
-3. Install dependencies via Homebrew: `brew install python@3.9 gnupg oath-toolkit`
+3. Install dependencies via Homebrew: `brew install python@3.11 gnupg oath-toolkit`
 4. clone the SecureDrop Client repo and install its dependencies
    ```
    git clone git@github.com:freedomofpress/securedrop-client.git
@@ -420,7 +420,7 @@ import pdb; pdb.set_trace()
 Then you can use [`pdb` commands](https://docs.python.org/3/library/pdb.html#debugger-commands) as normal.
 
 Logs can be found in the `{sdc-home}/logs`. If you are debugging a version of this application installed from a deb package in Qubes, you can debug issues by looking at the log file in `~/.securedrop_client/logs/client.log`. You can also add additional log lines in the running code in
-`/opt/venvs/securedrop-client/lib/python3.9/site-packages/securedrop_client/`.
+`/opt/venvs/securedrop-client/lib/python3.11/site-packages/securedrop_client/`.
 
 
 [MAY]: https://datatracker.ietf.org/doc/html/rfc2119#section-5


### PR DESCRIPTION
## Status

Ready for review

## Description

Update python version referenced in readme.  Refs https://github.com/freedomofpress/securedrop-client/pull/1958 

## Test Plan
Visual review

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
