### PR TITLE
Remove references to obsolete securedrop-workstation-svs-disp package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -64,6 +64,3 @@ Package: securedrop-workstation-viewer
 Architecture: all
 Depends: securedrop-workstation-config,securedrop-workstation-grsec,apparmor-profiles,apparmor-profiles-extra,apparmor-utils,audacious,eog,evince,file-roller,gedit,totem,heif-gdk-pixbuf
 Description: This is the SecureDrop workstation SecureDrop Viewer Disposable VM template configuration package. This package provides dependencies and configuration for the Qubes SecureDrop workstation sd-viewer Template VM.
-Provides: securedrop-workstation-svs-disp
-Conflicts: securedrop-workstation-svs-disp
-Replaces: securedrop-workstation-svs-disp


### PR DESCRIPTION
## Status

Ready for review 

## Description

The svs-disp package was made obsolete in Oct. 2020 (https://github.com/freedomofpress/securedrop-builder/pull/198), and given the fresh installs for both 4.1 and 4.2 since then, there's no need to continue keeping the Provides/Conflicts/Replaces stanzas.

## Test Plan

* [ ] Visual review

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [x] No update to the AppArmor profile is required for these changes

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
