### PR TITLE
Plaintext to print via libreoffice (fix wrapping)

### DIFF
--- a/export/securedrop_export/print/service.py
+++ b/export/securedrop_export/print/service.py
@@ -34,7 +34,6 @@ MIMETYPE_ARCHIVE = [
 # see /usr/share/cups/mime/mime.types
 MIMETYPE_PRINT_WITHOUT_CONVERSION = [
     "application/pdf",
-    "text/plain",
     "image/gif",
     "image/png",
     "image/jpeg",


### PR DESCRIPTION
## Description

When printing plaintext files or printing the transcript, the messages would get wrapped truncated mid-word instead of wrapping words around. By sending it via libreoffice, this kind of formatting is automatically handled.

Fixes #2442. It also has the side-effect of increasing the page margins. My assumption is that it's fine and not worth fiddling on libreoffice via parameters.

| **Before**| **After** |
|---|---|
| ![Screenshot 2025-06-30 at 13-15-14 before pdf](https://github.com/user-attachments/assets/121b9c1a-3e2b-46d8-987b-86667f6dd2bc) | ![Screenshot 2025-06-30 at 13-15-36 after pdf](https://github.com/user-attachments/assets/7b305f16-eb46-482c-88ec-407cbccbb9ca)

## Test Plan

- [x] Reply to test source with long reply
- [x] Print transcript
- [x] Ensure wrapping respects words
- [x] Test submitting a txt file as the test source and print that file and ensure that it also gets correctly truncated
- [x] Light testing on a couple of other files to ensure they are unnaffected
