### PR TITLE
Clean up client and proxy README files

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -385,14 +385,7 @@ Note: One of the functional tests deletes a source, so you may need to add it ba
 
 ## Making a Release
 
-1. Update versions: `./update_version.sh $new_version_number` and add a new entry in the changelog.
-2. Commit the changes with commit message `securedrop-client $new_version_number` and make a PR.
-3. You should confirm via a manual debian package build and manual testing in Qubes that there are no regressions (this is limited pre-release QA).
-4. Once your PR is approved, you can add a tag: `git tag -a $new_version_number`.
-5. Perform the release signing ceremony on the tag. Push the tag.
-6. The signer should create the source tarball via `python3 setup.py sdist`.
-7. Add a detached signature (with the release key) for the source tarball.
-8. Submit the source tarball and signature via PR into this [repository](https://github.com/freedomofpress/securedrop-builder) along with the debian changelog addition. This tarball and changelog will be used by the package builder.
+See our [documentation for releasing SecureDrop Workstation Debian packages](https://developers.securedrop.org/en/latest/workstation_release_management.html#release-a-debian-package).
 
 ## Debugging
 

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -88,7 +88,7 @@ See our [documentation for managing dependencies](https://developers.securedrop.
 
 ## Making a Release
 
-See our [documentation for releasing Debian packages](https://developers.securedrop.org/en/latest/workstation_release_management.html#release-a-debian-package).
+See our [documentation for releasing SecureDrop Workstation Debian packages](https://developers.securedrop.org/en/latest/workstation_release_management.html#release-a-debian-package).
 
 ## Configuration
 

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -4,15 +4,15 @@
 Workstation](https://github.com/freedomofpress/securedrop-workstation) project.
 
 The code in this repository implements a proxy across two APIs: the [Qubes RPC
-protocol](https://www.qubes-os.org/doc/qrexec3/) and the [SecureDrop
-API](https://docs.securedrop.org/en/latest/development/journalist_api.html).
+protocol](https://www.qubes-os.org/doc/qrexec/) and the [SecureDrop
+API](https://developers.securedrop.org/en/latest/journalist_api.html).
 This proxy is used to forward requests from the securedrop workstation client to
 the securedrop server.
 
-This code is still in development, and not quite ready for integration with the
-rest of the Securedrop Workstation project. However, it is ready to be poked at
-and demonstrated. Feel free to explore and contribute! You'll need a machine
-running [Qubes OS](https://qubes-os.org).
+The proxy is implemented in Rust. The tests are implemented in Python.
+
+The proxy is packaged as the `securedrop-proxy` Debian package, which is
+installed in the `sd-proxy` VM after provisioning a SecureDrop Workstation.
 
 ## Security Properties
 
@@ -72,57 +72,23 @@ The proxy works by reading a JSON object from the standard input, generating an
 HTTP request from that JSON, making that request against the remote server, and
 then either (a) writing to the standard output a JSON object which represents
 the remote server's response or (b) streaming the response directly to the
-standard output. For discussion about the shape of the request and response
-objects, see
-https://github.com/freedomofpress/securedrop-workstation/issues/107.
+standard output.
 
 ## Quick Start
 
-1. [Install Poetry](https://python-poetry.org/docs/#installing-with-the-official-installer)
-2. Run `make test` to verify the installation
+
+1. Install Rust from Debian stable packages or via [rustup](https://rustup.rs/)
+2. [Install Poetry](https://python-poetry.org/docs/#installing-with-the-official-installer)
+3. Run `make test` to build the proxy using Rust and verify the installation
 
 ## Managing Dependencies
 
-We use Poetry to manage dependencies for this project.
-
-### Development dependencies
-
-You can add development dependencies via  `poetry add <name> --group dev`.
-Make sure you commit changes to the lockfile along with changes to `pyproject.toml`.
-
-To update the dependency to the latest version within the specified
-version constraints, simply run `poetry update <name>` and commit the resutling
-changes.
-
-To update to a new major version (e.g., from 1.0.0 to 2.0.0), you will typically have to
-update `pyproject.toml`.
-
-### Production dependencies
-
-To add a production dependency, use `poetry add <name>`, and to update it,
-use `poetry update <name>`.
-
-For our production Debian packages, we use locally built wheels instead of
-downloading wheels from PyPI.
-
-This means that whenever you add or update a production dependency, you also
-have to build and commit a new wheel according to the process described in the
-[securedrop-builder](https://github.com/freedomofpress/securedrop-builder)
-repository.
-
-This will result in an updated `build-requirements.txt` file you can add to your
-PR in this repository.
+We use Poetry to manage Python test dependencies for this project, and Cargo to manage Rust dependencies.
+See our [documentation for managing dependencies](https://developers.securedrop.org/en/latest/dependency_updates.html).
 
 ## Making a Release
 
-1. Update versions: `./update_version.sh $new_version_number` and add a new entry in the changelog.
-2. Commit the changes with commit message `securedrop-proxy $new_version_number` and make a PR.
-3. You should confirm via a manual debian package build and manual testing in Qubes that there are no regressions (this is limited pre-release QA).
-4. Once your PR is approved, you can add a tag: `git tag $new_version_number`.
-5. Perform the release signing ceremony on the tag. Push the tag.
-6. The signer should create the source tarball via `python3 setup.py sdist`.
-7. Add a detached signature (with the release key) for the source tarball.
-8. Submit the source tarball and signature via PR into this [repository](https://github.com/freedomofpress/securedrop-debian-packaging). This tarball will be used by the package builder.
+See our [documentation for releasing Debian packages](https://developers.securedrop.org/en/latest/workstation_release_management.html#release-a-debian-package).
 
 ## Configuration
 
@@ -145,93 +111,3 @@ with:
 ## Tests
 
 Unit tests can be run with `make test`.
-
-## Example Commands
-
-The following commands can be used to demonstrate the proxy.
-
-This demonstrates proxying a request which has an `application/json` response:
-
-    $ cat examples/posts.json | ./sd-proxy.py ./config-example.yaml
-
-This demonstrates proxying a request which has a `text/html` response
-and thus is saved to a temp file. The name of the temp file is
-included in the result printed to STDOUT- in dev mode, the file can be
-read at that name under `/tmp`.
-
-    $ cat examples/html.json | ./sd-proxy.py ./config-example.yaml
-
-Finally, this demonstrates some error handling. The request contains invalid
-JSON. The proxy detects the malformed request, and prints an error message.
-(The error message itself is considered a valid proxy response).
-
-    $ cat examples/bad.json | ./sd-proxy.py ./config-example.yaml
-
-## Qubes Integration
-
-Until we determine how we wish to package and install this script,
-demonstrating the proxy in a Qubes environment is a somewhat manual
-process.
-
-First, determine which of your VMs will be acting as the proxy VM
-(where this code will be running), and which will be acting as the
-client VM (where the client code will be running). For the purposes of
-this documentation, we assume the client is running in
-`securedrop-client`, and the proxy is running in `securedrop-proxy`.
-
-Edit `qubes/securedrop.Proxy` to reflect the path to `entrypoint.sh`
-in this repo. Also edit the directory to this repo code in `entrypoint.sh`.
-Next, run `sudo cp qubes/securedrop.Proxy /etc/qubes-rpc/securedrop.Proxy`.
-This will move `securedrop.Proxy` (the qubes-rpc "server path definition" file)
-into place in `/etc/qubes-rpc/`.
-
-In `dom0`, create the file `/etc/qubes-rpc/policy/securedrop.Proxy`
-with the contents
-
-    securedrop-client securedrop-proxy allow
-    @anyvm @anyvm deny
-
-Replace the VM names in the first line above with the correct source and
-destination names for your environment. The second line should appear as is.
-
-Also in `dom0`, edit `/etc/qubes-rpc/policy/qubes.Filecopy`, to add
-near the top:
-
-    securedrop-proxy securedrop-client allow
-
-(again replacing the VM names with the correct source and destination
-names for your environment). This allows non-JSON responses to be
-moved to the client VM using Qubes' native inter-VM file copy service.
-
-Copy `config-example.yaml` to `config.yaml`, and edit it to reflect
-your situation. Ensure that `target_vm` is set to the correct client VM
-name, and that `dev` is `False`. This documentation assumes
-you've left `host` set to `jsonplaceholder.typicode.com`.
-
-At this point, in the client VM you should be able to do
-
-    $ echo '{"method":"GET","path_query":"/posts?userId=1"}' | /usr/lib/qubes/qrexec-client-vm securedrop-proxy securedrop.Proxy
-
-(again replacing `securedrop-proxy` with the name of your proxy AppVM)
-You should see a successful JSON response as returned by the remote server.
-
-Try now
-
-    $ echo '{"method":"GET","path_query":""}' | /usr/lib/qubes/qrexec-client-vm securedrop-proxy securedrop.Proxy
-
-If you have configured everything correctly, you should see a JSON
-response which include a `body` which looks like:
-
-    { ...
-      "body": "{\"filename\": \"7463c589-92d2-46ba-845f-3ace2587916d\"}"
-    }
-
-If you look in `~/QubesIncoming/securedrop-proxy`, you should see a
-new file with that name. The content of that file will reflect the content
-returned by the remote server.
-
-Finally, try invoking an error by providing an invalid JSON request.
-Notice that you receive a `400` response from the proxy:
-
-    $ echo '[INVALID' | /usr/lib/qubes/qrexec-client-vm securedrop-proxy securedrop.Proxy
-    {"body": "{\"error\": \"Invalid JSON in request\"}", "version": "0.1.1", "status": 400, "headers": {"Content-Type": "application/json"}}


### PR DESCRIPTION
Resolves #2429
Resolves #1689

## Description

This includes:
- Pointer to the `app` rewrite
- Pointers to the new `try-client-pr.py` script
- Updates to links that pointed to archived repos due to the monorepo transition
- Updates to links to developer documentation, which has moved to https://developers.securedrop.org/ (these all redirected, but it's nicer to point to the canonical URLs)
- Updates to project status where appropriate
- Consolidation of developer docs that were largely duplicative
- Removal of sections from the proxy README that are no longer applicable to the Rust implementation