### PR TITLE
[app] handle requests to sd-proxy

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -58,7 +58,7 @@ typings/
 .yarn-integrity
 
 # dotenv environment variables file
-.env
+.env.local
 .env.test
 
 # parcel-bundler cache (https://parceljs.org/)

--- a/app/package.json
+++ b/app/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "main": ".vite/build/main.js",
   "scripts": {
-    "start": "electron-forge start",
+    "start": "./run.sh",
     "package": "electron-forge package",
     "publish": "electron-forge publish",
     "fix": "eslint --fix . && prettier --write .",

--- a/app/run.sh
+++ b/app/run.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash 
+
+set -eo pipefail 
+umask 077
+
+echo "Building proxy..."
+make -C ../proxy build
+
+function configure_environment() {
+    echo "Configuring .env.local..."
+
+    # Configure Vite environment variables
+    LOCAL_DOTENV_FILE=".env.local"
+    : > "$LOCAL_DOTENV_FILE"
+
+    sd_proxy_cmd="$(cargo metadata --format-version 1 | jq -r '.target_directory')/debug/securedrop-proxy"
+
+    ENV_VARS=(
+        "VITE_SD_PROXY_ORIGIN=\"http://localhost:8081/\""
+        "VITE_SD_PROXY_CMD=\"$sd_proxy_cmd\""
+    )
+
+
+    for var in "${ENV_VARS[@]}"; do 
+        echo "$var" >> "$LOCAL_DOTENV_FILE"
+    done
+}
+
+configure_environment
+
+electron-forge start

--- a/app/src/frontend/App.tsx
+++ b/app/src/frontend/App.tsx
@@ -1,5 +1,24 @@
 function App() {
-  return <p>Hello world</p>;
+  const dummyRequest = async function () {
+    console.log("sending dummy request");
+    const res = await window.electronAPI.request({
+      method: "GET",
+      path_query: "/test",
+      stream: false,
+      headers: {},
+    });
+    console.log("received dummy response");
+    console.log(res);
+  };
+
+  return (
+    <div>
+      <p>Hello world</p>
+      <button onClick={() => dummyRequest()} title="Dummy Request">
+        Dummy Request
+      </button>
+    </div>
+  );
 }
 
 export default App;

--- a/app/src/frontend/preload.d.ts
+++ b/app/src/frontend/preload.d.ts
@@ -1,0 +1,9 @@
+import { ElectronAPI } from "../preload";
+
+declare global {
+  interface Window {
+    electronAPI: ElectronAPI;
+  }
+}
+
+export {};

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -1,7 +1,8 @@
-import { app, BrowserWindow } from "electron";
+import { app, BrowserWindow, ipcMain } from "electron";
 import path from "node:path";
 
 import { openDatabase, closeDatabase } from "./database";
+import { proxy, ProxyRequest } from "./proxy";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const db = openDatabase();
@@ -38,4 +39,9 @@ app.on("window-all-closed", () => {
 
 app.on("before-quit", () => {
   closeDatabase();
+});
+
+ipcMain.handle("request", async (event, request: ProxyRequest) => {
+  const result = await proxy(request);
+  return result;
 });

--- a/app/src/preload.ts
+++ b/app/src/preload.ts
@@ -1,2 +1,12 @@
 // See the Electron documentation for details on how to use preload scripts:
 // https://www.electronjs.org/docs/latest/tutorial/process-model#preload-scripts
+import { contextBridge, ipcRenderer } from "electron";
+import { ProxyRequest } from "././proxy";
+
+const electronAPI = {
+  request: (request: ProxyRequest) => ipcRenderer.invoke("request", request),
+};
+
+contextBridge.exposeInMainWorld("electronAPI", electronAPI);
+
+export type ElectronAPI = typeof electronAPI;

--- a/app/src/proxy.test.ts
+++ b/app/src/proxy.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import child_process from "node:child_process";
+import EventEmitter from "events";
+import { Readable, Writable } from "stream";
+
+import { proxyInner, ProxyRequest } from "./proxy";
+
+vi.mock("child_process");
+
+const mockChildProcess = (): child_process.ChildProcess => {
+  const proc = new EventEmitter() as child_process.ChildProcess;
+
+  proc.stdout = new EventEmitter() as Readable;
+  proc.stderr = new EventEmitter() as Readable;
+  proc.stdin = new Writable();
+  proc.stdin._write = () => {};
+
+  return proc;
+};
+
+describe("Test executing proxy", () => {
+  let process: child_process.ChildProcess;
+
+  beforeEach(() => {
+    process = mockChildProcess();
+    vi.spyOn(child_process, "spawn").mockReturnValueOnce(process);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("proxy should return ProxyResponse with deserialized JSON on successful response", async () => {
+    const proxyExec = proxyInner(
+      {} as ProxyRequest,
+      "mock-proxy-command",
+      [],
+      "",
+      1000,
+    );
+
+    const respData = {
+      foo: "bar",
+      baz: ["foo", "bar"],
+      key: 123,
+    };
+    const respHeaders = {
+      Connection: "Keep-Alive",
+      "Content-Type": "text/html",
+    };
+    const respStatus = 200;
+    const response = {
+      status: respStatus,
+      headers: respHeaders,
+      body: respData,
+    };
+    process.stdout?.emit("data", JSON.stringify(response));
+
+    process.emit("close", 0);
+
+    const { data, status, headers } = await proxyExec;
+
+    expect(data).toEqual(respData);
+    expect(headers).toEqual(respHeaders);
+    expect(status).toEqual(respStatus);
+  });
+
+  it("proxy should error on invalid JSON response data", async () => {
+    const proxyExec = proxyInner(
+      {} as ProxyRequest,
+      "mock-proxy-command",
+      [],
+      "",
+      1000,
+    );
+
+    process.stdout?.emit("data", "this is not valid JSON");
+
+    process.emit("close", 0);
+
+    await expect(proxyExec).rejects.toThrowError(SyntaxError);
+  });
+
+  it("proxy should error on non-404 4xx response code", async () => {
+    const proxyExec = proxyInner(
+      {} as ProxyRequest,
+      "mock-proxy-command",
+      [],
+      "",
+      1000,
+    );
+
+    const respData = "Rate Limited";
+    const respStatus = 429;
+    const response = {
+      status: respStatus,
+      headers: {},
+      body: respData,
+    };
+    process.stdout?.emit("data", JSON.stringify(response));
+
+    process.emit("close", 0);
+
+    await expect(proxyExec).rejects.toThrowError(
+      `Client error ${respStatus}: ${respData}`,
+    );
+  });
+
+  it("proxy should return success on 404", async () => {
+    const proxyExec = proxyInner(
+      {} as ProxyRequest,
+      "mock-proxy-command",
+      [],
+      "",
+      1000,
+    );
+
+    const respData = "Not Found";
+    const respStatus = 404;
+    const response = {
+      status: respStatus,
+      headers: {},
+      body: respData,
+    };
+    process.stdout?.emit("data", JSON.stringify(response));
+
+    process.emit("close", 0);
+
+    const { data, status } = await proxyExec;
+
+    expect(data).toEqual(respData);
+    expect(status).toEqual(respStatus);
+  });
+
+  it("proxy should error on 5xx response code", async () => {
+    const proxyExec = proxyInner(
+      {} as ProxyRequest,
+      "mock-proxy-command",
+      [],
+      "",
+      1000,
+    );
+
+    const respData = "Service Unavailable";
+    const respStatus = 503;
+    const response = {
+      status: respStatus,
+      headers: {},
+      body: respData,
+    };
+    process.stdout?.emit("data", JSON.stringify(response));
+
+    process.emit("close", 0);
+
+    await expect(proxyExec).rejects.toThrowError(
+      `Server error ${respStatus}: ${respData}`,
+    );
+  });
+
+  it("proxy should fail on proxy-command exit error code", async () => {
+    const proxyExec = proxyInner(
+      {} as ProxyRequest,
+      "mock-proxy-command",
+      [],
+      "",
+      1000,
+    );
+
+    process.stderr?.emit("data", "error");
+    process.emit("close", 1);
+
+    await expect(proxyExec).rejects.toThrowError(
+      "Process exited with non-zero code 1: error",
+    );
+  });
+
+  it("proxy should handle subprocess error", async () => {
+    const proxyExec = proxyInner(
+      {} as ProxyRequest,
+      "mock-proxy-command",
+      [],
+      "",
+      1000,
+    );
+
+    process.emit("error", "error");
+
+    await expect(proxyExec).rejects.toThrowError("error");
+  });
+
+  it("proxy should handle SIGTERM", async () => {
+    const proxyExec = proxyInner(
+      {} as ProxyRequest,
+      "mock-proxy-command",
+      [],
+      "",
+      1000,
+    );
+
+    process.emit("close", 0, "SIGTERM");
+
+    await expect(proxyExec).rejects.toThrowError(
+      "Process terminated with signal SIGTERM",
+    );
+  });
+});

--- a/app/src/proxy.ts
+++ b/app/src/proxy.ts
@@ -1,0 +1,108 @@
+import child_process from "node:child_process";
+import { JSONObject } from "./utils";
+
+export type ProxyRequest = {
+  method: "GET" | "POST" | "DELETE";
+  path_query: string;
+  stream: false;
+  body?: string;
+  headers: object;
+};
+
+export type ProxyResponse = {
+  data: JSONObject;
+  status: number;
+  headers: Map<string, string>;
+};
+
+const DEFAULT_PROXY_VM_NAME = "sd-proxy";
+const DEFAULT_PROXY_CMD_TIMEOUT_MS = 5000;
+
+export async function proxy(request: ProxyRequest): Promise<ProxyResponse> {
+  let proxyCommand = "";
+  let proxyCommandOptions: string[] = [];
+
+  if (import.meta.env.MODE == "development") {
+    proxyCommand = import.meta.env.VITE_SD_PROXY_CMD;
+  } else {
+    proxyCommand = "/usr/lib/qubes/qrexec-client-vm";
+
+    const proxyVmName =
+      import.meta.env.VITE_PROXY_VM_NAME || DEFAULT_PROXY_VM_NAME;
+    proxyCommandOptions = [proxyVmName, "securedrop.Proxy"];
+  }
+
+  return proxyInner(
+    request,
+    proxyCommand,
+    proxyCommandOptions,
+    import.meta.env.VITE_SD_PROXY_ORIGIN,
+    DEFAULT_PROXY_CMD_TIMEOUT_MS,
+  );
+}
+
+export async function proxyInner(
+  request: ProxyRequest,
+  proxyCommand: string,
+  proxyCommandOptions: string[],
+  proxyOrigin: string,
+  proxyCommandTimeout: number,
+): Promise<ProxyResponse> {
+  return new Promise((resolve, reject) => {
+    const process = child_process.spawn(proxyCommand, proxyCommandOptions, {
+      env: { SD_PROXY_ORIGIN: proxyOrigin },
+      timeout: proxyCommandTimeout,
+    });
+
+    let stdout = "";
+    let stderr = "";
+    process.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+
+    process.stderr.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    process.on("close", (code, signal) => {
+      if (signal) {
+        reject(new Error(`Process terminated with signal ${signal}`));
+      } else if (code != 0) {
+        reject(
+          new Error(`Process exited with non-zero code ${code}: ${stderr}`),
+        );
+      } else {
+        try {
+          const result = JSON.parse(stdout);
+          const status = result["status"];
+          const body = result["body"];
+
+          if (!status) {
+            reject(new Error(`Invalid response: no status code found.\n`));
+          }
+          // Ignore 404s for 4xx error response
+          if (status >= 400 && status < 500 && status != 404) {
+            reject(new Error(`Client error ${status}: ${body}`));
+          } else if (status >= 500 && status < 600) {
+            reject(new Error(`Server error ${status}: ${body}`));
+          }
+
+          resolve({
+            data: body,
+            status: status,
+            headers: result["headers"] || {},
+          });
+        } catch (error) {
+          reject(error);
+        }
+      }
+    });
+
+    process.on("error", (error) => {
+      reject(error);
+    });
+
+    process.stdin.write(JSON.stringify(request) + "\n");
+    process.stdin.end();
+  });
+}

--- a/app/src/utils.ts
+++ b/app/src/utils.ts
@@ -2,3 +2,10 @@
 export function sum(a: number, b: number): number {
   return a + b;
 }
+
+type JSONPrimitive = string | number | boolean | null;
+type JSONArray = JSONValue[];
+export interface JSONObject {
+  [key: string]: JSONValue;
+}
+export type JSONValue = JSONPrimitive | JSONArray | JSONObject;

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -1,0 +1,14 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  // localdev-only: path to locally-build securedrop-proxy binary
+  readonly VITE_SD_PROXY_CMD: string;
+  // securedrop-proxy VM name when running in Qubes environment
+  readonly VITE_PROXY_VM_NAME: string;
+  // SD_PROXY_ORIGIN env var to pass into securedrop-proxy binary
+  readonly VITE_SD_PROXY_ORIGIN: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "commonjs",
+    "module": "esnext",
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Status
Ready for review

## Description

Fixes #2504 

Implements `proxy` to send requests to `sd-proxy`, with the proxy command + proxy origin configured via environment.

## Test Plan

## Checklist

If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:

 - [ ] I have tested these changes in the appropriate Qubes environment
 - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
 - [ ] These changes should not need testing in Qubes

If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:

 - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
 - [ ] No update to the AppArmor profile is required for these changes
 - [ ] I don't know and would appreciate guidance

If these changes modify the database schema, you should include a database migration. Please check as applicable:

 - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
 - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
 - [ ] I need help writing a database migration
 - [ ] No database schema changes are needed

[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
