### PR TITLE
Add batch actions top bar element

### DIFF
--- a/client/securedrop_client/gui/main.py
+++ b/client/securedrop_client/gui/main.py
@@ -29,7 +29,7 @@ from securedrop_client import __version__, state
 from securedrop_client.db import Source, User
 from securedrop_client.gui.auth import LoginDialog
 from securedrop_client.gui.shortcuts import Shortcuts
-from securedrop_client.gui.widgets import BottomPane, LeftPane, MainView
+from securedrop_client.gui.widgets import BottomPane, InnerTopPane, LeftPane, MainView
 from securedrop_client.logic import Controller
 from securedrop_client.resources import load_all_fonts, load_css, load_icon
 
@@ -62,6 +62,11 @@ class Window(QMainWindow):
         self.setStyleSheet(load_css("sdclient.css"))
         self.setWindowTitle(_("SecureDrop Client {}").format(__version__))
         self.setWindowIcon(load_icon(self.icon))
+
+        # Top Pane to hold batch actions, eventually will also hold
+        # search bar for keyword filtering. The Top Pane is not a top-level
+        # layout element, but instead is nested inside the central widget view.
+        self.top_pane = InnerTopPane()
 
         # Bottom Pane to display activity and error messages
         self.bottom_pane = BottomPane()
@@ -104,6 +109,7 @@ class Window(QMainWindow):
         views used in the UI.
         """
         self.controller = controller
+        self.top_pane.setup(self.controller)
         self.bottom_pane.setup(self.controller)
         self.left_pane.setup(self, self.controller)
         self.main_view.setup(self.controller)

--- a/client/securedrop_client/locale/messages.pot
+++ b/client/securedrop_client/locale/messages.pot
@@ -112,6 +112,12 @@ msgstr ""
 msgid "Last Refresh: never"
 msgstr ""
 
+msgid "DELETE SOURCES"
+msgstr ""
+
+msgid "Delete selected source accounts"
+msgstr ""
+
 msgid "{}"
 msgstr ""
 

--- a/client/securedrop_client/resources/css/sdclient.css
+++ b/client/securedrop_client/resources/css/sdclient.css
@@ -115,6 +115,39 @@ QWidget {
     background-color: #85f6fe;
 }
 
+#InnerTopPane {
+    background-color: #f3f5f9;
+}
+
+#BatchActionWidget {
+    background-color: #fff;
+    min-height: 24px;
+    margin: 2px;
+}
+
+#BatchActionToolbar QToolButton {
+    font-family: 'Montserrat';
+    font-weight: 600;
+    font-size: 12px;
+    padding: 2px;
+    color: #2a319d;
+    background-color: #fff;
+    border: 2px solid #2a319d;
+}
+
+#BatchActionToolbar QToolButton:disabled {
+    color: #a5a8d8;
+    background-color: #9495b9;
+    border: 2px solid #a5a8d8;
+}
+
+#BatchActionToolbar QToolButton:hover,
+#BatchActionToolbar QToolButton:checked {
+    background-color: #05a6fe;
+    border: 2px solid #05a6fe;
+    color: #fff;
+}
+
 #MainView {
     min-height: 558;
 }


### PR DESCRIPTION
## Status

Ready for review but presumes #2230 which should be reviewed first, will rebase once that's merged

## Description

Add Top Bar UI element nested inside main layout, which will hold "Delete Sources" toolbar button (and eventually, other toolbar buttons).  UI-only changes towards, #2160

## Test Plan

- [ ] Visual review
- [ ] CI

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
