### PR TITLE
Add hover styling to ModalDialog.dangerous (destructive) buttons

### DIFF
--- a/client/securedrop_client/gui/base/dialog_button.css
+++ b/client/securedrop_client/gui/base/dialog_button.css
@@ -25,6 +25,18 @@
     color: #ffffff;
 }
 
+#ModalDialog.dangerous #ModalDialog_button_box QPushButton#ModalDialog_primary_button:hover {
+    background-color: #de043b;
+    border-color: #ff3366;
+}
+
+#ModalDialog.dangerous #ModalDialog_button_box QPushButton#ModalDialog_cancel_button:hover {
+    background-color: #de043b;
+    border-color: #ff3366;
+    color: #ffffff;
+}
+
+
 #ModalDialog_button_box QPushButton#ModalDialog_primary_button::disabled {
     border: 2px solid #c2c4e3;
     background-color: #c2c4e3;


### PR DESCRIPTION
## Status

Ready for review 

## Description

Add hover state to ModalDialog.dangerous button styling, used for Delete Source dialog confirmation.

There was no hover colour branding guideline for Cantankerous Coral that I could find in our ux resources, so I have chosen a very slightly different coral shade arbitrarily based on trying to keep the same saturation and not add more colours to the palette. I am not a designer. I do not have strong opinions on colour. The most important thing is that the destructive action's _non_-default button (the destructive action) undergoes a high-contrast change (white background, coral text -> coral background, white text) when moused over, to give as much feedback as possible to the user. 

## Test Plan

- [x] Visual review
- [x] CI

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
