### PR TITLE
Fix paths in the dbmate command

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,7 @@
     "postinstall": "electron-builder install-app-deps",
     "build:unpack": "pnpm run build && electron-builder --dir",
     "build:linux": "pnpm run build && electron-builder --linux",
-    "dbmate": "sh -c 'dbmate --url sqlite:$HOME/.config/SecureDrop/db.sqlite --migrations-dir ./src/database/migrations --schema-file ./src/database/schema.sql \"$@\"' _"
+    "dbmate": "sh -c 'dbmate --url sqlite:$HOME/.config/SecureDrop/db.sqlite --migrations-dir ./src/main/database/migrations --schema-file ./src/main/database/schema.sql \"$@\"' _"
   },
   "keywords": [],
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Status

Ready for review

## Description

`pnpm dbmate` wasn't working before because the paths to the migrations and schema files were wrong. This fixes them.
