### PR TITLE
Switch to builtin venv instead of virtualenv

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,19 +2,19 @@ Source: securedrop-client
 Section: unknown
 Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Build-Depends: debhelper-compat (= 11), dh-apparmor, dh-exec, python3-virtualenv, libssl-dev, pkg-config, libclang-dev, qubesdb-dev
+Build-Depends: debhelper-compat (= 11), dh-apparmor, dh-exec, python3-venv, libssl-dev, pkg-config, libclang-dev, qubesdb-dev
 Standards-Version: 3.9.8
 Homepage: https://github.com/freedomofpress/securedrop-client
 X-Python3-Version: >= 3.5
 
 Package: securedrop-client
 Architecture: any
-Depends: ${python3:Depends}, ${shlibs:Depends}, ${misc:Depends}, python3-pyqt5, python3-pyqt5.qtsvg, python3-qubesdb, desktop-file-utils
+Depends: ${shlibs:Depends}, ${misc:Depends}, python3, python3-pyqt5, python3-pyqt5.qtsvg, python3-qubesdb, desktop-file-utils
 Description: securedrop client for qubes workstation
 
 Package: securedrop-export
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, udisks2, cups, printer-driver-brlaser, printer-driver-hpcups, system-config-printer, xpp, libcups2, gnome-disk-utility, libreoffice,
+Depends: ${misc:Depends}, python3, udisks2, cups, printer-driver-brlaser, printer-driver-hpcups, system-config-printer, xpp, libcups2, gnome-disk-utility, libreoffice,
  desktop-file-utils, shared-mime-info, libfile-mimeinfo-perl
 Description: Submission export scripts for SecureDrop Workstation
  This package provides scripts used by the SecureDrop Qubes Workstation to
@@ -27,7 +27,7 @@ Description: Provides an apt keyring for SecureDrop-related packages, so the mas
 
 Package: securedrop-log
 Architecture: all
-Depends: python3-distutils, ${misc:Depends}, ${python3:Depends}
+Depends: python3-distutils, ${misc:Depends}
 Description: Python module and qrexec service to store logs for SecureDrop Workstation
  This package provides Python module and qrexec service files to create a logging VM in
  SecureDrop Workstation project in Qubes.
@@ -56,7 +56,7 @@ Description: Whonix configuration for SecureDrop.
 
 Package: securedrop-workstation-config
 Architecture: all
-Depends: ${python3:Depends}, python3-qubesdb, rsyslog, mailcap, apparmor, nautilus, securedrop-keyring, xfce4-terminal
+Depends: python3-qubesdb, rsyslog, mailcap, apparmor, nautilus, securedrop-keyring, xfce4-terminal
 Description: This is the SecureDrop workstation template configuration package.
  This package provides dependencies and configuration for the Qubes SecureDrop workstation VM Templates.
 

--- a/debian/securedrop-client.lintian-overrides
+++ b/debian/securedrop-client.lintian-overrides
@@ -21,3 +21,4 @@ securedrop-client: script-not-executable
 
 # This is our virtualenv's interpreter
 securedrop-client: unusual-interpreter
+securedrop-client: wrong-path-for-interpreter

--- a/debian/securedrop-export.lintian-overrides
+++ b/debian/securedrop-export.lintian-overrides
@@ -21,6 +21,7 @@ securedrop-export: script-not-executable
 
 # This is our virtualenv's interpreter
 securedrop-export: unusual-interpreter
+securedrop-export: wrong-path-for-interpreter
 
 # This is intentional
 securedrop-export: file-in-etc-not-marked-as-conffile [etc/udisks2/tcrypt.conf]

--- a/debian/setup-venv.sh
+++ b/debian/setup-venv.sh
@@ -11,7 +11,7 @@ fi
 WHEELS_DIR="/builder/securedrop-${NAME}/wheels"
 PIP_ARGS="--ignore-installed --no-index --find-links ${WHEELS_DIR} --no-deps --no-cache-dir --no-use-pep517"
 
-/usr/bin/python3 -m virtualenv $VENV_ARGS ./debian/securedrop-${NAME}/opt/venvs/securedrop-${NAME}
+/usr/bin/python3 -m venv $VENV_ARGS ./debian/securedrop-${NAME}/opt/venvs/securedrop-${NAME}
 ./debian/securedrop-${NAME}/opt/venvs/securedrop-${NAME}/bin/pip install $PIP_ARGS --require-hashes \
     -r ${NAME}/build-requirements.txt
 ./debian/securedrop-${NAME}/opt/venvs/securedrop-${NAME}/bin/pip install $PIP_ARGS ./${NAME}


### PR DESCRIPTION
## Status

Ready for review 

## Description

For our purposes, venv should be a drop-in replacement for virtualenv, with the advantage that it's maintained in the standard library and is a bit slimmer. Diffoscoping shows internal changes to the activation scripts and entry points but nothing that should functionally affect us.

SecureDrop server is already using venv for its packages, so this brings us into alignment.

Also do a little cleanup on the dependencies because lintian started complaining a bit more; ensure that both securedrop-client and securedrop-export have explicit `python3` dependencies, and remove the now obsolete `${python3:Depends}` magic dependencies.
## Test Plan

* [ ] CI passes

## Checklist

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [x] No update to the AppArmor profile is required for these changes
 - [x] No database schema changes are needed
