### PR TITLE
Remove (sys/sd)-whonix default prompt

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -50,7 +50,7 @@ Package: securedrop-whonix-config
 Section: admin
 Architecture: all
 # FIXME: s/tor/anon-gw-anonymizer-config/ (requires Whonix repositories in piuparts)
-Depends: ${misc:Depends}, securedrop-qubesdb-tools, tor
+Depends: ${misc:Depends}, securedrop-qubesdb-tools, tor, systemcheck
 Description: Whonix configuration for SecureDrop.
  This package configures Whonix/Tor for SecureDrop.
 

--- a/debian/securedrop-whonix-config.install
+++ b/debian/securedrop-whonix-config.install
@@ -1,1 +1,2 @@
 whonix-config/app_journalist.auth_private.tmpl /usr/share/securedrop-whonix-config
+whonix-config/etc/systemcheck.d/50_securedrop.conf /etc/systemcheck.d/

--- a/whonix-config/etc/systemcheck.d/50_securedrop.conf
+++ b/whonix-config/etc/systemcheck.d/50_securedrop.conf
@@ -1,0 +1,11 @@
+## SKIP NON-ACTIONABLE MESSAGES
+# Reducing messages that make automated tests more difficult.
+
+# Skip info about enabled derivative repository
+systemcheck_skip_functions+=" check_apt_repository"
+
+# Skip OS updates check (already ensured in SD updater)
+systemcheck_skip_functions+=" check_operating_system"
+
+# Skip donate message
+systemcheck_skip_functions+=" donate"


### PR DESCRIPTION
## Status

Ready for review

Removes out-of-the-box `INFO`-level Whonix systemcheck prompts. This is helpful for GUI tests. Furthermore, it should of no consequence to an end-user, since:
- **Derivative repo:** it simply informs about the installed debian repositories.
- **Updates check:** whonix-gateway-17 update checks are already enforced [by our updater](https://github.com/freedomofpress/securedrop-workstation/blob/f493665/sdw_updater/Updater.py#L51)

## Description

Fixes #2277

## Test Plan

- [ ] CI passes
- [ ] Visual Review
- [ ] Test Code
  - [ ] be on a system with the workstation uninstalled (or not installed at all)  
  - [ ] build client packages 
  - [ ] copy to and install `securedrop-whonix-config` package in whonix-gateway-17 template and shut it down
  - [ ] `make dev` in workstation
  - [ ] confirm that sd-whonix does not show any confirmation prompts

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
