### PR TITLE
[app] sync journalist metadata

### DIFF
--- a/app/src/main/database/migrations/20250819160236_add_journalists.sql
+++ b/app/src/main/database/migrations/20250819160236_add_journalists.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+CREATE TABLE IF NOT EXISTS journalists (
+    uuid text primary key,
+    data json,
+    version text,
+);
+
+-- migrate:down
+DROP TABLE journalists;

--- a/app/src/main/sync.test.ts
+++ b/app/src/main/sync.test.ts
@@ -7,10 +7,11 @@ import type {
   MetadataResponse,
   SourceMetadata,
   ItemMetadata,
+  JournalistMetadata,
 } from "../../src/types";
 import * as proxyModule from "../../src/main/proxy";
 
-function mockDB({ index = { sources: {}, items: {} } } = {}) {
+function mockDB({ index = { sources: {}, items: {}, journalists: {} } } = {}) {
   return {
     getVersion: vi.fn(() => "v1"),
     getIndex: vi.fn(() => index),
@@ -40,6 +41,15 @@ function mockItemMetadata(uuid: string, source_uuid: string): ItemMetadata {
     journalist_uuid: "test_journalist",
     is_deleted_by_source: false,
     seen_by: [],
+  };
+}
+
+function mockJournalistMetadata(uuid: string): JournalistMetadata {
+  return {
+    uuid: uuid,
+    username: "test_journalist",
+    first_name: "foo",
+    last_name: "bar",
   };
 }
 
@@ -85,7 +95,9 @@ describe("syncMetadata", () => {
       items: {
         uuid2: "def",
       },
-      journalists: {},
+      journalists: {
+        uuid3: "ghi",
+      },
     };
     const metadata: MetadataResponse = {
       sources: {
@@ -93,6 +105,9 @@ describe("syncMetadata", () => {
       },
       items: {
         uuid2: mockItemMetadata("uuid2", "uuid1"),
+      },
+      journalists: {
+        uuid3: mockJournalistMetadata("uuid3"),
       },
     };
     // Client index is empty
@@ -144,7 +159,9 @@ describe("syncMetadata", () => {
       items: {
         uuid2: "v2",
       },
-      journalists: {},
+      journalists: {
+        uuid3: "v2",
+      },
     };
     db = mockDB();
 
@@ -180,7 +197,9 @@ describe("syncMetadata", () => {
         item1: "v1",
         item2: "outOfDate",
       },
-      journalists: {},
+      journalists: {
+        journalist1: "v1",
+      },
     };
 
     // Server index doesn't have item2: it has been deleted
@@ -191,7 +210,9 @@ describe("syncMetadata", () => {
       items: {
         item1: "v2",
       },
-      journalists: {},
+      journalists: {
+        journalist1: "v2",
+      },
     };
     db = mockDB({
       index: clientIndex,
@@ -204,6 +225,7 @@ describe("syncMetadata", () => {
     expect(metadataToUpdate).toEqual({
       sources: ["source1"],
       items: ["item1"],
+      journalists: ["journalist1"],
     });
   });
 
@@ -217,7 +239,9 @@ describe("syncMetadata", () => {
         item1: "v1",
         item2: "outOfDate",
       },
-      journalists: {},
+      journalists: {
+        journalist1: "v1",
+      },
     };
 
     // Server index doesn't have item2: it has been deleted
@@ -228,7 +252,9 @@ describe("syncMetadata", () => {
       items: {
         item1: "v2",
       },
-      journalists: {},
+      journalists: {
+        journalist1: "v2",
+      },
     };
     const metadata: MetadataResponse = {
       sources: {
@@ -236,6 +262,9 @@ describe("syncMetadata", () => {
       },
       items: {
         item1: mockItemMetadata("item1", "source1"),
+      },
+      journalists: {
+        journalist1: mockJournalistMetadata("journalist1"),
       },
     };
 
@@ -275,7 +304,9 @@ describe("syncMetadata", () => {
         item1: "v2",
         item2: "v2",
       },
-      journalists: {},
+      journalists: {
+        journalist1: "v2",
+      },
     };
 
     // Client index has old item version
@@ -287,7 +318,9 @@ describe("syncMetadata", () => {
         item1: "v1",
         item2: "v2",
       },
-      journalists: {},
+      journalists: {
+        journalist1: "v2",
+      },
     };
     db = mockDB({
       index: clientIndex,
@@ -301,6 +334,7 @@ describe("syncMetadata", () => {
     expect(metadataToUpdate).toEqual({
       items: ["item1"],
       sources: [],
+      journalists: [],
     });
 
     const metadata: MetadataResponse = {
@@ -308,6 +342,7 @@ describe("syncMetadata", () => {
       items: {
         item1: mockItemMetadata("item1", "source1"),
       },
+      journalists: {},
     };
 
     const proxyMock = mockProxyResponses([

--- a/app/src/main/sync.ts
+++ b/app/src/main/sync.ts
@@ -115,9 +115,29 @@ export function reconcileIndex(
     db.deleteItems(itemsToDelete);
   }
 
+  const journalistsToUpdate: string[] = [];
+  Object.keys(serverIndex.journalists).forEach((journalistID) => {
+    if (
+      !clientIndex.journalists[journalistID] ||
+      serverIndex.journalists[journalistID] !=
+        clientIndex.journalists[journalistID]
+    ) {
+      journalistsToUpdate.push(journalistID);
+    }
+    // Also check for journalists to delete
+    const journalistsToDelete = Object.keys(clientIndex.journalists).filter(
+      (journalist) =>
+        !Object.keys(serverIndex.journalists).includes(journalist),
+    );
+    if (journalistsToDelete.length > 0) {
+      db.deleteJournalists(journalistsToDelete);
+    }
+  });
+
   return {
     sources: sourcesToUpdate,
     items: itemsToUpdate,
+    journalists: journalistsToUpdate,
   };
 }
 

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -59,6 +59,7 @@ export type Index = {
 export type MetadataRequest = {
   sources: string[];
   items: string[];
+  journalists: string[];
 };
 
 export type MetadataResponse = {
@@ -67,6 +68,9 @@ export type MetadataResponse = {
   };
   items: {
     [uuid: string]: ItemMetadata;
+  };
+  journalists: {
+    [uuid: string]: JournalistMetadata;
   };
 };
 
@@ -98,6 +102,13 @@ export type SubmissionMetadata = {
   size: number;
   is_read: boolean;
   seen_by: string[];
+};
+
+export type JournalistMetadata = {
+  uuid: string;
+  username: string;
+  first_name: string;
+  last_name: string;
 };
 
 /** API v1 Types */


### PR DESCRIPTION
Fixes #2560 

Now that the API returns journalist metadata, add `journalists` to client DB and sync as part of metadata sync

## Test plan
`pnpm test` suite passes.
