### PR TITLE
Remove outdated setuptools install_requires and python_requires

### DIFF
--- a/client/setup.py
+++ b/client/setup.py
@@ -21,8 +21,6 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="AGPLv3+",
-    install_requires=["SQLAlchemy", "alembic", "securedrop-sdk", "python-dateutil", "arrow"],
-    python_requires=">=3.5",
     url="https://github.com/freedomofpress/securedrop-client",
     packages=setuptools.find_packages(include=["securedrop_client", "securedrop_client.*"]),
     include_package_data=True,

--- a/export/setup.py
+++ b/export/setup.py
@@ -12,8 +12,6 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="GPLv3+",
-    install_requires=[],
-    python_requires=">=3.5",
     url="https://github.com/freedomofpress/securedrop-export",
     packages=setuptools.find_packages(exclude=["docs", "tests"]),
     classifiers=[

--- a/log/setup.py
+++ b/log/setup.py
@@ -12,8 +12,6 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="GPLv3+",
-    install_requires=[],
-    python_requires=">=3.5",
     packages=setuptools.find_packages(exclude=["docs", "tests"]),
     url="https://github.com/freedomofpress/securedrop-log",
     classifiers=[


### PR DESCRIPTION


## Status

Ready for review 
## Description

These are outdated since we now require Python 3.11, and in the case of the client, will pull in the old securedrop-sdk package that we no longer use.

## Test Plan

* [x] CI passes

