### PR TITLE
Replace XPP with GTK print dialog

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           if [[ "${{ matrix.component }}" == "export" ]]; then
             make -C ${{ matrix.component }} ci-install-deps
+            sudo -u user poetry config virtualenvs.options.system-site-packages true
           fi
           sudo -u user poetry -C ${{ matrix.component }} install
       - name: Run test

--- a/debian/control
+++ b/debian/control
@@ -14,8 +14,10 @@ Description: securedrop client for qubes workstation
 
 Package: securedrop-export
 Architecture: all
-Depends: ${misc:Depends}, python3, udisks2, cups, ipp-usb, avahi-daemon, systemd, system-config-printer, xpp, libcups2, gnome-disk-utility, libreoffice,
- desktop-file-utils, shared-mime-info, libfile-mimeinfo-perl
+Depends: ${misc:Depends}, python3, udisks2, cups, ipp-usb, avahi-daemon,
+ systemd, system-config-printer, libcups2, gnome-disk-utility, libreoffice,
+ desktop-file-utils, shared-mime-info, libfile-mimeinfo-perl,
+ python3-gi, python3-gi-cairo, gir1.2-gtk-4.0
 Description: Submission export scripts for SecureDrop Workstation
  This package provides scripts used by the SecureDrop Qubes Workstation to
  export submissions from the client to external storage, via the sd-export

--- a/debian/setup-venv.sh
+++ b/debian/setup-venv.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 NAME=$1
-if [[ $NAME == "client" ]]; then
+if [[ $NAME == "client" || $NAME == "export" ]]; then
     VENV_ARGS="--system-site-packages"
 else
     VENV_ARGS=""

--- a/export/Makefile
+++ b/export/Makefile
@@ -35,7 +35,7 @@ semgrep-local:
 
 # Install dependencies in CI
 ci-install-deps:
-	apt-get install --yes libreoffice
+	apt-get install --yes libreoffice python3-gi python3-gi-cairo gir1.2-gtk-4.0
 
 # Explanation of the below shell command should it ever break.
 # 1. Set the field separator to ": ##" and any make targets that might appear between : and ##

--- a/export/poetry.lock
+++ b/export/poetry.lock
@@ -770,6 +770,19 @@ files = [
 plugins = ["importlib-metadata"]
 
 [[package]]
+name = "pygobject-stubs"
+version = "2.13.0"
+description = "Typing stubs for PyGObject"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pygobject_stubs-2.13.0.tar.gz", hash = "sha256:4f608f5dfe10c3173f0a082416e22e27b693743c2a635de245c78a51458e2ab6"},
+]
+
+[package.extras]
+dev = ["PyGObject", "black (>=25.1.0)", "codespell (>=2.4.1)", "isort (>=6.0.1)", "pre-commit", "ruff (>=0.9.10)"]
+
+[[package]]
 name = "pytest"
 version = "8.3.4"
 description = "pytest: simple powerful testing with Python"
@@ -1297,4 +1310,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "8b8e46c126b7cacb1103b3827b1b5a51101031cbc3b7f8657135b44e731f94e8"
+content-hash = "781838405cd08dd2bf3ac7aaf7dd5cfa273e5e1e47c58217cbaa5850b89dfef8"

--- a/export/pyproject.toml
+++ b/export/pyproject.toml
@@ -18,6 +18,7 @@ pytest-cov = "^6.0.0"
 pytest-mock = "^3.14.0"
 semgrep = "^1.100.0"
 types-pexpect = "^4.9.0.20241208"
+pygobject-stubs = "*"
 
 [tool.mypy]
 python_version = "3.11"

--- a/export/securedrop_export/print/print_dialog.py
+++ b/export/securedrop_export/print/print_dialog.py
@@ -42,9 +42,11 @@ class PrintDialog(Gtk.Application):
             printer = self.dialog.get_selected_printer()
             page_setup = self.dialog.get_page_setup()
 
-            # Fix upstream GTK page ranges:
-            #   - not properly passed to IPP printers
-            #   -
+            # GTK in bookworm has a bug in which page ranges are not properly
+            # passed to IPP printers, we work around that by explicitly
+            # passing them to CUPS, and disallowing multiple ranges.
+            #   - https://gitlab.gnome.org/GNOME/gtk/-/issues/7528
+            #   - https://gitlab.gnome.org/GNOME/gtk/-/issues/7527
             page_range_str = ""
             page_ranges = settings.get_page_ranges()
             if len(page_ranges) > 1:

--- a/export/securedrop_export/print/print_dialog.py
+++ b/export/securedrop_export/print/print_dialog.py
@@ -25,7 +25,7 @@ class PrintDialog(Gtk.Application):
         window = Gtk.Window(application=app)
         self.dialog = Gtk.PrintUnixDialog.new(
             "Print Document",  # FIXME: this should be localized
-            window
+            window,
         )
         self.dialog.connect("response", self.on_response)
         self.dialog.show()
@@ -65,7 +65,9 @@ class PrintDialog(Gtk.Application):
             self.dialog.hide()
             job = Gtk.PrintJob.new(
                 "print job",  # FIXME: this should be localized
-                printer, settings, page_setup
+                printer,
+                settings,
+                page_setup,
             )
             job.set_source_file(self.file_to_print)
             job.send(self.on_job_complete, user_data=None)
@@ -98,7 +100,7 @@ class PrintDialog(Gtk.Application):
             buttons=Gtk.ButtonsType.OK,
             text="Page Range Limitation",  # FIXME: this should be localized
             secondary_text="Providing multiple page ranges is not "
-            "supported at this time.\nPlease use only one, e.g. \"2-4\".",
+            'supported at this time.\nPlease use only one, e.g. "2-4".',
         )
         dialog.connect("response", lambda d, _: d.close())
         dialog.show()

--- a/export/securedrop_export/print/print_dialog.py
+++ b/export/securedrop_export/print/print_dialog.py
@@ -1,0 +1,65 @@
+import logging
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+
+from gi.repository import Gtk  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+
+def open_print_dialog(file_to_print):
+    app = PrintDialog(file_to_print)
+    app.run()
+
+
+class PrintDialog(Gtk.Application):
+    def __init__(self, file_to_print):
+        super().__init__(application_id="org.securedrop.PrintDialog")
+        self.file_to_print = file_to_print
+        self.connect("activate", self.on_activate)
+
+    def on_activate(self, app):
+        """On GUI startup"""
+        window = Gtk.Window(application=app)
+        self.dialog = Gtk.PrintUnixDialog.new("Print Document", window)
+        self.dialog.connect("response", self.on_response)
+        self.dialog.show()
+        window.hide()
+
+    def on_response(self, parent_widget, response_id):
+        """
+        When the user clicks one of the print dialog's action buttons
+        [ CANCEL ] [ PRINT ]
+        """
+
+        if response_id == Gtk.ResponseType.OK:  # Print
+            self.dialog.hide()
+            settings = self.dialog.get_settings()
+            printer = self.dialog.get_selected_printer()
+            page_setup = self.dialog.get_page_setup()
+            job = Gtk.PrintJob.new("print job", printer, settings, page_setup)
+            job.set_source_file(self.file_to_print)
+            job.send(self.on_job_complete, user_data=None)
+        elif response_id == Gtk.ResponseType.APPLY:  # Preview (if available)
+            pass
+        elif response_id in (
+            Gtk.ResponseType.CANCEL,  # Cancel button
+            Gtk.ResponseType.DELETE_EVENT,  # Window closed
+        ):
+            self.quit()
+
+    def on_job_complete(self, print_job, user_data, error):
+        """
+        When print dialog sends over the data to CUPS for printing. This does
+        not necessarily mean that the file has been fully printed. At this
+        point we just want the print dialog to disappear.
+        """
+        if error:
+            # Error does not need to be communicated to the user
+            #   - notifications already show current print issues
+            #   - printer icon in tray menu shows print errors
+            #   - future print dialogs display issues with a printer
+            pass
+        self.quit()  # Close print dialog and exit GTK application

--- a/export/securedrop_export/print/print_dialog.py
+++ b/export/securedrop_export/print/print_dialog.py
@@ -47,7 +47,6 @@ class PrintDialog(Gtk.Application):
             # passing them to CUPS, and disallowing multiple ranges.
             #   - https://gitlab.gnome.org/GNOME/gtk/-/issues/7528
             #   - https://gitlab.gnome.org/GNOME/gtk/-/issues/7527
-            page_range_str = ""
             page_ranges = settings.get_page_ranges()
             if len(page_ranges) > 1:
                 self.show_error_disallowed_range()

--- a/export/securedrop_export/print/print_dialog.py
+++ b/export/securedrop_export/print/print_dialog.py
@@ -23,7 +23,10 @@ class PrintDialog(Gtk.Application):
     def on_activate(self, app):
         """On GUI startup"""
         window = Gtk.Window(application=app)
-        self.dialog = Gtk.PrintUnixDialog.new("Print Document", window)
+        self.dialog = Gtk.PrintUnixDialog.new(
+            "Print Document",  # FIXME: this should be localized
+            window
+        )
         self.dialog.connect("response", self.on_response)
         self.dialog.show()
         window.hide()
@@ -48,8 +51,10 @@ class PrintDialog(Gtk.Application):
                 self.show_error_disallowed_range()
                 return
             elif len(page_ranges) == 1:
-                start = page_ranges[0].start + 1  # start at 0
-                end = page_ranges[0].end + 1  # start at 0
+                # `page_ranges` is 0-indexed, but CUPS wants the range to be 1-indexed
+                start = page_ranges[0].start + 1
+                end = page_ranges[0].end + 1
+
                 if start == end:
                     page_range_str = str(start)
                 else:
@@ -57,7 +62,10 @@ class PrintDialog(Gtk.Application):
                 settings.set("cups-page-ranges", page_range_str)
 
             self.dialog.hide()
-            job = Gtk.PrintJob.new("print job", printer, settings, page_setup)
+            job = Gtk.PrintJob.new(
+                "print job",  # FIXME: this should be localized
+                printer, settings, page_setup
+            )
             job.set_source_file(self.file_to_print)
             job.send(self.on_job_complete, user_data=None)
         elif response_id == Gtk.ResponseType.APPLY:  # Preview (if available)
@@ -87,9 +95,9 @@ class PrintDialog(Gtk.Application):
             modal=True,
             message_type=Gtk.MessageType.ERROR,
             buttons=Gtk.ButtonsType.OK,
-            text="Page Range Limitation",
-            secondary_text="Providing multiple page ranges are not "
-            "supported at this time.\nPlease use only one (e.g. '2-4')",
+            text="Page Range Limitation",  # FIXME: this should be localized
+            secondary_text="Providing multiple page ranges is not "
+            "supported at this time.\nPlease use only one, e.g. \"2-4\".",
         )
         dialog.connect("response", lambda d, _: d.close())
         dialog.show()

--- a/export/securedrop_export/print/service.py
+++ b/export/securedrop_export/print/service.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from securedrop_export.directory import safe_mkdir
 from securedrop_export.exceptions import ExportException
 
+from .print_dialog import open_print_dialog
 from .status import Status
 
 logger = logging.getLogger(__name__)
@@ -254,14 +255,7 @@ class Service:
             raise ExportException(sdstatus=Status.ERROR_PRINT)
 
         logger.info("Opening print dialog")
-        try:
-            # We can switch to using libreoffice --pt $printer_cups_name
-            # here, and either print directly (headless) or use the GUI
-            subprocess.check_call(
-                ["xpp", file_to_print],
-            )
-        except subprocess.CalledProcessError as e:
-            raise ExportException(sdstatus=Status.ERROR_PRINT, sderror=e.output)
+        open_print_dialog(str(file_to_print))
 
     def check_output_and_stderr(
         self, command: str, error_status: Status, ignore_stderr_startswith=None


### PR DESCRIPTION
## Status

Ready for review. Should wait for https://github.com/freedomofpress/securedrop-client/pull/2332 to be merged in order to do final testing prior to merge. But otherwise fine to have its review done.

## Description

Fixes #2156.

## Test Plan

Setup:
- [ ] Access to recommended printer. 
- [ ] `make build-debs`
- [ ] Install export deb in large template
- [ ] Shut down template and ensure `sd-devices` is restarted

Test prior to rebasing on top of https://github.com/freedomofpress/securedrop-client/pull/2332 (assuming merged and on main):
- [x] When the user clicks Print on a downloaded submission:
  - [x]   a "Preparing to print..." message is displayed
  - [x] the `sd-devices` VM is started
  - [x] the user is prompted to connect a supported printer
- [x] When the user connects a printer, attaches it to the sd-devices VM, and clicks Continue:
  - [ ] <strike>a "Printing..." message is displayed</strike> (should not be the case anymore)
  - [x] a gnome-looking print dialog is displayed with ~~`sdw-printer`~~ the name of the printer
  - [ ] (alternative A) Clicking Print prints the file
  - [x] (alternative B)  Clicking Cancel exits without issues
  - [x]  (alternative C) Closing print dialog
  - [x] client (or `sd-app` for that matter) no longer shows any dialog (print-related)

Test after rebasing on top of https://github.com/freedomofpress/securedrop-client/pull/2332:
- repeat https://github.com/freedomofpress/securedrop-client/pull/2332's test plan
## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
