### PR TITLE
Log performance of IPC calls to the console

### DIFF
--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -1,14 +1,46 @@
 // See the Electron documentation for details on how to use preload scripts:
 // https://www.electronjs.org/docs/latest/tutorial/process-model#preload-scripts
 import { contextBridge, ipcRenderer } from "electron";
-import type { ProxyRequest, SyncMetadataRequest } from "../types";
+import type {
+  ProxyJSONResponse,
+  ProxyRequest,
+  ProxyResponse,
+  SyncMetadataRequest,
+} from "../types";
+
+// Log the performance of IPC calls
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function logIpcCall<T>(name: string, fn: (...args: any[]) => Promise<T>) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return async (...args: any[]): Promise<T> => {
+    console.debug(`[IPC] ${name} called`);
+    const start = performance.now();
+    const result = await fn(...args);
+    const end = performance.now();
+    const duration = end - start;
+    let timeStr;
+    if (duration < 1000) {
+      timeStr = `${duration.toFixed(2)}ms`;
+    } else {
+      timeStr = `${(duration / 1000).toFixed(2)}s`;
+    }
+    console.debug(`[IPC] ${name} finished in ${timeStr}`);
+    return result;
+  };
+}
 
 const electronAPI = {
-  request: (request: ProxyRequest) => ipcRenderer.invoke("request", request),
-  requestStream: (request: ProxyRequest, downloadPath: string) =>
-    ipcRenderer.invoke("request", request, downloadPath),
-  syncMetadata: (request: SyncMetadataRequest) =>
+  request: logIpcCall<ProxyJSONResponse>("request", (request: ProxyRequest) =>
+    ipcRenderer.invoke("request", request),
+  ),
+  requestStream: logIpcCall<ProxyResponse>(
+    "requestStream",
+    (request: ProxyRequest, downloadPath: string) =>
+      ipcRenderer.invoke("requestStream", request, downloadPath),
+  ),
+  syncMetadata: logIpcCall("syncMetadata", (request: SyncMetadataRequest) =>
     ipcRenderer.invoke("syncMetadata", request),
+  ),
 };
 
 contextBridge.exposeInMainWorld("electronAPI", electronAPI);

--- a/app/src/renderer/views/SignIn.tsx
+++ b/app/src/renderer/views/SignIn.tsx
@@ -5,11 +5,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 
-import type {
-  ProxyRequest,
-  ProxyJSONResponse,
-  TokenResponse,
-} from "../../types";
+import type { ProxyRequest, TokenResponse } from "../../types";
 import { useAppDispatch } from "../hooks";
 import {
   setAuth,
@@ -56,7 +52,7 @@ function SignInView() {
 
     // Authenticate to the API
     try {
-      const res: ProxyJSONResponse = await window.electronAPI.request({
+      const res = await window.electronAPI.request({
         method: "POST",
         path_query: "/api/v1/token",
         stream: false,


### PR DESCRIPTION
Split from #2559.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] run `pnpm dev`, log in against a dev server, see that the IPC call is logged in the console (I've verified this)

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
