### PR TITLE
Avoid export failure with extra button-presses; show helpful error message on every Export Wizard Screen 

### DIFF
--- a/client/securedrop_client/gui/conversation/export/export_wizard.py
+++ b/client/securedrop_client/gui/conversation/export/export_wizard.py
@@ -191,6 +191,9 @@ class ExportWizard(QWizard):
             page.set_complete(False)
         self._start_animate_activestate()
 
+        # Disable the continue button until the qProcess completes
+        self.next_button.setEnabled(False)
+
         # Registered fields let us access the passphrase field
         # of the PassphraseRequestPage from the wizard parent
         passphrase_untrusted = self.field("passphrase")
@@ -214,6 +217,9 @@ class ExportWizard(QWizard):
             page.set_complete(True)
         self._stop_animate_activestate()
         self.current_status = status
+
+        # Button was disabled when the previous request was made; re-enable it
+        self.next_button.setEnabled(True)
 
     def _create_preflight(self) -> QWizardPage:
         return PreflightPage(self.export, self.summary_text)

--- a/client/securedrop_client/gui/conversation/export/export_wizard_page.py
+++ b/client/securedrop_client/gui/conversation/export/export_wizard_page.py
@@ -369,7 +369,7 @@ class InsertUSBPage(ExportWizardPage):
                 ExportStatus.MULTI_DEVICE_DETECTED,
             )
         else:
-            return super().isComplete()
+            return self.isComplete()
 
 
 class FinalPage(ExportWizardPage):

--- a/client/securedrop_client/gui/conversation/export/export_wizard_page.py
+++ b/client/securedrop_client/gui/conversation/export/export_wizard_page.py
@@ -353,7 +353,7 @@ class InsertUSBPage(ExportWizardPage):
                     self.update_content(status)
                 self.no_device_hint += 1
             else:
-                # Hide the error hint, it visible, so that if the user navigates
+                # Hide the error hint, if visible, so that if the user navigates
                 # forward then back they don't see an unneeded hint
                 self.error_details.hide()
                 self.wizard().next()

--- a/client/securedrop_client/gui/conversation/export/export_wizard_page.py
+++ b/client/securedrop_client/gui/conversation/export/export_wizard_page.py
@@ -318,6 +318,8 @@ class ErrorPage(ExportWizardPage):
     @pyqtSlot(object)
     def on_status_received(self, status: ExportStatus) -> None:
         self.status = status
+        if self.wizard() and isinstance(self.wizard().currentPage(), ErrorPage):
+            self.update_content(status=status, should_show_hint=True)
 
 
 class InsertUSBPage(ExportWizardPage):

--- a/client/securedrop_client/gui/conversation/export/export_wizard_page.py
+++ b/client/securedrop_client/gui/conversation/export/export_wizard_page.py
@@ -207,7 +207,7 @@ class ExportWizardPage(QWizardPage):
 
         return super().nextId()
 
-    def update_content(self, status: ExportStatus, should_show_hint: bool = False) -> None:
+    def update_content(self, status: ExportStatus, should_show_hint: bool = True) -> None:
         """
         Update page's content based on new status.
         """
@@ -319,7 +319,7 @@ class ErrorPage(ExportWizardPage):
     def on_status_received(self, status: ExportStatus) -> None:
         self.status = status
         if self.wizard() and isinstance(self.wizard().currentPage(), ErrorPage):
-            self.update_content(status=status, should_show_hint=True)
+            self.update_content(status)
 
 
 class InsertUSBPage(ExportWizardPage):
@@ -347,10 +347,10 @@ class InsertUSBPage(ExportWizardPage):
                 ExportStatus.INVALID_DEVICE_DETECTED,
                 ExportStatus.DEVICE_WRITABLE,
             ):
-                self.update_content(status, should_show_hint=True)
+                self.update_content(status)
             elif status == ExportStatus.NO_DEVICE_DETECTED:
                 if self.no_device_hint > 0:
-                    self.update_content(status, should_show_hint=True)
+                    self.update_content(status)
                 self.no_device_hint += 1
             else:
                 # Hide the error hint, it visible, so that if the user navigates
@@ -383,14 +383,14 @@ class FinalPage(ExportWizardPage):
     @pyqtSlot(object)
     def on_status_received(self, status: ExportStatus) -> None:
         self.status = status
-        self.update_content(status)
+        self.update_content(status, should_show_hint=False)
 
         # The completeChanged signal alerts the page to recheck its completion status,
         # which we need to signal since we have custom isComplete() logic
         if self.wizard() and isinstance(self.wizard().currentPage(), FinalPage):
             self.completeChanged.emit()
 
-    def update_content(self, status: ExportStatus, should_show_hint: bool = False) -> None:
+    def update_content(self, status: ExportStatus, should_show_hint: bool = True) -> None:
         header = None
         body = None
         if status == ExportStatus.SUCCESS_EXPORT:
@@ -491,7 +491,7 @@ class PassphraseWizardPage(ExportWizardPage):
                 ExportStatus.ERROR_UNLOCK_LUKS,
                 ExportStatus.ERROR_UNLOCK_GENERIC,
             ):
-                self.update_content(status, should_show_hint=True)
+                self.update_content(status)
             else:
                 self.wizard().next()
 


### PR DESCRIPTION
## Status

Ready for review 

## Description

- Disable Continue button while export QProcess is running, in addition to staying on the current page. This prevents the issue of a doubleclick or button-mash moving the wizard to a failure state (#1926, #2098). 
- Display error hint on Export Failed screen (#2098)
- (small refactor: default behaviour of `update_content` is to show error hints, since that's what we want in all cases except the final screen)

Fixes #2098 , Fixes #1926
see https://github.com/freedomofpress/securedrop-workstation/issues/1103#issuecomment-2217204131

## Test Plan
- [x] CI
- [x] Visual review
- [x] Do Something Bad (eg pull out USB during export, insert incompatible USB and press "next") and see error page with descriptive text
- [x] Button-mashing doesn't lead to Export Failed screen (#1926)
- [x] No pink hint shown on Success screen (Success screen says Export Successful and a reminder to be careful with files.)

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
