### PR TITLE
[0.13.2] Backport #2196: Have BaseErrors trigger DownloadDecryptionException in download flow

### DIFF
--- a/client/securedrop_client/api_jobs/downloads.py
+++ b/client/securedrop_client/api_jobs/downloads.py
@@ -164,9 +164,7 @@ class DownloadJob(SingleObjectApiJob):
             mark_as_downloaded(type(db_object), db_object.uuid, session)
             logger.info(f"File downloaded to {destination}")
             return destination
-        except BaseError as e:
-            raise e
-        except (ValueError, FileNotFoundError, RuntimeError) as e:
+        except (ValueError, FileNotFoundError, RuntimeError, BaseError) as e:
             logger.error("Download failed")
             logger.debug(f"Download failed: {e}")
             raise DownloadDecryptionException(

--- a/client/securedrop_client/gui/widgets.py
+++ b/client/securedrop_client/gui/widgets.py
@@ -2434,6 +2434,9 @@ class FileWidget(QWidget):
 
     @pyqtSlot(str, str, str)
     def _on_file_downloaded(self, source_uuid: str, file_uuid: str, filename: str) -> None:
+        logger.debug(
+            f"_on_file_downloaded: {source_uuid} / {file_uuid} ({filename}), expected {self.uuid}"
+        )
         if file_uuid == self.uuid:
             self.downloading = False
             QTimer.singleShot(
@@ -2442,6 +2445,9 @@ class FileWidget(QWidget):
 
     @pyqtSlot(str, str, str)
     def _on_file_missing(self, source_uuid: str, file_uuid: str, filename: str) -> None:
+        logger.debug(
+            f"_on_file_missing: {source_uuid} / {file_uuid} ({filename}), expected {self.uuid}"
+        )
         if file_uuid == self.uuid:
             self.downloading = False
             QTimer.singleShot(

--- a/client/tests/api_jobs/test_downloads.py
+++ b/client/tests/api_jobs/test_downloads.py
@@ -262,7 +262,7 @@ def test_MessageDownloadJob_with_base_error(mocker, homedir, session, session_ma
     mocker.patch.object(api_client, "download_submission", side_effect=BaseError)
     decrypt_fn = mocker.patch.object(job.gpg, "decrypt_submission_or_reply")
 
-    with pytest.raises(BaseError):
+    with pytest.raises(DownloadDecryptionException):
         job.call_api(api_client, session)
 
     assert message.content is None


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #2196.

## Testing

* [ ] CI is passing
* [ ] base is `release/0.13.2`
* [ ] Only contains changes from #2196.
