### PR TITLE
Use check_call instead of check_output where output is not required

### DIFF
--- a/export/securedrop_export/print/service.py
+++ b/export/securedrop_export/print/service.py
@@ -173,7 +173,7 @@ class Service:
         # Compile and install drivers that are not already installed
         if not os.path.exists(printer_ppd):
             logger.info("Installing printer drivers")
-            self.safe_check_call(
+            self.check_output_and_stderr(
                 command=[
                     "sudo",
                     "ppdc",
@@ -190,7 +190,7 @@ class Service:
     def _setup_printer(self, printer_uri, printer_ppd):
         # Add the printer using lpadmin
         logger.info(f"Setting up printer {self.printer_name}")
-        self.safe_check_call(
+        self.check_output_and_stderr(
             command=[
                 "sudo",
                 "lpadmin",
@@ -243,7 +243,6 @@ class Service:
         # convert the file to pdf as printer drivers do not support this format
 
         if self._is_open_office_file(file_to_print):
-
             try:
                 logger.info("Converting Office document to pdf")
                 folder = os.path.dirname(file_to_print)
@@ -269,7 +268,9 @@ class Service:
         except subprocess.CalledProcessError as e:
             raise ExportException(sdstatus=Status.ERROR_PRINT, sderror=e.output)
 
-    def safe_check_call(self, command: str, error_status: Status, ignore_stderr_startswith=None):
+    def check_output_and_stderr(
+        self, command: str, error_status: Status, ignore_stderr_startswith=None
+    ):
         """
         Wrap subprocess.check_output to ensure we wrap CalledProcessError and return
         our own exception, and log the error messages.

--- a/export/securedrop_export/print/service.py
+++ b/export/securedrop_export/print/service.py
@@ -243,14 +243,14 @@ class Service:
         # convert the file to pdf as printer drivers do not support this format
 
         if self._is_open_office_file(file_to_print):
+            logger.info("Converting Office document to pdf")
+            folder = os.path.dirname(file_to_print)
+            converted_filename = file_to_print + ".pdf"
+            converted_path = os.path.join(folder, converted_filename)
+
             try:
-                logger.info("Converting Office document to pdf")
-                folder = os.path.dirname(file_to_print)
-                converted_filename = file_to_print + ".pdf"
-                converted_path = os.path.join(folder, converted_filename)
                 subprocess.check_call(["unoconv", "-o", converted_path, file_to_print])
                 file_to_print = converted_path
-
             except subprocess.CalledProcessError as e:
                 raise ExportException(sdstatus=Status.ERROR_PRINT, sderror=e.output)
 
@@ -260,13 +260,13 @@ class Service:
             subprocess.check_call(
                 ["xpp", "-P", self.printer_name, file_to_print],
             )
-            # This is an addition to ensure that the entire print job is transferred over.
-            # If the job is not fully transferred within the timeout window, the user
-            # will see an error message.
-            self._wait_for_print()
-
         except subprocess.CalledProcessError as e:
             raise ExportException(sdstatus=Status.ERROR_PRINT, sderror=e.output)
+
+        # This is an addition to ensure that the entire print job is transferred over.
+        # If the job is not fully transferred within the timeout window, the user
+        # will see an error message.
+        self._wait_for_print()
 
     def check_output_and_stderr(
         self, command: str, error_status: Status, ignore_stderr_startswith=None

--- a/export/tests/print/test_service.py
+++ b/export/tests/print/test_service.py
@@ -338,31 +338,29 @@ class TestPrint:
         file = "/tmp/definitely-an-office-file.odt"
 
         with (
-            mock.patch.object(self.service, "safe_check_call") as scc,
+            mock.patch("subprocess.check_call") as sp,
             mock.patch("securedrop_export.print.service.logger.info") as log,
         ):
             self.service._print_file(file)
 
-        assert scc.call_count == 2
-        scc.assert_has_calls(
+        assert sp.call_count == 2
+        sp.assert_has_calls(
             [
                 mock.call(
-                    command=[
+                    [
                         "unoconv",
                         "-o",
                         "/tmp/definitely-an-office-file.odt.pdf",
                         "/tmp/definitely-an-office-file.odt",
                     ],
-                    error_status=Status.ERROR_PRINT,
                 ),
                 mock.call(
-                    command=[
+                    [
                         "xpp",
                         "-P",
                         "sdw-printer",
                         "/tmp/definitely-an-office-file.odt.pdf",
                     ],
-                    error_status=Status.ERROR_PRINT,
                 ),
             ]
         )
@@ -390,26 +388,24 @@ class TestPrint:
             b"printer sdw-printer is idle\n",
         ],
     )
-    def test__wait_for_print_waits_correctly(self, mock_subprocess, mock_time):
+    def test__wait_for_print_waits_correctly(self, mock_sp, mock_time):
         file = "/tmp/happy-to-print-you.pdf"
 
-        with (
-            mock.patch.object(self.service, "safe_check_call") as scc,
+        with (mock.patch("subprocess.check_call") as mock_subprocess,
             mock.patch("securedrop_export.print.service.logger.info") as log,
         ):
             self.service._print_file(file)
 
-        assert scc.call_count == 1
-        scc.assert_has_calls(
+        assert mock_subprocess.call_count == 1
+        mock_subprocess.assert_has_calls(
             [
                 mock.call(
-                    command=[
+                    [
                         "xpp",
                         "-P",
                         "sdw-printer",
                         "/tmp/happy-to-print-you.pdf",
                     ],
-                    error_status=Status.ERROR_PRINT,
                 ),
             ]
         )

--- a/export/tests/print/test_service.py
+++ b/export/tests/print/test_service.py
@@ -182,27 +182,27 @@ class TestPrint:
 
         assert ex.value.sdstatus is Status.ERROR_PRINTER_INSTALL
 
-    def test_safe_check_call(self):
+    def test_check_output_and_stderr(self):
         # This works, since `ls` is a valid comand
-        self.service.safe_check_call(["ls"], Status.PRINT_TEST_PAGE_SUCCESS)
+        self.service.check_output_and_stderr(["ls"], Status.PRINT_TEST_PAGE_SUCCESS)
 
-    def test_safe_check_call_invalid_call(self):
+    def test_safe_check_output_invalid_call(self):
         with pytest.raises(ExportException) as ex:
-            self.service.safe_check_call(["ls", "kjdsfhkdjfh"], Status.ERROR_PRINT)
+            self.service.check_output_and_stderr(["ls", "kjdsfhkdjfh"], Status.ERROR_PRINT)
 
         assert ex.value.sdstatus is Status.ERROR_PRINT
 
-    def test_safe_check_call_write_to_stderr_and_ignore_error(self):
-        self.service.safe_check_call(
+    def test_safe_check_output_write_to_stderr_and_ignore_error(self):
+        self.service.check_output_and_stderr(
             ["python3", "-c", "import sys;sys.stderr.write('hello')"],
             error_status=Status.PRINT_TEST_PAGE_SUCCESS,
             ignore_stderr_startswith=b"hello",
         )
 
-    def test_safe_check_call_write_to_stderr_wrong_ignore_param(self):
+    def test_safe_check_output_write_to_stderr_wrong_ignore_param(self):
         # This one writes to stderr and ignores the wrong string, so we expect an exception
         with pytest.raises(ExportException) as ex:
-            self.service.safe_check_call(
+            self.service.check_output_and_stderr(
                 ["python3", "-c", "import sys;sys.stderr.write('hello\n')"],
                 error_status=Status.ERROR_PRINT,
                 ignore_stderr_startswith=b"world",
@@ -372,11 +372,13 @@ class TestPrint:
             ]
         )
 
-    def test_safe_check_call_has_error_in_stderr(self):
+    def test_safe_check_output_has_error_in_stderr(self):
         mock.patch("subprocess.run")
 
         with mock.patch("subprocess.run"), pytest.raises(ExportException) as ex:
-            self.service.safe_check_call(command="ls", error_status=Status.PRINT_TEST_PAGE_SUCCESS)
+            self.service.check_output_and_stderr(
+                command="ls", error_status=Status.PRINT_TEST_PAGE_SUCCESS
+            )
 
         assert ex.value.sdstatus is Status.PRINT_TEST_PAGE_SUCCESS
 
@@ -391,7 +393,8 @@ class TestPrint:
     def test__wait_for_print_waits_correctly(self, mock_sp, mock_time):
         file = "/tmp/happy-to-print-you.pdf"
 
-        with (mock.patch("subprocess.check_call") as mock_subprocess,
+        with (
+            mock.patch("subprocess.check_call") as mock_subprocess,
             mock.patch("securedrop_export.print.service.logger.info") as log,
         ):
             self.service._print_file(file)


### PR DESCRIPTION
## Status

Ready for review

## Description

Fixes #2119
- Use check_call instead of check_output if don't need output
- Rename `safe_check_call` to `safe_check_output` for clarity, since that's what it does

Note: `safe_check_output` will error if stderr is not empty OR in a list of predefined messages of which we're aware. For example, we use this to suppress lpadmin warnings about printer drivers reaching deprecation. (:grimacing: ). 
In this case, one of our dependencies printed a console warning, and `safe_check_output` rightly complained. I could have continued to use that method and just added an `ignore_stderr_startswith` but that feels brittle, it depends on the error string never changing.

The next thing we should do is move to a fully modern supported print workflow, as we have discussed in a few places.  
  
## Test Plan

- [ ] visual review
- [x] printing successful (per below)
- `make build-debs` from the tip of this branch.
- clone `sd-large-bookworm-template`. assign this to be the template for sd-devices-dvm. 
- install new securedrop-export deb into that template. Shut it down and shut down sd-devices if running. 
- print a doc that needs conversion to PDF (office doc) from sd-app.


## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
