### PR TITLE
Visually update download progress bars every second

### DIFF
--- a/client/securedrop_client/gui/base/progress.py
+++ b/client/securedrop_client/gui/base/progress.py
@@ -32,10 +32,14 @@ class FileDownloadProgressBar(QProgressBar):
         # the timer in update_speed
         self.size_signal.connect(self.setValue)
         self.decrypting_signal.connect(self.handle_decrypting)
-        self.timer = QTimer(self)
-        self.timer.setInterval(100)
-        self.timer.timeout.connect(self.update_speed)
-        self.timer.start()
+        self.speed_timer = QTimer(self)
+        self.speed_timer.setInterval(100)
+        self.speed_timer.timeout.connect(self.update_speed)
+        self.speed_timer.start()
+        self.display_timer = QTimer(self)
+        self.display_timer.setInterval(1000)
+        self.display_timer.timeout.connect(self.update_display)
+        self.display_timer.start()
         # The most recently calculated speed
         self.speed = 0.0
         # The last time we updated the speed
@@ -45,8 +49,9 @@ class FileDownloadProgressBar(QProgressBar):
 
     def handle_decrypting(self, decrypting: bool) -> None:
         if decrypting:
-            # Stop the speed timer and then switch to an indeterminate progress bar
-            self.timer.stop()
+            # Stop the timers and then switch to an indeterminate progress bar
+            self.speed_timer.stop()
+            self.display_timer.stop()
             self.setMaximum(0)
             self.setValue(0)
 
@@ -92,7 +97,6 @@ class FileDownloadProgressBar(QProgressBar):
 
         self.last_total_time = now
         self.last_total_bytes = value
-        self.update_display()
 
     def proxy(self) -> "ProgressProxy":
         """Get a proxy that updates this widget."""

--- a/client/tests/gui/base/test_progress.py
+++ b/client/tests/gui/base/test_progress.py
@@ -26,42 +26,49 @@ def mock_monotonic(mocker):
 
 def test_progress(mock_monotonic):
     widget = FileDownloadProgressBar(100_000_000)
-    # Disable the timer as we manually control time
-    widget.timer.stop()
+    # Disable the timers as we manually control time
+    widget.speed_timer.stop()
+    widget.display_timer.stop()
     # At first the progress bar displays "%p" (current value) plus a literal "%"
     assert widget.format() == "%p%"
-    # after two timer ticks, it should now take over display formatting
+    # after two speed timer ticks, it should now take over display formatting
     widget.update_speed()
     widget.update_speed()
+    widget.update_display()
     # The progress bar should now display calculated percentage
     assert widget.format() == "0%"
     # Add some data and move forward one second
     widget.proxy().set_value(1_000_000)
     mock_monotonic.increment()
     widget.update_speed()
+    widget.update_display()
     assert widget.format() == "1% | 292KB/s"
 
     # Again
     widget.proxy().set_value(2_000_000)
     mock_monotonic.increment()
     widget.update_speed()
+    widget.update_display()
     assert widget.format() == "2% | 498KB/s"
 
     # A lot of data at once
     widget.proxy().set_value(99_000_000)
     mock_monotonic.increment()
     widget.update_speed()
+    widget.update_display()
     assert widget.format() == "99% | 28MB/s"
 
     # 99.99999% does not round to 100%
     widget.proxy().set_value(99_999_999)
     mock_monotonic.increment()
     widget.update_speed()
+    widget.update_display()
     assert widget.format() == "99% | 20MB/s"
 
     # 100% has no speed
     widget.proxy().set_value(100_000_000)
     widget.update_speed()
+    widget.update_display()
     assert widget.format() == "100%"
 
     # Switch to indetermininate mode as we decrypt


### PR DESCRIPTION


## Status

Ready for review 

## Description

The current 100ms refresh is too fast to actually read the numbers, so slow it down to 1s, which is roughly what browsers do. We continue to calculate speed at a 100ms interval to have good smoothing.

Refs <https://github.com/freedomofpress/securedrop-client/issues/1104#issuecomment-2825726618>.
Refs <https://github.com/freedomofpress/securedrop-client/issues/1104#issuecomment-2826921573>.

## Test Plan

* [ ] Open the client, download a large-ish file, observe progress only advances/updates every second.

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [x] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
