### PR TITLE
build: replicate `freedomofpress/securedrop`'s verification of head, tag, and working tree

### DIFF
--- a/scripts/build-debs.sh
+++ b/scripts/build-debs.sh
@@ -10,10 +10,17 @@
 
 set -euxo pipefail
 
+# --- BEGIN keep this section in sync with securedrop, so that build logs from
+# both repositories can be verified in the same way. ---
+
 git --no-pager log -1 --oneline --show-signature --no-color
 # We intentionally want the git tag list to be word-split
 # shellcheck disable=SC2046
 git --no-pager tag -v $(git tag --points-at HEAD)
+# Record if we're building with local (i.e., post-signature) changes present.
+git status --short
+
+# --- END keep this section in sync. ---
 
 OCI_RUN_ARGUMENTS="--user=root -v $(pwd):/src:Z"
 


### PR DESCRIPTION
## Status

Ready for review

## Description

See <https://github.com/freedomofpress/securedrop/pull/7478#discussion_r2008409253>, and review along with freedomofpress/securedrop#7478.


## Test Plan

- [ ] New checks are visible in CI.