### PR TITLE
Memoize most React components

### DIFF
--- a/app/src/renderer/components/Avatar.test.tsx
+++ b/app/src/renderer/components/Avatar.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it } from "vitest";
+import Avatar from "./Avatar";
+import { testMemoization } from "../test-component-setup";
+
+describe("Avatar Component Memoization", () => {
+  const cases: Array<[{ designation: string; isActive?: boolean }, number]> = [
+    // Initial render
+    [{ designation: "Cool Source", isActive: false }, 1],
+    // Same props - should not re-render
+    [{ designation: "Cool Source", isActive: false }, 1],
+    // Change designation - should re-render
+    [{ designation: "Different Source", isActive: false }, 2],
+    // Change isActive - should re-render
+    [{ designation: "Different Source", isActive: true }, 3],
+    // Back to same props as step 3 - should re-render (props changed from step 4)
+    [{ designation: "Different Source", isActive: false }, 4],
+  ];
+
+  it("should handle memoization correctly", testMemoization(Avatar, cases));
+});

--- a/app/src/renderer/components/Avatar.tsx
+++ b/app/src/renderer/components/Avatar.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from "react";
 import { getInitials } from "../utils";
 
 interface AvatarProps {
@@ -5,8 +6,8 @@ interface AvatarProps {
   isActive?: boolean;
 }
 
-function Avatar({ designation, isActive }: AvatarProps) {
-  const initials = getInitials(designation);
+const Avatar = memo(function Avatar({ designation, isActive }: AvatarProps) {
+  const initials = useMemo(() => getInitials(designation), [designation]);
 
   return (
     <div
@@ -19,6 +20,6 @@ function Avatar({ designation, isActive }: AvatarProps) {
       {initials}
     </div>
   );
-}
+});
 
 export default Avatar;

--- a/app/src/renderer/components/LoadingIndicator.test.tsx
+++ b/app/src/renderer/components/LoadingIndicator.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it } from "vitest";
+import LoadingIndicator from "./LoadingIndicator";
+import { testMemoization } from "../test-component-setup";
+
+describe("LoadingIndicator Component Memoization", () => {
+  const cases: Array<[Record<string, never>, number]> = [
+    // Initial render
+    [{}, 1],
+    // Same props (no props) - should not re-render
+    [{}, 1],
+    // Another identical render - should not re-render
+    [{}, 1],
+  ];
+
+  it(
+    "should handle memoization correctly",
+    testMemoization(LoadingIndicator, cases),
+  );
+});

--- a/app/src/renderer/components/LoadingIndicator.tsx
+++ b/app/src/renderer/components/LoadingIndicator.tsx
@@ -1,4 +1,7 @@
-function LoadingIndicator() {
+import { memo } from "react";
+
+const LoadingIndicator = memo(function LoadingIndicator() {
   return <div className="flex items-center justify-center">Loading...</div>;
-}
+});
+
 export default LoadingIndicator;

--- a/app/src/renderer/views/Inbox/MainContent.tsx
+++ b/app/src/renderer/views/Inbox/MainContent.tsx
@@ -1,5 +1,5 @@
 import { useParams } from "react-router";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { SourceWithItems } from "../../../types";
@@ -34,41 +34,45 @@ function MainContent() {
     }
   }, [sourceUuid]);
 
-  let header: React.ReactNode = null;
-  let content: React.ReactNode = null;
+  const { header, content } = useMemo(() => {
+    let header: React.ReactNode = null;
+    let content: React.ReactNode = null;
 
-  // If we have a source UUID, show the source content
-  if (sourceUuid) {
-    if (loading) {
-      // Loading
-      header = <p>{t("loading.header")}</p>;
-      content = <p>{t("loading.content")}</p>;
-    } else if (!sourceWithItems) {
-      // Source not found
-      header = <p>{t("sourceNotFound.header")}</p>;
-      content = <p>{t("sourceNotFound.content")}</p>;
+    // If we have a source UUID, show the source content
+    if (sourceUuid) {
+      if (loading) {
+        // Loading
+        header = <p>{t("loading.header")}</p>;
+        content = <p>{t("loading.content")}</p>;
+      } else if (!sourceWithItems) {
+        // Source not found
+        header = <p>{t("sourceNotFound.header")}</p>;
+        content = <p>{t("sourceNotFound.content")}</p>;
+      } else {
+        // Source found, display items
+        const designation = toTitleCase(
+          sourceWithItems.data.journalist_designation,
+        );
+        header = (
+          <>
+            <Avatar designation={designation} isActive={false} />
+            <p className="ml-2">{designation}</p>
+          </>
+        );
+        content = <Conversation sourceWithItems={sourceWithItems} />;
+      }
     } else {
-      // Source found, display items
-      const designation = toTitleCase(
-        sourceWithItems.data.journalist_designation,
+      // Show empty state when no source is selected
+      header = <></>;
+      content = (
+        <div className="flex flex-1 items-center justify-center w-full h-full">
+          <EmptyState />
+        </div>
       );
-      header = (
-        <>
-          <Avatar designation={designation} isActive={false} />
-          <p className="ml-2">{designation}</p>
-        </>
-      );
-      content = <Conversation sourceWithItems={sourceWithItems} />;
     }
-  } else {
-    // Show empty state when no source is selected
-    header = <></>;
-    content = (
-      <div className="flex flex-1 items-center justify-center w-full h-full">
-        <EmptyState />
-      </div>
-    );
-  }
+
+    return { header, content };
+  }, [sourceUuid, loading, sourceWithItems, t]);
 
   return (
     <div className="flex-1 flex flex-col h-full min-h-0">

--- a/app/src/renderer/views/Inbox/MainContent/Conversation.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it } from "vitest";
+import Conversation from "./Conversation";
+import { testMemoization } from "../../../test-component-setup";
+import type { SourceWithItems } from "../../../../types";
+
+describe("Conversation Component Memoization", () => {
+  const mockSourceWithItems: SourceWithItems = {
+    uuid: "source-1",
+    data: {
+      uuid: "source-1",
+      journalist_designation: "test source",
+      is_starred: false,
+      last_updated: "2025-01-15T10:00:00Z",
+      public_key: "test-public-key",
+      fingerprint: "test-fingerprint",
+    },
+    items: [
+      {
+        uuid: "item-1",
+        data: {
+          kind: "message",
+          uuid: "item-1",
+          source: "source-1",
+          size: 1024,
+          seen_by: [],
+          is_read: false,
+        },
+      },
+    ],
+  };
+
+  const cases: Array<[{ sourceWithItems: SourceWithItems | null }, number]> = [
+    // Initial render with source
+    [{ sourceWithItems: mockSourceWithItems }, 1],
+    // Same props - should not re-render
+    [{ sourceWithItems: mockSourceWithItems }, 1],
+    // Null source - should re-render
+    [{ sourceWithItems: null }, 2],
+    // Back to same source - should re-render
+    [{ sourceWithItems: mockSourceWithItems }, 3],
+    // Different source - should re-render
+    [
+      {
+        sourceWithItems: {
+          ...mockSourceWithItems,
+          uuid: "source-2",
+          data: { ...mockSourceWithItems.data, uuid: "source-2" },
+        },
+      },
+      4,
+    ],
+  ];
+
+  it(
+    "should handle memoization correctly",
+    testMemoization(Conversation, cases),
+  );
+});

--- a/app/src/renderer/views/Inbox/MainContent/Conversation.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation.tsx
@@ -3,14 +3,16 @@ import { toTitleCase } from "../../../utils";
 import Item from "./Conversation/Item";
 import { Form, Input, Button } from "antd";
 import { useTranslation } from "react-i18next";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, memo, useMemo } from "react";
 import "./Conversation.css";
 
 interface ConversationProps {
   sourceWithItems: SourceWithItems | null;
 }
 
-function Conversation({ sourceWithItems }: ConversationProps) {
+const Conversation = memo(function Conversation({
+  sourceWithItems,
+}: ConversationProps) {
   const { t } = useTranslation("MainContent");
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
@@ -22,9 +24,20 @@ function Conversation({ sourceWithItems }: ConversationProps) {
     }
   }, [sourceWithItems?.items]);
 
-  if (!sourceWithItems) return null;
+  const designation = useMemo(
+    () => sourceWithItems?.data.journalist_designation,
+    [sourceWithItems?.data.journalist_designation],
+  );
 
-  const designation = sourceWithItems.data.journalist_designation;
+  const placeholderText = useMemo(
+    () =>
+      t("conversation.messagePlaceholder", {
+        designation: designation ? toTitleCase(designation) : "",
+      }),
+    [t, designation],
+  );
+
+  if (!sourceWithItems) return null;
 
   return (
     <div className="flex flex-col h-full w-full min-h-0">
@@ -34,7 +47,7 @@ function Conversation({ sourceWithItems }: ConversationProps) {
           className="absolute inset-0 overflow-y-auto p-4 pb-0"
         >
           {sourceWithItems.items.map((item) => (
-            <Item key={item.uuid} item={item} designation={designation} />
+            <Item key={item.uuid} item={item} designation={designation || ""} />
           ))}
         </div>
       </div>
@@ -44,9 +57,7 @@ function Conversation({ sourceWithItems }: ConversationProps) {
             <div className="relative">
               <Input.TextArea
                 rows={4}
-                placeholder={t("conversation.messagePlaceholder", {
-                  designation: toTitleCase(designation),
-                })}
+                placeholder={placeholderText}
                 className="w-full border border-gray-300 rounded-lg p-3 text-gray-900 resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 conversation-textarea"
               />
               <Button
@@ -62,6 +73,6 @@ function Conversation({ sourceWithItems }: ConversationProps) {
       </div>
     </div>
   );
-}
+});
 
 export default Conversation;

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.tsx
@@ -1,6 +1,7 @@
 import { Checkbox, Button, Tooltip } from "antd";
 import { StarFilled, StarOutlined, PaperClipOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
+import { memo, useMemo } from "react";
 
 import type { Source as SourceType } from "../../../../../types";
 import { formatDate, toTitleCase } from "../../../../utils";
@@ -15,7 +16,7 @@ export interface SourceProps {
   onClick: (sourceId: string) => void;
 }
 
-function Source({
+const Source = memo(function Source({
   source,
   isSelected,
   isActive,
@@ -25,11 +26,15 @@ function Source({
 }: SourceProps) {
   const { t, i18n } = useTranslation("Sidebar");
   const { t: tCommon } = useTranslation("common");
-  const designation = toTitleCase(source.data.journalist_designation);
-  const lastUpdated = formatDate(
-    source.data.last_updated,
-    i18n.language,
-    tCommon,
+
+  const designation = useMemo(
+    () => toTitleCase(source.data.journalist_designation),
+    [source.data.journalist_designation],
+  );
+
+  const lastUpdated = useMemo(
+    () => formatDate(source.data.last_updated, i18n.language, tCommon),
+    [source.data.last_updated, i18n.language, tCommon],
   );
 
   return (
@@ -133,6 +138,6 @@ function Source({
       </div>
     </div>
   );
-}
+});
 
 export default Source;


### PR DESCRIPTION
This prevents them from needing to be re-rendered if the input props don't change. Together this is sufficient to make e.g. starring a source not require re-rendering all the unaffected sources. It does not yet fix the overall performance of loading new source rows.

In general:
* `memo`: applied to entire components
* `useMemo`: applied to calculated values
* `useCallback`: applied to functions

The more complicated places that these wrap are good candidates for splitting out into separate components, which'll also make profiling them easier. But I'll defer that for another PR.

Much of this was driven by Claude Code.

Refs #2616.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] load 1000 sources in to the database
* [ ] check out this PR and run `pnpm dev`, then ctrl+r on the login screen so the React dev tools load
* [ ] click use offline; wait for the source list to load
* [ ] start the react profiler, star a source, and then stop the profiler
* [ ] look at the profiler output, and see that only one source was re-rendered.

Here's a video recording of me stepping through the profiler part (with audio).

https://github.com/user-attachments/assets/191dc3a5-50a0-4140-9165-79987e2e4ec9

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
