### PR TITLE
chore: ignore CVE-2024-56201 in `jinja2`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ safety:  ## Run safety dependency checks on build dependencies
 		--ignore 67895 \
 		--ignore 70612 \
 		--ignore 71591 \
+		--ignore 74735 \
  		-r
 
 .PHONY: shellcheck


### PR DESCRIPTION
## Status

Ready for review


## Description

Ignores Safety alert no. 74735 (CVE-2024-56201) in `jinja2` per freedomofpress/fpf-misc-resources#60.