### PR TITLE
[app] remove generic type from ProxyResponse

### DIFF
--- a/app/integration_tests/proxy.test.ts
+++ b/app/integration_tests/proxy.test.ts
@@ -85,12 +85,7 @@ describe("Test executing JSON proxy commands against httpbin", async () => {
   );
 
   it("path query with query parameters", async () => {
-    interface Response {
-      args: {
-        [key: string]: string;
-      };
-    }
-    const result = await proxyJSONRequest<Response>(
+    const result = await proxyJSONRequest(
       {
         method: "GET",
         path_query: "/get?foo=bar",
@@ -138,12 +133,7 @@ describe("Test executing JSON proxy commands against httpbin", async () => {
   });
 
   it("request with headers", async () => {
-    interface Response {
-      headers: {
-        [key: string]: string;
-      };
-    }
-    const result = await proxyJSONRequest<Response>(
+    const result = await proxyJSONRequest(
       {
         method: "GET",
         path_query: "/headers",
@@ -158,7 +148,7 @@ describe("Test executing JSON proxy commands against httpbin", async () => {
 
   it("request with body", async () => {
     const input = { id: 42, title: "test" };
-    const result = await proxyJSONRequest<typeof input>(
+    const result = await proxyJSONRequest(
       {
         method: "POST",
         path_query: "/post",
@@ -220,7 +210,7 @@ describe("Test executing streaming proxy", async () => {
   it.for([401, 403, 429, 500, 503, 504])(
     "4xx/5xx HTTP codes return error",
     async (statusCode: number) => {
-      const response: ProxyJSONResponse<string> = (await proxyStreamRequest(
+      const response: ProxyJSONResponse = (await proxyStreamRequest(
         {
           method: "GET",
           path_query: `/status/${statusCode}`,
@@ -230,7 +220,7 @@ describe("Test executing streaming proxy", async () => {
         proxyCommand(1000),
         "/tmp/baz",
         3,
-      )) as ProxyJSONResponse<string>;
+      )) as ProxyJSONResponse;
 
       expect(response.error);
       expect(response.status).toEqual(statusCode);

--- a/app/src/main/proxy.test.ts
+++ b/app/src/main/proxy.test.ts
@@ -57,10 +57,7 @@ describe("Test executing proxy with JSON requests", () => {
       baz: ["foo", "bar"],
       key: 123,
     };
-    const proxyExec = proxyJSONRequest<RespData>(
-      {} as ProxyRequest,
-      mockProxyCommand(),
-    );
+    const proxyExec = proxyJSONRequest({} as ProxyRequest, mockProxyCommand());
 
     const respHeaders = {
       Connection: "Keep-Alive",
@@ -94,10 +91,7 @@ describe("Test executing proxy with JSON requests", () => {
   });
 
   it("proxy should error on non-404 4xx response code", async () => {
-    const proxyExec = proxyJSONRequest<string>(
-      {} as ProxyRequest,
-      mockProxyCommand(),
-    );
+    const proxyExec = proxyJSONRequest({} as ProxyRequest, mockProxyCommand());
 
     const respData = "Rate Limited";
     const respStatus = 429;

--- a/app/src/main/proxy.ts
+++ b/app/src/main/proxy.ts
@@ -18,11 +18,11 @@ const DEFAULT_STREAM_MAX_RETRY_ATTEMPTS = 3;
 // Proxies a network request through sd-proxy
 // For streaming requests, `downloadPath` must be specified as
 // the file location where stream data is downloaded
-export async function proxy<T>(
+export async function proxy(
   request: ProxyRequest,
   downloadPath?: string,
   abortSignal?: AbortSignal,
-): Promise<ProxyResponse<T>> {
+): Promise<ProxyResponse> {
   let command = "";
   let commandOptions: string[] = [];
 
@@ -62,7 +62,7 @@ export async function proxy<T>(
   return proxyJSONRequest(request, proxyCommand);
 }
 
-function parseJSONResponse<T>(response: string): ProxyJSONResponse<T> {
+function parseJSONResponse(response: string): ProxyJSONResponse {
   const result = JSON.parse(response);
   const status = result["status"];
   let body = result["body"];
@@ -75,9 +75,7 @@ function parseJSONResponse<T>(response: string): ProxyJSONResponse<T> {
   if (!error) {
     try {
       if (body && typeof body === "string") {
-        body = JSON.parse(body) as T;
-      } else {
-        body = body as T;
+        body = JSON.parse(body);
       }
     } catch (e) {
       console.log(
@@ -93,10 +91,10 @@ function parseJSONResponse<T>(response: string): ProxyJSONResponse<T> {
   };
 }
 
-export async function proxyJSONRequest<T>(
+export async function proxyJSONRequest(
   request: ProxyRequest,
   command: ProxyCommand,
-): Promise<ProxyJSONResponse<T>> {
+): Promise<ProxyJSONResponse> {
   return new Promise((resolve, reject) => {
     const process = child_process.spawn(command.command, command.options, {
       env: { SD_PROXY_ORIGIN: command.proxyOrigin },
@@ -139,12 +137,12 @@ export async function proxyJSONRequest<T>(
   });
 }
 
-export async function proxyStreamRequest<T>(
+export async function proxyStreamRequest(
   request: ProxyRequest,
   command: ProxyCommand,
   downloadPath: string,
   maxRetryAttempts: number,
-): Promise<ProxyResponse<T>> {
+): Promise<ProxyResponse> {
   let writeStream: fs.WriteStream;
   try {
     const downloadDir = path.dirname(downloadPath);
@@ -180,12 +178,12 @@ export async function proxyStreamRequest<T>(
 
 // Streams proxy request through sd-proxy, writing stream output to
 // the provided writeStream.
-export async function proxyStreamInner<T>(
+export async function proxyStreamInner(
   request: ProxyRequest,
   command: ProxyCommand,
   writeStream: Writable,
   offset?: number,
-): Promise<ProxyResponse<T>> {
+): Promise<ProxyResponse> {
   return new Promise((resolve, reject) => {
     let stderr = "";
     let stdout = "";

--- a/app/src/main/sync.test.ts
+++ b/app/src/main/sync.test.ts
@@ -46,9 +46,7 @@ function mockItemMetadata(uuid: string, source_uuid: string): ItemMetadata {
 describe("syncMetadata", () => {
   let db: DB;
 
-  function mockProxyResponses(
-    responses: ProxyJSONResponse<any>[], // eslint-disable-line @typescript-eslint/no-explicit-any
-  ): MockInstance {
+  function mockProxyResponses(responses: ProxyJSONResponse[]): MockInstance {
     const mock = vi.spyOn(proxyModule, "proxy");
     responses.forEach((response) => {
       mock.mockImplementationOnce(() => {

--- a/app/src/main/sync.ts
+++ b/app/src/main/sync.ts
@@ -21,7 +21,7 @@ async function getIndex(
       Authorization: `Token ${authToken}`,
       "If-None-Match": currentVersion,
     },
-  })) as ProxyJSONResponse<Index>;
+  })) as ProxyJSONResponse;
 
   if (resp.error) {
     return Promise.reject(
@@ -30,7 +30,7 @@ async function getIndex(
   }
 
   if (resp.data) {
-    return resp.data;
+    return resp.data as Index;
   }
 
   // Version matches, there's nothing to do!
@@ -57,7 +57,7 @@ async function fetchMetadata(
       Authorization: `Token ${authToken}`,
     },
     body: JSON.stringify(request),
-  })) as ProxyJSONResponse<MetadataResponse>;
+  })) as ProxyJSONResponse;
 
   if (resp.error) {
     return Promise.reject(
@@ -66,7 +66,7 @@ async function fetchMetadata(
   }
 
   if (resp.data) {
-    return resp.data;
+    return resp.data as MetadataResponse;
   }
   return Promise.reject(
     `Error fetching metadata from server: ${resp.status}: no data`,

--- a/app/src/renderer/views/SignIn.tsx
+++ b/app/src/renderer/views/SignIn.tsx
@@ -56,18 +56,17 @@ function SignInView() {
 
     // Authenticate to the API
     try {
-      const res: ProxyJSONResponse<TokenResponse> =
-        await window.electronAPI.request({
-          method: "POST",
-          path_query: "/api/v1/token",
-          stream: false,
-          body: JSON.stringify({
-            username: values.username,
-            passphrase: values.passphrase,
-            one_time_code: values.oneTimeCode,
-          }),
-          headers: {},
-        } as ProxyRequest);
+      const res: ProxyJSONResponse = await window.electronAPI.request({
+        method: "POST",
+        path_query: "/api/v1/token",
+        stream: false,
+        body: JSON.stringify({
+          username: values.username,
+          passphrase: values.passphrase,
+          one_time_code: values.oneTimeCode,
+        }),
+        headers: {},
+      } as ProxyRequest);
 
       // If the status is not 200, fail
       if (res.status !== 200) {
@@ -84,15 +83,17 @@ function SignInView() {
         return;
       }
 
+      let resp = res.data as TokenResponse;
+
       try {
         // Update the session state
         dispatch(
           setAuth({
-            expiration: res.data.expiration,
-            token: res.data.token,
-            journalistUUID: res.data.journalist_uuid,
-            journalistFirstName: res.data.journalist_first_name,
-            journalistLastName: res.data.journalist_last_name,
+            expiration: resp.expiration,
+            token: resp.token,
+            journalistUUID: resp.journalist_uuid,
+            journalistFirstName: resp.journalist_first_name,
+            journalistLastName: resp.journalist_last_name,
           } as AuthData),
         );
 

--- a/app/src/renderer/views/SignIn.tsx
+++ b/app/src/renderer/views/SignIn.tsx
@@ -83,7 +83,7 @@ function SignInView() {
         return;
       }
 
-      let resp = res.data as TokenResponse;
+      const resp = res.data as TokenResponse;
 
       try {
         // Update the session state

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -14,11 +14,11 @@ export type ProxyCommand = {
   abortSignal?: AbortSignal;
 };
 
-export type ProxyResponse<T> = ProxyJSONResponse<T> | ProxyStreamResponse;
+export type ProxyResponse = ProxyJSONResponse | ProxyStreamResponse;
 
-export type ProxyJSONResponse<T> = {
+export type ProxyJSONResponse = {
   error: boolean;
-  data?: T;
+  data?: JSONValue;
   status: number;
   headers: Map<string, string>;
 };
@@ -40,11 +40,11 @@ export type ms = number & { readonly __unit: "ms" };
 /** Sync types */
 
 // IPC request for syncMetadata operation
-export interface SyncMetadataRequest {
+export type SyncMetadataRequest = {
   authToken: string;
-}
+};
 
-export interface Index {
+export type Index = {
   sources: {
     [uuid: string]: string;
   };
@@ -54,34 +54,34 @@ export interface Index {
   journalists: {
     [uuid: string]: string;
   };
-}
+};
 
-export interface MetadataRequest {
+export type MetadataRequest = {
   sources: string[];
   items: string[];
-}
+};
 
-export interface MetadataResponse {
+export type MetadataResponse = {
   sources: {
     [uuid: string]: SourceMetadata;
   };
   items: {
     [uuid: string]: ItemMetadata;
   };
-}
+};
 
-export interface SourceMetadata {
+export type SourceMetadata = {
   uuid: string;
   journalist_designation: string;
   is_starred: boolean;
   last_updated: string;
   public_key: string;
   fingerprint: string;
-}
+};
 
 export type ItemMetadata = ReplyMetadata | SubmissionMetadata;
 
-export interface ReplyMetadata {
+export type ReplyMetadata = {
   kind: "reply";
   uuid: string;
   source: string;
@@ -89,23 +89,23 @@ export interface ReplyMetadata {
   journalist_uuid: string;
   is_deleted_by_source: boolean;
   seen_by: string[];
-}
+};
 
-export interface SubmissionMetadata {
+export type SubmissionMetadata = {
   kind: "file" | "message";
   uuid: string;
   source: string;
   size: number;
   is_read: boolean;
   seen_by: string[];
-}
+};
 
 /** API v1 Types */
 
-export interface TokenResponse {
+export type TokenResponse = {
   expiration: string;
   token: string;
   journalist_uuid: string;
   journalist_first_name: string;
   journalist_last_name: string;
-}
+};


### PR DESCRIPTION
Adding the generic type annotation to `ProxyResponse` is proving to be more cumbersome than useful. Revert back to having `ProxyJSONResponse` just return a `JSONObject` in its data, and cast as needed in the caller.