### PR TITLE
Enable typescript stack traces

### DIFF
--- a/app/electron.vite.config.ts
+++ b/app/electron.vite.config.ts
@@ -44,9 +44,15 @@ export default defineConfig(({ mode }) => {
     main: {
       plugins: [externalizeDepsPlugin()],
       define: mainVars,
+      build: {
+        sourcemap: true,
+      },
     },
     preload: {
       plugins: [externalizeDepsPlugin()],
+      build: {
+        sourcemap: true,
+      },
     },
     renderer: {
       resolve: {

--- a/app/package.json
+++ b/app/package.json
@@ -69,13 +69,15 @@
     "@tailwindcss/vite": "^4.1.11",
     "antd": "^5.26.4",
     "better-sqlite3": "^12.1.0",
-    "i18next": "^25.3.2",
     "dbmate": "^2.27.0",
+    "i18next": "^25.3.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-i18next": "^15.6.0",
     "react-redux": "^9.2.0",
     "react-router": "^7.6.3",
+    "source-map-support": "^0.5.21",
     "tailwindcss": "^4.1.11"
-  }
+  },
+  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748"
 }

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -29,12 +29,12 @@ importers:
       better-sqlite3:
         specifier: ^12.1.0
         version: 12.1.0
-      i18next:
-        specifier: ^25.3.2
-        version: 25.3.2(typescript@5.8.3)
       dbmate:
         specifier: ^2.27.0
         version: 2.27.0
+      i18next:
+        specifier: ^25.3.2
+        version: 25.3.2(typescript@5.8.3)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -50,6 +50,9 @@ importers:
       react-router:
         specifier: ^7.6.3
         version: 7.6.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      source-map-support:
+        specifier: ^0.5.21
+        version: 0.5.21
       tailwindcss:
         specifier: ^4.1.11
         version: 4.1.11
@@ -1904,11 +1907,8 @@ packages:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie@1.0.2:
-    resolution:
-      {
-        integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
 
   copy-to-clipboard@3.3.3:
     resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
@@ -2620,10 +2620,7 @@ packages:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-parse-stringify@3.0.1:
-    resolution:
-      {
-        integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==,
-      }
+    resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -2652,10 +2649,7 @@ packages:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   i18next@25.3.2:
-    resolution:
-      {
-        integrity: sha512-JSnbZDxRVbphc5jiptxr3o2zocy5dEqpVm9qCGdJwRNO+9saUJS0/u4LnM/13C23fUEWxAylPqKU/NpMV/IjqA==,
-      }
+    resolution: {integrity: sha512-JSnbZDxRVbphc5jiptxr3o2zocy5dEqpVm9qCGdJwRNO+9saUJS0/u4LnM/13C23fUEWxAylPqKU/NpMV/IjqA==}
     peerDependencies:
       typescript: ^5
     peerDependenciesMeta:
@@ -3754,15 +3748,12 @@ packages:
       react: ^19.1.0
 
   react-i18next@15.6.0:
-    resolution:
-      {
-        integrity: sha512-W135dB0rDfiFmbMipC17nOhGdttO5mzH8BivY+2ybsQBbXvxWIwl3cmeH3T9d+YPBSJu/ouyJKFJTtkK7rJofw==,
-      }
+    resolution: {integrity: sha512-W135dB0rDfiFmbMipC17nOhGdttO5mzH8BivY+2ybsQBbXvxWIwl3cmeH3T9d+YPBSJu/ouyJKFJTtkK7rJofw==}
     peerDependencies:
-      i18next: ">= 23.2.3"
-      react: ">= 16.8.0"
-      react-dom: "*"
-      react-native: "*"
+      i18next: '>= 23.2.3'
+      react: '>= 16.8.0'
+      react-dom: '*'
+      react-native: '*'
       typescript: ^5
     peerDependenciesMeta:
       react-dom:
@@ -3798,14 +3789,11 @@ packages:
     engines: {node: '>=0.10.0'}
 
   react-router@7.6.3:
-    resolution:
-      {
-        integrity: sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==,
-      }
-    engines: { node: ">=20.0.0" }
+    resolution: {integrity: sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
-      react: ">=18"
-      react-dom: ">=18"
+      react: '>=18'
+      react-dom: '>=18'
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -3983,10 +3971,7 @@ packages:
     engines: {node: '>=10'}
 
   set-cookie-parser@2.7.1:
-    resolution:
-      {
-        integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==,
-      }
+    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -4500,11 +4485,8 @@ packages:
         optional: true
 
   void-elements@3.1.0:
-    resolution:
-      {
-        integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
+    engines: {node: '>=0.10.0'}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -7581,7 +7563,7 @@ snapshots:
 
   i18next@25.3.2(typescript@5.8.3):
     dependencies:
-      "@babel/runtime": 7.27.6
+      '@babel/runtime': 7.27.6
     optionalDependencies:
       typescript: 5.8.3
 
@@ -8778,7 +8760,7 @@ snapshots:
 
   react-i18next@15.6.0(i18next@25.3.2(typescript@5.8.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3):
     dependencies:
-      "@babel/runtime": 7.27.6
+      '@babel/runtime': 7.27.6
       html-parse-stringify: 3.0.1
       i18next: 25.3.2(typescript@5.8.3)
       react: 19.1.0

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -1,3 +1,4 @@
+import "source-map-support/register";
 import { app, BrowserWindow, ipcMain } from "electron";
 import { join } from "path";
 import { optimizer, is } from "@electron-toolkit/utils";


### PR DESCRIPTION
## Status

Ready for review

## Description

Fixes https://github.com/freedomofpress/securedrop-client/issues/2576

This PR adds the [source-map-support](https://www.npmjs.com/package/source-map-support) npm dependency, and imports it at the top of the main process.

And it edits the electron-vite config to build source maps when building main and preload:

```sh
$ pnpm build
$ ls -l out/main
total 48
-rw-r--r--  1 user  staff   5907 Aug  5 09:18 index.js
-rw-r--r--  1 user  staff  15972 Aug  5 09:18 index.js.map
```

The `.map` file is new, and this is used to map the typescript source to the compiled javascript.

## Test Plan

First, trigger an error in the main process. An easy way to do this is to change the `request` IPC function from this:

```ts
  ipcMain.handle("request", async (_event, request: ProxyRequest) => {
    const result = await proxy(request);
    return result;
  });
```

To this:

```ts
  ipcMain.handle("request", async (_event, request: ProxyRequest) => {
    throw new Error("Testing error handling in main process");
    // const result = await proxy(request);
    // return result;
  });
```

Now, when you try signing in, it throws an error.

Start the app with `pnpm dev`, then try logging in with any username, passphrase, and 2fa code. In the terminal, the stack trace should show the correct file and line number:

```
Error occurred in handler for 'request': Error: Testing error handling in main process
    at /Users/user/code/freedomofpress/securedrop-client/app/src/main/index.ts:60:11
    at Session.<anonymous> (node:electron/js2c/browser_init:2:107040)
    at Session.emit (node:events:518:28)
```

---

If you try the same thing in the main branch, this is the stack trace:

```
Error occurred in handler for 'request': Error: Testing error handling in main process
    at /Users/user/code/freedomofpress/securedrop-client/app/out/main/index.js:110:11
    at Session.<anonymous> (node:electron/js2c/browser_init:2:107040)
    at Session.emit (node:events:518:28)
```
