### PR TITLE
Upgrade to cargo-vet 0.10.0

### DIFF
--- a/.github/workflows/cargo-vet.yml
+++ b/.github/workflows/cargo-vet.yml
@@ -18,7 +18,7 @@ jobs:
     # Keep version in sync with rust-toolchain.toml
     container: rust:1.81.0
     env:
-      CARGO_VET_VERSION: 0.9.0
+      CARGO_VET_VERSION: 0.10.0
     steps:
     - uses: actions/checkout@v4
     - uses: actions/cache@v4

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -128,16 +128,16 @@ notes = "Rust Project member"
 
 [[trusted.flate2]]
 criteria = "safe-to-deploy"
-user-id = 4333
-start = "2020-09-30"
-end = "2024-08-12"
+user-id = 980 # Sebastian Thiel (Byron)
+start = "2023-08-15"
+end = "2024-08-29"
 notes = "Rust Project member"
 
 [[trusted.flate2]]
 criteria = "safe-to-deploy"
-user-id = 980 # Sebastian Thiel (Byron)
-start = "2023-08-15"
-end = "2024-08-29"
+user-id = 4333
+start = "2020-09-30"
+end = "2024-08-12"
 notes = "Rust Project member"
 
 [[trusted.futures-channel]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -2,7 +2,7 @@
 # cargo-vet config file
 
 [cargo-vet]
-version = "0.9"
+version = "0.10"
 
 [imports.bytecode-alliance]
 url = "https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1014,7 +1014,7 @@ who = "Henri Sivonen <hsivonen@hsivonen.fi>"
 criteria = "safe-to-deploy"
 user-id = 4484 # Henri Sivonen (hsivonen)
 start = "2019-02-26"
-end = "2024-08-28"
+end = "2025-10-23"
 notes = "I, Henri Sivonen, wrote encoding_rs for Gecko and have reviewed contributions by others. There are two caveats to the certification: 1) The crate does things that are documented to be UB but that do not appear to actually be UB due to integer types differing from the general rule; https://github.com/hsivonen/encoding_rs/issues/79 . 2) It would be prudent to re-review the code that reinterprets buffers of integers as SIMD vectors; see https://github.com/hsivonen/encoding_rs/issues/87 ."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 


### PR DESCRIPTION
## Status

Ready for review 

## Description

It wanted to perform some trivial reordering of the audits file.

Refs <https://github.com/freedomofpress/securedrop-tooling/issues/17>.

## Test Plan

* [x] CI passes
* [x] visual review
