### PR TITLE
Refactor DeleteSourceDialog so it accepts Set[Source]

### DIFF
--- a/client/securedrop_client/gui/actions.py
+++ b/client/securedrop_client/gui/actions.py
@@ -80,7 +80,7 @@ class DeleteSourceAction(QAction):
         source: Source,
         parent: QMenu,
         controller: Controller,
-        confirmation_dialog: Callable[[Source], QDialog],
+        confirmation_dialog: Callable[[set[Source]], QDialog],
     ) -> None:
         self.source = source
         self.controller = controller
@@ -88,7 +88,9 @@ class DeleteSourceAction(QAction):
 
         super().__init__(text, parent)
 
-        self._confirmation_dialog = confirmation_dialog(self.source)
+        # DeleteSource Dialog can accept more than one source (bulk delete),
+        # but when triggered from this menu, only applies to one source
+        self._confirmation_dialog = confirmation_dialog(set([self.source]))
         self._confirmation_dialog.accepted.connect(
             lambda: self.controller.delete_source(self.source)
         )
@@ -119,6 +121,7 @@ class DeleteConversationAction(QAction):
 
         super().__init__(text, parent)
 
+        # DeleteConversationDialog accepts only one source
         self._confirmation_dialog = confirmation_dialog(self.source)
         self._confirmation_dialog.accepted.connect(lambda: self._on_confirmation_dialog_accepted())
         self.triggered.connect(self.trigger)

--- a/client/securedrop_client/gui/source/delete/dialog.py
+++ b/client/securedrop_client/gui/source/delete/dialog.py
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from gettext import gettext as _
+from gettext import ngettext
 
 from securedrop_client.db import Source
 from securedrop_client.gui.base import ModalDialog
@@ -26,23 +27,34 @@ from securedrop_client.gui.base import ModalDialog
 class DeleteSourceDialog(ModalDialog):
     """Used to confirm deletion of source accounts."""
 
-    def __init__(self, source: Source) -> None:
+    def __init__(self, sources: set[Source]) -> None:
         super().__init__(show_header=False, dangerous=True)
+        self.sources = sources
 
-        self.source = source
+        # If the dialog is constructed with no sources, show a warning; otherwise,
+        # confirm the number and designation of the sources to be deleted
+        num_sources = len(sources)
+        if num_sources == 0:
+            self._show_warning_nothing_selected()
+        else:
+            continue_text = ngettext(
+                "YES, DELETE ENTIRE SOURCE ACCOUNT",
+                "YES, DELETE {number} SOURCE ACCOUNTS",
+                num_sources,
+            ).format(number=num_sources)
 
-        self.body.setText(self.make_body_text())
-        self.continue_button.setText(_("YES, DELETE ENTIRE SOURCE ACCOUNT"))
-        self.cancel_button.setDefault(True)
-        self.cancel_button.setFocus()
-        self.confirmation_label.setText(_("Are you sure this is what you want?"))
-        self.adjustSize()
+            self.body.setText(self.make_body_text(self.sources))
+            self.continue_button.setText(continue_text)
+            self.cancel_button.setDefault(True)
+            self.cancel_button.setFocus()
+            self.confirmation_label.setText(_("Are you sure this is what you want?"))
+            self.adjustSize()
 
-    def make_body_text(self) -> str:
+    def make_body_text(self, sources: set[Source]) -> str:
         message_tuple = (
-            "<style>",
-            "p {{white-space: nowrap;}}",
-            "</style>",
+            "<p>",
+            _("Delete entire account for: {source_or_sources}?"),
+            "</p>",
             "<p><b>",
             _("When the entire account for a source is deleted:"),
             "</b></p>",
@@ -58,4 +70,23 @@ class DeleteSourceDialog(ModalDialog):
             "<p>&nbsp;</p>",
         )
 
-        return "".join(message_tuple).format(source=f"<b>{self.source.journalist_designation}</b>")
+        return "".join(message_tuple).format(
+            source_or_sources=f"<b>{self._get_source_names(sources)}</b>"
+        )
+
+    def _get_source_names(self, sources: set[Source]) -> str:
+        """
+        Helper. Return a comma-separated list of journalist designations.
+        """
+        return ", ".join([s.journalist_designation for s in sources])
+
+    def _show_warning_nothing_selected(self) -> None:
+        """
+        Helper. Display warning if no sources are selected for deletion.
+        Disables "Continue" button so user must close or cancel dialog.
+        """
+        self.continue_button.setEnabled(False)
+        self.cancel_button.setFocus()
+        self.cancel_button.setDefault(True)
+        self.body.setText(_("No sources have been selected."))
+        self.adjustSize()

--- a/client/securedrop_client/locale/messages.pot
+++ b/client/securedrop_client/locale/messages.pot
@@ -14,7 +14,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.15.0\n"
+"Generated-By: Babel 2.16.0\n"
 
 msgid "{application_name} is already running"
 msgstr ""
@@ -370,9 +370,14 @@ msgid "This file type cannot be printed."
 msgstr ""
 
 msgid "YES, DELETE ENTIRE SOURCE ACCOUNT"
-msgstr ""
+msgid_plural "YES, DELETE {number} SOURCE ACCOUNTS"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "Are you sure this is what you want?"
+msgstr ""
+
+msgid "Delete entire account for: {source_or_sources}?"
 msgstr ""
 
 msgid "When the entire account for a source is deleted:"
@@ -385,5 +390,8 @@ msgid "Your organization will not be able to send them replies."
 msgstr ""
 
 msgid "All files and messages from that source will also be destroyed."
+msgstr ""
+
+msgid "No sources have been selected."
 msgstr ""
 

--- a/client/tests/gui/source/delete/test_dialog.py
+++ b/client/tests/gui/source/delete/test_dialog.py
@@ -1,22 +1,90 @@
-import unittest
+import pytest
 
-from securedrop_client.gui.source.delete import DeleteSourceDialog as Dialog
+from securedrop_client.gui.source.delete import DeleteSourceDialog
 from tests import factory
 
 
-class DeleteSourceDialogTest(unittest.TestCase):
-    def setUp(self):
-        self._source = factory.Source()
-        factory.File(source=self._source)
-        self.dialog = Dialog(self._source)
+@pytest.fixture(
+    params=[set(), set([factory.Source()]), set([factory.Source(), factory.Source()])],
+)
+def dialog(request):
+    """
+    Set up the dialog under various conditions: 0 sources, 1 source, >1 source.
+    Tests that target a specific configuration can use decorators to skip unwanted
+    conditions.
+    """
+    # Give the source(s) a submission
+    for source in request.param:
+        factory.File(source=source)
+    return DeleteSourceDialog(request.param)
 
-    def test_default_button_is_safer_choice(self):
+
+class TestDeleteSourceDialog:
+    def test_dialog_setup(self, dialog):
+        assert type(dialog) is DeleteSourceDialog
+        assert type(dialog.sources) is set
+        assert dialog.dangerous
+
+    def test_default_button_is_safer_choice(self, dialog):
         # This test does rely on an implementation detail (the buttons)
         # but I couldn't find a way to test this properly using key events.
-        assert not self.dialog.continue_button.isDefault()
-        assert self.dialog.cancel_button.isDefault()
+        assert not dialog.continue_button.isDefault()
+        assert dialog.cancel_button.isDefault()
 
-    def test_displays_important_information_when_shown(self):
-        assert "not be able to send them replies" in self.dialog.text()
-        assert "source will not be able to log in" in self.dialog.text()
-        assert "files and messages from that source will also be destroyed" in self.dialog.text()
+    def test_displays_important_information_when_shown(self, dialog):
+        if len(dialog.sources) < 1:
+            pytest.skip("Skip if no sources")
+        assert "not be able to send them replies" in dialog.text()
+        assert "source will not be able to log in" in dialog.text()
+        assert "files and messages from that source will also be destroyed" in dialog.text()
+
+    def test_dialog_continue_button_adapts_to_source_count(self, dialog):
+        count = len(dialog.sources)
+
+        if count < 1:
+            pytest.skip("Skip if no sources")
+
+        if count == 1:
+            assert dialog.continue_button.text() == "YES, DELETE ENTIRE SOURCE ACCOUNT"
+        elif count > 1:
+            assert dialog.continue_button.text() == f"YES, DELETE {count} SOURCE ACCOUNTS"
+        else:
+            # should be unreachable due to decorator
+            pytest.fail("Unreachable, or so we thought")
+
+    def test_no_sources_shows_error_text(self, dialog):
+        if len(dialog.sources) > 0:
+            pytest.skip("Skip if sources")
+
+        assert dialog.text() == "No sources have been selected."
+
+    def test_no_sources_continue_button_disabled(self, dialog):
+        if len(dialog.sources) > 0:
+            pytest.skip("Skip if sources")
+
+        assert not dialog.continue_button.isEnabled()
+
+    def test_correct_format_body_text(self):
+        """
+        For n > 1 sources, ensure the warning text includes
+        all the journalist desginators.
+        """
+        sources = set()
+        names = [
+            "source one",
+            "source two",
+            "source three",
+            "source four",
+            "source five",
+            "source six",
+            "source seven",
+        ]
+
+        for item in names:
+            source = factory.Source(journalist_designation=item)
+            sources.update([source])
+
+        dialog = DeleteSourceDialog(sources)
+
+        for n in names:
+            assert n in dialog.make_body_text(sources)

--- a/client/tests/gui/test_widgets.py
+++ b/client/tests/gui/test_widgets.py
@@ -4353,7 +4353,7 @@ def test_ConversationView_add_not_downloaded_file(mocker, homedir, source, sessi
 def test_DeleteSource_from_source_menu_when_user_is_loggedout(mocker):
     mock_controller = mocker.MagicMock()
     mock_controller.api = None
-    mock_source = mocker.MagicMock()
+    mock_source = factory.Source()
     mock_delete_source_dialog_instance = mocker.MagicMock(DeleteSourceDialog)
     mock_delete_source_dialog = mocker.MagicMock()
     mock_delete_source_dialog.return_value = mock_delete_source_dialog_instance


### PR DESCRIPTION
## Status

Ready for review

## Description

Refactor DeleteSourceDialog so it takes a set of sources instead of a single source. Display a user-friendly error message if the empty set is provided. Add parameterized unit tests to test empty, n=1, and n>1 conditions. This does not include any actual batch delete functionality, but it is in preparation for that change.

I was tempted to also refactor the DeleteSource and DeleteConversation dialogs into one dialog element, since there's no reason not to and is in line with what we did on the Print, Print Conversation, and Print Transcript dialogs, but I think it's too much scope creep. But it would be a straightforward refactor PR later on if anyone wants to take it on.

This PR makes minor string changes that will need il8n.

Towards #2160 

## Test Plan

- [ ] Visual review
- [ ] CI

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
