### PR TITLE
[0.10.2] Pin builder version for builds at pre-rust-proxy ref

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           repository: "freedomofpress/securedrop-builder"
           path: "securedrop-builder"
-          ref: "3ae85f538e9b37dff5be0033f58370a982b099ff"
+          ref: "securedrop-client-0.10.2"
           lfs: true
       - name: Install dependencies
         run: |
@@ -58,7 +58,7 @@ jobs:
         with:
           repository: "freedomofpress/securedrop-builder"
           path: "securedrop-builder"
-          ref: "3ae85f538e9b37dff5be0033f58370a982b099ff"
+          ref: "securedrop-client-0.10.2"
           lfs: true
       - name: Build packages
         run: |
@@ -87,7 +87,7 @@ jobs:
         with:
           repository: "freedomofpress/securedrop-builder"
           path: "securedrop-builder"
-          ref: "3ae85f538e9b37dff5be0033f58370a982b099ff"
+          ref: "securedrop-client-0.10.2"
           lfs: true
       - name: Build packages
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           repository: "freedomofpress/securedrop-builder"
           path: "securedrop-builder"
+          ref: "3ae85f538e9b37dff5be0033f58370a982b099ff"
           lfs: true
       - name: Install dependencies
         run: |
@@ -57,6 +58,7 @@ jobs:
         with:
           repository: "freedomofpress/securedrop-builder"
           path: "securedrop-builder"
+          ref: "3ae85f538e9b37dff5be0033f58370a982b099ff"
           lfs: true
       - name: Build packages
         run: |
@@ -85,6 +87,7 @@ jobs:
         with:
           repository: "freedomofpress/securedrop-builder"
           path: "securedrop-builder"
+          ref: "3ae85f538e9b37dff5be0033f58370a982b099ff"
           lfs: true
       - name: Build packages
         run: |

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@ safety:  ## Run safety dependency checks on build dependencies
 		--ignore 61601 \
 		--ignore 61893 \
 		--ignore 62044 \
+		--ignore 67895 \
+		--ignore 71064 \
  		-r
 
 .PHONY: shellcheck

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,8 @@ safety:  ## Run safety dependency checks on build dependencies
 		--ignore 62044 \
 		--ignore 67895 \
 		--ignore 71064 \
- 		-r
+                --ignore 70612 \
+        	-r
 
 .PHONY: shellcheck
 shellcheck:  ## Lint shell scripts


### PR DESCRIPTION
## Status

ready for review
Refs #2049 

## Description

- pins securedrop-builder version to allow building pre-RiiR sd-proxy packages.

## Test Plan

- [x] CI is passing
- [ ] ~We're all cool with having a commit hash in there instead of a signed tag :/~ Visual review OK + verification of `securedrop-client-0.10.2` tag (developer key) in builder repo

