### PR TITLE
Configure weekly dependabot updates for app/

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,18 @@ updates:
     schedule:
       interval: "weekly"
 
+  - package-ecosystem: npm
+    directory: "/app"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        patterns: ["*"]
+        dependency-type: "production"
+      dev-dependencies:
+        patterns: ["*"]
+        dependency-type: "development"
+
   # Python development dependencies
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION

## Status

Ready for review 

## Description

Have dependabot update our npm dependencies on a weekly basis. (Once we get farther along we could have it update electron packages on a faster schedule if we find the need.)

It should submit two PRs, one for production dependencies and another for development ones.

## Test Plan

* [ ] visual review; easier to approve and see if it works/doesn't work and then update

