### PR TITLE
Implement dropdown filter controls via CSS

### DIFF
--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -136,8 +136,10 @@ function SourceList() {
           return false;
         }
 
+        return true;
+
         // Then filter by the selected filter option
-        switch (filter) {
+        /*switch (filter) {
           case "unread":
             return !source.isRead;
           case "read":
@@ -149,7 +151,7 @@ function SourceList() {
           case "all":
           default:
             return true; // "all" filter shows everything
-        }
+        }*/
       })
       .sort((a, b) => {
         const dateA = new Date(a.data.last_updated).getTime();
@@ -161,10 +163,10 @@ function SourceList() {
           return dateB - dateA; // Descending: newest first
         }
       });
-  }, [sources, searchTerm, filter, sortedAsc]);
+  }, [sources, searchTerm, sortedAsc]);
 
   return (
-    <div className="flex-1 flex flex-col min-h-0">
+    <div className="flex-1 flex flex-col min-h-0 sd-sourcelist">
       {/* Header with select all and action buttons */}
       <div className="sd-bg-primary sd-border-secondary px-4 py-3 border-b flex-shrink-0">
         <div className="flex items-center justify-between gap-2 min-w-0">

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -1,22 +1,13 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { useNavigate, useParams } from "react-router";
-import { Checkbox, Button, Dropdown, Input, Tooltip } from "antd";
-import {
-  Trash,
-  Mail,
-  Search,
-  CalendarArrowDown,
-  CalendarArrowUp,
-  ChevronDown,
-  ChevronUp,
-} from "lucide-react";
+import { Checkbox, Button, Tooltip } from "antd";
+import { Trash, Mail } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import type { Source as SourceType } from "../../../../types";
 import Source from "./SourceList/Source";
 import LoadingIndicator from "../../../components/LoadingIndicator";
-
-type filterOption = "all" | "read" | "unread" | "starred" | "unstarred";
+import FilterControls, { type filterOption } from "./SourceList/FilterControls";
 
 function SourceList() {
   const { t } = useTranslation("Sidebar");
@@ -172,37 +163,6 @@ function SourceList() {
       });
   }, [sources, searchTerm, filter, sortedAsc]);
 
-  const dropdownItems = useMemo(
-    () => [
-      {
-        key: "all",
-        label: t("sourcelist.filters.all"),
-        onClick: () => handleFilterChange("all"),
-      },
-      {
-        key: "read",
-        label: t("sourcelist.filters.read"),
-        onClick: () => handleFilterChange("read"),
-      },
-      {
-        key: "unread",
-        label: t("sourcelist.filters.unread"),
-        onClick: () => handleFilterChange("unread"),
-      },
-      {
-        key: "starred",
-        label: t("sourcelist.filters.starred"),
-        onClick: () => handleFilterChange("starred"),
-      },
-      {
-        key: "unstarred",
-        label: t("sourcelist.filters.unstarred"),
-        onClick: () => handleFilterChange("unstarred"),
-      },
-    ],
-    [t, handleFilterChange],
-  );
-
   return (
     <div className="flex-1 flex flex-col min-h-0">
       {/* Header with select all and action buttons */}
@@ -243,46 +203,16 @@ function SourceList() {
             )}
           </div>
 
-          <Input
-            placeholder={t("sourcelist.search.placeholder")}
-            prefix={<Search size={18} />}
-            value={searchTerm}
-            onChange={handleSearchChange}
-            className="flex-1 min-w-0 max-w-xs"
-            allowClear
+          <FilterControls
+            searchTerm={searchTerm}
+            filter={filter}
+            sortedAsc={sortedAsc}
+            dropdownOpen={dropdownOpen}
+            onSearchChange={handleSearchChange}
+            onFilterChange={handleFilterChange}
+            onToggleSort={handleToggleSort}
+            onDropdownOpenChange={setDropdownOpen}
           />
-
-          <div className="flex items-center gap-1 flex-shrink-0">
-            <Dropdown
-              menu={{ items: dropdownItems }}
-              trigger={["click"]}
-              onOpenChange={setDropdownOpen}
-            >
-              <Button type="text" data-testid="filter-dropdown">
-                {dropdownItems.find((item) => item.key === filter)?.label}{" "}
-                {dropdownOpen ? (
-                  <ChevronUp size={18} />
-                ) : (
-                  <ChevronDown size={18} />
-                )}
-              </Button>
-            </Dropdown>
-
-            <Tooltip title={t("sourcelist.sort.tooltip")}>
-              <Button
-                type="text"
-                icon={
-                  sortedAsc ? (
-                    <CalendarArrowUp size={18} />
-                  ) : (
-                    <CalendarArrowDown size={18} />
-                  )
-                }
-                onClick={handleToggleSort}
-                data-testid="sort-button"
-              />
-            </Tooltip>
-          </div>
         </div>
       </div>
 

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList/FilterControls.css
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList/FilterControls.css
@@ -1,0 +1,13 @@
+/* nothing to hide for filter-all */
+.sd-sourcelist:has(.sd-filter-read) .sd-source-unread {
+    display: none;
+}
+.sd-sourcelist:has(.sd-filter-unread) .sd-source-read {
+    display: none;
+}
+.sd-sourcelist:has(.sd-filter-starred) .sd-source-unstarred {
+    display: none;
+}
+.sd-sourcelist:has(.sd-filter-unstarred) .sd-source-starred {
+    display: none;
+}

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList/FilterControls.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList/FilterControls.tsx
@@ -8,6 +8,7 @@ import {
   ChevronUp,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import "./FilterControls.css";
 
 type filterOption = "all" | "read" | "unread" | "starred" | "unstarred";
 
@@ -78,6 +79,7 @@ function FilterControls({
 
       <div className="flex items-center gap-1 flex-shrink-0">
         <Dropdown
+          className={`sd-filter-${filter}`}
           menu={{ items: dropdownItems }}
           trigger={["click"]}
           onOpenChange={onDropdownOpenChange}

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList/FilterControls.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList/FilterControls.tsx
@@ -1,0 +1,111 @@
+import { useMemo } from "react";
+import { Button, Dropdown, Input, Tooltip } from "antd";
+import {
+  Search,
+  CalendarArrowDown,
+  CalendarArrowUp,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+type filterOption = "all" | "read" | "unread" | "starred" | "unstarred";
+
+interface FilterControlsProps {
+  searchTerm: string;
+  filter: filterOption;
+  sortedAsc: boolean;
+  dropdownOpen: boolean;
+  onSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onFilterChange: (newFilter: filterOption) => void;
+  onToggleSort: () => void;
+  onDropdownOpenChange: (open: boolean) => void;
+}
+
+function FilterControls({
+  searchTerm,
+  filter,
+  sortedAsc,
+  dropdownOpen,
+  onSearchChange,
+  onFilterChange,
+  onToggleSort,
+  onDropdownOpenChange,
+}: FilterControlsProps) {
+  const { t } = useTranslation("Sidebar");
+
+  const dropdownItems = useMemo(
+    () => [
+      {
+        key: "all",
+        label: t("sourcelist.filters.all"),
+        onClick: () => onFilterChange("all"),
+      },
+      {
+        key: "read",
+        label: t("sourcelist.filters.read"),
+        onClick: () => onFilterChange("read"),
+      },
+      {
+        key: "unread",
+        label: t("sourcelist.filters.unread"),
+        onClick: () => onFilterChange("unread"),
+      },
+      {
+        key: "starred",
+        label: t("sourcelist.filters.starred"),
+        onClick: () => onFilterChange("starred"),
+      },
+      {
+        key: "unstarred",
+        label: t("sourcelist.filters.unstarred"),
+        onClick: () => onFilterChange("unstarred"),
+      },
+    ],
+    [t, onFilterChange],
+  );
+
+  return (
+    <>
+      <Input
+        placeholder={t("sourcelist.search.placeholder")}
+        prefix={<Search size={18} />}
+        value={searchTerm}
+        onChange={onSearchChange}
+        className="flex-1 min-w-0 max-w-xs"
+        allowClear
+      />
+
+      <div className="flex items-center gap-1 flex-shrink-0">
+        <Dropdown
+          menu={{ items: dropdownItems }}
+          trigger={["click"]}
+          onOpenChange={onDropdownOpenChange}
+        >
+          <Button type="text" data-testid="filter-dropdown">
+            {dropdownItems.find((item) => item.key === filter)?.label}{" "}
+            {dropdownOpen ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
+          </Button>
+        </Dropdown>
+
+        <Tooltip title={t("sourcelist.sort.tooltip")}>
+          <Button
+            type="text"
+            icon={
+              sortedAsc ? (
+                <CalendarArrowUp size={18} />
+              ) : (
+                <CalendarArrowDown size={18} />
+              )
+            }
+            onClick={onToggleSort}
+            data-testid="sort-button"
+          />
+        </Tooltip>
+      </div>
+    </>
+  );
+}
+
+export default FilterControls;
+export type { filterOption };

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.tsx
@@ -44,6 +44,9 @@ const Source = memo(function Source({
       className={`flex items-center px-4 py-3 border-b border-gray-100 cursor-pointer transition-colors duration-150 ease-in-out
         ${isActive ? "bg-blue-500 text-white hover:bg-blue-600" : "hover:bg-gray-50"}
         ${isSelected && !isActive ? "bg-blue-25" : ""}
+        sd-source
+        ${source.data.is_starred ? "sd-source-starred" : "sd-source-unstarred"}
+        ${source.isRead ? "sd-source-read" : "sd-source-unread"}
 `}
       onClick={() => onClick(source.uuid)}
     >


### PR DESCRIPTION
Using CSS classes and rules, automatically hide sources based on the filter settings.
    
The not-yet implemented part is processing the filter state in JS for when we need to do bulk actions.

Fixes #2634.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
