### PR TITLE
[0.14.0] Backport "[0.14.0] Hide continue button on delete dialog if no sources selected."

### DIFF
--- a/client/securedrop_client/gui/source/delete/dialog.py
+++ b/client/securedrop_client/gui/source/delete/dialog.py
@@ -83,9 +83,10 @@ class DeleteSourceDialog(ModalDialog):
     def _show_warning_nothing_selected(self) -> None:
         """
         Helper. Display warning if no sources are selected for deletion.
-        Disables "Continue" button so user must close or cancel dialog.
+        Hides "Continue" button so user must close or cancel dialog.
         """
         self.continue_button.setEnabled(False)
+        self.continue_button.setVisible(False)
         self.cancel_button.setFocus()
         self.cancel_button.setDefault(True)
         self.body.setText(_("No sources have been selected."))

--- a/client/tests/gui/source/delete/test_dialog.py
+++ b/client/tests/gui/source/delete/test_dialog.py
@@ -58,11 +58,12 @@ class TestDeleteSourceDialog:
 
         assert dialog.text() == "No sources have been selected."
 
-    def test_no_sources_continue_button_disabled(self, dialog):
+    def test_no_sources_continue_button_not_shown(self, dialog):
         if len(dialog.sources) > 0:
             pytest.skip("Skip if sources")
 
         assert not dialog.continue_button.isEnabled()
+        assert not dialog.continue_button.isVisible()
 
     def test_correct_format_body_text(self):
         """


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Backport of #2291.

## Testing

* [x] CI is passing
* [x] base is `release/0.14.0`
* [x] Only contains changes from #2291.
