### PR TITLE
feat(`DeleteSourceDialog`): when lots of sources are selected for deletion, block the continue button for 5 seconds

### DIFF
--- a/client/securedrop_client/locale/messages.pot
+++ b/client/securedrop_client/locale/messages.pot
@@ -395,6 +395,9 @@ msgstr[1] ""
 msgid "Are you sure this is what you want?"
 msgstr ""
 
+msgid "{text} (wait {delay} sec)"
+msgstr ""
+
 msgid "Delete entire account for: {source_or_sources}?"
 msgstr ""
 

--- a/client/tests/functional/data/test_confirm_before_deleting_lots_of_sources.yml
+++ b/client/tests/functional/data/test_confirm_before_deleting_lots_of_sources.yml
@@ -1,0 +1,1510 @@
+interactions:
+- request:
+    body: '{"username": "journalist", "passphrase": "correct horse battery staple
+      profanity oil chewy", "one_time_code": "781231"}'
+    headers: {}
+    method: POST
+    uri: api/v1/token
+  response: !!python/object:securedrop_client.sdk.JSONResponse
+    data:
+      expiration: '2024-10-29T05:04:46.484292Z'
+      journalist_first_name: null
+      journalist_last_name: null
+      journalist_uuid: ba39d10f-13cd-45d5-b6d5-ca33b7151490
+      token: IjZwemZBai1NVzA3MDNTdTZnU2RhNEg4RmFCSGJyYl9oUEZ0TUpOVlhOUlki.ZyBQzA.Qy-WxRYQ-kareM2KY2wXGWztTq4
+    headers:
+      connection: close
+      content-length: '290'
+      content-type: application/json
+      date: Tue, 29 Oct 2024 03:04:46 GMT
+      server: Werkzeug/2.2.3 Python/3.8.10
+    status: 200
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token IjZwemZBai1NVzA3MDNTdTZnU2RhNEg4RmFCSGJyYl9oUEZ0TUpOVlhOUlki.ZyBQzA.Qy-WxRYQ-kareM2KY2wXGWztTq4
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/users
+  response: !!python/object:securedrop_client.sdk.JSONResponse
+    data:
+      users:
+      - first_name: null
+        last_name: null
+        username: journalist
+        uuid: ba39d10f-13cd-45d5-b6d5-ca33b7151490
+      - first_name: null
+        last_name: null
+        username: dellsberg
+        uuid: 8ebea9a6-be81-43a4-8ae7-2a77b4a635f6
+      - first_name: null
+        last_name: null
+        username: deleted
+        uuid: 32f2439c-c131-4bb6-a881-afbbbae0cd8a
+    headers:
+      connection: close
+      content-length: '474'
+      content-type: application/json
+      date: Tue, 29 Oct 2024 03:04:46 GMT
+      server: Werkzeug/2.2.3 Python/3.8.10
+    status: 200
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token IjZwemZBai1NVzA3MDNTdTZnU2RhNEg4RmFCSGJyYl9oUEZ0TUpOVlhOUlki.ZyBQzA.Qy-WxRYQ-kareM2KY2wXGWztTq4
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/sources
+  response: !!python/object:securedrop_client.sdk.JSONResponse
+    data:
+      sources:
+      - add_star_url: /api/v1/sources/2181a381-51c9-460e-b52e-7905a335b4ee/add_star
+        interaction_count: 6
+        is_flagged: false
+        is_starred: false
+        journalist_designation: countrywide cabinetmaker
+        key:
+          fingerprint: BE71318F9076DEE2B806DDE93B29F92283020B8A
+          public: '-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+            Comment: BE71 318F 9076 DEE2 B806  DDE9 3B29 F922 8302 0B8A
+
+            Comment: Source Key <3OOVCADDFSCVYIMMLG6JOULS7GQDFIY5JVIGNGGQTV6
+
+
+            xsFNBFGRxNABEADLYLOUTjT3ngVTjIJDrNYhUjUEC0eev0JkYzThNuh13/wtvsyI
+
+            RRoBIF/qP0MxEtzBcDBX7tlC3QMq/W6tDy8U4vcdSiCnGUTk14u8OyU3m7LYGSwy
+
+            ovztZiN9RWtDOFIFtj+kahmu0KZOSmu0uFfgx1ftk9pJwX4BDkVSuBW3XjivPitq
+
+            Yjwy4/Y1ne+0IePZdF1p/+QXNw/uNvUfl0UD9BKuMhBw3xAIcz0XECeMxd6JsqII
+
+            g/75oCePaPW/YlV6iC7Mb18qGYuLSvzhsxK0ptY0ZbTqjK8/Q/2fzB9cM5Yk4whc
+
+            bhzjcWaovgYvVs5U+BrkxzmL6Ighvg7aREelAsJk8GHeUASoEU5XdStem/LiSTYf
+
+            u9ieRQa8GgZIBr/5R5wSJJOzJQjyYP339bbN1wPkUog2wfDSv2EH9vUg8pT4pYod
+
+            W1OYDSfS7YzU5oMug8v5QPzDw6PRuL73igsWzZJJi6O3MLX0yb2XxGCsb8jyjEPX
+
+            7veMkkEx5XVoL1NpKj5w3U0TJ25wzz2g+cPsaG7qEkFuMP0K2Dz7cHPkcgNCNamc
+
+            bBeZX0zp9jP4YOaLKPSATkW2LPtkYPvQB2omEk9VCbEEuEd8XDVVK7jrGZtm6lL3
+
+            7YxY+HoceoLn0/Kuk5zJ+giTnZGp5Abm33283zCzkSghQnhoa71GwobiPQARAQAB
+
+            wsHJBB8BCgB9BYJRkcTQAwsJBwkQOyn5IoMCC4pHFAAAAAAAHgAgc2FsdEBub3Rh
+
+            dGlvbnMuc2VxdW9pYS1wZ3Aub3JnesZWVc7r5OTC8wjjc8oEBb6GCWbVhlQDPEKf
+
+            Xd1iI58DFQoIApsBAh4BFiEEvnExj5B23uK4Bt3pOyn5IoMCC4oAAKmLD/9dZH8H
+
+            ppEc6os+yqUNQmnB2ru6Fq/4mua/rSxHrdf6rgx7I+oVy4L0LFOzQ1tlpfkEdDEe
+
+            eF5jwrc2EK3Y/+fSv1Rc1zzkt2UHfDNi/0EFUx435o2vO1Hiuzb+IWep/FYDI4iE
+
+            fFllkbyB1yx+mBMMs/ulvOcBHAbGhgYUReW2vNdWE+0txkrSdsx/wWbEy4YruIHs
+
+            iiQB+2KrHNh0WhjW0IDpzihPfd9T9V+aMLT2HbuvLls2ZoPhtQg8DPBWl94ieJo7
+
+            aFM6rI1g8zOMsxun/A37UzLu3k+5An/9pdNrcVhXkdHr0d5Ww6WPeVqYQ+gCDnCg
+
+            F63N5MQbiYSmLVwyAh5U89FW0XkTWBJWSKXVz1A4VP5FeYxACEsEHyG7qOG7mVwW
+
+            HJxJoOycFUAbOJS8/3P7pFZEuBebtKF0adrLyKsmM7qq6iwu05D5/MXeZUdKaBr/
+
+            AsXN/RkpJiHxRLZbgf9a3qKRmfg36bPw20T7ghTvOqQusYQjkbhInNMDirysG2ZD
+
+            GUuBD3/HQyIwqmvmWZMKvQFISlkaMx8YWqJ5rFkLosZ9EHUdJ2syPduX/cSe88cN
+
+            nC2CM7VPCB3tXzpvbNrSmVnBDnla8z/BH6cGC+9bkBVrlTYTby4CeELFUs36GD1X
+
+            8x8YvRsl3TTOTCixkoac0tCu10gWTIcIlXlACM11U291cmNlIEtleSA8M09PVkNB
+
+            RERGU0NWWUlNTUxHNkpPVUxTN0dRREZJWTVKVklHTkdHUVRWNjRRTzJPWFZGS0lP
+
+            R08yREM2UjRGWUk2RFJXRUlWVVVETzVTTTJZNVJFSzdQTUw1TUFBUFBKTEhITlhC
+
+            WT0+wsHMBBMBCgCABYJRkcTQAwsJBwkQOyn5IoMCC4pHFAAAAAAAHgAgc2FsdEBu
+
+            b3RhdGlvbnMuc2VxdW9pYS1wZ3Aub3JnBQaj+q+++g2idSeTjAPh1vRfizpiwNZY
+
+            x5ld4B+TpbYDFQoIApkBApsBAh4BFiEEvnExj5B23uK4Bt3pOyn5IoMCC4oAAPGL
+
+            EACXWtOdFkrZYbxoWj7l6TFGaZHhcgLTf109necN5ee1ScOMwXPuXUSTTVVOrEf8
+
+            KBIMF3YRgSlvVRb5cu0tj3FJINWfoqM2pNm8IrQeGtc5P4yj7lfqcdWNxcsfRoiX
+
+            hBvDgAICZGlXKFCk8JgHSzl3zAzAk2VMtfWONsXYvuyLZ6ywbz+P2drSEgPQLyWo
+
+            GciT/wiFdbCF5teU0/zsTge08nd9lny6x0objhCoKwqAt8wLIM3/Ux0B0Z+5F579
+
+            0e/jGojG+Vx0gDO/6cIXTb35FSHBJktFcsuFZcmSApF/Ws+zAP1JlJ6nMp5FqmLE
+
+            oB26Q83A3xJGO5jQNKseYi3D94+E4jvInMdPfP+caTTZgAEeRSJElFA275CdBhdY
+
+            ClbWXMRJTqngbSPJCMysLwwIpzZIi5W9gz7O6u/7zsLJ9OqHBy1UQEkfySjCnKyX
+
+            he2gMyVSeO6Q52+kmttn67v5ZrVUb+J5snjFuGVvWoRIvWokb1ysYW19o95vpEsH
+
+            BpGtappRkLheqSX3ZiplmfYVoobIFLg3n18NskzR8xPXqh2x2qGt8KJpH9s67fWZ
+
+            oxhdK/WTGkuZlGTCH/wXPeFm5fePT1NASXNrxJQFjTGfTW4MG3dZNyoerkFWDJId
+
+            w5tHM6ctGXFWY7h/2VgapB1R5zi94eGdvtagVK2U5YvNLM7BTQRRkcTQARAAr5A5
+
+            WkJaWau7vSHQA8wNP3IiWBezpQEN4+jVzz4QsoF6j9pdFdeNrsqF5VsVd8xYO15J
+
+            hpveotGqrZzveQSMdQ/dGzwOTkDx3g9I1+hv1sapiVowZFtsYwNrtpiLDk/yPBz0
+
+            0OqBEiVsl3hkiePrlw+alSKQvn4JObnIJ8VcYWY7ywnkwEK2LcAKlTPhrTQPOqvP
+
+            PxM316a3gK7MWw1PJqJTyVRcSXkFQa3EOQijzfDUO6snJAfxOoEvxDWsPBb+GO0c
+
+            +iJvktTzAXfr4LMgCexEzWcUKSCZYY9L0h1dBrcZLj6mjUlaacXi1oqE9FbGRBt4
+
+            nBEqhg0Ft//cL9AUoMhK3+9rfobO5jDViYiWB5peKQfHptsEvH4dGLq7cRqHK+3y
+
+            kHXdxp7AWjgA9G8rekAIvxmPPvCSnlg9HpoJw0IiqRAb89Vxk/OizQCPOgBivKj/
+
+            41VsMsRA/CtpixBLGp/KO7KSG68hhTtWqQdpKJ21OrfD0HJ/Hpnw4wcJy8HjI0t9
+
+            HaZZ1zfMhHfjFvlffMzPfkHX7doLp3fVX5YFeX+NqCXKM86NZX1NUTwKfaBQX6rH
+
+            78hNaVtMzgmt4nvYcIMGXDl4aqIPYasPCF6aYn8HAKWtPxl7g+okZf+R0ZKqMCqO
+
+            REIiWH8K6rvS4/kzoC+uxfW3rM5FuNbpANZe+Y8AEQEAAcLBvgQYAQoAcgWCUZHE
+
+            0AkQOyn5IoMCC4pHFAAAAAAAHgAgc2FsdEBub3RhdGlvbnMuc2VxdW9pYS1wZ3Au
+
+            b3JnCCuZGP5PUtk6m31ydDr1LzO81FYfVzPzLMXcIwol6QwCmwgWIQS+cTGPkHbe
+
+            4rgG3ek7KfkigwILigAAdoYQAJ2moQ+qhZIx37eJzo8seg0CKqt8t0IUkEcRXsYH
+
+            01K4pPY2Z/ikWbeKnz1DujPiEANg429vZdU4YTA8fZ5FxHCxjVqO81jZcgBFEC+J
+
+            fldFVINjuqder5P8OjFSC+9qpTLzZczVzOxxqFiEMuL3sZEkviuVBOcyH+ARRWfD
+
+            EmCFbt4hSDBfCa8NRmIOpsq/wRWTjcZLnbAHEwD/MPmTHDjfmq2Da6AVD6tu8f2c
+
+            ACbqU+oPdmKr5e9YY0gE0zFMEQW+Ynqqbi1RxHAXvXqrOey0/7hcyAH9nh/MrViw
+
+            oyvIqdjErEwFhN1kzVkFqQqscZ9CqoD5EU5c8Y/gEU3vkNEhz08VwXqG+uGFzYXo
+
+            XqAB+bjn04AlLzzYDoL6r4OT1cTN0IiH4oaE4T1FESliWvd7Q9A1nc2chgOVa+nU
+
+            7e/zan1MRCu6HoNo7WgmbEqvmxeQOUnT/H+dODOcMsG9Hq2+JVtzmFoTdrx/7Jao
+
+            uVnv5zSeHmtMzNcd6J0M7QQdfog5mah7IxKnqzbCnl5RwOXXDfbzKs9MFukcLi4+
+
+            c02a19zJ6AKhpefrkGhrvMNA9sRmf9lXhZoHT0sZGiDxVtP473oLyOfYJe02ByUA
+
+            MczEtP9WLymcHE0fW7RDz5gOSszqnUA/y4I1MOxDos7wUyHQq89TQ3jartm3hwR4
+
+            +DEp
+
+            =0AyD
+
+            -----END PGP PUBLIC KEY BLOCK-----
+
+            '
+          type: PGP
+        last_updated: '2024-10-29T02:57:39.328596Z'
+        number_of_documents: 2
+        number_of_messages: 1
+        remove_star_url: /api/v1/sources/2181a381-51c9-460e-b52e-7905a335b4ee/remove_star
+        replies_url: /api/v1/sources/2181a381-51c9-460e-b52e-7905a335b4ee/replies
+        submissions_url: /api/v1/sources/2181a381-51c9-460e-b52e-7905a335b4ee/submissions
+        url: /api/v1/sources/2181a381-51c9-460e-b52e-7905a335b4ee
+        uuid: 2181a381-51c9-460e-b52e-7905a335b4ee
+      - add_star_url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797/add_star
+        interaction_count: 6
+        is_flagged: false
+        is_starred: false
+        journalist_designation: colorless empiricism
+        key:
+          fingerprint: 57B00252EE19F277DCAA65685458F61D0279E13D
+          public: '-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+            Comment: 57B0 0252 EE19 F277 DCAA  6568 5458 F61D 0279 E13D
+
+            Comment: Source Key <7IQOLX37FFIWKHBNJURFXZ2XZVVYXUBLZ7MDHR5W64B
+
+
+            xsFNBFGRxNABEADL9+ovwTAH0ztMm0E/uMc+zM5l2iCS1YRAU2QMVuQLfUvY0e7b
+
+            tD+7hUf14XVTGJn17jdKN+Ng5Al8ozL7xfsxRrr+nOJjABC0ojFV7ArsF7+qTxQG
+
+            kvXwUeuossiYZlGpu/OSKkCwEaeMUKlSd3HC4lRudKFBFhk9EzakCjXbOEijtwGB
+
+            S9oOUJ/Lt/vVMV5ThBwsUlTMCdd+P8qBibqyLh+kLhZZ3nFYsHdLs0gNbzwnRZeO
+
+            npQn4IPeoG12EeUIQSiTTKdnwxYoaaFqDbEZcIcjtm3+iN+exkpByviNJAFWahLF
+
+            dHXHF6fbxRj+o2HAJgTJ2V63lPjYI3OokhPEHojOU2Hkfu4W9mtBuGfnEnislr9O
+
+            FP6ilcHS+3AUtbgEo+CXhwlq6XJWg7smSZZZ2nMMn5l+ryxcQc+xZ0UwnjL4CzNN
+
+            OY1tAboUUbSdjQKDEkk45koBeN1bbnrETwSBVKg4c2mlfoDUDLCTVv52+3f4Solp
+
+            o8n3OInh8XLhP2WqOwVEtXHSQWTVUvwUAg7VtB3OeTJrdniTRDhjrecJHMfrPHnq
+
+            jP0j0n0FWi+OB9cf3g+gFH2BjM4rGoMDclgm/ipJO7/0go0dldlLOf0nOVzBbu5B
+
+            oaIELQiXkx7T5BZ/WltWNKjyVj7JR71hTbvT78kcSsKcNkQT/uwJiPdt1QARAQAB
+
+            wsHJBB8BCgB9BYJRkcTQAwsJBwkQVFj2HQJ54T1HFAAAAAAAHgAgc2FsdEBub3Rh
+
+            dGlvbnMuc2VxdW9pYS1wZ3Aub3JnwlM+YZLak0Z4ThYOUT9EApDGoCiWgPeXQEiE
+
+            SVGPg2UDFQoIApsBAh4BFiEEV7ACUu4Z8nfcqmVoVFj2HQJ54T0AALklEACEDYP5
+
+            gy39zjlTGYLErMZxS0ErDg4nUtnt+qN6gl3JiBcWCA+Gjs4RXVoxollsBa6dlYNw
+
+            +Qik8Yk3mLKhjaLLCTpAUm1wXMf08rXOH/xwHihr+npwuibo/WcRpZc1Pecs5kTT
+
+            2lbXuU/9GPgWrfnHZvL6Zc7LKlwause/Vn+XwdLRo54dGuwiusy7WPIRkTPRAy95
+
+            A0TcqfWfQlgWiB4Pfv+wTuV11Xlmfw+vHgqTDsI0pdx/QGNZVB3XwfoqqwCmWYRp
+
+            1X90kqWGueKYqWFIIMusdlj+q0pygueDHGrhXPjauPxp0ihPCXMESd3uRQR3jHZK
+
+            Mr++olmbEIlwlSQnHp5lJlraAhXRjYwd0pPBfPU5M4R/GKtTRRy/nCpBXuA6LPEa
+
+            gWm5lUkZSgrWnEBzHubaHGt6xQENLHUAWa/hAU45YRXAkA4djB01ilc/h5T8Sb/4
+
+            VMzgFTeM+h1kzey7qeSxPwQbYi+DwNJQzVzzifpUW2O3btna28xPjwEr9RATdVT9
+
+            T5zoEaUG7qKpGbNYH6GuRBYEDBEmN51WKSCSAz7eRGUgw4edAva/Mjcn5we6YlSR
+
+            2Bx3H6jMukMUKTx00jevYVL2USoCzoxO6CrCekTtag1zLa7kDtzRp/0z8C2bX44G
+
+            CDxmgxQ6sGXl67kZKkUJTXlSAPcqyH999rC+Cc11U291cmNlIEtleSA8N0lRT0xY
+
+            MzdGRklXS0hCTkpVUkZYWjJYWlZWWVhVQkxaN01ESFI1VzY0QjRPUk1ZTldaV1Y1
+
+            V1g2Uk1DN1hZUlZRU0pCVEU3Q0c3U0xTSjZDQUVYUURBUE9aTDZZTFZBSU01UjM1
+
+            WT0+wsHMBBMBCgCABYJRkcTQAwsJBwkQVFj2HQJ54T1HFAAAAAAAHgAgc2FsdEBu
+
+            b3RhdGlvbnMuc2VxdW9pYS1wZ3Aub3JnKNHMGikCWejBmH2DPelDOinoz5LAhVbX
+
+            ctFbBpTMJ4EDFQoIApkBApsBAh4BFiEEV7ACUu4Z8nfcqmVoVFj2HQJ54T0AAIQf
+
+            D/wNGqQBf8Z0leZKkw+P/E+HfazifPJXolOTXTxh1YpdbsBpet6mS8IuBAPco7uP
+
+            ONJalKBjVno7OROIfZjqWxwrF0YpFagWy3RnjBoDIJb55JHrGxxkh2qOnIQ86Iy6
+
+            ailfrycepjafImUKPo4Sh/1ihx8vO8UsXpNgzMV1lU56HsN4Ec9rVh4QoCt2igW1
+
+            FOyqBU8QgyEm2vyKqbDsdWROXomoi2zJeSQSyVm7mpyKl2CcE77sCDcqgOmGVv4m
+
+            sZ0hPC+fh6kx+waiy/6OxLRAsdpY10agU0cIxnV/7cD6tZP2jwEocmKsnpAT1v6z
+
+            RgDw6evB1Bea7JqrgQof/gnqYs0hufdQWDJEcDE7rVy2ops4UlgDbE9Mc2EtJFmg
+
+            +Zzkhsh6L7w7gsTndm7NaBFpRJTcjvYHc6N547+TqYI2CCY37LROPoIapJXnoELL
+
+            DE1iYCFoqR6C3OdsdkTa0T6pQ6bJUV30bkScuBsOHx6vEBV5m8pD5q0ysS9egl+p
+
+            j+a0aOOma2ESrkbbFOv+ZFnlnGt2iD6DFDDTHLWHSS+LVrqUOA1Ojz93YVuFsjiN
+
+            6a7scvHz6j/QeOThT+Xs5Chfw5AifGzFqSTMIeWtaMCtfyAiQQw7+PudXkpdqpTT
+
+            J6ZLZy3kSioh1KoQDh/fLo7buhG/z1OMXN59EdPfeTaEr87BTQRRkcTQARAAx1af
+
+            rYqUdjqLek+SXGacVWLVnH+gr0fBQ9dxpX2xVP9+0Wo8iuuGkPod8tiGCdt7bSQw
+
+            QrEGYq2Z3F8fI7ZwSKdO5grlbCpGcDdOH1vgcXQvRZ8AHxKE+HbGurGiFQcZQgCa
+
+            LdbBFfQV5jEj25Ze8U5+Th4jUp1+eqpBvrPcKIzo6RjEevEryxphqV765+0ZlUoG
+
+            rSXAPdPmkQCi/NEAv0A4fmEFxJ6Kc5CX5mFIRXJpFh4ltA03msfVBEIj5UdoBm7G
+
+            XWR8yX/TS8GfVRbHRmfyY/YUn/xqYzyaQGrG+rUiubDmuli0HT9esNCemnIg9Rik
+
+            hiZOS3sHAPC5eJRqggBSzKm1VYfRqdKWXK2SE32JKXyYwNWqkbuNbYcfDWt60D/9
+
+            CtKQl6gjJKxL2lXKvf3wvRC+Ue976UvUQP981Ct377IqGJ6/WynT3nZhAFgJIOwa
+
+            4Cl5dhU+mGla2HX6//62FZhz2LlOf8IjhbIM7veoMyeLdIy46Nns8X8j4O4pjEck
+
+            Je4FhY3OcaFpsHAGaejAm4wIlDCssgjoHUqZX4yCv7eHQLh/K0c7KrAKxmdorqwU
+
+            x1eNTXP0uWTlQM3LtOf6nqIboqzz3aDDkQGkWzgHFjtDOviDR2M04uLfK531Wmyh
+
+            4Lc20kEBMZxw3kD0BjqHWqvF+wunM4bLqdRSgHsAEQEAAcLBvgQYAQoAcgWCUZHE
+
+            0AkQVFj2HQJ54T1HFAAAAAAAHgAgc2FsdEBub3RhdGlvbnMuc2VxdW9pYS1wZ3Au
+
+            b3Jn1oJC5PHXJP73+0ukJ4uH15Tp6wZ73plzXUicMVzpFLgCmwgWIQRXsAJS7hny
+
+            d9yqZWhUWPYdAnnhPQAA3BoP+gNvSLZETWA3B3HfFre0x598uqdWGxXrPXUiuCO4
+
+            4RU56n++CpmJ7FtuCkUkCJBKFfETRRFICsBG0B/3LtYbSdCSYsUCcUDFr4m72VSj
+
+            LKozMB0/yJiWIW7J22M0D7ZPerWX7cJpkH7XUdlgSfp+CgWawL0e23zyTTu9+wdk
+
+            iOThBUyzgVp84MrSlrXnpUe/NbVRnNeNs0ajhlLNoGW0VJtttndTy9R7XtRQKwCW
+
+            mWBE7z0JRLKEhURMqBnEEcFcHKAqDDpDdBoOE3EgqqIhlwM+Jm0nNSRnJzY2nakw
+
+            gOGNNjnYN7i1a7QdisoyXL56M52z0BTOfMKbxfMjIqUXuTn7ZyNfoS+XYR2mLPW5
+
+            EKbxJ7jaWZR2QY9aUwiJPSr8IfMaJoFScewWXAeWOFeegWdsrPNSdoH3lonxMzMY
+
+            MQ9rpL2fLvjD9LgTu/g1cZijbvkl4gfthhZu27EyufGj2H8BROVVNGTqHmPKDF3S
+
+            dvssBNntADI9owH0ZBPx0fBp6ITmtcJHJcKJNBMa7Z/0HZZvO9FLEdkAB5x6XzfW
+
+            XJSjsJsFS+JaDG+75f2APKL/+L57VnDghMzN8PQduMf7Cu5rhO/i4a3Qk2cCIshT
+
+            NNL0LthM5HQvOuKNHxP+znf144+abyH0Ihmg1GGB2Ycvc82l23XBO4ytigTpKbid
+
+            i7ZQ
+
+            =HJ7i
+
+            -----END PGP PUBLIC KEY BLOCK-----
+
+            '
+          type: PGP
+        last_updated: '2024-10-29T02:57:48.542919Z'
+        number_of_documents: 2
+        number_of_messages: 2
+        remove_star_url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797/remove_star
+        replies_url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797/replies
+        submissions_url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797/submissions
+        url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797
+        uuid: 037a1924-f61e-4f43-9bd2-887e407f4797
+      - add_star_url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1/add_star
+        interaction_count: 6
+        is_flagged: false
+        is_starred: false
+        journalist_designation: deluxe saccharin
+        key:
+          fingerprint: 8E788CBBDDC0BC6DB4172DCD755F50BE34128196
+          public: '-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+            Comment: 8E78 8CBB DDC0 BC6D B417  2DCD 755F 50BE 3412 8196
+
+            Comment: Source Key <YABZLM7P45I3AIBNMZDNPZHLN5IVX3O23PUWDJY3SCD
+
+
+            xsFNBFGRxNABEAC0VVe7/mckOyor3sTwoGwvrtOiUaYXDwenILWG+evAB4QvvCH2
+
+            SGb1sXdmKYBpTXFWebgVSTcJnruybz2/j898mucd4HCFrRt3Ryug1goAPPYwMAGR
+
+            lX/0rbWwSnsNOxUPyyoSGOwOnjGdUeKV6Zz9XJbeErfULbU6cvx696VDB0+Yf0De
+
+            Mjs+FSJeESdZAhdKEnBIbUKqsUEYJ9Mw9g5fmeYzfC7Yk++6mzbO/Ar0r3yToceF
+
+            BHTa6/FmF5Ur0y1KpPb+NKd/wpl6mWdwRCCM77oikS0wk388eLbi2yn1oNG2Gf4n
+
+            VRXnks+YMcfvyb3XAv1ZmBGHDNNT+78nbEmHdXDr5gOKhHTzYATOCSE5PBF+E0t+
+
+            BYJgjA0JBvFQ+aTnqvv5WhKwvPsX+xz0sQOqvvDAq3jB9ELqtbhRjB/nieGmsHvh
+
+            5z+o6H/mpLdqF1ewsx2DCKjXSRF9R+oXEpLDVKFyFvxAkMs9feP2Zn27FKglREHt
+
+            VMcWgg///NKuQDPyXc0QohjTTCADjOI28WHU1srlUYkCr3PrrnEhm7RUJrglULD8
+
+            Q1UdRdro/us4eOn6KdzK8GZr/onWjyKDIqYAG8RM9pUqP0kJHXBp7CzmDdCpb66Q
+
+            3jTN3bwYg/DNebxpUXqRgiy6BDERCKrkowaurMxH8LLGdxoekD1kJPkISQARAQAB
+
+            wsHJBB8BCgB9BYJRkcTQAwsJBwkQdV9QvjQSgZZHFAAAAAAAHgAgc2FsdEBub3Rh
+
+            dGlvbnMuc2VxdW9pYS1wZ3Aub3JnjBQPAqZm8Y5OEEmYRBYK6PbKVOd42XRT0dgu
+
+            cTvpudMDFQoIApsBAh4BFiEEjniMu93AvG20Fy3NdV9QvjQSgZYAAIJLD/9Kr9jZ
+
+            yDM+IEbjKNhtfFYtBzHWijDDkdb4ZUBwcaw9jhUDHHLTGQH+nxw9qSqWq6pqcY2u
+
+            5sQpyeN21UxYQLZkdK2J/GBbvpZAEQJcKYanxs67aMnsCt9yjcU+GMcc3Ej5S0Wq
+
+            fxDEnm3H/SBXOiSyLhqByhGaedrBgIOM8jihtlj0gBvMCCZlHwm1uz0l6cRLxLeh
+
+            MRK1Scr8L/q1oqBmov5dQUrIprxopivg7XGmb2di7UyIKIZJ8EkN5jCyQMLPzYLl
+
+            EDGf7FXGoF8Y7mGitYvDoE4UlHjarT/szn9R+aW7j3/Has4DoMKByP/x0tCJsbpW
+
+            W6I3dbgdbfX/UvfVwk/quQEXhOUAhhqx/jSK6pk1Cj8gEF5gox5dMjxYa5YDC1/C
+
+            2a/8NO0Egpf0RL96Eocq39tTdnCFpnpvBkHvtCn/AvwgpO6EXtPiup/uC1HVX5pp
+
+            0uzMuzHenvXFS1ehOSUlal5e8sswXRF3Wxd0uHKTs/HEsyQTTStAg6b1XtYEvM60
+
+            CUiARBWSH+Jjhv840dPPPobifSlh0cEvJs4sApkRgoFI9ookSs0cjt0+abcRBiA0
+
+            7aD5fBdGT7ANAmRJ2WhvTxD2N1WVN7Mx3PXmw46/2yLSawFmLml2zg5NAjTnzSjq
+
+            ps1wljoYYXT+yX+vU+5FQJDR+xJLbuwtWE6fc811U291cmNlIEtleSA8WUFCWkxN
+
+            N1A0NUkzQUlCTk1aRE5QWkhMTjVJVlgzTzIzUFVXREpZM1NDRFoyRjRVWkpKUFJV
+
+            UktJWjU0TEQ0VlE2SFNTMk1IR1JUMkhVWlFSNEpIQTJHUEtOU0dKVk5XVTZTRkY1
+
+            UT0+wsHMBBMBCgCABYJRkcTQAwsJBwkQdV9QvjQSgZZHFAAAAAAAHgAgc2FsdEBu
+
+            b3RhdGlvbnMuc2VxdW9pYS1wZ3Aub3Jnop1VqTEVx2YHInfpu2dTyYE2Ty6yVhbA
+
+            EKUuT/+1B28DFQoIApkBApsBAh4BFiEEjniMu93AvG20Fy3NdV9QvjQSgZYAABwJ
+
+            D/0Uq/Ex3TpNNWzP4JvENcCueU9dgn1ae5SKewkwWv33cetX3dwMRBGVdeZvdjBc
+
+            PibnY4f3YenCBLbfzqE+4GjGcdxfNSSCUQam60wyUldNdRb+nlPQXtJddRL8m7WT
+
+            uBLARnZB1qywkU9sxZjEmeUNXoXXta4Z2G8QkrJ3AvPrMg5S3iTPdW3nggTOnbQA
+
+            Whg3ppLmIc6neGuyZ2s+chXmfJJ1I0N4GcPCFofc1MP4CO6WXagJXrCmsK8Sw0Fa
+
+            BMxOv896oD06FvKQeKxIOjoIQX5UDzgHFwo91Jdt/qZF4/j5xfw5aUK74BLQ7Rzs
+
+            8LZIpvrbomVs27so4qCBYS+AC5umXgvwdDRUbC6O+tqBF9jGI///UmmSslSfzQ92
+
+            C0Qs/hS2d4g3qFOBPZRjVGiko2vLV7qKBidlBy/YFAe6PI55raiOaV4pMftakGb+
+
+            fbldG088aSXwc2LiSF4NB6PfzL94LdjRMsfSECBNrOKMbWMSK/6R5G0nJouHl1NG
+
+            EEfhh9SgS6LQJxzR+AF+gn0y6Ycv3Olyh3Qb+NZ4WaKV509071UxbXwhJZ3AQWDX
+
+            ZHGz88yebYZNR3eZzpHBYHCk9C7m90vV2q9IWtBlNPvKWrdfCggGw1QnJaHBEDJu
+
+            N4KXb+XbRfA4G+IWlTfW9CPsrk9yMxk61e5rYRt5KPT2mc7BTQRRkcTQARAAvkZZ
+
+            uFNiBjP954csxyKxiNBA40dH28+eVx2s+EzfvCwCofZJEHadonPEEdu6stpxoP3l
+
+            nebKfZpKvjOBWHX+kyJGgezkRgxBPPNubfz6sGjUkUoNKBIrcIgW1zWRp/5WTVpn
+
+            sZrFVKwxe1cw/L1kdVRQPI4ywQkiJqoZFEUEENCuiH0MuDwXLJkPIix+fQGPg5af
+
+            k6zsAcV3fb57I/IsKa2Yyb80byaeOJxIzNWazgpM/Oad/YxwEU3KDEYuSHAJYvH5
+
+            AJRHgOqpfV3Q5S3brPimkC1DbxbB7rE9EzcwAbG0CkxJCMiPU9n6WUdSuOPKVivJ
+
+            5/F0CPfqTejIEzC5biub0cN9aT1/o18RAUMmW8B4LCgtA3vXhsz7FAAX0vobvYHS
+
+            D1D8zVFZ7rT6YTvIyGhE5BjmRpyn+4rm1DFodeaoIO9SM+mXgoBvf/S4+rMjx/2g
+
+            AigSBn+VWua2qh509y82Z3P2cG9m8to+Zf77Zwyu0HqsrDdLuEqm1vuGj0NAuvsO
+
+            WLjnBp035giXiNvMFnnebv8OODayk5a08tMQVCGMJ4UTDVCm2qHOHGE7arPDwaqm
+
+            lX0RLV9pbYHuR1eS5ZcRbsrKFo/VCvsqHp1zXI6MHXC1nn+fvM2cTo+nGUcsMtwm
+
+            2/L0ekNTziqAj2EKVQPq5VLz85w4qSjKnr6IusUAEQEAAcLBvgQYAQoAcgWCUZHE
+
+            0AkQdV9QvjQSgZZHFAAAAAAAHgAgc2FsdEBub3RhdGlvbnMuc2VxdW9pYS1wZ3Au
+
+            b3Jn2W2I60fm91BJCOEBFJg0+J03+8B4UeFbG7P1xKB/urcCmwgWIQSOeIy73cC8
+
+            bbQXLc11X1C+NBKBlgAAuXIP/jMYZP/QW/7+MiQ6nmOGFDov/uBCwXWLIMTQXj7m
+
+            UvdXzaGVV7bOrNHaZ5fGbX7DTEGlr/k+5xozuU5NVIyQGKxjp5IDcIip83DO8fZr
+
+            mKhl1K7YMf1gCLtkDIoair1AV+ktE38dpnNptwwNBkzhdPUDNhBEnmXt6v3QVkSi
+
+            KbBb15Ry4E+jY5xILzYXR8lJ+o7ibzuReMSGUTT3GzkZMDWBLxBF4yZyOJRDEu/Z
+
+            8Sf9vJQNPz983C5HXTy1JI/GlZ3AEK/da6TJGOsTc4uCvYQZsRNxrUZzaBjPJf3Y
+
+            L8m6sSy1x3e0E+iuLHmPvYjdTv3CAqK9/BHIapNWy93PMeSOLRXXDO7i9qbFl7FU
+
+            NGiIgLCwC0ELbQxxAbrEOjK42PLv91C6YGE+5wJz2ziDmuV4gNLx8Y2F6IiDd+TD
+
+            iu9+Z5QaGGdCepiI7DNcMLN6M72BeQrzt2TBMnbv9MFRBmkLARE27HYZ2c08upqw
+
+            acBwydfWMV8hJPOM0mJmU+/x7jickah0rBh1TTQ68K9uXJPWlgE8iTmSlVXDHkOH
+
+            bMltzHXRrcVb3rMnl9+hdtU4s4RawGOXeCCRUKHKLHUcAGwHvf/DYu6Nt3y8gfSQ
+
+            eMfocikqzaUVfVTm+Pz20YUwYrJJi2Ad8+4NvoNK/Rc0aGlTTsMkfxLzhVVtXIoV
+
+            Wqs1
+
+            =iSCT
+
+            -----END PGP PUBLIC KEY BLOCK-----
+
+            '
+          type: PGP
+        last_updated: '2024-10-29T02:57:58.778392Z'
+        number_of_documents: 2
+        number_of_messages: 2
+        remove_star_url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1/remove_star
+        replies_url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1/replies
+        submissions_url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1/submissions
+        url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1
+        uuid: d72d84c7-fc29-44da-a5fa-8bb966359ee1
+      - add_star_url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8/add_star
+        interaction_count: 6
+        is_flagged: false
+        is_starred: false
+        journalist_designation: depressant surgery
+        key:
+          fingerprint: 9FCC5955F2F5FD0945BF2F1EFC6E887AD5475FE0
+          public: '-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+            Comment: 9FCC 5955 F2F5 FD09 45BF  2F1E FC6E 887A D547 5FE0
+
+            Comment: Source Key <OVXIPW3O2MH34FCOM7K7XF2QTMFF4DWCCPTRP3BEZGR
+
+
+            xsFNBFGRxNABEAC2iqHuZpH0COiVpFOhZvyU2hmg0/EUKn9MGkPfUWrz8LY9r7SS
+
+            B0zWeU8EdDD9qUemjelnHBN9XrReDr0LGvgHWJhswpKpLKSI8Kq+1fvo5uzz+mnw
+
+            VaAT4tzN5Csqc6vhc/fGEkkrKrG4axyx4tVeHjIfLiPg4zFJ4SUCWPcDOgjZzw2H
+
+            pdSDyl3JbtFOKG8j5YIy1Bd7w1kVv6FqTd7cge1Gj8RRdVQKJwZuwb6zqUvhAUez
+
+            YsgzL39QfrfNjpd63PBefR3WSw2QxaAn0qgp9R7JzA5Q81OeT5BASoGD7T4hVtvc
+
+            4fRFgmbDvdBI7cLx/5/NLKu2N868ANsMnjmcgjAh5GlJjXzWrpbxkIN6ci5gZasG
+
+            5Qi5C1qAOU6FUpeL3XjriK9fXSRk7eyGrnE0ku59oahmnogoa4b6e8qcIz6AuxIT
+
+            9LijP4Y3FCtzPylLzYynicMDlCOME84Bac9p171HbRsTnssY8jA+ZT/trah9t23h
+
+            rhAHSGCyTVUSBWy4b4IjcO6/bj34wyM0wRkCIt/9WfuE2p51SDPiahfGNYiMUaU4
+
+            am/I/yzwvBVxeLjJ3DYevvVE++iijIuikTI0IyRsXHoaFuhbtS3cONgGMzuWfEbg
+
+            68DE550ZFQsj+ZWQDm6aLp0Q0BirQooe39GouC9ZIt2stCgKT2eiiuGXywARAQAB
+
+            wsHJBB8BCgB9BYJRkcTQAwsJBwkQ/G6IetVHX+BHFAAAAAAAHgAgc2FsdEBub3Rh
+
+            dGlvbnMuc2VxdW9pYS1wZ3Aub3Jny7Rrz/yiY8uemfQx6cUqHBUOkEaXkd642xhG
+
+            4rD8mskDFQoIApsBAh4BFiEEn8xZVfL1/QlFvy8e/G6IetVHX+AAAPBnD/0deD3a
+
+            8Pjiq/Blh1bExC0vhSkRCAZeTw6BUxpQyHKOA6X8QhjsuWXQVlfcItSJZwte1hFV
+
+            Y9EoetizSYltNh6chAO/1WXHPfhaQ4ZqEqaSum/0II+lO/Dh4gMjWSnWR8+G9JTc
+
+            KqAYq5eK6VWWLbiehcd80UYDqAwPIIEYnWckyYa1qmmCgYv+MEY7Dwn9Du3t10kh
+
+            MvrcWQhzx2GKBQ+6SjGursqBlSaA3TPZRn4ei6GFvBaBx4oyylb7FVHVcRduni9Y
+
+            S1sXN8dCMoX4iIfb2jULDyg11YOJ6eAGz9VChi1w59/akanlp3t8YFZ8L3uKfqeV
+
+            +evwCesVDNziN/9WJm865zEsFhE0jkQT2X2vvGWgzS8+O+d6L+ykAeJo/VNdF6cu
+
+            zm9RL9vJC/eKMh7DGFeaPDRB0o5s6d661BKqe0RsVKRv4DvCFi7oUl6aoY1g5mfM
+
+            etPoe1P5l1rl1pjxeUkztU09NilInTeSIGV7BYVdhSc3MoEK/8euFj0vajEvWKp7
+
+            KGIsml8bpzSphBvNHB40+AfcX2DgAfM0xegMJHHOXnrlG1UJeegwPqO7+FVAnLuk
+
+            gTm8gZ9U1DjCW3NiJbHZT+ZWeeeNY25M6kSsAUOf6LeCw5ljfd2S1QPEDONoe0w+
+
+            ffV2NFdavpoNHdUzb9uJrh6bCA+bDSuB+Zbm+M11U291cmNlIEtleSA8T1ZYSVBX
+
+            M08yTUgzNEZDT003SzdYRjJRVE1GRjREV0NDUFRSUDNCRVpHUkJNR0tKSlFCNDZG
+
+            UVM1TDdKTTRWTTdNTkVDSU1HVzUyWkVCN0pGREE1S0k0RkJNSFFLRUxVTE5LRkEy
+
+            ST0+wsHMBBMBCgCABYJRkcTQAwsJBwkQ/G6IetVHX+BHFAAAAAAAHgAgc2FsdEBu
+
+            b3RhdGlvbnMuc2VxdW9pYS1wZ3Aub3Jnj2rbfQJJIrFFf+aHxQLRZ7N5TJt+qe2m
+
+            3jHsJ6QKLnUDFQoIApkBApsBAh4BFiEEn8xZVfL1/QlFvy8e/G6IetVHX+AAAKUB
+
+            D/4oXIyMYXJL/RFThHk46LQBozB2HxJfZV5RMAWbjD6B+XzeMVNDcXCNOE+JCd2E
+
+            2HdlNbzl3GNIlF1YWyB86LEBg5c5ouh4LB4454Sj4hj81LvCN2T93DLQD+nPmCcZ
+
+            Twdmq2mIMBDaIUZmdfHsaO/aEpyz44P72QjvG8vBBF3Tgo8on53zpIfxOT+H8VrP
+
+            EQ1galD3LcNmp/J3VxGO7Y178k5iuKj/Bfh0JIh0RN2UG0nwB52M05m33tBvsvL4
+
+            D6DnYva8VUEwuJBkbsqk+0hX+l8gm+eIQovVYmBPfn89FvO2Lsq+/XpyZIWnwAKo
+
+            lG3TbMaj86ZXbIUjKDVJDM0vNgFr/8vFrNjPZiqNcuNEpV7JIU3hW6xeeFP/AXgd
+
+            JaoBj0olt7OAvvduQdf/whjmGkYSQIGhy+UaUWWsBSHzNFdlV4liifvlCT+MwUcI
+
+            qimDzJok28GSEC0S/Dnox+yB+U4gyTjEOr9iOC0ZOZhcSHPseOfgk0+vY3i/Q+mn
+
+            jElXtYilFP38kgcCslroacNHRoFcbyX/519X9OeuA5cwnbwazAeEpahTvVtYR7oH
+
+            23qxnaxcb/U+otPLNRLVyM7rh9nHW/RlIGVpNvXQi51EwjS/ivpgB2S2I1tOz6wH
+
+            s4XqpChjAIQNz76NV/Ipvs5FJUhzuYH1UEU82UjGsAoGFs7BTQRRkcTQARAA0w/h
+
+            Kxdrr1v0s2I+FeWb7WWFoJK1IBoiVJiL7ja12EZQTlpgi/vsVaNPar3eU7CT+ORp
+
+            6TN1dpHF1skuTLZlvv8kkIEW+rMEhDBu9fljBhC2QUfy3s7i01ccYIH8OyVfHSPq
+
+            Wf/9j+BP5uhwQNKf+oL6OXdv7GWLyXFzvIg8twJ9U+OiJezYkBPNeZ4PPHg5OaTk
+
+            1xKrRzZSUwmQcvcJ/uoLViRnr4JZ/yW3JZ3TXXmSpgzqRZtYvt3/ueKIgcqmAAnu
+
+            xdpC7L/zKeKm593qvw2hgM2QbehmzluZOx8xbz4cVbaEirH3hM2foPLGEWBkafel
+
+            HiPB3FbQnAXUFVRLkfOaAHZ9hBb1l9tLgCQv8Z30yy2WYj/8BgTcp9knw4o2Tr1i
+
+            a1c9iPSI44+LJuS+OZ8GHplr8w1wo3HCwnWwAB9IO0R/rxXScp6Ph2YL3lKzZTU6
+
+            uPfGxadRXMLFERb02d36kBT4Wp0QfpuibkaV3ZWckBLX6fp6fZF7zYKo+XKsDKAR
+
+            5t5oRcWs/ySjgxW3DORHYB6Zjp6uREDkvH6iFW2erZ6Qvzl+8p9xQp3r/dBLtL+G
+
+            PHzs2icz56cLhNP7HKywD6d/Dfn/mXHdUpecmwQq3EsI62ptHFI5yIyPKMVnf9pK
+
+            /XwurRsUf91Ib+bl+3yfQxbBqz7b4PQcnCOk/K8AEQEAAcLBvgQYAQoAcgWCUZHE
+
+            0AkQ/G6IetVHX+BHFAAAAAAAHgAgc2FsdEBub3RhdGlvbnMuc2VxdW9pYS1wZ3Au
+
+            b3Jn6VgMO+n9K60kfSnlTXGKJDY8BMSuy4mQKthDgNgTqXkCmwgWIQSfzFlV8vX9
+
+            CUW/Lx78boh61Udf4AAAT9sP/Rc6Kb6U4Z5pbdTfa5trQ3brhhzbXriM2Db6/niI
+
+            g7y7AqUHoj1p40FIQdMXMTyDp99Q2WwbPbbY4H0B+nm+vLFH2J1hiwP2qURGYfcs
+
+            Hq0HMrM60WjNnCZuer8QMH/2Yr7BJL19yP6Ssjlk8ZD021rEOnojyrHDm1ka775Y
+
+            DAhKo/JcHFI3eg6fiMSeyw0pN2C3Cx9QjVA4bz5RpEHkasPSyDx3daccxAi6gvtV
+
+            P2aXoPuMB62b+v+nC0S+x1BaxZg38LfeDRq2DDYZRAjtmx8iLPP8FxEdlSlvqnSv
+
+            KPWsqqdxwZkWASqPJu3XN0W4CJyovzwLOJcveyfTYfaonUJi40uyOQQw25/uwQ5z
+
+            VgUPy+HGl1WjX782bAXC+ERWd1LUI2MczAd7pPO7p/QOQ2/9LSrLdI0P/QuG1ZgH
+
+            HXde7NF+xN7ThH0M3fryKz25bbzh773r4Lbxk9z1fq78PtIKFK0RGQ4sMVgtoiyo
+
+            soGeNl2RtM+UKm6oInH4qSxCyvO/1g+A8+c9UG7bmmASN6BKfMtz2Bi2GG61wecd
+
+            RVsf23+pUQ3bFgYLJXBMT1jBDXAP+xV6VJf5ONfWl/tQaG853u5sz7Y5G7Nd5sL3
+
+            RwakocKajOf9n3FTptOKxBPUfbJafZhBOonIgdlPuDXXmOUf4m66wMHDPUQv1HvT
+
+            0BrP
+
+            =jY3W
+
+            -----END PGP PUBLIC KEY BLOCK-----
+
+            '
+          type: PGP
+        last_updated: '2024-10-29T02:58:09.003247Z'
+        number_of_documents: 2
+        number_of_messages: 2
+        remove_star_url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8/remove_star
+        replies_url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8/replies
+        submissions_url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8/submissions
+        url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8
+        uuid: 234105f1-b0e2-4164-bb78-e81e731279d8
+    headers:
+      connection: close
+      content-length: '21643'
+      content-type: application/json
+      date: Tue, 29 Oct 2024 03:04:46 GMT
+      server: Werkzeug/2.2.3 Python/3.8.10
+    status: 200
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token IjZwemZBai1NVzA3MDNTdTZnU2RhNEg4RmFCSGJyYl9oUEZ0TUpOVlhOUlki.ZyBQzA.Qy-WxRYQ-kareM2KY2wXGWztTq4
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/submissions
+  response: !!python/object:securedrop_client.sdk.JSONResponse
+    data:
+      submissions:
+      - download_url: /api/v1/sources/2181a381-51c9-460e-b52e-7905a335b4ee/submissions/b700ee09-34bd-4dd0-bff0-28fa9952e65a/download
+        filename: 2-countrywide_cabinetmaker-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        - 8ebea9a6-be81-43a4-8ae7-2a77b4a635f6
+        size: 766
+        source_url: /api/v1/sources/2181a381-51c9-460e-b52e-7905a335b4ee
+        submission_url: /api/v1/sources/2181a381-51c9-460e-b52e-7905a335b4ee/submissions/b700ee09-34bd-4dd0-bff0-28fa9952e65a
+        uuid: b700ee09-34bd-4dd0-bff0-28fa9952e65a
+      - download_url: /api/v1/sources/2181a381-51c9-460e-b52e-7905a335b4ee/submissions/f71b4b85-0c92-4702-bb64-9eb9f1be8b20/download
+        filename: 3-countrywide_cabinetmaker-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        size: 650
+        source_url: /api/v1/sources/2181a381-51c9-460e-b52e-7905a335b4ee
+        submission_url: /api/v1/sources/2181a381-51c9-460e-b52e-7905a335b4ee/submissions/f71b4b85-0c92-4702-bb64-9eb9f1be8b20
+        uuid: f71b4b85-0c92-4702-bb64-9eb9f1be8b20
+      - download_url: /api/v1/sources/2181a381-51c9-460e-b52e-7905a335b4ee/submissions/e7df5dca-8bcb-4982-a596-45f35c027dae/download
+        filename: 4-countrywide_cabinetmaker-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        - 8ebea9a6-be81-43a4-8ae7-2a77b4a635f6
+        size: 650
+        source_url: /api/v1/sources/2181a381-51c9-460e-b52e-7905a335b4ee
+        submission_url: /api/v1/sources/2181a381-51c9-460e-b52e-7905a335b4ee/submissions/e7df5dca-8bcb-4982-a596-45f35c027dae
+        uuid: e7df5dca-8bcb-4982-a596-45f35c027dae
+      - download_url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797/submissions/8422f9fa-2d6b-431f-a8e9-bbac5a694052/download
+        filename: 1-colorless_empiricism-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        - 8ebea9a6-be81-43a4-8ae7-2a77b4a635f6
+        size: 804
+        source_url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797
+        submission_url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797/submissions/8422f9fa-2d6b-431f-a8e9-bbac5a694052
+        uuid: 8422f9fa-2d6b-431f-a8e9-bbac5a694052
+      - download_url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797/submissions/6a34daea-5fb5-4c8b-a63a-8d7a728bc504/download
+        filename: 2-colorless_empiricism-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        - 8ebea9a6-be81-43a4-8ae7-2a77b4a635f6
+        size: 710
+        source_url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797
+        submission_url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797/submissions/6a34daea-5fb5-4c8b-a63a-8d7a728bc504
+        uuid: 6a34daea-5fb5-4c8b-a63a-8d7a728bc504
+      - download_url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797/submissions/72d48f81-4dc4-4074-b8fb-591b02c67319/download
+        filename: 3-colorless_empiricism-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        - 8ebea9a6-be81-43a4-8ae7-2a77b4a635f6
+        size: 650
+        source_url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797
+        submission_url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797/submissions/72d48f81-4dc4-4074-b8fb-591b02c67319
+        uuid: 72d48f81-4dc4-4074-b8fb-591b02c67319
+      - download_url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797/submissions/ce543a4c-a824-4151-9da4-18fa7046561f/download
+        filename: 4-colorless_empiricism-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        size: 650
+        source_url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797
+        submission_url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797/submissions/ce543a4c-a824-4151-9da4-18fa7046561f
+        uuid: ce543a4c-a824-4151-9da4-18fa7046561f
+      - download_url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1/submissions/184baac3-7bdf-4077-971f-e8b4c89c2af7/download
+        filename: 1-deluxe_saccharin-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        size: 1124
+        source_url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1
+        submission_url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1/submissions/184baac3-7bdf-4077-971f-e8b4c89c2af7
+        uuid: 184baac3-7bdf-4077-971f-e8b4c89c2af7
+      - download_url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1/submissions/cd0e1356-0637-4b07-8c1a-40aea03d4c2f/download
+        filename: 2-deluxe_saccharin-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        size: 687
+        source_url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1
+        submission_url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1/submissions/cd0e1356-0637-4b07-8c1a-40aea03d4c2f
+        uuid: cd0e1356-0637-4b07-8c1a-40aea03d4c2f
+      - download_url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1/submissions/153934ef-5555-4bca-9a28-30abb6186b39/download
+        filename: 3-deluxe_saccharin-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        - 8ebea9a6-be81-43a4-8ae7-2a77b4a635f6
+        size: 650
+        source_url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1
+        submission_url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1/submissions/153934ef-5555-4bca-9a28-30abb6186b39
+        uuid: 153934ef-5555-4bca-9a28-30abb6186b39
+      - download_url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1/submissions/09f5c737-2475-4bf0-a409-fb855eca0635/download
+        filename: 4-deluxe_saccharin-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        size: 650
+        source_url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1
+        submission_url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1/submissions/09f5c737-2475-4bf0-a409-fb855eca0635
+        uuid: 09f5c737-2475-4bf0-a409-fb855eca0635
+      - download_url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8/submissions/4abc3b07-51fc-4366-8c46-8204b40608bd/download
+        filename: 1-depressant_surgery-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        size: 619
+        source_url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8
+        submission_url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8/submissions/4abc3b07-51fc-4366-8c46-8204b40608bd
+        uuid: 4abc3b07-51fc-4366-8c46-8204b40608bd
+      - download_url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8/submissions/07717606-0447-4e9a-b93c-d758f9c40ac1/download
+        filename: 2-depressant_surgery-msg.gpg
+        is_file: false
+        is_message: true
+        is_read: true
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        size: 707
+        source_url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8
+        submission_url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8/submissions/07717606-0447-4e9a-b93c-d758f9c40ac1
+        uuid: 07717606-0447-4e9a-b93c-d758f9c40ac1
+      - download_url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8/submissions/09f23990-dd94-4607-b744-cd6aef6cd7c1/download
+        filename: 3-depressant_surgery-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        size: 650
+        source_url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8
+        submission_url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8/submissions/09f23990-dd94-4607-b744-cd6aef6cd7c1
+        uuid: 09f23990-dd94-4607-b744-cd6aef6cd7c1
+      - download_url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8/submissions/091f6975-17a9-4a15-b09e-443662ca0a78/download
+        filename: 4-depressant_surgery-doc.gz.gpg
+        is_file: true
+        is_message: false
+        is_read: true
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        size: 650
+        source_url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8
+        submission_url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8/submissions/091f6975-17a9-4a15-b09e-443662ca0a78
+        uuid: 091f6975-17a9-4a15-b09e-443662ca0a78
+    headers:
+      connection: close
+      content-length: '9872'
+      content-type: application/json
+      date: Tue, 29 Oct 2024 03:04:47 GMT
+      server: Werkzeug/2.2.3 Python/3.8.10
+    status: 200
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token IjZwemZBai1NVzA3MDNTdTZnU2RhNEg4RmFCSGJyYl9oUEZ0TUpOVlhOUlki.ZyBQzA.Qy-WxRYQ-kareM2KY2wXGWztTq4
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/replies
+  response: !!python/object:securedrop_client.sdk.JSONResponse
+    data:
+      replies:
+      - filename: 6-countrywide_cabinetmaker-reply.gpg
+        is_deleted_by_source: false
+        journalist_first_name: ''
+        journalist_last_name: ''
+        journalist_username: deleted
+        journalist_uuid: 32f2439c-c131-4bb6-a881-afbbbae0cd8a
+        reply_url: /api/v1/sources/2181a381-51c9-460e-b52e-7905a335b4ee/replies/e329bf3b-e25f-4ec3-85a7-6d5b88464b19
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        - 32f2439c-c131-4bb6-a881-afbbbae0cd8a
+        size: 1293
+        source_url: /api/v1/sources/2181a381-51c9-460e-b52e-7905a335b4ee
+        uuid: e329bf3b-e25f-4ec3-85a7-6d5b88464b19
+      - filename: 5-colorless_empiricism-reply.gpg
+        is_deleted_by_source: false
+        journalist_first_name: ''
+        journalist_last_name: ''
+        journalist_username: deleted
+        journalist_uuid: 32f2439c-c131-4bb6-a881-afbbbae0cd8a
+        reply_url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797/replies/f67c91e4-e0d5-4fb7-b36f-fcc1447a91ff
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        - 32f2439c-c131-4bb6-a881-afbbbae0cd8a
+        size: 1331
+        source_url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797
+        uuid: f67c91e4-e0d5-4fb7-b36f-fcc1447a91ff
+      - filename: 6-colorless_empiricism-reply.gpg
+        is_deleted_by_source: false
+        journalist_first_name: ''
+        journalist_last_name: ''
+        journalist_username: dellsberg
+        journalist_uuid: 8ebea9a6-be81-43a4-8ae7-2a77b4a635f6
+        reply_url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797/replies/cb9e979b-bd0f-41fe-b6c2-c8c6f5631e6d
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        - 8ebea9a6-be81-43a4-8ae7-2a77b4a635f6
+        size: 1237
+        source_url: /api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797
+        uuid: cb9e979b-bd0f-41fe-b6c2-c8c6f5631e6d
+      - filename: 5-deluxe_saccharin-reply.gpg
+        is_deleted_by_source: false
+        journalist_first_name: ''
+        journalist_last_name: ''
+        journalist_username: deleted
+        journalist_uuid: 32f2439c-c131-4bb6-a881-afbbbae0cd8a
+        reply_url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1/replies/653d00b0-19af-4731-835b-6bb35029791d
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        - 32f2439c-c131-4bb6-a881-afbbbae0cd8a
+        size: 1651
+        source_url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1
+        uuid: 653d00b0-19af-4731-835b-6bb35029791d
+      - filename: 6-deluxe_saccharin-reply.gpg
+        is_deleted_by_source: false
+        journalist_first_name: ''
+        journalist_last_name: ''
+        journalist_username: deleted
+        journalist_uuid: 32f2439c-c131-4bb6-a881-afbbbae0cd8a
+        reply_url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1/replies/438bfb33-cf67-47d4-a215-7adf2fd45a8f
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        - 32f2439c-c131-4bb6-a881-afbbbae0cd8a
+        size: 1214
+        source_url: /api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1
+        uuid: 438bfb33-cf67-47d4-a215-7adf2fd45a8f
+      - filename: 5-depressant_surgery-reply.gpg
+        is_deleted_by_source: false
+        journalist_first_name: ''
+        journalist_last_name: ''
+        journalist_username: deleted
+        journalist_uuid: 32f2439c-c131-4bb6-a881-afbbbae0cd8a
+        reply_url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8/replies/a72beea0-977f-450b-a857-80aa7f9a2c6a
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        - 32f2439c-c131-4bb6-a881-afbbbae0cd8a
+        size: 1146
+        source_url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8
+        uuid: a72beea0-977f-450b-a857-80aa7f9a2c6a
+      - filename: 6-depressant_surgery-reply.gpg
+        is_deleted_by_source: false
+        journalist_first_name: ''
+        journalist_last_name: ''
+        journalist_username: deleted
+        journalist_uuid: 32f2439c-c131-4bb6-a881-afbbbae0cd8a
+        reply_url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8/replies/7f82f306-9245-48b6-baac-782025ebf8f5
+        seen_by:
+        - ba39d10f-13cd-45d5-b6d5-ca33b7151490
+        - 32f2439c-c131-4bb6-a881-afbbbae0cd8a
+        size: 1234
+        source_url: /api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8
+        uuid: 7f82f306-9245-48b6-baac-782025ebf8f5
+    headers:
+      connection: close
+      content-length: '4789'
+      content-type: application/json
+      date: Tue, 29 Oct 2024 03:04:47 GMT
+      server: Werkzeug/2.2.3 Python/3.8.10
+    status: 200
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token IjZwemZBai1NVzA3MDNTdTZnU2RhNEg4RmFCSGJyYl9oUEZ0TUpOVlhOUlki.ZyBQzA.Qy-WxRYQ-kareM2KY2wXGWztTq4
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8/submissions/4abc3b07-51fc-4366-8c46-8204b40608bd/download
+  response: !!python/object:securedrop_client.sdk.StreamedResponse
+    contents: !!binary |
+      wcFMA8PnxMCiIBsqARAAy4LvSS1qO4Q+KA/rk2yMKvqQaGFb3+AYu5+0q/281aqkMKcUOWPBwsGW
+      PXW+GXiu6hau0KI6Q+xE9HJGjC8bXm7QeSpCBja7cDtMhZW1XAw1NPZyyOeHAxyZHbjqDBThg62g
+      vrGOKwFhA4xnfT3x7rpvo5ASrRjtFc31fjnziYNXJpizt3Ftvl3yrI/uBuRDt7EKI22uD7kkrszW
+      RqtfGpQ3Hkq/RHTtJrjCNzyVDX/YSMKfPiOsFluF+hE7BdUG+W7SQa27wM2Ldo2pxZVKP4dgFinO
+      8z1qGpevFPHt3F5XTviDfxJt5z0TwAq2RcTX7yh4n/BBEHijpG/Gx/9ciPBPmSqSEdnakWn+CHYb
+      rrRTdxvTa3T7QY/NeN+6sXPxw9D3ef7HvfDbOBFdV7ZD0vdqZOcM4SbuUp4uzcL42KFpKpZ8FJOd
+      h9oeBW2DIensjJrwSlMGF1Mstl6i03/vmIboLUaF25JodJnCPgk5PXnXKoGWObnNCzl5T3t4C1hO
+      Cc84NdabmRWeW/gHaaS+Tp+VMos20KxKrxESDh2A+dMWbFHu5q7fEws1tnTzRiSYqeCyhxz1oqXE
+      rqfbeinUjtB9prwSnqJnUdjVGGdRzhEPSCL4g5OiSADQ5ZbuIe0sl5OtfmbcGM2joS13fJfPI8js
+      ufn5rLufduDc8fvdoFbSWgEwY9/dgmpvREoTy9dHcmGWhRUkVWwsNOSV8aAoYfH7ACzZTzz26Uf0
+      4pAtxUsTIplVBryRPvmHGN9v1auKOBvKQHxu1c0IIlL2zkRDhvkmWiseDAqjwfiHDg==
+    filename: attachment; filename=1-depressant_surgery-msg.gpg
+    sha256sum: sha256:bd3eb4eba525a4b2ddce1f69a36a01588dd667bd2dde85852379b1c867e02079
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token IjZwemZBai1NVzA3MDNTdTZnU2RhNEg4RmFCSGJyYl9oUEZ0TUpOVlhOUlki.ZyBQzA.Qy-WxRYQ-kareM2KY2wXGWztTq4
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8/submissions/07717606-0447-4e9a-b93c-d758f9c40ac1/download
+  response: !!python/object:securedrop_client.sdk.StreamedResponse
+    contents: !!binary |
+      wcFMA8PnxMCiIBsqAQ//ZcIz51nmAXxckhIMoOV5uNiwrgcy5v2ApuP7lH+QCmumNZR0ogSN35Lo
+      GwfLD/9+MI6L4qhKb30DgqAshNGccHM+7dnAVY9IkvsVb6G5ZjUUz+c2XWrFpEw5PDvYg7GGyw80
+      NU5sLnA5GJ8w81jl9Jj+CiAz06lWMy5T4DyTic+uE5q48xT8lhL5UyLSau2uf6LIPh/DIBNtKAsr
+      3H7bnfqKXE21/LZQml80yjJWywTiAS5KlDjarV3CVVQwA/qIQQtjfB5KcO7OmGhl3ZRAgLEiArak
+      0W3D/sg2eWtYXci7q1VFBI93f1Uqj3dpGLQCiP1KiwJui5WWmF1VLSXIzy+FDswkwwU+ttr1FUvI
+      yb1gVConGfhd+hLmO+hEL8j+vDB1iGY5hQ6pgPzl8voCliWSp0JRXj2N409aDEiPrpzd8bPkA6IF
+      zL4k5o2TWYlGIPlSAuitHoG36Mt2S0rOtNRLgFnPUd2lUoiwIVqJHHl8cJo4C+FjTSsMo4LaKNru
+      xytQh1IJgl9YfWpdRH0vs3+KsPjGivd5LxhTg8B05a0BcdAfCwwzF9lfixDZJ5izV99XW4xzvtiw
+      nkp3vSkfVklbvQFKTGkqPeGLKvtkIOqIAGGtqUt2Lnig9S12zGPTl3F/tAKlLmKKb+HCOc+73tvR
+      xjT932QWDnknW/ZLP8jSsgHC5GhFDlG9xMRWJ5cdXjhIz2o2K6NMLs++OhkMHVtMDA5YcoiF3e0P
+      aPmvaVabkZVCt4RO0til58XL0ZuW731fq5ZdQimnt+G9QEupISNtLjDyXQzCLyjbFJyKNAHjIF9p
+      yLtMr86umQWrdGlXalAjCYX70cs1ZgONlph49cdc/0XYlsRy4TnwIzW0y3Ey7cz3WZpC5OA3+xwh
+      63//Kt5dO/3i/JDnT2pCIOjE+zASBe8=
+    filename: attachment; filename=2-depressant_surgery-msg.gpg
+    sha256sum: sha256:0ceb56a054dae0b49fd2fe2915130d771789b6b041ea577127209857551c9b49
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token IjZwemZBai1NVzA3MDNTdTZnU2RhNEg4RmFCSGJyYl9oUEZ0TUpOVlhOUlki.ZyBQzA.Qy-WxRYQ-kareM2KY2wXGWztTq4
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1/submissions/184baac3-7bdf-4077-971f-e8b4c89c2af7/download
+  response: !!python/object:securedrop_client.sdk.StreamedResponse
+    contents: !!binary |
+      wcFMA8PnxMCiIBsqARAAl7N1H/7f5PFPMJWFEmG3M2FDOzbgwZ7WtProUHz2nyPTuceITPJUWBGm
+      TWi67mp86J4V368UvEi9gu8/z3IoFqrGiklSROc27s8f1uDXklSmTNTtC2sOAxhFtNL1M/AK/agA
+      yJ539hbKlPY7hiaxOsjXu09OjeK+SeWoA4OUJuFU/pIW4quZDm9z/NBs8TystdMgKya6X3hrdNkc
+      B1CglqaUzJOMnlpbLxGfAwHwLe18F2Klvdb6hEhU8WVI0TQzzKXCYhpRJqk8hfvm1r65yhQZ2/kj
+      VlcBISpWmXs8M2CnxmgtsKnm6qE1l4WEzoKGQaudxryYYmmDHgKXSZuh74DLkkZjr19RqTs4b/+t
+      dzl2iRJYP6ieV25bJjRo1mGnRwoREo7F6DESeB44GWXR96iDb6Z4mftiOf6eoNCutwHpmaFqC1xL
+      LKCEFBfgJDW57kCk6YLeCFROhM1Mo0uc7dYix9Nf2AmYsjluSmPq2dJfWtVnkjzrhaIIwK4NLpGW
+      EpgbtGyU2bwTXfpFJqnd+8eq8ylGXp/Qkn44Nv0zIc2WwxLPZxf7vK6Q7kJ4UFCnY3uCVBWz8k6G
+      S6b6CGGljfjgHrT1NZqZClY/+EkedSB8DnwMZA0/k/r5U8K2ryb+nV98uJceXExTdgXRLKso2iSS
+      Rerpmry2RQ+ifADqSOTSwZIBjt0jmpl8a20Tk8TM1IZt3tcsOysS5a2jU+JSfta+Shh2NFKLnla6
+      nV6j8gW6UGBXCTu2A1ZvFEsJGr8MWV+VhsnhLPkSjkDwFUercIOZLtuw2BC746RJK5nTZ4eRmc+z
+      /7OSih8XBUKohytSwoA7hwiNUIWP2AOXK4V+p4IUVjLddehR9PwQNY6cBnxrYwfkv5/6CUuRc0d+
+      v79U//rWkWDqqRsPgeVnDoSPnxUTE4hUBAXZS4zzCvXi25rnchQ2kq60gdaVlnmHR4NnoqqTtt1E
+      dwaffHwmE7rlyjsRvuSmIMwwlrT0+UlNa0jjj6YyFpe3/dRXRRx5eueDRxYivcaqd0Wg+ps6GXQT
+      Xjtz2HPtZ5C9PAmls9ezTCuDHmvFneU4ZCOhwPrIJjDL/O0NX/B0i7cTgmQQg4WSJUVEa8/CLoll
+      +7KBRqFWyJM2ervcXLaK1y3YaUvgNkGE3rOOuIQbeVfRk3j/k+KNpwtb/xHdtbqubRbZ9UeNT88/
+      pnevoY0qDNEHvm10w9kg5DgPeUgfz74yEf7vbVLoYl4qyvLc8YNsO7gPc1ouX1vT8bp0/0ldNX3j
+      0p/jHO2YCXc3lSUq8zD82Urmm58tlDjHpgA2Q6pMgb8N7TuNOmlVHJ7r558UthbxM1KF5gCRH6Hw
+      n6XeN5S3o62fqo/xoqpfWJR1nbZFoxbIGS4xGln9B8wmEsAv8LJqpmHn05L2I5K7R4P4x/6z2Oyf
+      tWzWgnjYUKSHPRMtAr7rQttOybM0U82WsseR5mNvVBLgGoGTubTncbk=
+    filename: attachment; filename=1-deluxe_saccharin-msg.gpg
+    sha256sum: sha256:9e3c17c03be13012fa302c7a8ced152a400a0b8ae25141469ab88c9419335581
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token IjZwemZBai1NVzA3MDNTdTZnU2RhNEg4RmFCSGJyYl9oUEZ0TUpOVlhOUlki.ZyBQzA.Qy-WxRYQ-kareM2KY2wXGWztTq4
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1/submissions/cd0e1356-0637-4b07-8c1a-40aea03d4c2f/download
+  response: !!python/object:securedrop_client.sdk.StreamedResponse
+    contents: !!binary |
+      wcFMA8PnxMCiIBsqAQ//f6wIyTojn4E8IjUw5As1wlFV0f0Pr9H7g5oXK77aNfVpUJvFm0oqFKPg
+      cKRfB1SsrRTxkVaGt7njTL98kI2euVI2DhM05AjpX11a66cfVGRF44LZNIDRUv1OzPIADvOLnB18
+      /JldwItPKuyHShwUWSoWQcoE2zZG8z+NGz2mTfrVocktCi6TeZAY0vEyxv1RuULhcEeVQ+CE/sWw
+      EJ+pe0DEElf0TMt9GHUPBEzXgaKKADx4IawTweoPaZDc4JgIIZ10CFx7/EJzhlzc9z4KfXl2CNVN
+      bCZL9wmkvZ4LRf5CHRhaacAaT4DFF/tR9S4bxoqO3b9Ea9mRO8oQLYk6s/JYtdBUB0C3s7Zuv6lv
+      feU2QF1S5UwALWv+5xeJMy0C9AK1kI38tjEXEjEphgUOTmtTCTty+KP6ZQqqDFnRU0TLrABz8vFb
+      FAozC6pIy5uwAunBfFDiP0ydSS9t3Ufz7L06/Bsl1fCrt/Ty+d/5QwHXQsC2yfJnBtBKBJucJedL
+      cb+HiNKlfRNMQLvw/FDIAjkdyR7hJYiaEv83EEkF8nrVaWi7RPybpd/vUzxxIa9WIbMsc0d2vNsU
+      ybqE3jTlywUPG75rS782uvomrGgt8kQ2K6hLsjkItd+SpMBw1FNekABcwCURykL5wOUNG/KeBqQr
+      s07XlFamdo5ebXwSegnSngHRtGg0V/MuFaVqoC45DNWarrql+LV8KiuwPqdhTZy85J+qTaCq7sJl
+      NPUgFCTP1GZkJmb0FVZAGEkUIqoyoUNAFSrd5J+exTFjhOV5RQjURnobVB4MNeUdpEXbUlmkQY5K
+      S5wJl2TqiLrYlqZSOM7TQfnyb3X49Hkd24/ZQ1e6K/LnqhnQ3JfW0mBY862QgHkykbz1fkaQDQ+r
+      BBcz
+    filename: attachment; filename=2-deluxe_saccharin-msg.gpg
+    sha256sum: sha256:771ba0e707db189de00cab04bc2de93b2a006784c7227563219b42356e4c755e
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token IjZwemZBai1NVzA3MDNTdTZnU2RhNEg4RmFCSGJyYl9oUEZ0TUpOVlhOUlki.ZyBQzA.Qy-WxRYQ-kareM2KY2wXGWztTq4
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797/submissions/8422f9fa-2d6b-431f-a8e9-bbac5a694052/download
+  response: !!python/object:securedrop_client.sdk.StreamedResponse
+    contents: !!binary |
+      wcFMA8PnxMCiIBsqAQ//TW2QanYCLNqUb2Tl31xcYAkma/DOC9vK/+dX/7ZmKj4Er19oriDJka2G
+      oIs0miz5+Y/BYZjChZMd9T9A+Lz31NDmfolhfCzrRXxb7jrnvp5fwAjJUJZb1VjbeOV8VEAoFdUL
+      u7io/pX14G1WW6x46MF8/+i+Q/zxMP0NgH5z2UU1T3Ix7EudJb7md6Krz038FevgLor/X+tjUVoU
+      bsn/2KR/z/yL4j09qoj54sKtjigvtWg/cm2Qa1tESCw1Y7Tb/WjEM7NBa6YjVI3qnaLUd5BGUFPz
+      Fwgb8XfxgXRd7a3KcZ2CmySQVTp+bVbUQeVHCrDlhytN7VqMOIZzqCSeQReYhXieURvCwZm8jm8w
+      a8jGtp8fvsMVq4pLmez7uhDXwagQqUB3sXnUeipq9l+lPKGSkU12RotpRPKWHrJPyW1zyvw8G+yD
+      UrkAJ3z45Gw1xiYxtt5yw4CWH2390hBbWb/nS5AajUGRpGEvbDJ1vb/Au8OQWQTw5BmSJR3hvDNg
+      EexazttHUcdgj2Sf6LFKxuJEv6eDIqUpj8e87pcBrTMG3ptWgys4QOSG/87Cs5AQCBMDrNjX19H4
+      1cEnUqiTlkftyYp+4VlxF7dQZvevxRTuZu6r8jf2AWnft0JE383hXSvxoxXDsJZ3/kOwaOKuZfl3
+      3aVJj4dxa34k3NRaotTSwFIBUpv8o4e2NquJavXPyILPKS9EW7Ud1UDouGKHpBREH+cmAny7KHgU
+      oLbfUTM+A4t3t+i+BcGT2T0bzwjC7pPaWQPpAdgyKyPXOazvcb6gRBzqKsAIyzLrzL6yEOSPYpbK
+      46erw5JFtItEAC3EPJCnBx2dgX5p246OyUOnyk4vAr5fCrtYauKXPZDWsO4+FvRfoYbLkDwVmpQv
+      j0YHdD/eWvf85Vg/NYCJQ27u1zN6tscfSjDVHZDyXV1J5N7414cZaCC3JO/SxKWaObjjyYDaS7mm
+      XdChRycPMkZ9sfB4jv3lOuZqn7YqJh9+s9yTEcD330kUEfTkSB0D0rK7A9QWuI6nf5vOxfpRKb1x
+      K1ReocsC
+    filename: attachment; filename=1-colorless_empiricism-msg.gpg
+    sha256sum: sha256:4b68ddeb6d45adb7cf8e3c3fdc7fae798ab3a69ee39405a6f3c2c488078d85b7
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token IjZwemZBai1NVzA3MDNTdTZnU2RhNEg4RmFCSGJyYl9oUEZ0TUpOVlhOUlki.ZyBQzA.Qy-WxRYQ-kareM2KY2wXGWztTq4
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797/submissions/6a34daea-5fb5-4c8b-a63a-8d7a728bc504/download
+  response: !!python/object:securedrop_client.sdk.StreamedResponse
+    contents: !!binary |
+      wcFMA8PnxMCiIBsqARAAkop/u1+TZ5SeCjs+JObeZt3JwixKZUHu6T6xWsLG0VQTCwQG15atM14W
+      uKSuY4dTbNSdONxQ3KEvY3N44YVQ2GE7uFBX6FtzD2lmfezNiNkMyMjUqvtvD18E+Dw/VStbcyfC
+      evHLHIQGtFRxvoZm7bU7gteSQSmJVDmKSaA6JjbLZKDs2V+XbtI6wRZB7oDJCQ6WeDaRsE5sXOpU
+      rbux888XWHZBpRnUWh5fYtjSiOe9zVp1kaKhcKJCotoXziEuX/7jVWd4NwjvU0qBnkVvJanyK/XO
+      GIQ6YQFiXS6MUcr8hCaoBsZKrGqAe2cF59oN6Le88E/dRYM/ed+nxdCSJnfnHkg6D0/v1bYBJm45
+      0ohZAa8l+f1mjebEnyFDgOIcFUFnEh1sVJkiVNocmfd8fgmoeMV0TLWpxoc5Bv8F45/07CYx0Cvf
+      RmmlSaYXiGnDlammt0XD/1CpKd5mMEx0xJbEBdrHZb7IZ8/u/j8TbxAKpYEbHJA5OF9oLGJQNbGS
+      8wJN9cXH4hS+5fh0FCsHNsXOEfh8A/zwweGGELe1KuZY+z0vdpvblt7/5byn6AJZNR8n41wmLYNX
+      x6ofz2um44Q0DFGX0zGVfroL0DYyUB7T4U9mJq/VG5958px44/beI1/302LNgwz6bkWvD0c93vIY
+      sGcLUVXpU9USn2fHIqXStQHllHJNyLhHUtWZTT2KjXnzNvCByS6qwEDznGYCMMIZj6hlKtWdeO6g
+      2YrQi1ZedJz7Ai/wbDYbHuVTwmM3IJD1iLnNlSNZTXLPHy8WQe4IgptCLaH8SakyfD9SVwE9suvr
+      /8CG633j41uBWWcSnRndPpTGxtG/NPxxc/Yfbxet6K0NP9+8eRlEFZQ2ToHWynlFblg1jRnXIpBH
+      W2VgrolvL8JrIr/U7LSBYFU6qmNbvZcFjgc=
+    filename: attachment; filename=2-colorless_empiricism-msg.gpg
+    sha256sum: sha256:836347b9bafcfde59cc25644d6b3e9423f73e648997d59f4a488184cd4fe7929
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token IjZwemZBai1NVzA3MDNTdTZnU2RhNEg4RmFCSGJyYl9oUEZ0TUpOVlhOUlki.ZyBQzA.Qy-WxRYQ-kareM2KY2wXGWztTq4
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/sources/2181a381-51c9-460e-b52e-7905a335b4ee/submissions/b700ee09-34bd-4dd0-bff0-28fa9952e65a/download
+  response: !!python/object:securedrop_client.sdk.StreamedResponse
+    contents: !!binary |
+      wcFMA8PnxMCiIBsqARAAjRBFAGqAMA+ug8qrXcgFutoWglHqk7YySx/XHu0ooSJbPmLilsLBbqCD
+      Z4a3mtDXz1CO+RyREEzCP9F7sGOGvYQd7qzXQf1BQYCqCDzGt3ohOLSk7ISp/akEJf4mYGZWISXa
+      9+wXHYWzKgoKzHbWe4SRJwduQOcTCp/S1lwkugNFPQiUUhublq4aQfi9tboLcBJ2whKlYOwttZLp
+      +EnGn57tWRYpfH1FeBVyvGcxAWTy6XMUKti6x/fZ1LbryAGECFGUmvbAHBQ/JVBCnyxAzjX26oHJ
+      La7jR045c+bZIdRv+FLZT00znbk5B+BY0CPjsFEFHfQhhKQrHHw8nR1dgPh+RTbghX1V+rl3krAZ
+      AfSFrxFddVDsERSoMm+AND6dDcaJLqnYX7FLVnaMiYGmZK2RbXVYI03NUI3B2YpyQ7Oyvkz6IM1k
+      9XOk3+vTDyhgVkJL/dpVrp/s9IezcZgKmV6pyiKFVXGOkKZwiM0imPAqavxQhvO+svOOPhcPjxhg
+      V06WeHOAWUi0MTU8UUGgBn/Al6dxj4FUDOSEvSApNwn01Sy4djoj1pfvbC148vUHwGSiOQ0IPBrO
+      UOWRCbkIwqLrqPEU+RbcGZfju0u4exOsdc/3YkjCtjK+vjUlNORqfX7cw/7b48Uq6I9e0xh+x6Zl
+      nwGVZFI1lDN+Y2PICCfSwCwBV5L9LNApLMwXlhZQ/qzaM3iP/LqFgVgmgHRyryEzjASLzAGTdWhF
+      xiGiWgf4sbhDvTL1uf+CsM+2Cbk28aOxhDy1LzQoRXv2quXejcgqxuatSzVq+2ceHP3XkgUaIXOi
+      oIXFVKJr7ap/xCOZFHdpj3rBO7vbtYznBRs723nCgXHvBWXxzPiOH0GL7BDrV7ES68xG1KmGxp3l
+      eT+CmSf/7gpfEOkSDCz3O81w3shm1qbr0voXFPjrwsqHTMoJupQTQExfdK2KQNRrCpMPyhOoENwQ
+      doLMpUwLfpx5+euN8LaliQu4ovsCpyiKAg==
+    filename: attachment; filename=2-countrywide_cabinetmaker-msg.gpg
+    sha256sum: sha256:3f04f97a2e59a45ee09c7ae9fcf617f49868a09e919545046d94f8f99fd01612
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token IjZwemZBai1NVzA3MDNTdTZnU2RhNEg4RmFCSGJyYl9oUEZ0TUpOVlhOUlki.ZyBQzA.Qy-WxRYQ-kareM2KY2wXGWztTq4
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8/replies/a72beea0-977f-450b-a857-80aa7f9a2c6a/download
+  response: !!python/object:securedrop_client.sdk.StreamedResponse
+    contents: !!binary |
+      wcFMA8jCOdO1r3f5ARAAodX17mm2e1Jbq/KckR6Z1rAzMPOXWItY0CA3/UpE+lj1/gfIQJzKhGFl
+      lYXfYwRJhs+YfLp7HrhunhSw48891+9ue2rM7ibtwKmJ8RGkANzOXfMzccm9qy7EAuOfNK2R6kre
+      9zPcVme9UibEl7KOF8b+FOuGtD8I99bQbon5IxQPIr5K7HLys/uwbgl9vjjt2+pA+uTJa3nofPxw
+      rbQaQu0KkS46OhVesSVpo83odahPPn96Zokb0p9/cHZrU6LXyN3RzLnnqb4swXXguSarN4juqJ44
+      Mv7DWn0qG+P/BDkA35K/RZk0Vb/3wd2+LmBy/Ev5HIP+r0RxTkxTgfO3tVZ8JkfwerK0Qki8UYcD
+      XR3AgIFkr0SXhBVtJ+QNnCOez8G7ITIEf4ZbiNBQnKGWm9vaXreGHY1jI6gt/ZyEGWXcPaLGO9Pn
+      Oej0Z4fhbiKJbEAm79aXvJFaSsvS6I+Cb8hpEyhyx6d8VniX9ytfzNkfyRozZ4FzYZPFGc/SJWq4
+      OBDSct2n19a0zkM/SOgm7bcfuwFIKc2Ry7pb+Tct4K0srTaqTGeptxo9Aoa8TljgK397oDBcCtiw
+      8r0NdgPjE+Wdhd6zHx/KyP35h1dZyM2LkgQGtzakpT5D1uNlBGS6cGmgJ8Ax686oVxsytcq0338b
+      xfV4oShS1Q4WcRWEuH/BwUwDw+fEwKIgGyoBEADaiDujEAPP5uPFpKrZ7Bptn2uxQ7RhvZWFTtLV
+      LyZeNdr7KBWHqzcGpMHgM27Qhxl9Twxo0CICeffLgueLdCHYctav+QkyspbV1jcH1NDW+ZY8EFHg
+      zSR9haDhcJ3iEMJHzY3gE25cunqasZPE5EEQf8ai/Si/N4+BDKIpOIOO9upT6n/iLXheqSJ2zxK9
+      JeoMm6itHhkeu3L8c8W5AU2Nh/L9uGkFfERFkET5RKmddoZd3LBJJvlb50K6njSiI24lZyKePKpy
+      JEB7VpQINAv2DUk+rBWDIopTmkKxwhcmlsZvEd4AzEkRcnvh65Loh0bMIjmRvUVWShw3Ymq1qZ4E
+      kty9E8rv+AorJzv4L36Na6V+h4GdclpFOBhCk2G/w8o4s6zmM5vEFNPjpA3Pr6ndYQJp3CmCc7FD
+      cY22xaF3XLnqTwY76PO051icy+izsLFV6lqtFkqLJcZZze96IvFkPeHtJNKqnx1Gue3LDw6FtXEf
+      SQbTuDJd+EtsCCMyPVodJwfYruYDiBVBsZ/qXDGEMRE39BrJ9/niKEQY/HgraAq635b8Fq7GejnO
+      raNu/iUdM1UsdgL91cIYArdcLUemuxWlDpvatslnK/CryfMJwgZUGk4JP9dQcSgcf+0fdbRBbR5x
+      IczCSL5JjwaBFD/kmHwzIht+je34Wdo5bWHcgdJaAWBeyl1Tk1HnQ2kAiwCakF7c/T/xQfztMnK6
+      7r5Om4OHbc1PxBRXvBUJ2FCHtQm02XW2U8fOSUjOwDwPA/BkORQKknmZMZ6kLt7NYR6OomWPs6xq
+      QAX2fVQ2
+    filename: attachment; filename=5-depressant_surgery-reply.gpg
+    sha256sum: sha256:894190c56bf338b659750ac7fa420c55266367d33f5af560579b9f285203b77f
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token IjZwemZBai1NVzA3MDNTdTZnU2RhNEg4RmFCSGJyYl9oUEZ0TUpOVlhOUlki.ZyBQzA.Qy-WxRYQ-kareM2KY2wXGWztTq4
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/sources/234105f1-b0e2-4164-bb78-e81e731279d8/replies/7f82f306-9245-48b6-baac-782025ebf8f5/download
+  response: !!python/object:securedrop_client.sdk.StreamedResponse
+    contents: !!binary |
+      wcFMA8jCOdO1r3f5AQ/9FuFR4ZOOmIgDsiOl4mOshBYSzcBPxNc83pMgoIO+1jfivMYfSMoSR6Md
+      4HGJ041NpeCnOlS7GXDdqm2ieTkEfA6xORHexSqzAZzkNlW0rSj7Cj9EwPQEzRQ+ooo4MUW7RV9Y
+      kDQggS1hT9L92tgJR7MwMX7bSc+MdIJKfJfSqF9nbwMAC+kd1ZWHxmOVEUrNFAQ/3bBjGnlX41HY
+      yZA3DRWxnRXyRECOgFqeS/t0vlr85Mn8EHN4Y8csEf7GSGqUoJGeXQQ09YDrYBGx44eO2oJnwQKE
+      znHriQHZFu3ahNOnk6PAJAStLgmkT/CU83uBZTJOVu/44qebgiHovJglD8OrBjnqKyNdlJ93Id+Q
+      INYA49NM93r9yINpjDpdTFYXjx8DkKdjDLhrgQijWdqSFkscbf2evzJaYMffpcBOyFvuzzmDGhdm
+      Lc/KJYcRC7a361kOYhIs+HUtowalLbUJWORv6bfPg2Uz0d12ZkZSUVta/Gz5g6zfD4wUgCf97Dpu
+      b0FIivIuk+M3ud3HuTu7j5gW3Di+KJsVSihsTs7Rpm+aqcMDrlAM7Fs+xGS9sw696waCZMbnLoWl
+      yd1c/FKi3dioE2nox48XADPr64Rsw0McMTEqu2/IcsMX9JKRjouhVqhHjifxWNlvw/NDIYlJQvqt
+      gPg9MUJlE4CxfL7RV9nBwUwDw+fEwKIgGyoBD/9SXsfgDK1zXdyQMLQYoU+yBXqtV1fVfn6FLERg
+      UmanzOAH//qSRRbJEgI6fjuQXp/THtlmO/P8Hh9hoUmbtTNFXX2Ajzmfn1jQUXEAUIcpAqzFYpqO
+      A2GpzBYk2ZQSYPoGI/pv5UL3UqOmAaiTbo4Citxix7fvqTK33rgMvAar+2exn3x+BM9++4BMy1HB
+      1Q937O3ruGagxP3kfWTCJPmrAZiMTPu8PrH16NRrWfiVLRNB+BFS4wRk62glSOQo5jPGJyvVn/T2
+      TG7nI7czdOF+fxejeeeWdygxbsO132VI4Nwro53LUfH/TTCI2a2aDXv+wBRCA1ogO2CnJl2jr/F+
+      6CWoLBkNWaHmEvns7vZTarkDx3bw0Wp0sbLPDYa5pbA16UpjwRmhodFuCd2CzaBcqL3VME6XoYbu
+      sxKwqYKi0PGHzneL2V/5MJi9Iz9mz1M7Be6BIu6iQ7b3uLEGmr52o0/F/KYKhAPlmBTpSgB1JOh9
+      k5bvZBNbegxTHrIgSYdGp2pUonAISXT9hyFGumSjU6+qzEIzhH7gRgThmoDRGsuxxoHIRgNQlvtq
+      ReMsaByJ5wv5p2khBbxNIeXUBgBl7ULMaRJ5V3SEZTfXghaWeZ012leBY1guMafCMnGalVYh4aI+
+      1yPImIp12iFu123sNwTcp8RwGUL3ZFgfk9FlVtKyAV90lIFjztJClkUMSSYrthfzy+ePqfMaCirr
+      IZa0bRI7auXaArJgCZT8HksU+uSPqaLuC4Vk8dBZB98Dj+E34GDDZjQceixRZQFd9erbDqipearr
+      be2ffIhG6L6UUA1LPkFDDqdan7HfYcZSiNGiz5Up1B2aDkrT2NVTF3bGocipg8MUWUAIq6Kz2nXN
+      FwfYXP5X/f/PzYhac5o9LlNKHz+a8m3np1yUrJJYK3qYfnA9Gw==
+    filename: attachment; filename=6-depressant_surgery-reply.gpg
+    sha256sum: sha256:a6f84814ad43edf596c48d13c10e6945cdaba318e0212b23902a59454bb6e5c6
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token IjZwemZBai1NVzA3MDNTdTZnU2RhNEg4RmFCSGJyYl9oUEZ0TUpOVlhOUlki.ZyBQzA.Qy-WxRYQ-kareM2KY2wXGWztTq4
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1/replies/653d00b0-19af-4731-835b-6bb35029791d/download
+  response: !!python/object:securedrop_client.sdk.StreamedResponse
+    contents: !!binary |
+      wcFMA4bmF88QoBOQARAAk291eeew8q1c09hDx6Jst08ibWahAN7dxRLF2pSrAdopZzgN+a1UZQRw
+      RCrStftbA+4imAj55siiLw5J5NuTYXLR9yiY+bq/L6Yxzdj+aciXp5a69YlKT/IeTr+RBNj0nwbd
+      emFokSyayHmqgVE1ldXv4AC6J8bUMDHzqh4pJR4jBSWkm4EYjY3w76qbvH6SKKXKQYgmIrhJ02M6
+      zp7jADyXF5vQLhLZYz7qED2HZBFqo5Z7UbaBw1Zg+Sy9wIySivWDcwsYjL1psTzUkwH3K9apz43K
+      GQeLz3/XMsfZ8LMbsJJWvXPcRQ396aNcnOZf/9SYfzueD1UCt/EfiWmCtmqoWvzWvF7HC8nvoRWv
+      70olxVhTv3TaYewNwnpbyykIHHFzuXbq5hLh3BwEVSfx4ZqHJ07/5QrDa3CJcmpNsO/MX/Vp3tCw
+      3dCJPCka/Bs9ZQ+6CWhKcXb2N0BRiDG8eSGtCx/x7k6RHSX0guEKv4L1ojYR3OiLYST9e9JwCHiG
+      WhIbHpwi2o9hhesaYwDXfU2+FAVW4lmVHhXUX7/asFxfakZe7gBr2Uj28q/6z3m3s2GHlB4A5UpI
+      pRKjx6IgI+Wi80ZyjoMZE5SmiMs3p1hQHpYvY/Mqlayt9z9h0vO0LiDplfPyf0f2N/Yxc3LjyS1k
+      62MubnyIBvc2Hke9p1DBwUwDw+fEwKIgGyoBEACic+uLeEbmpUabrnXlvZKKCwYKI+iCvC/iJTTt
+      c9BD/6YZ54N2/1Wwhf+kQVQEwYgT+pkty4RvHJGltmowCveXjagOzq/GO1PxYf3OQbvv/cLkyhzF
+      UTxPbZkI8Gp1jit4siMWiUaRbsJ23mdih3lPnFwKNV+gbKn4PIC1rPe+m6EHdzpIfLqcDvZOAQGl
+      aNROes51srOogl/4qJWycqwz787Qi7jwA7TJ4GoZXuFvFI8cnlPAuPdZyxzMVTgQR00vRyiGaIGO
+      eswTPNBktL75QzhnSle0VCR1oFWO1Nqzfg5c5a68qb6t4wGyRR+1N84OXwoLOqJJxQqPBzVd8dvJ
+      r8JRJtZcClsGe4vo6daTkOw47YKGhB4TTdw47YGIBzMRS04XR98X4Ozx6JlrRYOMl08zEemaizvu
+      +PwpP+gxXZ3pAh2qa0mdDoCGBpN/oHfNNSopAg+GA1o9KHojudOrrJiFbk+fzpmua6N/jz87GDxZ
+      0I3PdNfXKpsk63AjS+iz5OjHgWI31LkLbgGAnzbFbxk6YnmSk0S3vZj2+Hazj67EOYYX1JH3u+6G
+      qyY7TTmN8/eJCjbnQDiW7DVxsLc5ealKJ895hEJ7F4+6xDdqzzV8/b8a4aaAgzrIHxJ+BFvTHzhB
+      Ql4AkHrXm23LHKz04EynFehqRrm2sqJFgh+lhtLBkgGYlmr/aLiNU+RzwdSpg9geYUBUDwoeir8J
+      0l8S/7tFiyk49Q7BZH8+S4zSV88DtxAATI86vMQgUOHU1mrbXcVnSpc+BUM8q46NS9qe0LD8q3it
+      2FIK/qgfLWlCooUKG7PTS7DngjGnSRMaNF+skwYe+FGmY1o+Ax229ENqKRpl6LP8u2o6DaHsfVkY
+      dPsshDgFQiBSXSZVrAcoVz1PhqO86TFjCZQM8OkMpRZJzgahwDXS7KcpnKF8vjahBBgzoxSgS8hT
+      gILC7mppA7jm2ox8hLvyrx/xCTbCUiNJMXRPzCfKCZxU32KpjFqsLkMd2gmxAzGc7uoph9dshyxs
+      e1U4uMgmIXSd4ULTTdwPG6pr6lzJrCeujnvQPHrNWA0vPDOvEBu61HTrsaRqfsn+dDwF2x/953xS
+      SJt65zLwjQSFO1TkMFVHa6ZenWfcdaG3tSI8zZj1VcTp0TjVjwcC3xYQuQsP7ZH+YPFEfaKegwvR
+      +rtTt03iciKI8AL53HBFX750fa/CFHp7RFNml3o7Y/OzvaIcu77rRR0eQQvksibyUNpdpQcPxKMG
+      Zm56hN4fCICZzJtlu6VOfdQCCURfVoSXBWDv/QgCtNExN0K2WI/ehCK05iw69uzgT3G2OHrsl1m8
+      LkrijPS13cm5loeCJ2eOT0N7+F6n/Y+yoYNwAbGwIOqM3PNPGUW7Psrxl+y8VvZXiMEEhHO093eK
+      wocuBdWdvgNBjao8SSDz7PN/h2JgcY+fE7E7iMPwGGXxQPgWN2Mz01ePIoffdFfkBBgRXo1Unw==
+    filename: attachment; filename=5-deluxe_saccharin-reply.gpg
+    sha256sum: sha256:bd141ca99b5e92c02f0424e0c333ff14bac363458685d56bf388b6bf601fefe4
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token IjZwemZBai1NVzA3MDNTdTZnU2RhNEg4RmFCSGJyYl9oUEZ0TUpOVlhOUlki.ZyBQzA.Qy-WxRYQ-kareM2KY2wXGWztTq4
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/sources/d72d84c7-fc29-44da-a5fa-8bb966359ee1/replies/438bfb33-cf67-47d4-a215-7adf2fd45a8f/download
+  response: !!python/object:securedrop_client.sdk.StreamedResponse
+    contents: !!binary |
+      wcFMA4bmF88QoBOQAQ//dO9nR4NOU0Mh5hpy1OBE1jEKuNIul+85T+GUx4uhEIqHVK2MbVPTIJx/
+      3QZ2gs3/QHYeyBapLM7dVP3x8yXpLeavl9epfUvoqjnSU+j+/MLg0+hMDkvO8Ogs+83H1lfKus7x
+      TCXxUuFhQA12BauFJ/A42sCR06J1O4gzSpiMhNHk3aeTdKKYnr8M8TpnLoBSCu4TLCsl3IjBTtbm
+      7hL4ogxVXa6qZIGfDJRoCUvup7pCKzoUAJJVgab1O3SCj0hfLCpgFNAPKbBCadE1XPwDGfBK6Pua
+      IbGr7uWz/V0quat1d7Y1Kcufv2rDFK/3mBnHBYTaJezJoFYw/eraoazb+nvR7+Ingn96RwVrjW+J
+      lFR0zVInkFuDbOxe+PfwyejJ1YYaCYiT7bxkAxZASz7QDM+fsgXJm4IP6st0Yl+RMxylEJ0RiuOI
+      lWGSQBZyk/FSWZPmNigWz6ek92L3I45WnjFlwy3deMPwATrH2XhZ7GVuGyeoAOm6zPYKtEEz3IVV
+      Ho2kuN27Ry/Np40SInGDnrK1jxHG6bP+p9ZdJ1JHKCQrwb/bNYyFOywEeTOLLnxrGvte5xDaPW32
+      4eNbWhKyJy0tq+mlkHzlmDKwWjmjyh0ui2NYaz5BLcYRN14Z8Ce9SIl3VmsaadjQwVW0T9j8s9sn
+      IWi0xInT1F/1e3oLv9rBwUwDw+fEwKIgGyoBD/9bSN3XvdY3MtJeKnYEg02nQblMKZU0DRTXWuNS
+      P4WAfzimrsom5xNE58tT26Oh6a0jcij9ong1/kJXcvNuOMVJRvRnpwAljJ61ywV+fo8I65aU0sPU
+      HwLWZeecgmyTTdQ03t4nNnID+EwQQcEFjiYokfcpwDLYncHYT1lUY9hmm3Aw8SR4wBARqVyCHXF1
+      SR3o2lMtj6+dH1O5rhiOxQ1zVIiCGp6qyLpJRdUm056fZi1ep6AztBmRyNcWGh8YZGOQv5xjfWW5
+      N/IRKJfvOs14RzhLilv0wLcReErMGQIwHDKoQf+4C1txCGgjRZNsSYiSz0aQtHQVB0zREqa7KK/1
+      bqQr13lnD7P3loAoeNZI/Zeju2y7zvLBjUkfDYJpbKtDMVNKUzZ/habYRTx4b28X2ireQFdux16+
+      0YEzVkvVy86sLs8AEYY/xN8RZgOLvmxDGiJtJHtZuDHLmiHBtiKZd3n1DjY0NqmJvyYmhuK03bfS
+      v5I1o1hQnhDJoFD9cxfy+XAh2HNvTfW2YeDtpgbTosRcgcFR6dvpT90uMExVZWOmrjPD1YTjrgVO
+      mV/y+CnQuvFfsJlMU4U+wqJP+EXcfST9th/xh2U5S5rOP3ieJ6WT/W+SCjeTGNpv2BE38mEt8JVf
+      lhx3x84w8uKxbAG7QvVS+qO5tjIfK2M+7otkCNKeAXvP31DT2Ffn7e+NXGRXm3EvgxhHCf4elQl1
+      bJ4ktW2giE0h2Jqrp4OM8nqyWljNfXp5kL8oXjuitgt3MCh2h7Ie5kshVLxNCsOZs+rs0t3ntNjE
+      LAyjbUd7xDZ/z66dkx87RA6mBREisVLxU+MI38T0QQ/UwzzRxbuLyR3dHGwVREoiilJ+v7WiAnVl
+      ngNOXxRCtbvOX3zBmcsKSvo=
+    filename: attachment; filename=6-deluxe_saccharin-reply.gpg
+    sha256sum: sha256:69d30a8ce10eb520fe449b7670e9621fd296181c63e745dff2fe048ff252ee4e
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token IjZwemZBai1NVzA3MDNTdTZnU2RhNEg4RmFCSGJyYl9oUEZ0TUpOVlhOUlki.ZyBQzA.Qy-WxRYQ-kareM2KY2wXGWztTq4
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797/replies/f67c91e4-e0d5-4fb7-b36f-fcc1447a91ff/download
+  response: !!python/object:securedrop_client.sdk.StreamedResponse
+    contents: !!binary |
+      wcFMAyydEJhus0f/AQ//YdfQ+8F+N+p1SmcVCLT7fT3TLdvxK0j4G0GbU1uSmbAtxtLDuiNC/Nlu
+      GQiDxnQuQvTUkdZ1yJN2r0w18/tb1UFHF4Mnxt0Dmor6H3l53P/kAnQv3vql4J/AK2eAn7J84nsd
+      RmKSoiO1zbqrFBVbu36yIFymDjH3vjGg+bua60ZcxCl9cW3E/Gyd83agMgJRQOe0v03ytGcD7F75
+      SHuUoGMHAQvENvvMAmoMtLCI8rBXo11lNgrj78Pg/LKFQmwTjijFiP/OmsIXImZjBJ3KvSqRQ0Sn
+      MD9YWdMLNiXyZ/nT5u+MwPhCe6u/J6D46njUs4WqqCyqiw9j05N6g1fV7eBjYM9gaBe4gjoHJtak
+      53jalg52d+omlJzpl0b0j7Et4T7LCsyT8mJhcRgBuZEvfLFVIcemJcKgDuUhy/g/m20TScGEWzDI
+      AflyhWhsVIE3yYuFDuRGxw+mRSeNW1gAqeTTjDIxn7F8N05b8ig/RzQ/Tw6/QgZ9Go/JVHA9Y5GU
+      aFjCs8z5ew8+KHh2tdMGwqRuahXPMGXSVSksFX7VSlJLo+/hJ7nGHPCOrGGjU/pC1xoImKinUcwC
+      3N+yTLOoEfROXqJQNy0DoYwWWr/T7NCm10OJEbUbuoW68zXuQQGO19Fnbe+DSV5ywUP0qICGE6OM
+      bjMuwHwaXX+iqWZwt37BwUwDw+fEwKIgGyoBD/9S4Z0wH6UhWDCAnSL2ZkMKnpZKjgx2gSTVLJlu
+      uYpNk/wi6kACO+rhEW09+kWWmdmziLu6Rn3wO9i1Cm4jH2LPq77RYNmnrW3aoeTZClKlWg9Nn26Z
+      vuv/PJCaNBkBqZStvzonA4QlBEQ0HK5uZn1QZNkjMbmU2XO3BZed9CVSeSAZ2Sr5D9hZb1/kaLqR
+      auvV7FP2NqPKjXaFQkuvM/5kYGSH9kK/mXB8f+laOWcEMHLrITJ2ZrIlUk5kncLDcjyoLxKEjyAT
+      Z0rMVtg+pkO/b1ryovW4dbfcsvesf68USRhoQctagNL00puBrX7En0ZYEIUXA8UDRGMogW+F7I0O
+      TFNA9q8kURbaIMy7FErfaKuibnyY7bi7F5dZXMlmmWafGCGz3lkMwJ2sT1O//WtZfgtcEJMKVlix
+      a1d1ub5kqI/FqseLXEvJyxQU1TgAWCmSAQYZcAg2cdMzY9fB7DlJgqDlmllw63qUH0OpxQZQqJkv
+      3Hdhw5IsnrP3p4nhggiSKr4dPlwGineqRCfYEVb8q64YBWOxDv+y4DQoL+7IAgP+UAtafRKVh0Jg
+      Ye1TzkJESR8uQel+RsZRveJ/t/yyLqMKmFyd7hArXpoyljbOc2ihCLIcOkiSe3QLgAoLKCfW7LAJ
+      nOTqSJWCPrR2BD/HpV+c8VJTHQt0Qn0yoeCF5NLAUgHEAedGUXheoAnC4Lfc5bnxPa9NEVJA9D8i
+      KHltFFSrQSIdf0lc079Ji/wYbY7MhcsFeAOPHvU7QKRCNMjziYLhG4FQieJJdA8F2uM8P8RQdT8Q
+      Gda8tdE69VHcWxonoJazjeTz2Z+6JQumWATcBVY3rtBcvMvRe2ucMfKlhjspVy6PMeq5LTyx5bo2
+      oOE7YyKstc3MOWa2ybr3Y6Pn2R0RZ5eX87pas+XHixafc4+/ZWd0VjMjseGFKG9YyK+7U7ozYXNe
+      heMs6pZ5SV8WwQWjfDdOIObPBpewBbZUsqkBAsVAAWnC48+o3JU2XYVzbFJpTvFlyCgaYmtA1Bc1
+      Yn9RTTIpjTUcAikNZMK3zKldQUk=
+    filename: attachment; filename=5-colorless_empiricism-reply.gpg
+    sha256sum: sha256:1d2cbcc318dc8539b6ff48d3bddded7dcf022ce9de64388c1e7a216f2b7a6bf4
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token IjZwemZBai1NVzA3MDNTdTZnU2RhNEg4RmFCSGJyYl9oUEZ0TUpOVlhOUlki.ZyBQzA.Qy-WxRYQ-kareM2KY2wXGWztTq4
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/sources/037a1924-f61e-4f43-9bd2-887e407f4797/replies/cb9e979b-bd0f-41fe-b6c2-c8c6f5631e6d/download
+  response: !!python/object:securedrop_client.sdk.StreamedResponse
+    contents: !!binary |
+      wcFMAyydEJhus0f/AQ/9HWF+rBZTS83WXtM8piYHPXDqlWsMekE+tFAE3FPpm4ZjbMyvw4Gb+5S0
+      tPqyhT0S/jcUtInZjYQtqiMSPLhR3WBmaP58mV02WOJi3rKehHe8TdCmTqMYyjYuwr1CECbVo/qM
+      Z0FuWh8HobeBCUPZ04sgsa+PaNOtmHBCrqzFwjejTNfgMIqVkymASG4LXZhPgLU4EKGJo51XkSl3
+      aSREQG0ZhkvgadjWa6/HncDly+NI1KHA/VyQaMO1gju3BBJ6y2lIz8F6L9+3wJ56XN98vYMS2nka
+      4nKWEOb2EvRWWSx1HY50569nwMmgForHmFnZWwOlk5JSR56+igwvRZqgiRIvPZKUybhxmPATHrky
+      4aphmNgKcOZrp2CbMUr/y3C1X3HLty9C3SCfY7Vl2KpTf8HeFjxxTAD/t3+VA0V6eN6w0eznuwHf
+      56G7jKQEaz8GQBaen9TmymHW3D897q7K6pwzoMy9IoH+mbcHPUdtiYBsoMy5CP9uzWhYebQ1c+sV
+      4W7kILFm9fIDtkLQGImW4diI9KAsWY026A2yFBaxXi8mvk3yk4aCqzKosvmt/Hh5J5OdA3WmciYd
+      c7ohnaB6N7N0OaIc8IldxpToyiBv0+HTzO4qQBQh5rN4Gr0obo4x5bo2lMjFGVi3QLM6Xj1RTqHG
+      lfyqht5vCvrXTtOhBMLBwUwDw+fEwKIgGyoBD/4xXQ60ikK+fp4fntcgqCw6B/eJmoVoiLRkgy+S
+      IQA00ucONk+VNhi8gz5c3kUMA9XxYhlTIR4NaLbfRRx96luY1L1E0enTUhVPD5JaiKqcuH461khw
+      7rU3e6qjibcu0iO8NvoqTIbI9jBzoofQEuFKRUxoNBd2G31XPXKuu/wg32JYZP+DtpBgMB2rt4A0
+      +Cj2mRB0ghS4Dn07InlkscHweMoDQgHn4tPzkp5OwHyU7nM+AFNlOY8lAiYvgVkdZ4Zirx2J0uf6
+      eZ7B4Sru/gN6jGwfvFbiDHWd6x79X2g7g2Y6hcn1aF70WHivnMz6fjGHO3IVvKh7iCbuVH2RJfYv
+      A+HVWLWO2Xl3cmgSi+MYyt+VbnUTnipIILZIsV9cGXj5fAu7N0aH1fqUZUTZv3h908/VA0VWJa+M
+      fSDe2PLsexFeSQbo4HIFREIgOKMWv6C1TGDtBSDeEQPhYnabWXq/haI1guDEmV5aFJtlfDfuzHIK
+      ZOBW5K86iIscxSNfUL3coESaTwh+ZaaTXLsRbGgWE/34maESzDRdWM1Q0XG3aQ2ynBqkOHXcXqKB
+      5jzdhsIeRBlzEFaeGPVAmI9MkOfG196OANBzdbhcLiFarE+sypdE7as7x8V7f4lGNeSxA71CVnGh
+      xsyfzg6p6RTN8dxWAwvW8D9Xae4AfGuPJ7u+W9K1AadPgLvNXWzWej/75yKaXK6FOblKcdJ21ma9
+      qDrfOsMaO5MtrKMBTw0/y3eVvh3wiY4qOzsD6NsCrYRg/r3FYnO6IeNwBYJm/7yPBC/RlFY+epGE
+      CHRFJ4qS/UljKaHB3fKjzvwpkoGf0PXvFJAtdB3U7mUZqCO908ZT0u3FrfBav0RC4ZD6bvdHE030
+      8VwrSvSIEe6FSabPSegl9QCLxjEKSBRShye6Mrse4k3PQEbl6IS2Ew==
+    filename: attachment; filename=6-colorless_empiricism-reply.gpg
+    sha256sum: sha256:ddcde377aabf009d20d68693797c7de1efe8c832badf19305e11387804f69771
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token IjZwemZBai1NVzA3MDNTdTZnU2RhNEg4RmFCSGJyYl9oUEZ0TUpOVlhOUlki.ZyBQzA.Qy-WxRYQ-kareM2KY2wXGWztTq4
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/sources/2181a381-51c9-460e-b52e-7905a335b4ee/replies/e329bf3b-e25f-4ec3-85a7-6d5b88464b19/download
+  response: !!python/object:securedrop_client.sdk.StreamedResponse
+    contents: !!binary |
+      wcFMA16VuDTG6QEUAQ/+I5YFbw5ZCdp2dYBfv8RiYLp9fQQIiRcvRj0EMBs3VXmGW+McrjOZ07/N
+      QcSStINC0wXCLkTYlobUcoiU3/nAbWQh1YdVXJrBgJLvUc4SMuS5uaU5bF4yTbLKT7JoNti3X2zO
+      31Kmia4vSUzx+Bu53ZYGuOr7cti/kENADagRsc6tPFcQRX16V4AZNolRvW3Ep40qYSdLzcUELyxD
+      tFy4tsprKMoa9R/ejUnda8++Q5g4Fn68iYsJhZKimseE3dUlZS7gLKf/6RzrySw6LTpYE3L3Xif2
+      xD6ZhNiEQUtBOvpMT/PsjcK0xVfJqbgLVyxnmui0wRPjSm6pN2ijNcgHJdRxlAoGpaS+R3MCzuBr
+      OKP0U8VVCqI0WhjE7wE7+aSyyxJ2jD4cz0mQDuvoy/dr1AhuuFXS4PpN6qNtHZKU7KCMXMwGtCi9
+      640xW4vUU3yi2XFZ2hYjU73RFOYtSi+qE8qOTjRLS7AXrxZmNjZ9aswfVAPey8WRfHk9uOG3tziY
+      SjdjGqrbFA7RM3wZBBg2dRPh1yh/JvsuM5jHZxgLRPySH1hRHWIw2YQ93yn6iHoPQBXL2Vp+1DNr
+      VhwAcUg7IEc1s6ak0tquyzq+w3zHPO/s0EK47e9qIap4pTSaCv7XAhZ32kfLalPveIu5jyBr1ArX
+      P/OUGLUw14z0FSxeOnvBwUwDw+fEwKIgGyoBD/wO8BvWWSy5znv3z5ewz6DGsBaXfBbzgAx+28/w
+      fmNa5cGwReRk7OX81N2w61JvhVKiRsUydWNEP2QR8MZ5wetBzOwTi7TohmEXYweRYDCH+c57UbES
+      66RtRgma//PERyy0+96suiVo9lEYxZnrlTrN+G22FEJfsc2F3Ox5xyh27/+jU55+wGOYjfwazZ89
+      QcgqfdSJaL0EukcdWHNdq6L/Sgzl6lGDHEhj+0t0QcA+2diOnMKvIlvIV2Nxc0Ft+dcaxmKLbIIW
+      idttpbVjnnhndrAA4rN6fOivO1ezIMChYwFPBccbb/HWE/fVvaFKAJRTZ9Xvjl1J0m+bq4I5zCnJ
+      N5/GHs9z+Q9hg52cSxs5AFmt+3dDsgpMnw1nq7cY9+w0Fjqmnwk+/I8nGexVcNPK+FOIuRxof5Mr
+      UX1oy5iRIFikneAE6iMIUc8o4WAvWL3qfV7Ubb0WZxiUYDpJFQhRfBukFYJzEFBR+ppQ8z/eqJpA
+      mtw41eoslr1Lzr6ckyI8k+yTxh62qbIuHyE6oAkAGK0Y+JQVAHfnqJSxsNyFfi56xtci30q7majo
+      qo5jciDoZPcmvr+4iWotjWXYB2oCOThIYCseUc0FfROUTmRqvT/0ymbuXIF8gMDuwIgk0RLd7B7y
+      wvPbTfW6A7LxVsQCpyv+N+tXuJSgwofBLxVYtdLALAG8ovfIL7v3AV9gVdDX2xJ2P/DXuUVqSOAX
+      VQLGbJdD7F6JeuQEwZ3C0iN/4Z2q1Lscy9mg5gSmiUowoqLcOXgnWd+rgVmRfEN6mNKNjxJDA7ex
+      zNFPAhGb+vCGcdGWVSJbDJiegnmtBNyMYwCCpPbTOirkBs6rjmn5j/10WLur4PPxgrw5nsz++bg/
+      neNTWFycDsPhY3/YZAAQrYQS4fDhPy506eNl7criuNdBTF4mCRLaSg3Kym4fTnw1mLdNfLYNNUzY
+      Ommr/WiQRA7TT0X2hsAc/X1HBOpbID+D9EGWZPPExxGpvVjPRITq
+    filename: attachment; filename=6-countrywide_cabinetmaker-reply.gpg
+    sha256sum: sha256:0eaa396278a17a7a36fc30f5a8f628af610ed66088c1b86d7474d584998776ce
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Token IjZwemZBai1NVzA3MDNTdTZnU2RhNEg4RmFCSGJyYl9oUEZ0TUpOVlhOUlki.ZyBQzA.Qy-WxRYQ-kareM2KY2wXGWztTq4
+      Content-Type:
+      - application/json
+    method: GET
+    uri: api/v1/users
+  response: !!python/object/apply:securedrop_client.sdk.sdlocalobjects.BaseError
+    args:
+    - 'Internal proxy error: error sending request for url (http://localhost:8081/api/v1/users):
+      client error (Connect)'
+    state:
+      msg: 'Internal proxy error: error sending request for url (http://localhost:8081/api/v1/users):
+        client error (Connect)'
+version: 1


### PR DESCRIPTION
## Status

Ready for review

## Description

Closes #2297 by blocking the `DeleteSourceDialog`'s "continue" button for 5 seconds, with a countdown timer.

## Test Plan

This can be tested easily with `make dev` with:

```patch
--- a/client/securedrop_client/gui/source/delete/dialog.py
+++ b/client/securedrop_client/gui/source/delete/dialog.py
@@ -27,7 +27,7 @@ from securedrop_client.gui.base import ModalDialog
 
 # Maximum number of source names to display in delete dialog before
 # (a) truncation of the list and (b) delayed confirmation:
-LOTS_OF_SOURCES = 30
+LOTS_OF_SOURCES = 2
 
 # Timers for delayed confirmation:
 SEC = 1000  # ms
```

Then:

1. [ ] With 1 or 2 sources selected, the `Yes, delete N source accounts button` is immediately enabled and works as expected.
2. [ ] With all 3 sources selected, the `Yes, delete N source accounts button`:
    1. [ ] is initially disabled;
    2. [ ] counts down from 5 seconds; and then
    3. [ ] becomes enabled and works as expected.