### PR TITLE
[0.11.0] Backport "fix(`sd-viewer`): open `.webm` videos in Totem"

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## 0.11.0-rc2
 
 * Fix how print_preflight status is interpreted by the client
+* Open `.webm` videos in Totem
 
 ## 0.11.0-rc1
 

--- a/workstation-config/mimeapps.list.sd-viewer
+++ b/workstation-config/mimeapps.list.sd-viewer
@@ -19,6 +19,7 @@ audio/x-wav=audacious.desktop
 video/quicktime=org.gnome.Totem.desktop
 video/x-theora+ogg=org.gnome.Totem.desktop
 video/mp4=org.gnome.Totem.desktop
+video/webm=org.gnome.Totem.desktop
 video/x-msvideo=org.gnome.Totem.desktop
 video/x-ms-wmv=org.gnome.Totem.desktop
 image/jpeg=org.gnome.eog.desktop


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #2106.

## Testing

* [x] CI is passing
* [x] base is `release/0.11.0`
* [ ] Only contains changes from #2106 plus the changelog entry
