### PR TITLE
Revert "Consolidate pip dependabot updates into a single PR"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,18 +7,49 @@ updates:
 
   # Python development dependencies
   - package-ecosystem: "pip"
-    directories:
-      - "/"
-      - "/client"
-      - "/export"
-      - "/log"
-      - "/proxy"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "development"
+  - package-ecosystem: "pip"
+    directory: "/client"
     schedule:
       interval: "weekly"
     allow:
       - dependency-type: "development"
     ignore:
       - dependency-name: "pyqt*"
+    groups:
+      dev-dependencies:
+        patterns: ["*"]
+        dependency-type: "development"
+  - package-ecosystem: "pip"
+    directory: "/export"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "development"
+    groups:
+      dev-dependencies:
+        patterns: ["*"]
+        dependency-type: "development"
+  - package-ecosystem: "pip"
+    directory: "/log"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "development"
+    groups:
+      dev-dependencies:
+        patterns: ["*"]
+        dependency-type: "development"
+  - package-ecosystem: "pip"
+    directory: "/proxy"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "development"
     groups:
       dev-dependencies:
         patterns: ["*"]


### PR DESCRIPTION
## Status

Ready for review

## Description

dependabot times out when trying to do all of our updates at once. This is still a beta feature, so let's go back to the old way that at least worked while GitHub fixes this.

This reverts commit 7933d2252d894ba60243ece12267417ea5cec443.

This reverts commit 87c09f9ff9b2e894a06e53be4b165a40b18e9652.

## Test Plan

* [ ] visual review
