### PR TITLE
Install nautilus file manager in export and viewer VMs.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Description: securedrop client for qubes workstation
 Package: securedrop-export
 Architecture: all
 Depends: ${python3:Depends}, ${misc:Depends}, udisks2, cups, printer-driver-brlaser, printer-driver-hpcups, system-config-printer, xpp, libcups2, unoconv, gnome-disk-utility,
- desktop-file-utils, shared-mime-info
+ desktop-file-utils, shared-mime-info, nautilus
 Description: Submission export scripts for SecureDrop Workstation
  This package provides scripts used by the SecureDrop Qubes Workstation to
  export submissions from the client to external storage, via the sd-export
@@ -55,13 +55,13 @@ Description: Whonix configuration for SecureDrop.
  
 Package: securedrop-workstation-config
 Architecture: all
-Depends: ${python3:Depends}, python3-qubesdb, rsyslog, mailcap, apparmor, nautilus, securedrop-keyring, xfce4-terminal
+Depends: ${python3:Depends}, python3-qubesdb, rsyslog, mailcap, apparmor, securedrop-keyring, xfce4-terminal
 Description: This is the SecureDrop workstation template configuration package.
  This package provides dependencies and configuration for the Qubes SecureDrop workstation VM Templates.
 
 Package: securedrop-workstation-viewer
 Architecture: all
-Depends: securedrop-workstation-config,securedrop-workstation-grsec,apparmor-profiles,apparmor-profiles-extra,apparmor-utils,audacious,eog,evince,file-roller,gedit,totem
+Depends: securedrop-workstation-config,securedrop-workstation-grsec,apparmor-profiles,apparmor-profiles-extra,apparmor-utils,audacious,eog,evince,file-roller,gedit,totem, nautilus
 Description: This is the SecureDrop workstation SecureDrop Viewer Disposable VM template configuration package. This package provides dependencies and configuration for the Qubes SecureDrop workstation sd-viewer Template VM.
 Provides: securedrop-workstation-svs-disp
 Conflicts: securedrop-workstation-svs-disp


### PR DESCRIPTION
## Status

Ready for review

## Description

Fixes #2037 

Removes `nautilus` from workstation-config package deps, installs it in export and workstation-viewer metapackages instead. 

This means a file manager will not be installed by default in `sd-app` or other small-template VMs - potentially frustrating for power users, but will also encourage the use of the intended VMs for file/disk operations.

(Not addressed in this PR: disabling file previews. )

## Test Plan

- [ ] CI is passing
- [ ] visual review

