### PR TITLE
chore: standardize on "drive" for USB export devices

### DIFF
--- a/client/securedrop_client/gui/conversation/export/export_wizard_constants.py
+++ b/client/securedrop_client/gui/conversation/export/export_wizard_constants.py
@@ -24,9 +24,9 @@ class Pages(IntEnum):
 
 # Human-readable status info
 STATUS_MESSAGES = {
-    ExportStatus.NO_DEVICE_DETECTED: _("No device detected"),
+    ExportStatus.NO_DEVICE_DETECTED: _("No USB drives detected"),
     ExportStatus.MULTI_DEVICE_DETECTED: _(
-        "Too many USB devices detected; please insert one supported device."
+        "Too many USB drives detected; please insert one supported drive."
     ),
     ExportStatus.INVALID_DEVICE_DETECTED: _(
         "Either the drive is not encrypted or there is something else wrong with it."
@@ -34,13 +34,13 @@ STATUS_MESSAGES = {
         "If this is a VeraCrypt drive, please unlock it from within "
         "the sd-devices VM, then try again."
     ),
-    ExportStatus.DEVICE_WRITABLE: _("The device is ready for export."),
-    ExportStatus.DEVICE_LOCKED: _("The device is locked."),
+    ExportStatus.DEVICE_WRITABLE: _("The drive is ready for export."),
+    ExportStatus.DEVICE_LOCKED: _("The drive is locked."),
     ExportStatus.ERROR_UNLOCK_LUKS: _("The passphrase provided did not work. Please try again."),
     ExportStatus.ERROR_MOUNT: _("Error mounting drive"),
     ExportStatus.ERROR_EXPORT: _("Error during export"),
     ExportStatus.ERROR_UNMOUNT_VOLUME_BUSY: _(
-        "Files were exported successfully, but the USB device could not be unmounted."
+        "Files were exported successfully, but the USB drive could not be unmounted."
     ),
     ExportStatus.ERROR_EXPORT_CLEANUP: _(
         "Files were exported successfully, but some temporary files remain on disk. "
@@ -48,7 +48,7 @@ STATUS_MESSAGES = {
     ),
     ExportStatus.SUCCESS_EXPORT: _("Export successful"),
     ExportStatus.DEVICE_ERROR: _(
-        "Error encountered with this device. See your administrator for help."
+        "Error encountered with this drive. See your administrator for help."
     ),
     ExportStatus.ERROR_MISSING_FILES: _("Files were moved or missing and could not be exported."),
     ExportStatus.CALLED_PROCESS_ERROR: _("Error encountered. Please contact support."),

--- a/client/securedrop_client/locale/messages.pot
+++ b/client/securedrop_client/locale/messages.pot
@@ -294,19 +294,19 @@ msgstr ""
 msgid "BACK"
 msgstr ""
 
-msgid "No device detected"
+msgid "No USB drives detected"
 msgstr ""
 
-msgid "Too many USB devices detected; please insert one supported device."
+msgid "Too many USB drives detected; please insert one supported drive."
 msgstr ""
 
 msgid "Either the drive is not encrypted or there is something else wrong with it.<br />If this is a VeraCrypt drive, please unlock it from within the sd-devices VM, then try again."
 msgstr ""
 
-msgid "The device is ready for export."
+msgid "The drive is ready for export."
 msgstr ""
 
-msgid "The device is locked."
+msgid "The drive is locked."
 msgstr ""
 
 msgid "The passphrase provided did not work. Please try again."
@@ -318,7 +318,7 @@ msgstr ""
 msgid "Error during export"
 msgstr ""
 
-msgid "Files were exported successfully, but the USB device could not be unmounted."
+msgid "Files were exported successfully, but the USB drive could not be unmounted."
 msgstr ""
 
 msgid "Files were exported successfully, but some temporary files remain on disk. Reboot to remove them."
@@ -327,7 +327,7 @@ msgstr ""
 msgid "Export successful"
 msgstr ""
 
-msgid "Error encountered with this device. See your administrator for help."
+msgid "Error encountered with this drive. See your administrator for help."
 msgstr ""
 
 msgid "Files were moved or missing and could not be exported."

--- a/export/README.md
+++ b/export/README.md
@@ -17,7 +17,7 @@ Printer support is currently limited to a subset of Brother and HP printers that
 
 ## Supported Export Devices
 
-Export to LUKS-encrypted or VeraCrypt-encrypted USB devices is supported.
+Export to LUKS-encrypted or VeraCrypt-encrypted USB drives is supported.
 
 ### LUKS
 Partition a drive (either the MBR/DOS or the GPT partition scheme is fine)
@@ -114,7 +114,7 @@ The supported device types for export are as follows, including the possible err
        Note: locked VeraCrypt drives also return this status, and a hint is shown to the user that they must
        manually unlock such drives before proceeding.
     - `DEVICE_LOCKED` if a supported drive is inserted but locked (a LUKS drive, since locked Veracrypt detection is not supported)
-    - `DEVICE_WRITABLE` if a supported USB device is attached and unlocked. (Only used for Preflight check)
+    - `DEVICE_WRITABLE` if a supported USB drive is attached and unlocked. (Only used for Preflight check)
     - `DEVICE_ERROR`: A problem was encountered and device state cannot be reported.
 
 2. `disk`: Attempts to send files to disk. Can return any Preflight status except `DEVICE_WRITABLE`, as well as

--- a/export/files/application-x-sd-export.xml
+++ b/export/files/application-x-sd-export.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
   <mime-type type="application/x-sd-export">
-    <comment>Archive for transfering files from the SecureDrop workstation to an external USB device.</comment>
+    <comment>Archive for transfering files from the SecureDrop workstation to an external USB drive.</comment>
     <glob pattern="*.sd-export"/>
   </mime-type>
 </mime-info>


### PR DESCRIPTION
## Status

Ready for review


## Description

Addresses [translators' feedback](https://weblate.securedrop.org/translate/securedrop/securedrop-client/en/?checksum=febe74af3844dfa9#comments) that referring to export "devices" (as opposed to "drives") is ambiguous, especially out of context.

*This pull request is a proposal,* on the grounds that it will take no more time to review this proposed solution than to talk about the problem it tries to solve.  Feel free to close this or suggest alternatives.


## Test Plan

- [ ] Visual review.
- [ ] Follow up on <https://weblate.securedrop.org/translate/securedrop/securedrop-client/en/?checksum=febe74af3844dfa9#comments>.