### PR TITLE
Make progress bars fit in narrow windows

### DIFF
--- a/client/securedrop_client/gui/widgets.py
+++ b/client/securedrop_client/gui/widgets.py
@@ -2814,6 +2814,7 @@ class FileWidget(QWidget):
         Update the download button to the animated "downloading" state.
         """
         self.downloading = True
+        self.no_file_name.hide()  # Hide to make room for the progress bar
         self.download_progress.setValue(0)
         self.download_progress.show()
         self.download_button.setText(_(" DOWNLOADING "))


### PR DESCRIPTION


## Status

Ready for review

## Description

If you make the client window as narrow as it can go, when a progress bar is displayed, the "Downloading" text gets cutoff, because there isn't enough space for all the different elements to be displayed.

Make it fit by hiding the "Encrypted file on server" text during the download. If the download fails, it'll get restored by the existing `_set_file_state()`.

Fixes #2423.

## Test Plan

* [ ] Make the client window as narrow as possible
* [ ] Download a file, observe no UI elements are clipped or cut off

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [x] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [x] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [x] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
