### PR TITLE
Upgrade Rust toolchain to 1.78.0

### DIFF
--- a/.github/workflows/cargo-vet.yml
+++ b/.github/workflows/cargo-vet.yml
@@ -16,7 +16,7 @@ jobs:
     name: Vet Dependencies
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.74.1
+    container: rust:1.78.0
     env:
       CARGO_VET_VERSION: 0.9.0
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
   rust:
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.74.1
+    container: rust:1.78.0
     steps:
       - uses: actions/checkout@v4
       - name: Configure Qubes repository

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,7 +7,7 @@ jobs:
   rust-audit:
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.74.1
+    container: rust:1.78.0
     steps:
       - uses: actions/checkout@v4
       - name: Check Rust dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,8 @@ jobs:
         run: apt-get install --yes build-essential curl libssl-dev pkg-config
         if: ${{ matrix.component == 'proxy' }}
       - uses: actions/checkout@v4
-      # Install Rust 1.74.1, keep in sync with rust-toolchain.toml
-      - uses: dtolnay/rust-toolchain@1.74.1
+      # Install Rust, keep in sync with rust-toolchain.toml
+      - uses: dtolnay/rust-toolchain@1.78.0
         if: ${{ matrix.component == 'proxy' }}
       - name: Install dependencies
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,8 @@ members = [
     "proxy"
 ]
 resolver = "2"
+
+[profile.release]
+# Let packaging take care of stripping debug symbols
+debug = "full"
+strip = "none"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.74.1"
+channel = "1.78.0"

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -15,7 +15,7 @@ COPY qubes_42.sources /etc/apt/sources.list.d/
 RUN sed -i s/##VERSION_CODENAME##/${DISTRO}/ /etc/apt/sources.list.d/qubes_42.sources
 
 # Keep in sync with rust-toolchain.toml
-ENV RUST_VERSION 1.74.1
+ENV RUST_VERSION 1.78.0
 ENV RUSTUP_VERSION 1.24.3
 ENV RUSTUP_INIT_SHA256 3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338
 ENV RUSTUP_HOME /opt/rustup


### PR DESCRIPTION
## Status

Ready for review

## Description

The "release" profile now strips debuginfo[1], so we need to re-enable it so
the Debian packaging can strip it and ship it in a separate dbgsym package.
    
[1] https://blog.rust-lang.org/2024/03/21/Rust-1.77.0.html#enable-strip-in-release-profiles-by-default

Fixes #2024.

## Test Plan

* [ ] CI passes

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
