### PR TITLE
Simplify pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,33 +1,17 @@
-## Status
+Fixes #
 
-Ready for review / Work in progress
-
-## Description
-
-Fixes #issue.
-
-## Test Plan
-
+## Test plan
+<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
 
 ## Checklist
 
-If these changes modify code paths involving cryptography, the opening of files in VMs or network (via the RPC service) traffic, Qubes testing in the staging environment is required. For fine tuning of the graphical user interface, testing in any environment in Qubes is required. Please check as applicable:
+<!-- If you leave any box below unchecked, please clarify where you may need support.
+     If you're unsure, that's fine — a reviewer can help you out. -->
 
- - [ ] I have tested these changes in the appropriate Qubes environment
- - [ ] I do not have an appropriate Qubes OS workstation set up (the reviewer will need to test these changes)
- - [ ] These changes should not need testing in Qubes
+This change accounts for:
+- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
+- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
+- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)
 
-If these changes add or remove files other than client code, the AppArmor profile may need to be updated. Please check as applicable:
-
- - [ ] I have updated the [AppArmor profile](https://github.com/freedomofpress/securedrop-client/blob/HEAD/files/usr.bin.securedrop-client)
- - [ ] No update to the AppArmor profile is required for these changes
- - [ ] I don't know and would appreciate guidance
-
-If these changes modify the database schema, you should include a database migration. Please check as applicable:
-
- - [ ] I have written a migration and upgraded a test database based on `main` and confirmed that the migration is [self-contained] and applies cleanly
- - [ ] I have written a migration but have not upgraded a test database based on `main` and would like the reviewer to do so
- - [ ] I need help writing a database migration
- - [ ] No database schema changes are needed
-
-[self-contained]: https://github.com/freedomofpress/securedrop-client#generating-and-running-database-migrations
+[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
+[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations


### PR DESCRIPTION
Same principles as https://github.com/freedomofpress/securedrop/blob/develop/.github/PULL_REQUEST_TEMPLATE.md

- Use project board to track state
- "Description" is implied
- When a checklist is not completed, that should always convey useful information

Also fixes a couple of links that were broken since monorepo.