### PR TITLE
Disallow selection of text in SourceList

### DIFF
--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -289,7 +289,7 @@ function SourceList() {
       {/* Sources list */}
       <div className="flex-1 min-h-0 relative">
         {loading && <LoadingIndicator />}
-        <div className="absolute inset-0 overflow-y-auto">
+        <div className="absolute inset-0 overflow-y-auto select-none">
           {filteredSources.map((source) => {
             const isSelected = selectedSources.has(source.uuid);
             const isActive = activeSourceUuid === source.uuid;


### PR DESCRIPTION
The primary function of the list is source selection; all the text rendered there is selectable in other ways, and the preview text is truncated anyway.

Fixes #2626.


## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] try selecting message preview text in the source list, it won't let you.
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
