### PR TITLE
Fix circular reference warning

### DIFF
--- a/app/src/renderer/views/SignIn.tsx
+++ b/app/src/renderer/views/SignIn.tsx
@@ -40,12 +40,15 @@ function SignInView() {
   const [authErrorMessage, setAuthErrorMessage] =
     useState<string>(errorMessageGeneric);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [hasValidationErrors, setHasValidationErrors] =
+    useState<boolean>(false);
 
   const onFinish: FormProps<FormValues>["onFinish"] = async (
     values: FormValues,
   ) => {
     // Clear any previous errors and set loading state
     setAuthError(false);
+    setHasValidationErrors(false);
     setIsSubmitting(true);
 
     // Authenticate to the API
@@ -105,6 +108,10 @@ function SignInView() {
     }
   };
 
+  const onFinishFailed: FormProps<FormValues>["onFinishFailed"] = () => {
+    setHasValidationErrors(true);
+  };
+
   const onValuesChange: FormProps<FormValues>["onValuesChange"] = async (
     _changedValues: Partial<FormValues>,
     _allValues: Partial<FormValues>,
@@ -113,12 +120,16 @@ function SignInView() {
     if (authError) {
       setAuthError(false);
     }
-    // Disable validation errors
-    form.setFields([
-      { name: "username", errors: [] },
-      { name: "passphrase", errors: [] },
-      { name: "oneTimeCode", errors: [] },
-    ]);
+
+    // Clear validation errors only if there are any, and only once per form submission cycle
+    if (hasValidationErrors) {
+      setHasValidationErrors(false);
+      form.setFields([
+        { name: "username", errors: [] },
+        { name: "passphrase", errors: [] },
+        { name: "oneTimeCode", errors: [] },
+      ]);
+    }
   };
 
   const useOffline = () => {
@@ -157,6 +168,7 @@ function SignInView() {
           <Form
             form={form}
             onFinish={onFinish}
+            onFinishFailed={onFinishFailed}
             onValuesChange={onValuesChange}
             layout="vertical"
             className="space-y-6"


### PR DESCRIPTION
## Status

Ready for review

## Description

I noticed that when I typed anything into the username field of SignInView, a circular reference warning appeared:

<img width="1202" height="725" alt="Screenshot_2025-07-25_13-16-04" src="https://github.com/user-attachments/assets/512c74ee-9841-4272-887b-2fc0865408dd" />

This fixes it. Now instead of trying to clear the errors every time any values change, it only clears the errors if there are errors.