### PR TITLE
fix(`securedrop-whonix-config`): depend on `anon-gw-anonymizer-config`

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -49,6 +49,7 @@ Description: Tools for configuring non-Qubes-aware applications from QubesDB.
 Package: securedrop-whonix-config
 Section: admin
 Architecture: all
+# FIXME: s/tor/anon-gw-anonymizer-config/ (requires Whonix repositories in piuparts)
 Depends: ${misc:Depends}, securedrop-qubesdb-tools, tor
 Description: Whonix configuration for SecureDrop.
  This package configures Whonix/Tor for SecureDrop.

--- a/debian/securedrop-whonix-config.securedrop-whonix-config.service
+++ b/debian/securedrop-whonix-config.securedrop-whonix-config.service
@@ -1,7 +1,16 @@
 [Unit]
 Description=SecureDrop Whonix configuration
 ConditionPathExists=/var/run/qubes-service/securedrop-whonix-config
+
+# Both Qubes's qubes-qrexec-agent (for QubesDB) and Whonix's
+# anon-gw-anonymizer-config (for configuration directories) must
+# have started *before* this service for it to run successfully,
+# since it's a one-shot operation rather than a long-lived service.
+Requires=anon-gw-anonymizer-config.service
+After=anon-gw-anonymizer-config.service
+Requires=qubes-qrexec-agent.service
 After=qubes-qrexec-agent.service
+
 Before=tor.service
 
 [Service]


### PR DESCRIPTION
## Status

Ready for review


## Description

Fixes <https://github.com/freedomofpress/securedrop-workstation/pull/1051#pullrequestreview-2097483051>.


## Test Plan

1. [ ] Build `securedrop-whonix-config`.
2. [ ] Install directly into `whonix-gateway-17`.
3. [ ] On `sd-whonix`, `systemctl securedrop-whonix-config` shows a successful execution.

Or follow the test plan in <https://github.com/freedomofpress/securedrop-workstation/pull/1051#issue-2322099098>.


## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - These changes should not need testing in Qubes