### PR TITLE
Use `pnpm exec` to run electron-vite

### DIFF
--- a/app/run.sh
+++ b/app/run.sh
@@ -29,4 +29,4 @@ function configure_environment() {
 
 configure_environment
 
-electron-vite dev
+pnpm exec electron-vite dev


### PR DESCRIPTION
If `electron-vite` is not in your PATH, `./run.sh` will fail, which is counter-intuitive.

This makes it so `pnpm start` and `./run.sh` will both work.
