### PR TITLE
Have BaseErrors trigger DownloadDecryptionException in download flow

### DIFF
--- a/client/securedrop_client/api_jobs/downloads.py
+++ b/client/securedrop_client/api_jobs/downloads.py
@@ -164,9 +164,7 @@ class DownloadJob(SingleObjectApiJob):
             mark_as_downloaded(type(db_object), db_object.uuid, session)
             logger.info(f"File downloaded to {destination}")
             return destination
-        except BaseError as e:
-            raise e
-        except (ValueError, FileNotFoundError, RuntimeError) as e:
+        except (ValueError, FileNotFoundError, RuntimeError, BaseError) as e:
             logger.error("Download failed")
             logger.debug(f"Download failed: {e}")
             raise DownloadDecryptionException(

--- a/client/securedrop_client/gui/widgets.py
+++ b/client/securedrop_client/gui/widgets.py
@@ -2434,6 +2434,9 @@ class FileWidget(QWidget):
 
     @pyqtSlot(str, str, str)
     def _on_file_downloaded(self, source_uuid: str, file_uuid: str, filename: str) -> None:
+        logger.debug(
+            f"_on_file_downloaded: {source_uuid} / {file_uuid} ({filename}), expected {self.uuid}"
+        )
         if file_uuid == self.uuid:
             self.downloading = False
             QTimer.singleShot(
@@ -2442,6 +2445,9 @@ class FileWidget(QWidget):
 
     @pyqtSlot(str, str, str)
     def _on_file_missing(self, source_uuid: str, file_uuid: str, filename: str) -> None:
+        logger.debug(
+            f"_on_file_missing: {source_uuid} / {file_uuid} ({filename}), expected {self.uuid}"
+        )
         if file_uuid == self.uuid:
             self.downloading = False
             QTimer.singleShot(

--- a/client/tests/api_jobs/test_downloads.py
+++ b/client/tests/api_jobs/test_downloads.py
@@ -262,7 +262,7 @@ def test_MessageDownloadJob_with_base_error(mocker, homedir, session, session_ma
     mocker.patch.object(api_client, "download_submission", side_effect=BaseError)
     decrypt_fn = mocker.patch.object(job.gpg, "decrypt_submission_or_reply")
 
-    with pytest.raises(BaseError):
+    with pytest.raises(DownloadDecryptionException):
         job.call_api(api_client, session)
 
     assert message.content is None


### PR DESCRIPTION
## Status

Ready for review

## Description

DownloadDecryptionException is specially handled in Controller.on_file_download_failure(), so if we raise a different exception class, the download animation will never be stopped because file_missing is never emitted.

It is worth a proper re-examination of our exception heirarchy and reducing the amount of indirection in the download flow, but that can be done outside of a hotfix.

More debug logging is added to trace when slots are triggered.

Refs #1633.

## Test Plan

Without this PR:
* [ ] Start the client with `./run.sh` + `make dev` server; login and do initial sync
* [ ] Upload a large-ish file (5MB) to the server
* [ ] In a Python shell, run `while True: subprocess.call(['pkill', '-9', '-e', 'securedrop-prox'])` (intentionally prox, there's a character limit on pkill)
* [ ] Download the large file; it should fail. Once it fails Ctrl+C the pkill loop
* [ ] A file download failed error message is shown, but the "Downloading" spinner animation is still going

With this PR:
* [ ] Start the client with `./run.sh` + `make dev` server; login and do initial sync
* [ ] Upload a large-ish file (5MB) to the server
* [ ] In a Python shell, run `while True: subprocess.call(['pkill', '-9', '-e', 'securedrop-prox'])` (intentionally prox, there's a character limit on pkill)
* [ ] Download the large file; it should fail. Once it fails Ctrl+C the pkill loop
* [ ] A file download failed error message is shown, and the "Downloading" spinner animation has stopped and replaced with the original "Download" button.


## Checklist

 - [x] These changes should not need testing in Qubes
 - [x] No update to the AppArmor profile is required for these changes
 - [x] No database schema changes are needed
