### PR TITLE
Auto-resumed failed downloads

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run tests without VCR cassettes
         run: |
           # Start the server in the background
-          NUM_SOURCES=5 make -C securedrop-server dev &
+          NUM_SOURCES=5 LOADDATA_ARGS="--random-file-size 3" make -C securedrop-server dev &
           # And install deps
           poetry -C client install --no-ansi
           # Wait for server to come up

--- a/client/securedrop_client/config.py
+++ b/client/securedrop_client/config.py
@@ -20,6 +20,7 @@ def try_qubesdb() -> Generator:
         yield db
 
     except ImportError:
+        logger.debug("QubesDB not available")
         yield db
 
     finally:
@@ -37,10 +38,12 @@ class Config:
     mapping = {
         "gpg_domain": "QUBES_GPG_DOMAIN",
         "journalist_key_fingerprint": "SD_SUBMISSION_KEY_FPR",
+        "download_retry_limit": "SD_DOWNLOAD_RETRY_LIMIT",
     }
 
     gpg_domain: str
     journalist_key_fingerprint: str
+    download_retry_limit: str
 
     @classmethod
     def load(self) -> "Config":

--- a/client/securedrop_client/config.py
+++ b/client/securedrop_client/config.py
@@ -2,7 +2,7 @@ import logging
 import os
 from collections.abc import Generator
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import MISSING, dataclass, fields
 
 logger = logging.getLogger(__name__)
 
@@ -41,27 +41,42 @@ class Config:
         "download_retry_limit": "SD_DOWNLOAD_RETRY_LIMIT",
     }
 
-    gpg_domain: str
     journalist_key_fingerprint: str
-    download_retry_limit: str
+    gpg_domain: str | None = None
+    download_retry_limit: int = 3
 
     @classmethod
-    def load(self) -> "Config":
+    def load(cls) -> "Config":
         """For each attribute, look it up from either QubesDB or the environment."""
         config = {}
 
         with try_qubesdb() as db:
-            for store, lookup in self.mapping.items():
+            for field in fields(cls):
+                lookup = cls.mapping[field.name]
                 if db:
                     logger.debug(f"Reading {lookup} from QubesDB")
                     value = db.read(f"/vm-config/{lookup}")
                     if not value or len(value) == 0:
-                        raise KeyError(f"Could not read from QubesDB: {lookup}")
-
+                        if field.default == MISSING:
+                            raise KeyError(f"Could not read {lookup} from QubesDB")
+                        # Normalize for parity with the case where os.environ.get() is None
+                        value = None
                 else:
                     logger.debug(f"Reading {lookup} from environment")
                     value = os.environ.get(lookup)
+                    if not value or len(value) == 0:
+                        # Same normalization used for QubesDB
+                        value = None
 
-                config[store] = value
+                if value is None and field.default != MISSING:
+                    logger.debug(f"Using default value for {lookup}")
+                    value = field.default
 
-        return Config(**config)
+                # Cast to int if needed (might raise if value is invalid)
+                # TODO: in theory we could `field.type(value)` but that doesn't
+                # handle union types
+                if field.type == int:
+                    value = int(value)
+                config[field.name] = value
+
+        return cls(**config)

--- a/client/securedrop_client/sdk/__init__.py
+++ b/client/securedrop_client/sdk/__init__.py
@@ -124,10 +124,7 @@ class API:
             pass  # We already have a default name
 
         # Load download retry limit from the config
-        self.download_retry_limit: int = 3
-        config = Config.load()
-        if config.download_retry_limit is not None:
-            self.download_retry_limit = int(config.download_retry_limit)
+        self.download_retry_limit = Config.load().download_retry_limit
 
     def _rpc_target(self) -> list:
         """In `development_mode`, check `cargo` for a locally-built proxy binary.

--- a/client/tests/sdk/README.md
+++ b/client/tests/sdk/README.md
@@ -88,7 +88,7 @@ The steps to generate new cassettes are split into two sections based on communi
 1. Start the server in a docker container by running:
 
     ```bash
-    NUM_SOURCES=5 make dev
+    NUM_SOURCES=5 LOADDATA_ARGS="--random-file-size 3" make dev
     ```
 
 2. Delete the cassettes you wish to regenerate or just delete all yaml files by running:
@@ -124,7 +124,7 @@ Once your proxy VM is set up, follow these steps:
 1. Start the server in a docker container on `sd-dev-proxy` by running:
 
     ```bash
-    NUM_SOURCES=5 make dev
+    NUM_SOURCES=5 LOADDATA_ARGS="--random-file-size 3" make dev
     ```
 
 2. Delete the cassettes you wish to regenerate or just delete all JSON files by running:

--- a/client/tests/sdk/data/test_download_submission_autoresume.yml
+++ b/client/tests/sdk/data/test_download_submission_autoresume.yml
@@ -1,0 +1,307 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token Im5fRGxUa0duSGZRT0hUaExaVUpuLUNBZjJjWTdoX1JzaEtXZjF1bGpNMFEi.Zkt5Eg.rhj_SR58sfebF374tCr9GGpLofM
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/submissions
+  response: !!python/object:securedrop_client.sdk.JSONResponse
+    data:
+      submissions:
+      - download_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b/submissions/591e6a8a-6d9c-4361-98da-ebbcbb0ac1da/download
+        filename: 1-sinister_potash-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - f422ae93-6d02-4699-9d0c-aa612c38d6e4
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 616
+        source_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b
+        submission_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b/submissions/591e6a8a-6d9c-4361-98da-ebbcbb0ac1da
+        uuid: 591e6a8a-6d9c-4361-98da-ebbcbb0ac1da
+      - download_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b/submissions/d67ec08f-626d-4e86-a9ce-a4489813b760/download
+        filename: 2-sinister_potash-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - c02c0512-89a8-496e-8f32-2ab65d80b030
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 700
+        source_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b
+        submission_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b/submissions/d67ec08f-626d-4e86-a9ce-a4489813b760
+        uuid: d67ec08f-626d-4e86-a9ce-a4489813b760
+      - download_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b/submissions/8a5fcca0-d4c5-48f1-8a44-f5581d8d7e8c/download
+        filename: 3-sinister_potash-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 651
+        source_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b
+        submission_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b/submissions/8a5fcca0-d4c5-48f1-8a44-f5581d8d7e8c
+        uuid: 8a5fcca0-d4c5-48f1-8a44-f5581d8d7e8c
+      - download_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b/submissions/7a998852-36fe-46d0-985c-8d0193328332/download
+        filename: 4-sinister_potash-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - f422ae93-6d02-4699-9d0c-aa612c38d6e4
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 651
+        source_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b
+        submission_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b/submissions/7a998852-36fe-46d0-985c-8d0193328332
+        uuid: 7a998852-36fe-46d0-985c-8d0193328332
+      - download_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca/submissions/a595250b-b66b-4a26-9d57-e29cdce886c5/download
+        filename: 1-irremediable_generosity-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - c02c0512-89a8-496e-8f32-2ab65d80b030
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 647
+        source_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca
+        submission_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca/submissions/a595250b-b66b-4a26-9d57-e29cdce886c5
+        uuid: a595250b-b66b-4a26-9d57-e29cdce886c5
+      - download_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca/submissions/71dfad99-5c06-4fd7-8605-ca6e3299bd5b/download
+        filename: 2-irremediable_generosity-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - c02c0512-89a8-496e-8f32-2ab65d80b030
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 766
+        source_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca
+        submission_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca/submissions/71dfad99-5c06-4fd7-8605-ca6e3299bd5b
+        uuid: 71dfad99-5c06-4fd7-8605-ca6e3299bd5b
+      - download_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca/submissions/4b22f2f9-70ea-4e3b-8d57-5e0b1b56b7fc/download
+        filename: 3-irremediable_generosity-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - f422ae93-6d02-4699-9d0c-aa612c38d6e4
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 651
+        source_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca
+        submission_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca/submissions/4b22f2f9-70ea-4e3b-8d57-5e0b1b56b7fc
+        uuid: 4b22f2f9-70ea-4e3b-8d57-5e0b1b56b7fc
+      - download_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca/submissions/04ff1e66-b076-47fe-a856-7a36d67655d4/download
+        filename: 4-irremediable_generosity-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - c02c0512-89a8-496e-8f32-2ab65d80b030
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 651
+        source_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca
+        submission_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca/submissions/04ff1e66-b076-47fe-a856-7a36d67655d4
+        uuid: 04ff1e66-b076-47fe-a856-7a36d67655d4
+      - download_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c/submissions/66219559-e3c7-4f84-8aa7-f8e52502e7fa/download
+        filename: 1-silver_anticipation-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - f422ae93-6d02-4699-9d0c-aa612c38d6e4
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 804
+        source_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c
+        submission_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c/submissions/66219559-e3c7-4f84-8aa7-f8e52502e7fa
+        uuid: 66219559-e3c7-4f84-8aa7-f8e52502e7fa
+      - download_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c/submissions/0ef40d58-1630-4f24-9d4e-122f71e6c0bc/download
+        filename: 2-silver_anticipation-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 710
+        source_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c
+        submission_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c/submissions/0ef40d58-1630-4f24-9d4e-122f71e6c0bc
+        uuid: 0ef40d58-1630-4f24-9d4e-122f71e6c0bc
+      - download_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c/submissions/63024ccd-6e0e-4130-9a0c-0ff08a3adda2/download
+        filename: 3-silver_anticipation-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - f422ae93-6d02-4699-9d0c-aa612c38d6e4
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 651
+        source_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c
+        submission_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c/submissions/63024ccd-6e0e-4130-9a0c-0ff08a3adda2
+        uuid: 63024ccd-6e0e-4130-9a0c-0ff08a3adda2
+      - download_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c/submissions/08aeb19a-b502-4118-8c2f-ea4280522004/download
+        filename: 4-silver_anticipation-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - f422ae93-6d02-4699-9d0c-aa612c38d6e4
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 651
+        source_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c
+        submission_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c/submissions/08aeb19a-b502-4118-8c2f-ea4280522004
+        uuid: 08aeb19a-b502-4118-8c2f-ea4280522004
+      - download_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1/submissions/6a22b2ca-66cd-407c-a7ad-6af36387718e/download
+        filename: 1-instructive_sachem-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 1124
+        source_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1
+        submission_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1/submissions/6a22b2ca-66cd-407c-a7ad-6af36387718e
+        uuid: 6a22b2ca-66cd-407c-a7ad-6af36387718e
+      - download_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1/submissions/171c74b8-e06b-42bc-8fd8-84e723b38490/download
+        filename: 2-instructive_sachem-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 687
+        source_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1
+        submission_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1/submissions/171c74b8-e06b-42bc-8fd8-84e723b38490
+        uuid: 171c74b8-e06b-42bc-8fd8-84e723b38490
+      - download_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1/submissions/293bdf38-3c64-44a9-878b-a80d66e40dea/download
+        filename: 3-instructive_sachem-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 651
+        source_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1
+        submission_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1/submissions/293bdf38-3c64-44a9-878b-a80d66e40dea
+        uuid: 293bdf38-3c64-44a9-878b-a80d66e40dea
+      - download_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1/submissions/cf6ab7c1-73d1-4c4d-ae3a-29b6e8d5feeb/download
+        filename: 4-instructive_sachem-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 651
+        source_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1
+        submission_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1/submissions/cf6ab7c1-73d1-4c4d-ae3a-29b6e8d5feeb
+        uuid: cf6ab7c1-73d1-4c4d-ae3a-29b6e8d5feeb
+      - download_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b/submissions/14e96ddd-1fda-4b1f-bb3f-390661a013a3/download
+        filename: 1-militaristic_formalin-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 619
+        source_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b
+        submission_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b/submissions/14e96ddd-1fda-4b1f-bb3f-390661a013a3
+        uuid: 14e96ddd-1fda-4b1f-bb3f-390661a013a3
+      - download_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b/submissions/9a680e36-11fa-48ff-96f8-5e3a109b2d5f/download
+        filename: 2-militaristic_formalin-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 707
+        source_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b
+        submission_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b/submissions/9a680e36-11fa-48ff-96f8-5e3a109b2d5f
+        uuid: 9a680e36-11fa-48ff-96f8-5e3a109b2d5f
+      - download_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b/submissions/17670653-7309-46be-a83b-f9be04939336/download
+        filename: 3-militaristic_formalin-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 651
+        source_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b
+        submission_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b/submissions/17670653-7309-46be-a83b-f9be04939336
+        uuid: 17670653-7309-46be-a83b-f9be04939336
+      - download_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b/submissions/38c4b583-d6c1-47bd-bf43-1003bca94c36/download
+        filename: 4-militaristic_formalin-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 651
+        source_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b
+        submission_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b/submissions/38c4b583-d6c1-47bd-bf43-1003bca94c36
+        uuid: 38c4b583-d6c1-47bd-bf43-1003bca94c36
+    headers:
+      connection: close
+      content-length: '13250'
+      content-type: application/json
+      date: Mon, 20 May 2024 16:23:53 GMT
+      server: Werkzeug/2.2.3 Python/3.8.10
+    status: 200
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token Im5fRGxUa0duSGZRT0hUaExaVUpuLUNBZjJjWTdoX1JzaEtXZjF1bGpNMFEi.Zkt5Eg.rhj_SR58sfebF374tCr9GGpLofM
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b/submissions/8a5fcca0-d4c5-48f1-8a44-f5581d8d7e8c/download
+  response: !!python/object:securedrop_client.sdk.StreamedResponse
+    contents: !!binary |
+      wcFMA8PnxMCiIBsqARAAiqV6F4Vh2Xz742FwQ1fl/Id/VfTAtiTE1N7lq6d24NVPxMozJby7WVCk
+      hAapdoHPT3XmDB67kj6mB4WuECU7LKbZgi3RnZ0hfXgsIDaatj2V6YeFuAnRgPb5zYx+duK3ZFhM
+      0vE2IHzyf0hgbkW/Zo4V71B3zEEXO08pm277VYA5O7KOlLJGABSUylNSjua0T7zrMkmdRQBVcSW0
+      81qaMLXaKK48IfVMtBue64Uj0YQfo9jB+ZvbVYNAzvzhr8FlC+mXWE9Y8j5IJotVe/YPtPRY7X9Z
+      ATRjjclysHka90R/+myTkNvOKX5tYnYBYeudJ/07BtDsB6Niai8M5KLqyOi8Lhfk6blXf0jPT1bS
+      vYjez/FTJkar2BBkzbtpCJiU5jW/4uMff86IqyARb5fz/v6fz08VlWtf1ySE4W/zXagz84Oyh1a3
+      dIoBt+Z53uKyV5dBmB+Hj3BYgjbdkoMzQxLAx0k3oZwzbnWauHx0HyXnXw3TcbRsHYKrkTaYtBOc
+      4SKNnQZmFAy/e3wEW9nj4ut517pLt6paVFjWfz9m2yAsoq6pwWdDJ7WU0HL2xzXzO7+y46hG1ji6
+      RpaE3rnws1xRrmgwD7IwLNt8z5sl5KYS1yOe0hl2yc5w5nV2k7BDXr4oksPN95vUOz+Spfq8pS4D
+      82fYFuHbgWFG2/aO45rSegHWhreGAL5isFlvtntR29kkLy7tJn5CAK2MwM7Ys3BjXg18Z694Lu1G
+      JWsmRDt79F11hmGeGBwTEKCEroCUrLxKEeLTs/ILT1dgMQPQib4VIA4cgmg0PDQ+u9RTEj1xSzwe
+      AHWdUuw6m5xQdvvv6TkWB3/uS4z1DYDl
+    filename: attachment; filename=3-sinister_potash-doc.gz.gpg
+    sha256sum: sha256:8bd5c37ff11167e6cabebb4f19131c04dfc3240d3b097b765fd6fbcf5ad1d090
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token Im5fRGxUa0duSGZRT0hUaExaVUpuLUNBZjJjWTdoX1JzaEtXZjF1bGpNMFEi.Zkt5Eg.rhj_SR58sfebF374tCr9GGpLofM
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b/submissions/8a5fcca0-d4c5-48f1-8a44-f5581d8d7e8c/download
+  response: !!python/object:securedrop_client.sdk.StreamedResponse
+    contents: !!binary |
+      wcFMA8PnxMCiIBsqARAAiqV6F4Vh2Xz742FwQ1fl/Id/VfTAtiTE1N7lq6d24NVPxMozJby7WVCk
+      hAapdoHPT3XmDB67kj6mB4WuECU7LKbZgi3RnZ0hfXgsIDaatj2V6YeFuAnRgPb5zYx+duK3ZFhM
+      0vE2IHzyf0hgbkW/Zo4V71B3zEEXO08pm277VYA5O7KOlLJGABSUylNSjua0T7zrMkmdRQBVcSW0
+      81qaMLXaKK48IfVMtBue64Uj0YQfo9jB+ZvbVYNAzvzhr8FlC+mXWE9Y8j5IJotVe/YPtPRY7X9Z
+      ATRjjclysHka90R/+myTkNvOKX5tYnYBYeudJ/07BtDsB6Niai8M5KLqyOi8Lhfk6blXf0jPT1bS
+      vYjez/FTJkar2BBkzbtpCJiU5jW/4uMff86IqyARb5fz/v6fz08VlWtf1ySE4W/zXagz84Oyh1a3
+      dIoBt+Z53uKyV5dBmB+Hj3BYgjbdkoMzQxLAx0k3oZwzbnWauHx0HyXnXw3TcbRsHYKrkTaYtBOc
+      4SKNnQZmFAy/e3wEW9nj4ut517pLt6paVFjWfz9m2yAsoq6pwWdDJ7WU0HL2xzXzO7+y46hG1ji6
+      RpaE3rnws1xRrmgwD7IwLNt8z5sl5KYS1yOe0hl2yc5w5nV2k7BDXr4oksPN95vUOz+Spfq8pS4D
+      82fYFuHbgWFG2/aO45rSegHWhreGAL5isFlvtntR29kkLy7tJn5CAK2MwM7Ys3BjXg18Z694Lu1G
+      JWsmRDt79F11hmGeGBwTEKCEroCUrLxKEeLTs/ILT1dgMQPQib4VIA4cgmg0PDQ+u9RTEj1xSzwe
+      AHWdUuw6m5xQdvvv6TkWB3/uS4z1DYDl
+    filename: attachment; filename=3-assessable_firmness-doc.gz.gpg
+    sha256sum: sha256:3aa5ec3fe60b235a76bfc2c3a5c5d525687f04c1670060632a21b6a77c131f65
+version: 1

--- a/client/tests/sdk/data/test_download_submission_autoresume_fail.yml
+++ b/client/tests/sdk/data/test_download_submission_autoresume_fail.yml
@@ -1,0 +1,265 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token Im5fRGxUa0duSGZRT0hUaExaVUpuLUNBZjJjWTdoX1JzaEtXZjF1bGpNMFEi.Zkt5Eg.rhj_SR58sfebF374tCr9GGpLofM
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/submissions
+  response: !!python/object:securedrop_client.sdk.JSONResponse
+    data:
+      submissions:
+      - download_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b/submissions/591e6a8a-6d9c-4361-98da-ebbcbb0ac1da/download
+        filename: 1-sinister_potash-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - f422ae93-6d02-4699-9d0c-aa612c38d6e4
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 616
+        source_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b
+        submission_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b/submissions/591e6a8a-6d9c-4361-98da-ebbcbb0ac1da
+        uuid: 591e6a8a-6d9c-4361-98da-ebbcbb0ac1da
+      - download_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b/submissions/d67ec08f-626d-4e86-a9ce-a4489813b760/download
+        filename: 2-sinister_potash-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - c02c0512-89a8-496e-8f32-2ab65d80b030
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 700
+        source_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b
+        submission_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b/submissions/d67ec08f-626d-4e86-a9ce-a4489813b760
+        uuid: d67ec08f-626d-4e86-a9ce-a4489813b760
+      - download_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b/submissions/8a5fcca0-d4c5-48f1-8a44-f5581d8d7e8c/download
+        filename: 3-sinister_potash-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 651
+        source_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b
+        submission_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b/submissions/8a5fcca0-d4c5-48f1-8a44-f5581d8d7e8c
+        uuid: 8a5fcca0-d4c5-48f1-8a44-f5581d8d7e8c
+      - download_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b/submissions/7a998852-36fe-46d0-985c-8d0193328332/download
+        filename: 4-sinister_potash-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - f422ae93-6d02-4699-9d0c-aa612c38d6e4
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 651
+        source_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b
+        submission_url: /api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b/submissions/7a998852-36fe-46d0-985c-8d0193328332
+        uuid: 7a998852-36fe-46d0-985c-8d0193328332
+      - download_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca/submissions/a595250b-b66b-4a26-9d57-e29cdce886c5/download
+        filename: 1-irremediable_generosity-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - c02c0512-89a8-496e-8f32-2ab65d80b030
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 647
+        source_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca
+        submission_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca/submissions/a595250b-b66b-4a26-9d57-e29cdce886c5
+        uuid: a595250b-b66b-4a26-9d57-e29cdce886c5
+      - download_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca/submissions/71dfad99-5c06-4fd7-8605-ca6e3299bd5b/download
+        filename: 2-irremediable_generosity-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - c02c0512-89a8-496e-8f32-2ab65d80b030
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 766
+        source_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca
+        submission_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca/submissions/71dfad99-5c06-4fd7-8605-ca6e3299bd5b
+        uuid: 71dfad99-5c06-4fd7-8605-ca6e3299bd5b
+      - download_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca/submissions/4b22f2f9-70ea-4e3b-8d57-5e0b1b56b7fc/download
+        filename: 3-irremediable_generosity-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - f422ae93-6d02-4699-9d0c-aa612c38d6e4
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 651
+        source_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca
+        submission_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca/submissions/4b22f2f9-70ea-4e3b-8d57-5e0b1b56b7fc
+        uuid: 4b22f2f9-70ea-4e3b-8d57-5e0b1b56b7fc
+      - download_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca/submissions/04ff1e66-b076-47fe-a856-7a36d67655d4/download
+        filename: 4-irremediable_generosity-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - c02c0512-89a8-496e-8f32-2ab65d80b030
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 651
+        source_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca
+        submission_url: /api/v1/sources/e3845811-fa9e-48d7-b1af-ae37363fc9ca/submissions/04ff1e66-b076-47fe-a856-7a36d67655d4
+        uuid: 04ff1e66-b076-47fe-a856-7a36d67655d4
+      - download_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c/submissions/66219559-e3c7-4f84-8aa7-f8e52502e7fa/download
+        filename: 1-silver_anticipation-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - f422ae93-6d02-4699-9d0c-aa612c38d6e4
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 804
+        source_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c
+        submission_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c/submissions/66219559-e3c7-4f84-8aa7-f8e52502e7fa
+        uuid: 66219559-e3c7-4f84-8aa7-f8e52502e7fa
+      - download_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c/submissions/0ef40d58-1630-4f24-9d4e-122f71e6c0bc/download
+        filename: 2-silver_anticipation-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 710
+        source_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c
+        submission_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c/submissions/0ef40d58-1630-4f24-9d4e-122f71e6c0bc
+        uuid: 0ef40d58-1630-4f24-9d4e-122f71e6c0bc
+      - download_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c/submissions/63024ccd-6e0e-4130-9a0c-0ff08a3adda2/download
+        filename: 3-silver_anticipation-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - f422ae93-6d02-4699-9d0c-aa612c38d6e4
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 651
+        source_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c
+        submission_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c/submissions/63024ccd-6e0e-4130-9a0c-0ff08a3adda2
+        uuid: 63024ccd-6e0e-4130-9a0c-0ff08a3adda2
+      - download_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c/submissions/08aeb19a-b502-4118-8c2f-ea4280522004/download
+        filename: 4-silver_anticipation-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - f422ae93-6d02-4699-9d0c-aa612c38d6e4
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 651
+        source_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c
+        submission_url: /api/v1/sources/bc46de2b-d079-47e1-9eb7-bd63586a1c6c/submissions/08aeb19a-b502-4118-8c2f-ea4280522004
+        uuid: 08aeb19a-b502-4118-8c2f-ea4280522004
+      - download_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1/submissions/6a22b2ca-66cd-407c-a7ad-6af36387718e/download
+        filename: 1-instructive_sachem-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 1124
+        source_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1
+        submission_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1/submissions/6a22b2ca-66cd-407c-a7ad-6af36387718e
+        uuid: 6a22b2ca-66cd-407c-a7ad-6af36387718e
+      - download_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1/submissions/171c74b8-e06b-42bc-8fd8-84e723b38490/download
+        filename: 2-instructive_sachem-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 687
+        source_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1
+        submission_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1/submissions/171c74b8-e06b-42bc-8fd8-84e723b38490
+        uuid: 171c74b8-e06b-42bc-8fd8-84e723b38490
+      - download_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1/submissions/293bdf38-3c64-44a9-878b-a80d66e40dea/download
+        filename: 3-instructive_sachem-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 651
+        source_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1
+        submission_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1/submissions/293bdf38-3c64-44a9-878b-a80d66e40dea
+        uuid: 293bdf38-3c64-44a9-878b-a80d66e40dea
+      - download_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1/submissions/cf6ab7c1-73d1-4c4d-ae3a-29b6e8d5feeb/download
+        filename: 4-instructive_sachem-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 651
+        source_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1
+        submission_url: /api/v1/sources/fb6dd019-6bb7-4229-87f8-f7839a1b47b1/submissions/cf6ab7c1-73d1-4c4d-ae3a-29b6e8d5feeb
+        uuid: cf6ab7c1-73d1-4c4d-ae3a-29b6e8d5feeb
+      - download_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b/submissions/14e96ddd-1fda-4b1f-bb3f-390661a013a3/download
+        filename: 1-militaristic_formalin-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 619
+        source_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b
+        submission_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b/submissions/14e96ddd-1fda-4b1f-bb3f-390661a013a3
+        uuid: 14e96ddd-1fda-4b1f-bb3f-390661a013a3
+      - download_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b/submissions/9a680e36-11fa-48ff-96f8-5e3a109b2d5f/download
+        filename: 2-militaristic_formalin-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 707
+        source_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b
+        submission_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b/submissions/9a680e36-11fa-48ff-96f8-5e3a109b2d5f
+        uuid: 9a680e36-11fa-48ff-96f8-5e3a109b2d5f
+      - download_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b/submissions/17670653-7309-46be-a83b-f9be04939336/download
+        filename: 3-militaristic_formalin-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 651
+        source_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b
+        submission_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b/submissions/17670653-7309-46be-a83b-f9be04939336
+        uuid: 17670653-7309-46be-a83b-f9be04939336
+      - download_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b/submissions/38c4b583-d6c1-47bd-bf43-1003bca94c36/download
+        filename: 4-militaristic_formalin-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - 76c1518d-6f30-47e8-8bbf-79a7118d8851
+        size: 651
+        source_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b
+        submission_url: /api/v1/sources/d7f172c7-69ce-4df1-a054-721a6f89269b/submissions/38c4b583-d6c1-47bd-bf43-1003bca94c36
+        uuid: 38c4b583-d6c1-47bd-bf43-1003bca94c36
+    headers:
+      connection: close
+      content-length: '13250'
+      content-type: application/json
+      date: Mon, 20 May 2024 16:23:54 GMT
+      server: Werkzeug/2.2.3 Python/3.8.10
+    status: 200
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token Im5fRGxUa0duSGZRT0hUaExaVUpuLUNBZjJjWTdoX1JzaEtXZjF1bGpNMFEi.Zkt5Eg.rhj_SR58sfebF374tCr9GGpLofM
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/sources/9d2f640a-6882-4039-963f-599a5ba9f82b/submissions/8a5fcca0-d4c5-48f1-8a44-f5581d8d7e8c/download
+  response: !!python/object/apply:securedrop_client.sdk.RequestTimeoutError []
+version: 1

--- a/client/tests/sdk/data/test_download_submission_stream_404.yml
+++ b/client/tests/sdk/data/test_download_submission_stream_404.yml
@@ -1,0 +1,278 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token Ik45WE1oNjFuVzdVc0V0VWZaSjJYemJTNmhiTnFseGpsLVNSc1hKYlV0Nm8i.Zldt-A.w3azL6o7YBKDKHb7INCMmotAAyE
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/submissions
+  response: !!python/object:securedrop_client.sdk.JSONResponse
+    data:
+      submissions:
+      - download_url: /api/v1/sources/13d40630-1880-4b2c-9378-194761ad743b/submissions/cc37508f-6e44-48b4-af17-5d5fa4f2b144/download
+        filename: 1-dun_washcloth-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - a7a4b9dc-6d1c-4696-ac85-97bab7bc3dfd
+        - 98ea9950-cc67-434a-9708-8452dfee162e
+        size: 616
+        source_url: /api/v1/sources/13d40630-1880-4b2c-9378-194761ad743b
+        submission_url: /api/v1/sources/13d40630-1880-4b2c-9378-194761ad743b/submissions/cc37508f-6e44-48b4-af17-5d5fa4f2b144
+        uuid: cc37508f-6e44-48b4-af17-5d5fa4f2b144
+      - download_url: /api/v1/sources/13d40630-1880-4b2c-9378-194761ad743b/submissions/3c130c08-a0d4-4dee-af0f-68546231632b/download
+        filename: 2-dun_washcloth-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - a7a4b9dc-6d1c-4696-ac85-97bab7bc3dfd
+        - 98ea9950-cc67-434a-9708-8452dfee162e
+        size: 700
+        source_url: /api/v1/sources/13d40630-1880-4b2c-9378-194761ad743b
+        submission_url: /api/v1/sources/13d40630-1880-4b2c-9378-194761ad743b/submissions/3c130c08-a0d4-4dee-af0f-68546231632b
+        uuid: 3c130c08-a0d4-4dee-af0f-68546231632b
+      - download_url: /api/v1/sources/13d40630-1880-4b2c-9378-194761ad743b/submissions/fc4b1821-fedc-4a33-b676-52b9211edf46/download
+        filename: 3-dun_washcloth-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - 98ea9950-cc67-434a-9708-8452dfee162e
+        size: 3684
+        source_url: /api/v1/sources/13d40630-1880-4b2c-9378-194761ad743b
+        submission_url: /api/v1/sources/13d40630-1880-4b2c-9378-194761ad743b/submissions/fc4b1821-fedc-4a33-b676-52b9211edf46
+        uuid: fc4b1821-fedc-4a33-b676-52b9211edf46
+      - download_url: /api/v1/sources/13d40630-1880-4b2c-9378-194761ad743b/submissions/b190a081-da3d-4138-bb75-b69214297138/download
+        filename: 4-dun_washcloth-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - 6e558b5e-313d-4488-9dcb-183b37b659d7
+        - 98ea9950-cc67-434a-9708-8452dfee162e
+        size: 3684
+        source_url: /api/v1/sources/13d40630-1880-4b2c-9378-194761ad743b
+        submission_url: /api/v1/sources/13d40630-1880-4b2c-9378-194761ad743b/submissions/b190a081-da3d-4138-bb75-b69214297138
+        uuid: b190a081-da3d-4138-bb75-b69214297138
+      - download_url: /api/v1/sources/ea57100b-4803-4349-991c-8363e9b0b9a9/submissions/f3b671cb-9edd-4e9f-b9e3-82f7681f8582/download
+        filename: 1-worth_finale-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - 98ea9950-cc67-434a-9708-8452dfee162e
+        size: 647
+        source_url: /api/v1/sources/ea57100b-4803-4349-991c-8363e9b0b9a9
+        submission_url: /api/v1/sources/ea57100b-4803-4349-991c-8363e9b0b9a9/submissions/f3b671cb-9edd-4e9f-b9e3-82f7681f8582
+        uuid: f3b671cb-9edd-4e9f-b9e3-82f7681f8582
+      - download_url: /api/v1/sources/ea57100b-4803-4349-991c-8363e9b0b9a9/submissions/3ae48557-d960-4b40-ace5-847afad6a398/download
+        filename: 2-worth_finale-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - 6e558b5e-313d-4488-9dcb-183b37b659d7
+        - 98ea9950-cc67-434a-9708-8452dfee162e
+        size: 766
+        source_url: /api/v1/sources/ea57100b-4803-4349-991c-8363e9b0b9a9
+        submission_url: /api/v1/sources/ea57100b-4803-4349-991c-8363e9b0b9a9/submissions/3ae48557-d960-4b40-ace5-847afad6a398
+        uuid: 3ae48557-d960-4b40-ace5-847afad6a398
+      - download_url: /api/v1/sources/ea57100b-4803-4349-991c-8363e9b0b9a9/submissions/78f9b152-4f7c-43c7-8764-4bfab366ec73/download
+        filename: 3-worth_finale-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - a7a4b9dc-6d1c-4696-ac85-97bab7bc3dfd
+        - 98ea9950-cc67-434a-9708-8452dfee162e
+        size: 3684
+        source_url: /api/v1/sources/ea57100b-4803-4349-991c-8363e9b0b9a9
+        submission_url: /api/v1/sources/ea57100b-4803-4349-991c-8363e9b0b9a9/submissions/78f9b152-4f7c-43c7-8764-4bfab366ec73
+        uuid: 78f9b152-4f7c-43c7-8764-4bfab366ec73
+      - download_url: /api/v1/sources/ea57100b-4803-4349-991c-8363e9b0b9a9/submissions/5bedf02f-7b90-45c9-acda-dd6298c9a3ca/download
+        filename: 4-worth_finale-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - 6e558b5e-313d-4488-9dcb-183b37b659d7
+        - 98ea9950-cc67-434a-9708-8452dfee162e
+        size: 3684
+        source_url: /api/v1/sources/ea57100b-4803-4349-991c-8363e9b0b9a9
+        submission_url: /api/v1/sources/ea57100b-4803-4349-991c-8363e9b0b9a9/submissions/5bedf02f-7b90-45c9-acda-dd6298c9a3ca
+        uuid: 5bedf02f-7b90-45c9-acda-dd6298c9a3ca
+      - download_url: /api/v1/sources/8873d8ba-9d1c-4f21-a022-93d9ef4b5027/submissions/0214c9fc-3894-45a4-afe5-8b62f07b6632/download
+        filename: 1-absurd_tranquillity-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - 6e558b5e-313d-4488-9dcb-183b37b659d7
+        - 98ea9950-cc67-434a-9708-8452dfee162e
+        size: 804
+        source_url: /api/v1/sources/8873d8ba-9d1c-4f21-a022-93d9ef4b5027
+        submission_url: /api/v1/sources/8873d8ba-9d1c-4f21-a022-93d9ef4b5027/submissions/0214c9fc-3894-45a4-afe5-8b62f07b6632
+        uuid: 0214c9fc-3894-45a4-afe5-8b62f07b6632
+      - download_url: /api/v1/sources/8873d8ba-9d1c-4f21-a022-93d9ef4b5027/submissions/06593305-2da0-4b97-86b4-15fe453eeb41/download
+        filename: 2-absurd_tranquillity-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - a7a4b9dc-6d1c-4696-ac85-97bab7bc3dfd
+        - 98ea9950-cc67-434a-9708-8452dfee162e
+        size: 710
+        source_url: /api/v1/sources/8873d8ba-9d1c-4f21-a022-93d9ef4b5027
+        submission_url: /api/v1/sources/8873d8ba-9d1c-4f21-a022-93d9ef4b5027/submissions/06593305-2da0-4b97-86b4-15fe453eeb41
+        uuid: 06593305-2da0-4b97-86b4-15fe453eeb41
+      - download_url: /api/v1/sources/8873d8ba-9d1c-4f21-a022-93d9ef4b5027/submissions/44beb9f0-463e-4057-9841-f4929480e790/download
+        filename: 3-absurd_tranquillity-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - 6e558b5e-313d-4488-9dcb-183b37b659d7
+        - 98ea9950-cc67-434a-9708-8452dfee162e
+        size: 3684
+        source_url: /api/v1/sources/8873d8ba-9d1c-4f21-a022-93d9ef4b5027
+        submission_url: /api/v1/sources/8873d8ba-9d1c-4f21-a022-93d9ef4b5027/submissions/44beb9f0-463e-4057-9841-f4929480e790
+        uuid: 44beb9f0-463e-4057-9841-f4929480e790
+      - download_url: /api/v1/sources/8873d8ba-9d1c-4f21-a022-93d9ef4b5027/submissions/a2cba210-ad3b-4db9-945c-4ec39e6b42e9/download
+        filename: 4-absurd_tranquillity-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - 6e558b5e-313d-4488-9dcb-183b37b659d7
+        - 98ea9950-cc67-434a-9708-8452dfee162e
+        size: 3684
+        source_url: /api/v1/sources/8873d8ba-9d1c-4f21-a022-93d9ef4b5027
+        submission_url: /api/v1/sources/8873d8ba-9d1c-4f21-a022-93d9ef4b5027/submissions/a2cba210-ad3b-4db9-945c-4ec39e6b42e9
+        uuid: a2cba210-ad3b-4db9-945c-4ec39e6b42e9
+      - download_url: /api/v1/sources/65f05a67-14b3-4575-bd25-28f2be3b91de/submissions/6f3f8533-f8ac-4e7c-b233-e816ed53f811/download
+        filename: 1-safe_scaffolding-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - a7a4b9dc-6d1c-4696-ac85-97bab7bc3dfd
+        - 98ea9950-cc67-434a-9708-8452dfee162e
+        size: 1124
+        source_url: /api/v1/sources/65f05a67-14b3-4575-bd25-28f2be3b91de
+        submission_url: /api/v1/sources/65f05a67-14b3-4575-bd25-28f2be3b91de/submissions/6f3f8533-f8ac-4e7c-b233-e816ed53f811
+        uuid: 6f3f8533-f8ac-4e7c-b233-e816ed53f811
+      - download_url: /api/v1/sources/65f05a67-14b3-4575-bd25-28f2be3b91de/submissions/566f916c-ac63-4806-b432-2d1b35d206a0/download
+        filename: 2-safe_scaffolding-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - 98ea9950-cc67-434a-9708-8452dfee162e
+        size: 687
+        source_url: /api/v1/sources/65f05a67-14b3-4575-bd25-28f2be3b91de
+        submission_url: /api/v1/sources/65f05a67-14b3-4575-bd25-28f2be3b91de/submissions/566f916c-ac63-4806-b432-2d1b35d206a0
+        uuid: 566f916c-ac63-4806-b432-2d1b35d206a0
+      - download_url: /api/v1/sources/65f05a67-14b3-4575-bd25-28f2be3b91de/submissions/6330ad50-b5b8-4c20-83b5-9bc13021c943/download
+        filename: 3-safe_scaffolding-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - a7a4b9dc-6d1c-4696-ac85-97bab7bc3dfd
+        - 98ea9950-cc67-434a-9708-8452dfee162e
+        size: 3684
+        source_url: /api/v1/sources/65f05a67-14b3-4575-bd25-28f2be3b91de
+        submission_url: /api/v1/sources/65f05a67-14b3-4575-bd25-28f2be3b91de/submissions/6330ad50-b5b8-4c20-83b5-9bc13021c943
+        uuid: 6330ad50-b5b8-4c20-83b5-9bc13021c943
+      - download_url: /api/v1/sources/65f05a67-14b3-4575-bd25-28f2be3b91de/submissions/e88c3b93-d833-4775-af72-a459be849557/download
+        filename: 4-safe_scaffolding-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - 98ea9950-cc67-434a-9708-8452dfee162e
+        size: 3684
+        source_url: /api/v1/sources/65f05a67-14b3-4575-bd25-28f2be3b91de
+        submission_url: /api/v1/sources/65f05a67-14b3-4575-bd25-28f2be3b91de/submissions/e88c3b93-d833-4775-af72-a459be849557
+        uuid: e88c3b93-d833-4775-af72-a459be849557
+      - download_url: /api/v1/sources/28d72c1b-d505-4ab1-ba04-928c1f8c614a/submissions/c73b889f-771b-4eef-8233-fbec2d1d888c/download
+        filename: 1-lapidary_phlegm-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - 98ea9950-cc67-434a-9708-8452dfee162e
+        size: 619
+        source_url: /api/v1/sources/28d72c1b-d505-4ab1-ba04-928c1f8c614a
+        submission_url: /api/v1/sources/28d72c1b-d505-4ab1-ba04-928c1f8c614a/submissions/c73b889f-771b-4eef-8233-fbec2d1d888c
+        uuid: c73b889f-771b-4eef-8233-fbec2d1d888c
+      - download_url: /api/v1/sources/28d72c1b-d505-4ab1-ba04-928c1f8c614a/submissions/1da67bc0-833c-49d9-9ca7-a1d67a13945f/download
+        filename: 2-lapidary_phlegm-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - 98ea9950-cc67-434a-9708-8452dfee162e
+        size: 707
+        source_url: /api/v1/sources/28d72c1b-d505-4ab1-ba04-928c1f8c614a
+        submission_url: /api/v1/sources/28d72c1b-d505-4ab1-ba04-928c1f8c614a/submissions/1da67bc0-833c-49d9-9ca7-a1d67a13945f
+        uuid: 1da67bc0-833c-49d9-9ca7-a1d67a13945f
+      - download_url: /api/v1/sources/28d72c1b-d505-4ab1-ba04-928c1f8c614a/submissions/ffa040c0-53fd-4526-bf3f-a1e15ae1bb74/download
+        filename: 3-lapidary_phlegm-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - 98ea9950-cc67-434a-9708-8452dfee162e
+        size: 3684
+        source_url: /api/v1/sources/28d72c1b-d505-4ab1-ba04-928c1f8c614a
+        submission_url: /api/v1/sources/28d72c1b-d505-4ab1-ba04-928c1f8c614a/submissions/ffa040c0-53fd-4526-bf3f-a1e15ae1bb74
+        uuid: ffa040c0-53fd-4526-bf3f-a1e15ae1bb74
+      - download_url: /api/v1/sources/28d72c1b-d505-4ab1-ba04-928c1f8c614a/submissions/2c36f04d-b683-45d4-96af-2f70e69a7f74/download
+        filename: 4-lapidary_phlegm-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - 98ea9950-cc67-434a-9708-8452dfee162e
+        size: 3684
+        source_url: /api/v1/sources/28d72c1b-d505-4ab1-ba04-928c1f8c614a
+        submission_url: /api/v1/sources/28d72c1b-d505-4ab1-ba04-928c1f8c614a/submissions/2c36f04d-b683-45d4-96af-2f70e69a7f74
+        uuid: 2c36f04d-b683-45d4-96af-2f70e69a7f74
+    headers:
+      connection: close
+      content-length: '13274'
+      content-type: application/json
+      date: Wed, 29 May 2024 18:03:46 GMT
+      server: Werkzeug/2.2.3 Python/3.8.10
+    status: 200
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token Ik45WE1oNjFuVzdVc0V0VWZaSjJYemJTNmhiTnFseGpsLVNSc1hKYlV0Nm8i.Zldt-A.w3azL6o7YBKDKHb7INCMmotAAyE
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/sources/13d40630-1880-4b2c-9378-194761ad743b/submissions/fc4b1821-fedc-4a33-b676-52b9211edf46404/download
+  response: !!python/object:securedrop_client.sdk.JSONResponse
+    data:
+      error: Not Found
+      message: The requested URL was not found on the server. If you entered the URL
+        manually please check your spelling and try again.
+    headers:
+      connection: close
+      content-length: '165'
+      content-type: application/json
+      date: Wed, 29 May 2024 18:03:46 GMT
+      server: Werkzeug/2.2.3 Python/3.8.10
+    status: 404
+version: 1

--- a/client/tests/sdk/utils.py
+++ b/client/tests/sdk/utils.py
@@ -1,3 +1,4 @@
+import functools
 from unittest.mock import patch
 
 import vcr
@@ -78,6 +79,7 @@ class VCRAPI(API):
         cassette patched into place.
         """
 
+        @functools.wraps(func)
         def wrapper(self, *args, **kwargs):
             # We have to specify an explicit path for each cassette because
             # we're not using vcr.use_cassette() directly as a decorator.


### PR DESCRIPTION
## Status

Ready for review

## Description

Will fix #1994.

I've primarily edited `API.download_submission`. There's a big code block the only runs if `self.proxy` is False, and if the proxy is in use it doesn't do anything yet. I'll still need to make this work with proxy v2.

The change works like this: The output file is opened for writing at the beginning, and then there's a loop that continues until the download is complete, or it has been retried 3 times. (I have a comment to make `RETRY_LIMIT` configurable, but it's hard-coded right now.)

Inside this loop, it tries to download the submission by sending the correct request to `self._send_json_request`. I've made it so `stream=True` is passed to `requests.request` on the download requests, which means the `requests.request` call returns immediately, but the content of the request is later streamed via `data.iter_content`. After `_send_json_request` returns, it streams a chunk at a time, writing that chunk to disk, and keeping track of how many bytes have been written in total.

If there's a `ReadTimeout`, `ConnectTimeout`, `ConnectionError`, or `TooManyRedirects` exception during the `data.iter_content` call (basically, if the download starts, but then it times out during one of the chunks), then it retries and the loop starts over. This time though, when it calls `self._send_json_request` it sends the appropriate `Range` header to just get the data from where it left off.

I've written a new test to test this, `TestAPI.test_download_submission_autoresume`. This works by stubbing `requests.request` with a fake version of it that, the first time it runs, makes the request timeout after serving 200 bytes, and subsequent times serves the request as it should. So, this should serve 200 bytes of the download, timeout, and then resume with a range request and finish.

The test passes, and I've confirmed that the code actually works like this. But the problem is that the test files are too small. In `API.download_submission`, the chunk size is 1024 bytes, but the test file I'm downloading is 651 bytes, which means that currently the test actually serves the entire 651 bytes in a single chunk and then raises a `ReadTimeout`. It still works, but it would be more realistic if we had a larger file to test with.

I confirmed that it works as it's supposed to by changing the chunk size in `API.download_submission` from 1024 to 64 bytes, and it basically sends 4 chunks (256 bytes) and then raises a `ReadTimeout` on the subsequent chunk. Then, on retry, it makes a range request and successfully finishes the download.

Can we add test data to the `securedrop` to include a bigger file? And also a binary file, like maybe a 200kb image or something, since all the file uploads now are text?

What's left:

- [x] Make `RETRY_LIMIT` configurable
- [x] Support proxy v2