### PR TITLE
docs(readme): add architecture diagram

### DIFF
--- a/log/README.md
+++ b/log/README.md
@@ -5,10 +5,41 @@ Workstation](https://github.com/freedomofpress/securedrop-workstation) project.
 
 This is a Python module and qrexec service for logging in Qubes.
 
-#### Quick Start
+## Quick Start
 
 1. [Install Poetry](https://python-poetry.org/docs/#installing-with-the-official-installer)
 2. Run `make test` to verify the installation
+
+## Architecture
+
+```mermaid
+graph TD
+
+subgraph sd-log
+subgraph systemd
+redis.service --before--- securedrop-log.service
+end
+subgraph qrexec
+securedrop.Log
+end
+
+redis.service --> Redis((Redis))
+securedrop.Log>securedrop.Log] --> securedrop-redis-log --"writes to"--> Redis
+Redis -.blocking read-loop.-> securedrop-log-saver
+securedrop-log.service --> securedrop-log-saver --> QubesIncomingLogs/
+end
+
+subgraph sd-app
+subgraph rsyslog
+sd-rsyslog --activated by--- /etc/rsyslog.d/sdlog.conf
+sd-rsyslog --configured by--- /etc/sd-rsyslog.conf
+sd-rsyslog -.qrexec.-> securedrop.Log
+end
+end
+
+securedrop-log???
+securedrop_log??? -.qrexec.-> securedrop.Log
+```
 
 ## How to use/try this?
 

--- a/log/README.md
+++ b/log/README.md
@@ -15,7 +15,7 @@ This is a Python module and qrexec service for logging in Qubes.
 ```mermaid
 graph TD
 
-subgraph sd-log
+subgraph "sink VM (e.g., sd-log)"
 subgraph systemd
 redis.service --before--- securedrop-log.service
 end
@@ -29,7 +29,7 @@ Redis -.blocking read-loop.-> securedrop-log-saver
 securedrop-log.service --> securedrop-log-saver --> QubesIncomingLogs/
 end
 
-subgraph sd-app
+subgraph "source VM (e.g., sd-app)"
 subgraph rsyslog
 sd-rsyslog --activated by--- /etc/rsyslog.d/sdlog.conf
 sd-rsyslog --configured by--- /etc/sd-rsyslog.conf


### PR DESCRIPTION
## Status

Ready for review

## Description

@deeplow and I have walked through the `log/` portion of this repository and mapped out:
- what spawns what services;
- what triggers what RPCs; and
- what reads/writes from/to what.

It should be descriptive and uncontroversial, except that we couldn't account for:
1. `securedrop-log`, which nothing in either `securedrop-client` or `securedrop-workstation` appears to invoke; or
2. `securedrop_log`, which nothing in either `securedrop-client` or `securedrop-workstation` appears to load.

Are they remnants of an earlier implementation, before the `securedrop-redis-log → securedrop-log-saver` buffering pipeline and the `sd-rsyslog → qrexec securedrop.Log` RPC?