### PR TITLE
Ignore bogus CVE-2019-8341

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ safety:  ## Run safety dependency checks on build dependencies
 		--ignore 61893 \
 		--ignore 62044 \
 		--ignore 67895 \
+		--ignore 70612 \
  		-r
 
 .PHONY: shellcheck


### PR DESCRIPTION
## Status

Ready for review

## Description

Same as <https://github.com/freedomofpress/fpf-misc-resources/pull/46>, where I wrote:
>  To quote a jinja2 maintainer: "This CVE is a bad joke"[1].
> 
> We don't use the vulnerable functions anyways.
> 
> [1] https://bugzilla.redhat.com/show_bug.cgi?id=1677653#c4


## Test Plan

* [ ] CI passes