### PR TITLE
Don't use deprecated `logging.warn`

### DIFF
--- a/client/securedrop_client/api_jobs/sync.py
+++ b/client/securedrop_client/api_jobs/sync.py
@@ -46,7 +46,7 @@ class MetadataSyncJob(ApiJob):
             os.environ.get("SDEXTENDEDTIMEOUT", self.DEFAULT_REQUEST_TIMEOUT)
         )
         if api_client.default_request_timeout != self.DEFAULT_REQUEST_TIMEOUT:
-            logger.warn(
+            logger.warning(
                 f"{self.__class__.__name__} will use "
                 f"default_request_timeout={api_client.default_request_timeout}"
             )


### PR DESCRIPTION
## Status

Ready for review 

## Description

Ironically calling `logging.warn` triggers warnings that it's deprecated, use the full warning instead.

## Test Plan

* [ ] CI passes

## Checklist

 - [x] These changes should not need testing in Qubes
 - [x] No update to the AppArmor profile is required for these changes
 - [x] No database schema changes are needed

