### PR TITLE
Display download progress for file downloads

### DIFF
--- a/client/poetry.lock
+++ b/client/poetry.lock
@@ -2163,4 +2163,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "04ad35e614ab24b0a2a27bfe981567a1af32c18db7561201bbf61adc0ea6ecd4"
+content-hash = "655ea43a59d4e6568dffbd451e3e54e84402fe1f1d856e42c2c98cc7bac2bb88"

--- a/client/securedrop_client/gui/base/__init__.py
+++ b/client/securedrop_client/gui/base/__init__.py
@@ -26,8 +26,10 @@ from securedrop_client.gui.base.misc import (
     SvgPushButton,
     SvgToggleButton,
 )
+from securedrop_client.gui.base.progress import FileDownloadProgressBar
 
 __all__ = [
+    "FileDownloadProgressBar",
     "ModalDialog",
     "PasswordEdit",
     "SDPushButton",

--- a/client/securedrop_client/gui/base/progress.py
+++ b/client/securedrop_client/gui/base/progress.py
@@ -1,0 +1,116 @@
+import math
+import time
+
+from PyQt5.QtCore import QTimer, pyqtBoundSignal, pyqtSignal
+from PyQt5.QtWidgets import QProgressBar
+
+from securedrop_client.utils import humanize_speed
+
+SMOOTHING_FACTOR = 0.3
+
+
+class FileDownloadProgressBar(QProgressBar):
+    """
+    A progress bar for file downloads.
+
+    It receives progress updates from the SDK and updates the total % downloaded,
+    as well as calculating the current speed.
+
+    We use an exponential moving average to smooth out the speed as suggested by
+    https://stackoverflow.com/a/3841706; the reported speed is 30% of the current
+    speed and 70% of the previous speed. It is updated every 100ms.
+    """
+
+    size_signal = pyqtSignal(int)
+    decrypting_signal = pyqtSignal(bool)
+
+    def __init__(self, file_size: int) -> None:
+        super().__init__()
+        self.setObjectName("FileDownloadProgressBar")
+        self.setMaximum(file_size)
+        # n.b. we only update the bar's value and let the text get updated by
+        # the timer in update_speed
+        self.size_signal.connect(self.setValue)
+        self.decrypting_signal.connect(self.handle_decrypting)
+        self.timer = QTimer(self)
+        self.timer.setInterval(100)
+        self.timer.timeout.connect(self.update_speed)
+        self.timer.start()
+        # The most recently calculated speed
+        self.speed = 0.0
+        # The last time we updated the speed
+        self.last_total_time = 0.0
+        # The number of bytes downloaded the last time we updated the speed
+        self.last_total_bytes = 0
+
+    def handle_decrypting(self, decrypting: bool) -> None:
+        if decrypting:
+            # Stop the speed timer and then switch to an indeterminate progress bar
+            self.timer.stop()
+            self.setMaximum(0)
+            self.setValue(0)
+
+    def update_display(self) -> None:
+        """Update the text displayed in the progress bar."""
+        # Use math.floor so we don't show 100% until we're actually done
+        maximum = self.maximum()
+        if maximum == 0:
+            # Race condition: we've likely switched to the indeterminate progress bar
+            # which has a maximum of 0. Treat it like 100% even though it won't show up
+            # just to avoid the DivisionByZero error.
+            percentage = 100
+        else:
+            # Calculate the raw percentage, round down to the nearest integer, but make sure it's
+            # not a negative number.
+            percentage = max(math.floor((self.value() / maximum) * 100), 0)
+        formatted_speed = humanize_speed(self.speed)
+        # TODO: localize this?
+        if percentage in (0, 100):
+            # If haven't started or have finished, don't display a 0B/s speed
+            self.setFormat(f"{percentage}%")
+        else:
+            self.setFormat(f"{percentage}% | {formatted_speed}")
+
+    def update_speed(self) -> None:
+        """Calculate the new speed and trigger updating the display."""
+        now = time.monotonic()
+        value = self.value()
+
+        # If this is the first update we report the speed as 0
+        if self.last_total_time == 0:
+            self.last_total_time = now
+            self.last_total_bytes = value
+            self.speed = 0
+            return
+
+        time_diff = now - self.last_total_time
+        bytes_diff = value - self.last_total_bytes
+        if time_diff > 0:
+            self.speed = (
+                1 - SMOOTHING_FACTOR
+            ) * self.speed + SMOOTHING_FACTOR * bytes_diff / time_diff
+
+        self.last_total_time = now
+        self.last_total_bytes = value
+        self.update_display()
+
+    def proxy(self) -> "ProgressProxy":
+        """Get a proxy that updates this widget."""
+        return ProgressProxy(self.size_signal, self.decrypting_signal)
+
+
+class ProgressProxy:
+    """
+    Relay the current download progress over to the UI; see
+    the FileDownloadProgressBar widget.
+    """
+
+    def __init__(self, size_signal: pyqtBoundSignal, decrypting_signal: pyqtBoundSignal) -> None:
+        self.size_signal = size_signal
+        self.decrypting_signal = decrypting_signal
+
+    def set_value(self, value: int) -> None:
+        self.size_signal.emit(value)
+
+    def set_decrypting(self) -> None:
+        self.decrypting_signal.emit(True)

--- a/client/securedrop_client/utils.py
+++ b/client/securedrop_client/utils.py
@@ -194,6 +194,36 @@ def humanize_filesize(filesize: int) -> str:
         return f"{math.floor(filesize / 1024**2)}MB"
 
 
+def humanize_speed(speed: float, length: int = 2) -> str:
+    """
+    Returns a human readable string of a speed, with an input unit of
+    bytes/second.
+
+    length controls how it should be rounded, e.g. length=3 will
+    give you 100KB/s, 4.02MB/s, 62.3KB/s, etc.
+    """
+
+    def adjust(x: float) -> float:
+        if x < 1:
+            # Less than 1B/s, just round to 0
+            return 0
+        if x >= 10**length:
+            return math.floor(x)
+        # Calculate digits ahead of decimal point
+        digits = math.ceil(math.log10(x))
+        if digits >= length:
+            return round(x)
+        # Otherwise keep a few digits after the decimal
+        return round(x, length - digits)
+
+    if speed < 1024:
+        return f"{adjust(speed)}B/s"
+    elif speed < 1024 * 1024:
+        return f"{adjust(speed / 1024)}KB/s"
+    else:
+        return f"{adjust(speed / 1024**2)}MB/s"
+
+
 @contextmanager
 def chronometer(logger: logging.Logger, description: str) -> Generator:
     """

--- a/client/tests/api_jobs/test_downloads.py
+++ b/client/tests/api_jobs/test_downloads.py
@@ -12,6 +12,7 @@ from securedrop_client.api_jobs.downloads import (
     ReplyDownloadJob,
 )
 from securedrop_client.crypto import CryptoError, GpgHelper
+from securedrop_client.gui.base.progress import ProgressProxy
 from securedrop_client.sdk import BaseError
 from securedrop_client.sdk import Submission as SdkSubmission
 from tests import factory
@@ -351,7 +352,9 @@ def test_FileDownloadJob_happy_path_no_etag(mocker, homedir, session, session_ma
     gpg = GpgHelper(homedir, session_maker, is_qubes=False)
     mock_decrypt = patch_decrypt(mocker, homedir, gpg, file_.filename)
 
-    def fake_download(sdk_obj: SdkSubmission, timeout: int) -> tuple[str, str]:
+    def fake_download(
+        sdk_obj: SdkSubmission, timeout: int, progress: ProgressProxy | None
+    ) -> tuple[str, str]:
         """
         :return: (etag, path_to_dl)
         """
@@ -389,7 +392,9 @@ def test_FileDownloadJob_happy_path_sha256_etag(
     gpg = GpgHelper(homedir, session_maker, is_qubes=False)
     mock_decrypt = patch_decrypt(mocker, homedir, gpg, file_.filename)
 
-    def fake_download(sdk_obj: SdkSubmission, timeout: int) -> tuple[str, str]:
+    def fake_download(
+        sdk_obj: SdkSubmission, timeout: int, progress: ProgressProxy
+    ) -> tuple[str, str]:
         """
         :return: (etag, path_to_dl)
         """
@@ -426,7 +431,9 @@ def test_FileDownloadJob_bad_sha256_etag(
 
     gpg = GpgHelper(homedir, session_maker, is_qubes=False)
 
-    def fake_download(sdk_obj: SdkSubmission, timeout: int) -> tuple[str, str]:
+    def fake_download(
+        sdk_obj: SdkSubmission, timeout: int, progress: ProgressProxy
+    ) -> tuple[str, str]:
         """
         :return: (etag, path_to_dl)
         """
@@ -455,7 +462,9 @@ def test_FileDownloadJob_happy_path_unknown_etag(mocker, homedir, session, sessi
 
     gpg = GpgHelper(homedir, session_maker, is_qubes=False)
 
-    def fake_download(sdk_obj: SdkSubmission, timeout: int) -> tuple[str, str]:
+    def fake_download(
+        sdk_obj: SdkSubmission, timeout: int, progress: ProgressProxy
+    ) -> tuple[str, str]:
         """
         :return: (etag, path_to_dl)
         """
@@ -494,7 +503,9 @@ def test_FileDownloadJob_decryption_error(
     gpg = GpgHelper(homedir, session_maker, is_qubes=False)
     mock_decrypt = mocker.patch.object(gpg, "decrypt_submission_or_reply", side_effect=CryptoError)
 
-    def fake_download(sdk_obj: SdkSubmission, timeout: int) -> tuple[str, str]:
+    def fake_download(
+        sdk_obj: SdkSubmission, timeout: int, progress: ProgressProxy
+    ) -> tuple[str, str]:
         """
         :return: (etag, path_to_dl)
         """
@@ -535,7 +546,9 @@ def test_FileDownloadJob_raises_on_path_traversal_attack(
     api_client = mocker.MagicMock()
     download_fn = mocker.patch.object(api_client, "download_reply")
 
-    def fake_download(sdk_obj: SdkSubmission, timeout: int) -> tuple[str, str]:
+    def fake_download(
+        sdk_obj: SdkSubmission, timeout: int, progress: ProgressProxy
+    ) -> tuple[str, str]:
         """
         :return: (etag, path-to-download)
         """

--- a/client/tests/gui/base/test_progress.py
+++ b/client/tests/gui/base/test_progress.py
@@ -1,0 +1,70 @@
+import pytest
+
+from securedrop_client.gui.base.progress import FileDownloadProgressBar
+
+
+@pytest.fixture
+def mock_monotonic(mocker):
+    """Allow us to manually advance time.monotonic(), which is used for calculating speed"""
+
+    class MockTime:
+        current_time = 1000.0
+
+        @classmethod
+        def mock_monotonic(cls):
+            return cls.current_time
+
+        @classmethod
+        def increment(cls, seconds=1.0):
+            cls.current_time += seconds
+            return cls.current_time
+
+    # Patch time.monotonic with our mock function
+    mocker.patch("time.monotonic", side_effect=MockTime.mock_monotonic)
+    return MockTime
+
+
+def test_progress(mock_monotonic):
+    widget = FileDownloadProgressBar(100_000_000)
+    # Disable the timer as we manually control time
+    widget.timer.stop()
+    # At first the progress bar displays "%p" (current value) plus a literal "%"
+    assert widget.format() == "%p%"
+    # after two timer ticks, it should now take over display formatting
+    widget.update_speed()
+    widget.update_speed()
+    # The progress bar should now display calculated percentage
+    assert widget.format() == "0%"
+    # Add some data and move forward one second
+    widget.proxy().set_value(1_000_000)
+    mock_monotonic.increment()
+    widget.update_speed()
+    assert widget.format() == "1% | 292KB/s"
+
+    # Again
+    widget.proxy().set_value(2_000_000)
+    mock_monotonic.increment()
+    widget.update_speed()
+    assert widget.format() == "2% | 498KB/s"
+
+    # A lot of data at once
+    widget.proxy().set_value(99_000_000)
+    mock_monotonic.increment()
+    widget.update_speed()
+    assert widget.format() == "99% | 28MB/s"
+
+    # 99.99999% does not round to 100%
+    widget.proxy().set_value(99_999_999)
+    mock_monotonic.increment()
+    widget.update_speed()
+    assert widget.format() == "99% | 20MB/s"
+
+    # 100% has no speed
+    widget.proxy().set_value(100_000_000)
+    widget.update_speed()
+    assert widget.format() == "100%"
+
+    # Switch to indetermininate mode as we decrypt
+    widget.proxy().set_decrypting()
+    # maximum() == 0 is what defines indeterminate mode
+    assert widget.maximum() == 0

--- a/client/tests/integration/test_styles_file_download_button.py
+++ b/client/tests/integration/test_styles_file_download_button.py
@@ -25,29 +25,3 @@ def test_styles(mocker, main_window):
     expected_image = load_icon("download_file.svg").pixmap(20, 20).toImage()
     assert download_button.icon().pixmap(20, 20).toImage() == expected_image
     assert download_button.palette().color(QPalette.Foreground).name() == "#2a319d"
-
-
-def test_styles_animated(mocker, main_window):
-    wrapper = main_window.main_view.view_layout.widget(main_window.main_view.CONVERSATION_INDEX)
-    conversation_scrollarea = wrapper.conversation_view._scroll
-    file_widget = conversation_scrollarea.widget().layout().itemAt(0).widget()
-    download_button = file_widget.download_button
-
-    file_widget.start_button_animation()
-
-    expected_image = load_icon("download_file.gif").pixmap(20, 20).toImage()
-    assert download_button.icon().pixmap(20, 20).toImage() == expected_image
-    assert download_button.font().family() == "Source Sans Pro"
-    assert QFont.Bold == download_button.font().weight()
-    assert download_button.font().pixelSize() == 13
-    assert download_button.palette().color(QPalette.Foreground).name() == "#05a6fe"
-
-    file_widget.eventFilter(download_button, QEvent(QEvent.HoverEnter))
-    expected_image = load_icon("download_file.gif").pixmap(20, 20).toImage()
-    assert download_button.icon().pixmap(20, 20).toImage() == expected_image
-    assert download_button.palette().color(QPalette.Foreground).name() == "#05a6fe"
-
-    file_widget.eventFilter(download_button, QEvent(QEvent.HoverLeave))
-    expected_image = load_icon("download_file.gif").pixmap(20, 20).toImage()
-    assert download_button.icon().pixmap(20, 20).toImage() == expected_image
-    assert download_button.palette().color(QPalette.Foreground).name() == "#05a6fe"

--- a/client/tests/sdk/utils.py
+++ b/client/tests/sdk/utils.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import vcr
 from vcr.request import Request
 
+from securedrop_client.gui.base.progress import ProgressProxy
 from securedrop_client.sdk import API, JSONResponse, StreamedResponse
 
 VCR = vcr.VCR(cassette_library_dir="tests/sdk/data/")
@@ -40,6 +41,7 @@ class VCRAPI(API):
         body: str | None = None,
         headers: dict[str, str] | None = None,
         timeout: int | None = None,
+        progress: ProgressProxy | None = None,
     ) -> StreamedResponse | JSONResponse:
         """If the cassette contains a VCR.py `Request` object corresponding to
         this request, play back the response.  If it's an exception, raise it to

--- a/client/tests/test_utils.py
+++ b/client/tests/test_utils.py
@@ -9,6 +9,7 @@ from securedrop_client.utils import (
     check_dir_permissions,
     check_path_traversal,
     humanize_filesize,
+    humanize_speed,
     relative_filepath,
     safe_mkdir,
 )
@@ -30,6 +31,21 @@ def test_humanize_file_size_megabytes():
     expected_humanized_filesize = "123MB"
     actual_humanized_filesize = humanize_filesize(123 * 1024 * 1024)
     assert expected_humanized_filesize == actual_humanized_filesize
+
+
+@pytest.mark.parametrize(
+    ("input", "expected"),
+    [
+        (0, "0B/s"),
+        (0.1, "0B/s"),
+        (1, "1B/s"),
+        (1234, "1.2KB/s"),
+        (678_123, "662KB/s"),
+        (12_345_678, "12MB/s"),
+    ],
+)
+def test_humanize_speed(input, expected):
+    assert expected == humanize_speed(input)
 
 
 def test_safe_mkdir_with_unsafe_path(homedir):


### PR DESCRIPTION
## Status

Ready for review

TODO:
* Visual alignment issue; need padding on the right side

## Description

Display a vanilla progress bar for file downloads that simply shows how much of the file has been downloaded so far.

A new FileDownloadProgressBar widget replaces the existing animated spinner, and we inject a signal through to the SDK to pass the current progress back to the widget.

The widget both displays the overall total progress as a percentage and also calculates the download speed by using an exponential moving average to smooth it out. A timer runs every 100ms to recalculate the speed.
    
A new utils.humanize_speed() is used to translate the raw bytes/second into a human-readable version with a focus on keeping the length of the string roughly consistent so there's less visual shifting.

Once the download has finished, an indeterminate progress bar is shown while decrypting since we don't (currently) have a way to report specific progress on that.

Fixes #1104.

## Test Plan

* [ ] Spin up dev server; then inside the container run `NUM_SOURCES=10 --random-file-size 100000` to generate 10 sources with 100MB attachments
* [ ] Download them, including starting multiple parallel downloads and switching to other sources
* [ ] Progress bar continues to update as expected, etc.

## Checklist

 - [x] These changes should not need testing in Qubes
   - everything should be testable with the dev client, since no proxy changes are needed
 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [ ] No database schema changes are needed
