### PR TITLE
Add more UI feedback to print, print transcript dialogs

### DIFF
--- a/client/securedrop_client/gui/base/dialog_button.css
+++ b/client/securedrop_client/gui/base/dialog_button.css
@@ -8,6 +8,12 @@
     border: 2px solid #05a6fe;
 }
 
+
+#ModalDialog_button_box QPushButton#ModalDialog_cancel_button::hover {
+    color: #05a6fe;
+    border: 2px solid #05a6fe;
+}
+
 #ModalDialog.dangerous #ModalDialog_button_box QPushButton {
     border-color: #ff3366;
     color: #ff3366;

--- a/client/securedrop_client/gui/base/dialog_button.css
+++ b/client/securedrop_client/gui/base/dialog_button.css
@@ -3,6 +3,11 @@
     color: #fff;
 }
 
+#ModalDialog_button_box QPushButton#ModalDialog_primary_button:hover {
+    background-color: #05a6fe;
+    border: 2px solid #05a6fe;
+}
+
 #ModalDialog.dangerous #ModalDialog_button_box QPushButton {
     border-color: #ff3366;
     color: #ff3366;

--- a/client/securedrop_client/gui/base/dialogs.css
+++ b/client/securedrop_client/gui/base/dialogs.css
@@ -73,3 +73,8 @@
     border: 2px solid rgba(42, 49, 157, 0.4);
     color: rgba(42, 49, 157, 0.4);
 }
+
+#ModalDialog_button_box QPushButton::hover {
+    color: #05a6fe;
+    border: 2px solid #05a6fe;
+}

--- a/client/securedrop_client/gui/conversation/export/print_dialog.py
+++ b/client/securedrop_client/gui/conversation/export/print_dialog.py
@@ -97,6 +97,7 @@ class PrintDialog(ModalDialog):
 
     @pyqtSlot()
     def _print_file(self) -> None:
+        self.start_animate_activestate()
         self._device.print(self.filepaths)
 
     @pyqtSlot()
@@ -104,6 +105,7 @@ class PrintDialog(ModalDialog):
         """
         Send a signal to close the print dialog.
         """
+        self.stop_animate_activestate()
         self.close()
 
     @pyqtSlot(object)

--- a/client/securedrop_client/gui/conversation/export/print_transcript_dialog.py
+++ b/client/securedrop_client/gui/conversation/export/print_transcript_dialog.py
@@ -21,6 +21,7 @@ class PrintTranscriptDialog(PrintDialog):
         self.transcript_location = filepath
 
     def _print_transcript(self) -> None:
+        self.start_animate_activestate()
         self._device.print(self.transcript_location)
 
     @pyqtSlot()


### PR DESCRIPTION
## Status

Ready for review

## Description

Fixes #2125

## Test Plan

- [x] CI passes
- [x] Visual review
- [x] Hover state (light blue) on print dialog Continue and Cancel buttons
- [x] Spinner animation on Continue button after print preflight (when dialog says "Ready to print ___") once user clicks it. Best tested by printing a file that requires PDF conversion, so the dialog is open for a while.

The easiest way to test may be to give sd-app network access, install all required dependencies, check out this branch in `sd-app`, and run `./run.sh --sdc-home=/home/user/.securedrop_client` with the venv activated, although you can also build from the tip of this branch and install the deb in sd-app.


## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
