### PR TITLE
Update macOS support to run on arm64

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -2,8 +2,7 @@
 all: help
 
 # We prefer to use python3.11 if it's available, especially on arm64 based Macs,
-# which would not be able to install the virtual environment without an x86_64
-# Python 3.11, but we're also OK with just python3 if that's all we've got
+# but we're also OK with just python3 if that's all we've got
 PYTHON := $(if $(shell bash -c "command -v python3.11"), python3.11, python3)
 
 SEMGREP_FLAGS := --exclude "tests/" --error --strict --verbose

--- a/client/README.md
+++ b/client/README.md
@@ -188,14 +188,7 @@ socat TCP4-LISTEN:8081,fork,reuseaddr TCP4:A.B.C.D:8081
 
 #### Set up the SecureDrop Client
 1. Open a new terminal window.
-2. Install Homebrew
-  a. If you use an Intel based machine, follow the instructions at https://brew.sh/
-  b. If you use an Apple Silicon based machine (M1 or M2 Macs):
-    1. (Informational) If you already have a native `arm64` version of Homebrew, you will wind up with a separate Homebrew installation for each architecture. While they do not conflict, combining them in your `PATH` permanently may cause confusion about which brews are installed where. You may want to modify your `PATH` temporarily to perform this installation. The environment you create in this session will continue to work in subsequent sessions.
-    2. Run `/usr/sbin/softwareupdate --install-rosetta` to allow you to run `x86_64` binaries
-    3. Enter a shell in `x86_64` mode with `arch -x86_64 bash`
-    4. Install Homebrew via the instructions at https://brew.sh/
-    5. Install the dependencies below in the same `x86_64` shell session
+2. Install [Homebrew](https://brew.sh/)
 3. Install dependencies via Homebrew: `brew install python@3.11 gnupg oath-toolkit`
 4. clone the SecureDrop Client repo and install its dependencies
    ```

--- a/client/poetry.lock
+++ b/client/poetry.lock
@@ -1166,6 +1166,25 @@ PyQt5-Qt5 = ">=5.15.2"
 PyQt5-sip = ">=12.11,<13"
 
 [[package]]
+name = "pyqt5"
+version = "5.15.11"
+description = "Python bindings for the Qt cross platform application toolkit"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "PyQt5-5.15.11-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:c8b03dd9380bb13c804f0bdb0f4956067f281785b5e12303d529f0462f9afdc2"},
+    {file = "PyQt5-5.15.11-cp38-abi3-macosx_11_0_x86_64.whl", hash = "sha256:6cd75628f6e732b1ffcfe709ab833a0716c0445d7aec8046a48d5843352becb6"},
+    {file = "PyQt5-5.15.11-cp38-abi3-manylinux_2_17_x86_64.whl", hash = "sha256:cd672a6738d1ae33ef7d9efa8e6cb0a1525ecf53ec86da80a9e1b6ec38c8d0f1"},
+    {file = "PyQt5-5.15.11-cp38-abi3-win32.whl", hash = "sha256:76be0322ceda5deecd1708a8d628e698089a1cea80d1a49d242a6d579a40babd"},
+    {file = "PyQt5-5.15.11-cp38-abi3-win_amd64.whl", hash = "sha256:bdde598a3bb95022131a5c9ea62e0a96bd6fb28932cc1619fd7ba211531b7517"},
+    {file = "PyQt5-5.15.11.tar.gz", hash = "sha256:fda45743ebb4a27b4b1a51c6d8ef455c4c1b5d610c90d2934c7802b5c1557c52"},
+]
+
+[package.dependencies]
+PyQt5-Qt5 = ">=5.15.2,<5.16.0"
+PyQt5-sip = ">=12.15,<13"
+
+[[package]]
 name = "pyqt5-qt5"
 version = "5.15.2"
 description = "The subset of a Qt installation needed by PyQt5."
@@ -1176,6 +1195,18 @@ files = [
     {file = "PyQt5_Qt5-5.15.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:1988f364ec8caf87a6ee5d5a3a5210d57539988bf8e84714c7d60972692e2f4a"},
     {file = "PyQt5_Qt5-5.15.2-py3-none-win32.whl", hash = "sha256:9cc7a768b1921f4b982ebc00a318ccb38578e44e45316c7a4a850e953e1dd327"},
     {file = "PyQt5_Qt5-5.15.2-py3-none-win_amd64.whl", hash = "sha256:750b78e4dba6bdf1607febedc08738e318ea09e9b10aea9ff0d73073f11f6962"},
+]
+
+[[package]]
+name = "pyqt5-qt5"
+version = "5.15.15"
+description = "The subset of a Qt installation needed by PyQt5."
+optional = false
+python-versions = "*"
+files = [
+    {file = "PyQt5_Qt5-5.15.15-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:eb74072935958a830887115b1de1ff26341fc2d5881b28129de39612b10a260e"},
+    {file = "PyQt5_Qt5-5.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f8b174725fbe29c1a22f8acce5798933a65c8a083f1d9833ff212479ec2b3c14"},
+    {file = "PyQt5_Qt5-5.15.15-py3-none-manylinux2014_x86_64.whl", hash = "sha256:611505d04ffb06a5e5bcf98f5ff0e4e15ba7785565ccbe7bd3b2e40642ea3bdd"},
 ]
 
 [[package]]
@@ -1206,6 +1237,36 @@ files = [
     {file = "PyQt5_sip-12.11.1-cp39-cp39-win32.whl", hash = "sha256:5c152878443c3e951d5db7df53509d444708dc06a121c267b548146be06b87f8"},
     {file = "PyQt5_sip-12.11.1-cp39-cp39-win_amd64.whl", hash = "sha256:bd935cc46dfdbb89c21042c1db2e46a71f25693af57272f146d6d9418e2934f1"},
     {file = "PyQt5_sip-12.11.1.tar.gz", hash = "sha256:97d3fbda0f61edb1be6529ec2d5c7202ae83aee4353e4b264a159f8c9ada4369"},
+]
+
+[[package]]
+name = "pyqt5-sip"
+version = "12.16.1"
+description = "The sip module support for PyQt5"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "PyQt5_sip-12.16.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:72e8be41f053cd2338d373b70cfa8f725f05c7551e014161ae0484c7ffdb5b3d"},
+    {file = "PyQt5_sip-12.16.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:389ea632df16794325652fe1a84d4ea77c7ed0240040979dada725473ad1d875"},
+    {file = "PyQt5_sip-12.16.1-cp310-cp310-win32.whl", hash = "sha256:b3bfe33e849818a32164fc19346fc889a47ba8b23f803508eac9a5d9d06f59d9"},
+    {file = "PyQt5_sip-12.16.1-cp310-cp310-win_amd64.whl", hash = "sha256:7fd6fbff57ba2cda32f1d5ea49500cff6f29e1cafdf41f40b99ed744bdac14a0"},
+    {file = "PyQt5_sip-12.16.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:09bfdb5f9adea15a542cbe4b89873a6b290c4f1669f66bb5f1a24993ce8bbdd0"},
+    {file = "PyQt5_sip-12.16.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:98b99fcdebbbfc999f4ab10829749151eb371b79201ecd98f20e934c16d0193e"},
+    {file = "PyQt5_sip-12.16.1-cp311-cp311-win32.whl", hash = "sha256:67dbdc1b3be045caebfc75ee87966e23c6bee61d94cb634ddd71b634c9089890"},
+    {file = "PyQt5_sip-12.16.1-cp311-cp311-win_amd64.whl", hash = "sha256:8afd633d5f35e4e5205680d310800d10d30fcbfb6bb7b852bfaa31097c1be449"},
+    {file = "PyQt5_sip-12.16.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f6724c590de3d556c730ebda8b8f906b38373934472209e94d99357b52b56f5f"},
+    {file = "PyQt5_sip-12.16.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:633cba509a98bd626def951bb948d4e736635acbd0b7fabd7be55a3a096a8a0b"},
+    {file = "PyQt5_sip-12.16.1-cp312-cp312-win32.whl", hash = "sha256:2b35ff92caa569e540675ffcd79ffbf3e7092cccf7166f89e2a8b388db80aa1c"},
+    {file = "PyQt5_sip-12.16.1-cp312-cp312-win_amd64.whl", hash = "sha256:a0f83f554727f43dfe92afbf3a8c51e83bb8b78c5f160b635d4359fad681cebe"},
+    {file = "PyQt5_sip-12.16.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2349f118dc6f01ee71fe57d8bab9e606ecf241468989abb23b5691d5538d7a69"},
+    {file = "PyQt5_sip-12.16.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:bbabdcc031e40417333bdd9e59d8add815c8f0663ebfcbcd3024bdeb55f35e9c"},
+    {file = "PyQt5_sip-12.16.1-cp313-cp313-win32.whl", hash = "sha256:b6d06f6b49c7cd70db44277e21134390dcabb709da434d63754c9968ff6d98e2"},
+    {file = "PyQt5_sip-12.16.1-cp313-cp313-win_amd64.whl", hash = "sha256:e2bd572cfb969089c2813c85d6e1393ec1a0aeecebc53934ba9f062acf440b50"},
+    {file = "PyQt5_sip-12.16.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:639d0f3767f17c9b7e2c1161a563f1a8da8dc16a348f9fc24314882c0ba57c5e"},
+    {file = "PyQt5_sip-12.16.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:c2b99bbd915f7649536b46be6f4740122c0ff1a76dc3dcb0c856c7cc770b3545"},
+    {file = "PyQt5_sip-12.16.1-cp39-cp39-win32.whl", hash = "sha256:9f6878df5cca870cd48b406c48136842c02f7b0e2a3b7c47cb84dcddcebc5758"},
+    {file = "PyQt5_sip-12.16.1-cp39-cp39-win_amd64.whl", hash = "sha256:ffd748efbc9396a7a72de0d617acfd248c04e02dd28cd80e6bc3bf26214786e7"},
+    {file = "pyqt5_sip-12.16.1.tar.gz", hash = "sha256:8c831f8b619811a32369d72339faa50ae53a963f5fdfa4d71f845c63e9673125"},
 ]
 
 [[package]]
@@ -2102,4 +2163,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "a0b64a53b147871dc01e63542d9f4907bcd4031be125251602f1de3d4d1bc01f"
+content-hash = "04ad35e614ab24b0a2a27bfe981567a1af32c18db7561201bbf61adc0ea6ecd4"

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -18,10 +18,16 @@ python-dateutil = "^2.7.5"
 # In production these two are installed using a system package
 # so match those versions exactly
 PyQt5 = [
-    {version = "=5.15.9", python = ">=3.11"}, # bookworm
+    {version = "=5.15.9", python = ">=3.11", platform = "linux"}, # bookworm
+    {version = "^5.15.11", python = ">=3.11", platform = "darwin"},
+]
+PyQt5-Qt5 = [
+    {version = "=5.15.2", python = ">=3.11", platform = "linux"}, # bookworm
+    {version = "^5.15.15", python = ">=3.11", platform = "darwin"},
 ]
 PyQt5-sip = [
-    {version = "=12.11.1", python = ">=3.11"}, # bookworm
+    {version = "=12.11.1", python = ">=3.11", platform = "linux"}, # bookworm
+    {version = "^12.16.1", python = ">=3.11", platform = "darwin"},
 ]
 PyAutoGUI = "*"
 babel = "^2.16.0"

--- a/client/run.sh
+++ b/client/run.sh
@@ -20,9 +20,6 @@ done
 source scripts/setup-tmp-directories.sh
 
 PYTHON="poetry run python"
-if [[ $OSTYPE == 'darwin'* ]] && [[ "$(uname -m)" == "arm64" ]]; then
-    PYTHON="arch -x86_64 ${PYTHON}"
-fi
 
 GNUPGHOME="$SDC_HOME/gpg"
 export GNUPGHOME


### PR DESCRIPTION
## Status

Ready for review

## Description

Fixes #2333.

Updates pyproject.toml to install a later version of PyQt5 - but only for macOS. Slightly later versions provide arm64 wheels, which makes installing the development environment a **lot** easier.

As arm64 PyQt5 wheels are only available for slightly later versions - install the latest possible version for macOS (darwin), but leave Linux packages at the specific pinned version (so it keeps it in sync with Debian bookworm).

Happy to tweak this if needed, and I understand this isn't your primary target environment if the change isn't wanted.

## Test Plan

- Check that the development client works under macOS without x86_64 Homebrew (screenshot attached from me running it, it's not perfect UI wise - but it works)
- Check that installing under Linux does **not** install different versions of packages - this should only impact macOS.

<img width="1840" alt="Screenshot 2024-12-14 at 21 28 34" src="https://github.com/user-attachments/assets/c5404834-dc41-408b-be56-2cf066baf80a" />

## Checklist

 - [x] These changes should not need testing in Qubes
 - [x] No update to the AppArmor profile is required for these changes
 - [x] No database schema changes are needed
