### PR TITLE
Fetch system language from backend

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -85,6 +85,10 @@ app.whenReady().then(() => {
     },
   );
 
+  ipcMain.handle("getSystemLanguage", async (_event): Promise<string> => {
+    const systemLanguage = process.env.LANG || app.getLocale() || "en";
+    return systemLanguage;
+  });
   createWindow();
 });
 

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -41,6 +41,9 @@ const electronAPI = {
   syncMetadata: logIpcCall("syncMetadata", (request: SyncMetadataRequest) =>
     ipcRenderer.invoke("syncMetadata", request),
   ),
+  getSystemLanguage: logIpcCall<string>("getSystemLanguage", () =>
+    ipcRenderer.invoke("getSystemLanguage"),
+  ),
 };
 
 contextBridge.exposeInMainWorld("electronAPI", electronAPI);

--- a/app/src/renderer/i18n.ts
+++ b/app/src/renderer/i18n.ts
@@ -2,11 +2,21 @@ import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import { resources } from "./locales";
 
-const initialLanguage = navigator.language || "en";
+// Get system language and update i18n
+const initializeLanguage = async () => {
+  try {
+    const systemLanguage = await window.electronAPI.getSystemLanguage();
+    if (systemLanguage && systemLanguage !== i18n.language) {
+      await i18n.changeLanguage(systemLanguage);
+    }
+  } catch (error) {
+    console.warn("Could not get system language:", error);
+  }
+};
 
 i18n.use(initReactI18next).init({
   resources,
-  lng: initialLanguage,
+  lng: "en", // This gets updated immediately to the system language
   fallbackLng: "en",
   defaultNS: "common",
   interpolation: {
@@ -15,4 +25,6 @@ i18n.use(initReactI18next).init({
   },
 });
 
+// Initialize system language after i18n is ready
+initializeLanguage();
 export default i18n;

--- a/app/src/renderer/test-component-setup.tsx
+++ b/app/src/renderer/test-component-setup.tsx
@@ -42,6 +42,8 @@ beforeEach(() => {
     request: vi.fn().mockResolvedValue({ data: "test" }),
     requestStream: vi.fn().mockResolvedValue({ sha256sum: "abc" }),
     getSystemLanguage: vi.fn().mockResolvedValue("en"),
+    // TODO: we may want a real mock here
+    syncMetadata: vi.fn().mockRejectedValue(new Error("mock not implemented")),
   } as ElectronAPI;
 });
 

--- a/app/src/renderer/test-component-setup.tsx
+++ b/app/src/renderer/test-component-setup.tsx
@@ -6,13 +6,10 @@ import * as matchers from "@testing-library/jest-dom/matchers";
 import { MemoryRouter, useLocation } from "react-router";
 import { Provider } from "react-redux";
 import React from "react";
-import i18n from "i18next";
 
 import { setupStore, type RootState } from "./store";
 import "./i18n";
-
-// Change the language to en to we can test for English strings
-i18n.changeLanguage("en");
+import type { ElectronAPI } from "../preload/index";
 
 // Mock global variables
 (global as any).__APP_VERSION__ = "6.6.6-test";
@@ -44,7 +41,8 @@ beforeEach(() => {
   (window as any).electronAPI = {
     request: vi.fn().mockResolvedValue({ data: "test" }),
     requestStream: vi.fn().mockResolvedValue({ sha256sum: "abc" }),
-  };
+    getSystemLanguage: vi.fn().mockResolvedValue("en"),
+  } as ElectronAPI;
 });
 
 // Component to track react-router location changes for testing

--- a/app/tsconfig.web.json
+++ b/app/tsconfig.web.json
@@ -5,7 +5,7 @@
     "src/renderer/env.d.ts",
     "src/renderer/**/*",
     "src/renderer/**/*.tsx",
-    "src/preload/*.d.ts",
+    "src/preload/**/*",
     "src/*.ts",
     "src/*.d.ts",
     "tests/",


### PR DESCRIPTION
Note: this depends on #2592.

Allows usage of the `LANG` environment variable.

Split from #2559.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] run `LANG=de pnpm dev` and in the browser console run `await window.electronAPI.getSystemLanguage();`; you should get `'de'`.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
