### PR TITLE
Add support for the fr locale

### DIFF
--- a/client/MANIFEST.in
+++ b/client/MANIFEST.in
@@ -29,5 +29,6 @@ prune securedrop_client/locale
 #     graft securedrop_client/locale/$LANG
 #
 # Please keep this list alphabetized.
+graft securedrop_client/locale/fr
 graft securedrop_client/locale/pt_PT
 graft securedrop_client/locale/zh_Hans


### PR DESCRIPTION
## Status

Ready for review 

## Description

Adds support for the `fr` locale in securedrop-client

## Test Plan

- [x] visual review
- [x] `make build-debs` succeeds
- [x] When client is started with French locale, (`$ LANG=fr securedrop-client` should be enough?) appropriate language strings are displayed in client

