### PR TITLE
Re-instate Python package discovery in securedrop-log's setup.py

### DIFF
--- a/log/setup.py
+++ b/log/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     license="GPLv3+",
     install_requires=[],
     python_requires=">=3.5",
-    packages=[],
+    packages=setuptools.find_packages(exclude=["docs", "tests"]),
     url="https://github.com/freedomofpress/securedrop-log",
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
## Status

Ready for review

## Description

This was a bad collision between 588988a ("Remove unused securedrop-log code") and 90424f8 ("log: reorganize code to split server from client").

The first commit removed all the Python packages from the securedrop-log component, removing the discovery of packages was needed. The second commit created a new Python package with the log_server code, and relied on the line being present.

This reverts the removal in 588988a.

## Test Plan

* [ ] Install into SDW, verify logs are flowing again.
* [ ] Check `systemctl status securedrop-log-server` in `sd-log` is happy.

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [x] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
