### PR TITLE
Upgrade `openssl` crate for RUSTSEC-2024-0357

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,9 +638,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl"
-version = "0.10.63"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
@@ -670,9 +670,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.99"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ safety:  ## Run safety dependency checks on build dependencies
 		--ignore 62044 \
 		--ignore 67895 \
 		--ignore 70612 \
+		--ignore 71591 \
  		-r
 
 .PHONY: shellcheck

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -128,15 +128,15 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.openssl]]
-version = "0.10.63"
-when = "2024-01-20"
+version = "0.10.66"
+when = "2024-07-21"
 user-id = 163
 user-login = "alex"
 user-name = "Alex Gaynor"
 
 [[publisher.openssl-sys]]
-version = "0.9.99"
-when = "2024-01-20"
+version = "0.9.103"
+when = "2024-07-20"
 user-id = 163
 user-login = "alex"
 user-name = "Alex Gaynor"


### PR DESCRIPTION
## Status

Ready for review

## Description

Could lead to undefined behavior; see <https://rustsec.org/advisories/RUSTSEC-2024-0357> for details.

## Test Plan

* [ ] CI passes

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
