### PR TITLE
Allow nautilus to have RWX memory

### DIFF
--- a/workstation-config/paxctld.conf
+++ b/workstation-config/paxctld.conf
@@ -115,3 +115,6 @@
 # /usr/lib/libreoffice/program/soffice.bin	m
 
 /usr/bin/totem			m
+
+# See <https://github.com/freedomofpress/securedrop-client/issues/2037>
+/usr/bin/nautilus		m


### PR DESCRIPTION


## Status

Ready for review

## Description

Otherwise grsec will stop it, see <https://github.com/freedomofpress/securedrop-client/issues/2037#issuecomment-2135222922>.

Fixes #2037.

## Test Plan

* [x] Install `securedrop-workstation-config` deb into `sd-app` (or another VM w/ grsec kernel)
* [x] Reboot VM or `systemctl restart paxctld`
* [x] Start nautilus and it opens instead of failing.
* [x] Check syslog that there are no grsec denials.

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment


If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [x] No update to the AppArmor profile is required for these changes

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
