### PR TITLE
eslint config: fix multiple projects warning

### DIFF
--- a/app/eslint.config.ts
+++ b/app/eslint.config.ts
@@ -38,7 +38,7 @@ export default tseslint.config(
       "import/resolver": {
         typescript: {
           alwaysTryTypes: true,
-          project: ["./tsconfig.node.json", "./tsconfig.web.json"],
+          project: "tsconfig.json",
         },
         node: {
           extensions: [".js", ".jsx", ".ts", ".tsx"],


### PR DESCRIPTION
## Status

Ready for review

## Description

eslint was issuing a warning:
```
Multiple projects found, consider using a single `tsconfig` with `references` to speed up, or use `noWarnOnMultipleProjects` to suppress this warning  
```

The root `tscondfig.json` is already set up with references to *.web.json and *.node.json

## Test Plan

Running `pnpm fix` or `eslint --fix` generates no warning logs