### PR TITLE
fix(`sd-viewer`): open `.webm` videos in Totem

### DIFF
--- a/workstation-config/mimeapps.list.sd-viewer
+++ b/workstation-config/mimeapps.list.sd-viewer
@@ -19,6 +19,7 @@ audio/x-wav=audacious.desktop
 video/quicktime=org.gnome.Totem.desktop
 video/x-theora+ogg=org.gnome.Totem.desktop
 video/mp4=org.gnome.Totem.desktop
+video/webm=org.gnome.Totem.desktop
 video/x-msvideo=org.gnome.Totem.desktop
 video/x-ms-wmv=org.gnome.Totem.desktop
 image/jpeg=org.gnome.eog.desktop


### PR DESCRIPTION
## Status

Ready for review

## Description

Fixes freedomofpress/securedrop-workstation#1138 by setting Totem as the default application for `video/webm` files.

## Test Plan

1. Apply this patch in `sd-large-bookworm-template`'s `/opt/sdw/mimeapps.list-sd-viewer`
2. Submit a `.webm` file to your SecureDrop test instance
3. Download it in the Client
4. Open it
5. [ ] The video plays in Totem in a disposable VM

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - These changes should not need testing in Qubes