### PR TITLE
Show full timestamps in UI

### DIFF
--- a/client/securedrop_client/gui/datetime_helpers.py
+++ b/client/securedrop_client/gui/datetime_helpers.py
@@ -14,7 +14,7 @@ def format_datetime_month_day(date: datetime.datetime) -> str:
     """
     Formats date as e.g. Sep 16
     """
-    return arrow.get(date).format("MMM D")
+    return arrow.get(date).format("MMM D, HH:mm")
 
 
 def localise_datetime(date: datetime.datetime) -> datetime.datetime:

--- a/client/securedrop_client/gui/widgets.py
+++ b/client/securedrop_client/gui/widgets.py
@@ -98,6 +98,7 @@ logger = logging.getLogger(__name__)
 
 MINIMUM_ANIMATION_DURATION_IN_MILLISECONDS = 300
 NO_DELAY = 1
+LAST_UPDATED_LABEL_TOOLTIP="Time of last activity from source"
 
 
 class BottomPane(QWidget):
@@ -1525,7 +1526,7 @@ class SourceWidget(QWidget):
     SPACER = 14
     BOTTOM_SPACER = 11
     STAR_WIDTH = 20
-    TIMESTAMP_WIDTH = 60
+    TIMESTAMP_WIDTH = 80
 
     SOURCE_NAME_CSS = load_css("source_name.css")
     SOURCE_PREVIEW_CSS = load_css("source_preview.css")
@@ -1594,6 +1595,7 @@ class SourceWidget(QWidget):
         self.timestamp.setSizePolicy(retain_space)
         self.timestamp.setFixedWidth(self.TIMESTAMP_WIDTH)
         self.timestamp.setObjectName("SourceWidget_timestamp")
+        self.timestamp.setToolTip(LAST_UPDATED_LABEL_TOOLTIP)
 
         # Create source_widget:
         # -------------------------------------------------------------------
@@ -1616,11 +1618,11 @@ class SourceWidget(QWidget):
         self.spacer.setFixedWidth(self.SPACER)
         source_widget_layout.addWidget(self.spacer, 0, 1, 1, 1)
         source_widget_layout.addWidget(self.name, 0, 2, 1, 1)
-        source_widget_layout.addWidget(self.paperclip, 0, 3, 1, 1)
+        source_widget_layout.addWidget(self.paperclip, 0, 3, 1, 1, alignment=Qt.AlignRight)
         source_widget_layout.addWidget(self.paperclip_disabled, 0, 3, 1, 1)
         source_widget_layout.addWidget(self.preview, 1, 2, 1, 1, alignment=Qt.AlignLeft)
         source_widget_layout.addWidget(self.deletion_indicator, 1, 2, 1, 1)
-        source_widget_layout.addWidget(self.timestamp, 1, 3, 1, 1)
+        source_widget_layout.addWidget(self.timestamp, 1, 3, 1, 1, alignment=Qt.AlignRight)
         source_widget_layout.addItem(QSpacerItem(self.BOTTOM_SPACER, self.BOTTOM_SPACER))
         self.source_widget.setLayout(source_widget_layout)
         layout = QHBoxLayout(self)
@@ -3797,6 +3799,7 @@ class LastUpdatedLabel(QLabel):
 
         # Set CSS id
         self.setObjectName("LastUpdatedLabel")
+        self.setToolTip(LAST_UPDATED_LABEL_TOOLTIP)
 
 
 class SourceProfileShortWidget(QWidget):

--- a/client/securedrop_client/gui/widgets.py
+++ b/client/securedrop_client/gui/widgets.py
@@ -98,7 +98,7 @@ logger = logging.getLogger(__name__)
 
 MINIMUM_ANIMATION_DURATION_IN_MILLISECONDS = 300
 NO_DELAY = 1
-LAST_UPDATED_LABEL_TOOLTIP="Time of last activity from source"
+LAST_UPDATED_LABEL_TOOLTIP = "Time of last activity from source"
 
 
 class BottomPane(QWidget):

--- a/client/tests/gui/test_datetime_helpers.py
+++ b/client/tests/gui/test_datetime_helpers.py
@@ -15,7 +15,7 @@ def test_format_datetime_month_day():
     # may result in UI issues - this test is a reminder to check both views!
     midnight_january_london = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.UTC)
 
-    assert format_datetime_month_day(midnight_january_london) == "Jan 1"
+    assert format_datetime_month_day(midnight_january_london) == "Jan 1, 00:00"
 
 
 def test_localise_datetime(mocker):
@@ -36,4 +36,4 @@ def test_format_datetime_local(mocker):
         return_value=QByteArray(b"Pacific/Auckland"),
     )
     evening_january_1_london = datetime.datetime(2023, 1, 1, 18, 0, 0, tzinfo=datetime.UTC)
-    assert format_datetime_local(evening_january_1_london) == "Jan 2"
+    assert format_datetime_local(evening_january_1_london) == "Jan 2, 07:00"


### PR DESCRIPTION
## Status

Ready for review

## Description

This modifies the securedrop UI so that it shows a timestamp rather than just the date for the most recent source message. This addresses these issues (which also include a fair bit of relevant prior discussion):
 - https://github.com/freedomofpress/securedrop-client/issues/1563
 - https://github.com/freedomofpress/securedrop-client/issues/538

At the guardian, timestamps are extremely valuable when working in a multi user environment and helping to coordinate work. 

It looks like this:

![415217006-68b7508c-06f2-4817-9664-e1219915ffab](https://github.com/user-attachments/assets/19a87cda-983a-408d-8b0b-0cbd40737408)


## Test Plan
I've tested this on my development qubes workstation

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
