### PR TITLE
Have `make build-debs` print tag signature, if any

### DIFF
--- a/scripts/build-debs.sh
+++ b/scripts/build-debs.sh
@@ -11,6 +11,9 @@
 set -euxo pipefail
 
 git --no-pager log -1 --oneline --show-signature --no-color
+# We intentionally want the git tag list to be word-split
+# shellcheck disable=SC2046
+git --no-pager tag -v $(git tag --points-at HEAD)
 
 OCI_RUN_ARGUMENTS="--user=root -v $(pwd):/src:Z"
 


### PR DESCRIPTION
## Status

Ready for review

## Description

If HEAD points to a tag, then run it through `git tag -v` to print the tag's signature instead of just the commit's.

## Test Plan

* [ ] Run the `git --no-pager tag -v $(git tag --points-at HEAD)` command against a commit that has a tag (i.e. the release/0.13.2 branch) and one that doesn't (this PR)
