### PR TITLE
build(pnpm): make `packages` explicit

### DIFF
--- a/app/pnpm-workspace.yaml
+++ b/app/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - .
+
 ignoredBuiltDependencies:
   - "@tailwindcss/oxide"
   - better-sqlite3


### PR DESCRIPTION
## Status

Ready for review

## Description

This is an attempt to fix #2535.  This `packages` value (i.e., the `app/` directory) is the [default](https://pnpm.io/pnpm-workspace_yaml) implicit for `app/pnpm-workspace.yaml`, but [Dependabot may need it to be explicit](https://github.com/freedomofpress/securedrop-client/actions/runs/16454068357/job/46506483513#step:3:329).


## Test Plan

Visual review after CI.  The real test (i.e., whether this closes #2535) will be whether Dependabot can suggest updates ([e.g.](https://github.com/freedomofpress/securedrop-client/security/dependabot/171)) once this is on `main`.