### PR TITLE
fix: two-part `ExecStartPost` needs `bash -c`

### DIFF
--- a/debian/securedrop-whonix-config.securedrop-whonix-config.service
+++ b/debian/securedrop-whonix-config.securedrop-whonix-config.service
@@ -8,7 +8,7 @@ Before=tor.service
 Type=oneshot
 User=root
 ExecStart=/usr/bin/template-from-qubesdb /usr/share/securedrop-whonix-config/app_journalist.auth_private.tmpl /var/lib/tor/authdir/app-journalist.auth_private
-ExecStartPost=chown debian-tor:debian-tor /var/lib/tor/authdir/app-journalist.auth_private && chmod 0600 /var/lib/tor/authdir/app-journalist.auth_private
+ExecStartPost=bash -c "chown debian-tor:debian-tor /var/lib/tor/authdir/app-journalist.auth_private && chmod 0600 /var/lib/tor/authdir/app-journalist.auth_private"
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
## Status

Ready for review

## Description

Towards freedomofpress/securedrop-workstation#1051, wraps the two commands in `securedrop-whonix-config`'s `ExecStartPost` directive in `bash -c`.  (We had this at some point last week; I think it got lost in a rebase.)


## Test Plan

- [ ] Visual review.


## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - These changes should not need testing in Qubes