### PR TITLE
Rename the app to SecureDrop, to avoid spaces in the config path

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
   "name": "securedrop-app",
   "version": "0.0.1",
   "description": "Graphical desktop app for SecureDrop",
-  "productName": "SecureDrop App",
+  "productName": "SecureDrop",
   "main": "./out/main/index.js",
   "author": {
     "name": "SecureDrop Team",


### PR DESCRIPTION
Fixes #2571.

This renames the productName from `SecureDrop Admin` to `SecureDrop`, which changes the Electron app data folder from `~/.config/SecureDrop App/` to `~/.config/SecureDrop/`.

You can now delete `~/.config/SecureDrop App/`, and the next time you run the SD app it write data to `~/.config/SecureDrop/`, which is where the sqlite3 database is stored.

The title of the app in the title bar is still "SecureDrop App", because that's in the `<title>` tag in `app/src/renderer/index.html`.