### PR TITLE
Upgrade jinja to 3.1.4 (dev tools)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -300,13 +300,13 @@ files = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.3"
+version = "3.1.4"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Jinja2-3.1.3-py3-none-any.whl", hash = "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa"},
-    {file = "Jinja2-3.1.3.tar.gz", hash = "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"},
+    {file = "jinja2-3.1.4-py3-none-any.whl", hash = "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"},
+    {file = "jinja2-3.1.4.tar.gz", hash = "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
## Status

Ready for review

## Description

jinja is a dependency of safety, so update it to address CVE-2024-34064.

I doubt safety is affected, but upgrading was easier than checking.

This does not upgrade jinja for use in the client, which is not affected by this vulnerability.

## Test Plan

* [ ] CI passes
