### PR TITLE
Exclude Babel header from i18n diff in `make check-strings` 

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -133,7 +133,7 @@ POT=${LOCALE_DIR}/messages.pot
 .PHONY: check-strings
 check-strings: ## Check that the translation catalog is up to date with source code
 	@make extract-strings
-	@git diff --exit-code ${LOCALE_DIR} || { echo "Translation catalog is out of date. Please run \"make extract-strings\" and commit the changes."; exit 1; }
+	@git diff --ignore-matching-lines="^Generated-By: Babel" --exit-code ${LOCALE_DIR} || { echo "Translation catalog is out of date. Please run \"make extract-strings\" and commit the changes."; exit 1; }
 
 .PHONY: extract-strings
 extract-strings: ## Extract translatable strings from source code


### PR DESCRIPTION
## Status

Ready for review

## Description

Refs https://github.com/freedomofpress/securedrop-client/pull/2053

## Test Plan

- [ ] Visual Review
- [ ] CI passing
- [x] `make check-strings` still correctly reports changes to catalog
  
## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
