### PR TITLE
Switch securedrop-client to Architecture: any

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,8 +8,8 @@ Homepage: https://github.com/freedomofpress/securedrop-client
 X-Python3-Version: >= 3.5
 
 Package: securedrop-client
-Architecture: all
-Depends: ${python3:Depends},${misc:Depends}, python3-pyqt5, python3-pyqt5.qtsvg, python3-qubesdb, desktop-file-utils
+Architecture: any
+Depends: ${python3:Depends}, ${shlibs:Depends}, ${misc:Depends}, python3-pyqt5, python3-pyqt5.qtsvg, python3-qubesdb, desktop-file-utils
 Description: securedrop client for qubes workstation
 
 Package: securedrop-export
@@ -53,7 +53,7 @@ Architecture: all
 Depends: ${misc:Depends}, securedrop-qubesdb-tools, tor
 Description: Whonix configuration for SecureDrop.
  This package configures Whonix/Tor for SecureDrop.
- 
+
 Package: securedrop-workstation-config
 Architecture: all
 Depends: ${python3:Depends}, python3-qubesdb, rsyslog, mailcap, apparmor, nautilus, securedrop-keyring, xfce4-terminal

--- a/debian/securedrop-client.lintian-overrides
+++ b/debian/securedrop-client.lintian-overrides
@@ -1,23 +1,14 @@
-securedrop-client: arch-independent-package-contains-binary-or-object
-
 # This is intentional
 securedrop-client: dir-or-file-in-opt
 
 # FIXME
 securedrop-client: extended-description-is-empty
 
-# FIXME: fix by switching to arch: any
-securedrop-client: missing-dependency-on-libc
-
 # FIXME: remove __pycache__ directories
 securedrop-client: package-installs-python-pycache-dir
 
 # FIXME: section shouldn't be "unknown"
 securedrop-client: section-is-dh_make-template
-
-# FIXME: fix by switching to arch: any
-securedrop-client: unstripped-binary-or-object [opt/venvs/securedrop-client/lib/python3.*/site-packages/markupsafe/*]
-securedrop-client: unstripped-binary-or-object [opt/venvs/securedrop-client/lib/python3.*/site-packages/sqlalchemy/*]
 
 # We don't care
 securedrop-client: no-manual-page


### PR DESCRIPTION
## Status

Ready for review

## Description

The client package contains a few complied Python extensions (markupsafe and SQLalchemy), which contain debug symbols that can be stripped out to a dbgsym package.

The automatic shlibs dependency also sets a versioned dependency on libc based on the compiled files.

Fixes #1848.

## Test Plan

* [ ] Visual review
* [ ] CI passes

## Checklist

 - [x] These changes should not need testing in Qubes
 - [x] No update to the AppArmor profile is required for these changes
 - [x] No database schema changes are needed
