### PR TITLE
Adjust location of semgrep override

### DIFF
--- a/client/scripts/verify-mo.py
+++ b/client/scripts/verify-mo.py
@@ -112,11 +112,11 @@ class CatalogVerifier:
         # We silence Bandit and Semgrep warnings on `shell=True`
         # because we want to inherit the Python virtual environment
         # in which we're invoked.
-        # nosemgrep: python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
         return subprocess.run(
             cmd,
             capture_output=True,
             env=os.environ,
+            # nosemgrep: python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
             shell=True,  # noqa: S602
             check=False,
         )


### PR DESCRIPTION
## Status

Ready for review

## Description

It now needs to suppress the `shell=True` line instead of the whole subprocess function call.

Fixes #2122

## Test Plan

* [ ] CI passes

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
