### PR TITLE
Use `Breaks` to remove old print-related dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,6 +18,7 @@ Depends: ${misc:Depends}, python3, udisks2, cups, ipp-usb, avahi-daemon,
  systemd, system-config-printer, libcups2, gnome-disk-utility, libreoffice,
  desktop-file-utils, shared-mime-info, libfile-mimeinfo-perl,
  python3-gi, python3-gi-cairo, gir1.2-gtk-4.0
+Breaks: printer-driver-brlaser, printer-driver-hpcups, xpp
 Description: Submission export scripts for SecureDrop Workstation
  This package provides scripts used by the SecureDrop Qubes Workstation to
  export submissions from the client to external storage, via the sd-export

--- a/debian/securedrop-export.lintian-overrides
+++ b/debian/securedrop-export.lintian-overrides
@@ -31,3 +31,6 @@ securedrop-export: control-file-is-empty [conffiles]
 
 # Preset options are missing from deb-systemd-helper
 securedrop-export: maintainer-script-calls-systemctl
+
+# We're abusing `Breaks` to remove obsolete dependencies
+securedrop-export: breaks-without-version


### PR DESCRIPTION
## Status

Ready for review

## Description

Now that we've switched over to IPP and the GTK print dialog, we no longer need the old printer drivers and XPP. There's no real harm in having them installed in the template, but it introduces a divergence with new installs, and in the case of XPP, keeps around very legacy/obsolete code.

We can abuse the `Breaks`[1] option to remove these packages, the Qubes effectively runs `apt-get dist-upgrade`, so the packages will get removed when upgrading securedrop-export.

[1] https://www.debian.org/doc/debian-policy/ch-relationships.html#packages-which-break-other-packages-breaks

Fixes #2425.

## Test Plan

* [ ] Set up a prod SDW
* [ ] Verify the sd-large template has sd-client 0.14, which has xpp/printer-drivers-* dependencies
* [ ] Check out this PR locally, run `make build-debs`, copy the output to a web accessible host:
   * e.g. copy the debs to a folder titled "bookworm", accessible via `https://example.org/apt/bookworm`
   * Then parallel to that, `mkdir -p dists/bookworm/main/binary-amd64/ && apt-ftparchive packages ./bookworm > dists/bookworm/main/binary-amd64/Packages`
   * You can look at https://legoktm.com/apt as an example
* [ ] back in the sd-large template, create `/etc/apt/sources.list.d/test.list` with the contents `deb [trusted=yes] https://example.org/apt bookworm main`
* [ ] run `apt update`, see that it says there are some packages pending update (but don't update them yet!)
* [ ] shut down sd-large, then kickoff the SDW updater
* [ ] once the update finishes, launch the sd-large template (or sd-devices VM), verify that sd-export updated to 0.15.0~rc1, and the xpp/printer-drivers-* dependencies are removed.

