### PR TITLE
Have run.sh automatically emit full debug logs

### DIFF
--- a/client/run.sh
+++ b/client/run.sh
@@ -71,5 +71,9 @@ fi
 
 wait
 
-echo "Starting client, log available at: $SDC_HOME/logs/client.log"
-$PYTHON -m securedrop_client --sdc-home "$SDC_HOME" --no-proxy "$qubes_flag" "$@"
+echo "Starting client, home directory: $SDC_HOME"
+# Create the log file ahead of time so we can tail it before the client launches
+mkdir -p "$SDC_HOME/logs"
+touch "$SDC_HOME/logs/client.log"
+tail -f "$SDC_HOME/logs/client.log" &
+LOGLEVEL=debug $PYTHON -m securedrop_client --sdc-home "$SDC_HOME" --no-proxy "$qubes_flag" "$@"


### PR DESCRIPTION
## Status

Ready for review

## Description

Instead of requiring the user to tail the logs in a separate process, just have run.sh do it for us.

## Test Plan

* [x] Visual review
* [x] Try using `./run.sh` and see that it emits logs

## Checklist

 - [x] These changes should not need testing in Qubes