### PR TITLE
Add AppArmor profile for securedrop-proxy

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -16,6 +16,7 @@ override_dh_auto_install:
 	cargo build --release --locked --features qubesdb
 	dh_auto_install
 	dh_apparmor --profile-name=usr.bin.securedrop-client -psecuredrop-client
+	dh_apparmor --profile-name=usr.bin.securedrop-proxy -psecuredrop-proxy
 
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete

--- a/debian/securedrop-proxy.install
+++ b/debian/securedrop-proxy.install
@@ -1,2 +1,3 @@
 proxy/qubes/securedrop.Proxy etc/qubes-rpc/
 target/release/securedrop-proxy usr/bin/
+proxy/usr.bin.securedrop-proxy /etc/apparmor.d/

--- a/proxy/usr.bin.securedrop-proxy
+++ b/proxy/usr.bin.securedrop-proxy
@@ -1,0 +1,12 @@
+abi <abi/3.0>,
+
+include <tunables/global>
+
+/usr/bin/securedrop-proxy {
+  include <abstractions/base>
+  include <abstractions/nameservice>
+  include <abstractions/openssl>
+  include <abstractions/ssl_certs>
+
+  /usr/bin/securedrop-proxy mr,
+}


### PR DESCRIPTION
## Status

Ready for review

## Description

Because this is a static Rust binary, it ends up being super simple, we just need to import the abstractions for DNS, OpenSSL and TLS certs.

Fixes #1889.

## Test Plan

* [ ] CI passes (esp. lint-apparmor job)
* [ ] Build debs, install new proxy deb into the sd-proxy VM, restart it. Then test basic sync, download and reply functionality through the client.
* [ ] Run `sudo aa-status` in sd-proxy, see that securedrop-proxy is in enforce mode
* [ ] Apply the following patch to the proxy and build a new proxy deb and install it into sd-proxy:
```diff
diff --git a/proxy/src/main.rs b/proxy/src/main.rs
index d1cb6563..64fd25dd 100644
--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -162,6 +162,15 @@ async fn proxy() -> Result<()> {
 #[tokio::main(flavor = "current_thread")]
 /// Entry-point: Every invocation handles a single request via `proxy()` and exits according to its success or failure.
 async fn main() -> ExitCode {
+    if std::env::args().any(|arg| arg == "--apparmor-test") {
+        println!(
+            "{}",
+            std::fs::read_to_string("/var/lib/qubes/first-boot-completed")
+                .unwrap()
+        );
+        println!("allowed");
+        return ExitCode::SUCCESS;
+    }
     match proxy().await {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
```
* [ ] Open a Terminal in `sd-proxy` and run `securedrop-proxy --apparmor-test`. You should get an error message like:
```
thread 'main' panicked at proxy/src/main.rs:169:18:
called `Result::unwrap()` on an `Err` value: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
which means that apparmor blocked opening the file.

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [x] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
