### PR TITLE
Use curl instead of dockerize in SDK CI

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -30,9 +30,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install poetry==1.6.1
-          wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz &&
-          tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz &&
-          rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
       - name: Run tests without VCR cassettes
         run: |
           # Start the server in the background
@@ -40,6 +37,7 @@ jobs:
           # And install deps
           poetry -C client install --no-ansi
           # Wait for server to come up
-          dockerize -wait http://127.0.0.1:8080 -timeout 5m
+          echo "Polling with curl --silent until the server is up..."
+          while ! curl --silent --fail --output /dev/null http://127.0.0.1:8080; do sleep 5; done
           # Run tests
           make -C client regenerate-sdk-cassettes


### PR DESCRIPTION
## Status

Ready for review

## Description

We just need a tool to wait until the HTTP service is working, and it turns out we can use curl for that by running it in a one-line bash loop, avoiding the need to download and extract dockerize.

This approach was inspired by the securedrop.org repository CI.[1]

[1] https://github.com/freedomofpress/securedrop.org/blob/6df3cd790a8cdc7409585c30813d01a5f6a5c37c/.circleci/config.yml#L59

Fixes #1999.

## Test Plan

* [ ] CI passes
