### PR TITLE
Add debouncing to the search field

### DIFF
--- a/app/src/renderer/hooks/index.ts
+++ b/app/src/renderer/hooks/index.ts
@@ -1,6 +1,8 @@
 import { useDispatch, useSelector, useStore } from "react-redux";
-import type { AppDispatch, AppStore, RootState } from "./store";
+import type { AppDispatch, AppStore, RootState } from "../store";
 
 export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
 export const useAppSelector = useSelector.withTypes<RootState>();
 export const useAppStore = useStore.withTypes<AppStore>();
+
+export { useDebounce } from "./useDebounce";

--- a/app/src/renderer/hooks/useDebounce.ts
+++ b/app/src/renderer/hooks/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
@@ -267,6 +267,36 @@ describe("Sources Component", () => {
   });
 
   describe("Search functionality", () => {
+    it("debounces search input to avoid excessive filtering", async () => {
+      renderWithProviders(<SourceList />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+      });
+
+      const searchInput = screen.getByTestId("source-search-input");
+
+      // Type quickly and check that we get the debounced result
+      await userEvent.type(searchInput, "alice");
+
+      // Should wait for debounce and then filter to only show Alice
+      await waitFor(
+        () => {
+          expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+          expect(
+            screen.queryByTestId("source-source-2"),
+          ).not.toBeInTheDocument();
+          expect(
+            screen.queryByTestId("source-source-3"),
+          ).not.toBeInTheDocument();
+          expect(
+            screen.queryByTestId("source-source-4"),
+          ).not.toBeInTheDocument();
+        },
+        { timeout: 1000 },
+      );
+    });
+
     it("filters sources by designation when search term is entered", async () => {
       renderWithProviders(<SourceList />);
 
@@ -274,14 +304,17 @@ describe("Sources Component", () => {
         expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
       });
 
-      const searchInput = screen.getByPlaceholderText("Search by name");
+      const searchInput = screen.getByTestId("source-search-input");
       await userEvent.type(searchInput, "alice");
 
-      // Only Alice Wonderland should be visible
-      expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
-      expect(screen.queryByTestId("source-source-2")).not.toBeInTheDocument();
-      expect(screen.queryByTestId("source-source-3")).not.toBeInTheDocument();
-      expect(screen.queryByTestId("source-source-4")).not.toBeInTheDocument();
+      // Wait for debounce
+      await waitFor(() => {
+        // Only Alice Wonderland should be visible
+        expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+        expect(screen.queryByTestId("source-source-2")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("source-source-3")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("source-source-4")).not.toBeInTheDocument();
+      });
     });
 
     it("filters sources case-insensitively", async () => {
@@ -291,14 +324,25 @@ describe("Sources Component", () => {
         expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
       });
 
-      const searchInput = screen.getByPlaceholderText("Search by name");
+      const searchInput = screen.getByTestId("source-search-input");
       await userEvent.type(searchInput, "BOB");
 
-      // Bob Builder should be visible (case-insensitive search)
-      expect(screen.queryByTestId("source-source-1")).not.toBeInTheDocument();
-      expect(screen.getByTestId("source-source-2")).toBeInTheDocument();
-      expect(screen.queryByTestId("source-source-3")).not.toBeInTheDocument();
-      expect(screen.queryByTestId("source-source-4")).not.toBeInTheDocument();
+      // Wait for debounce and Bob Builder should be visible (case-insensitive search)
+      await waitFor(
+        () => {
+          expect(
+            screen.queryByTestId("source-source-1"),
+          ).not.toBeInTheDocument();
+          expect(screen.getByTestId("source-source-2")).toBeInTheDocument();
+          expect(
+            screen.queryByTestId("source-source-3"),
+          ).not.toBeInTheDocument();
+          expect(
+            screen.queryByTestId("source-source-4"),
+          ).not.toBeInTheDocument();
+        },
+        { timeout: 1000 },
+      );
     });
 
     it("shows all sources when search is cleared", async () => {
@@ -308,7 +352,7 @@ describe("Sources Component", () => {
         expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
       });
 
-      const searchInput = screen.getByPlaceholderText("Search by name");
+      const searchInput = screen.getByTestId("source-search-input");
       await userEvent.type(searchInput, "alice");
       await userEvent.clear(searchInput);
 
@@ -511,7 +555,7 @@ describe("Sources Component", () => {
       });
 
       // Search for "b" (should match bob builder and charlie chaplin)
-      const searchInput = screen.getByPlaceholderText("Search by name");
+      const searchInput = screen.getByTestId("source-search-input");
       await userEvent.type(searchInput, "b");
 
       // Filter to starred (should only show bob builder since charlie isn't starred)
@@ -519,11 +563,22 @@ describe("Sources Component", () => {
       await userEvent.click(filterButton);
       await userEvent.click(screen.getByText("Starred"));
 
-      // Only Bob Builder should be visible (matches search "b" and is starred)
-      expect(screen.queryByTestId("source-source-1")).not.toBeInTheDocument();
-      expect(screen.getByTestId("source-source-2")).toBeInTheDocument();
-      expect(screen.queryByTestId("source-source-3")).not.toBeInTheDocument();
-      expect(screen.queryByTestId("source-source-4")).not.toBeInTheDocument();
+      await waitFor(
+        () => {
+          // Only Bob Builder should be visible (matches search "b" and is starred)
+          expect(
+            screen.queryByTestId("source-source-1"),
+          ).not.toBeInTheDocument();
+          expect(screen.getByTestId("source-source-2")).toBeInTheDocument();
+          expect(
+            screen.queryByTestId("source-source-3"),
+          ).not.toBeInTheDocument();
+          expect(
+            screen.queryByTestId("source-source-4"),
+          ).not.toBeInTheDocument();
+        },
+        { timeout: 1000 },
+      );
     });
 
     it("maintains sort order when filtering", async () => {

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from "react-i18next";
 import type { Source as SourceType } from "../../../../types";
 import Source from "./SourceList/Source";
 import LoadingIndicator from "../../../components/LoadingIndicator";
+import { useDebounce } from "../../../hooks";
 
 type filterOption = "all" | "read" | "unread" | "starred" | "unstarred";
 
@@ -33,6 +34,9 @@ function SourceList() {
   const [filter, setFilter] = useState<filterOption>("all");
   const [searchTerm, setSearchTerm] = useState("");
   const [dropdownOpen, setDropdownOpen] = useState(false);
+
+  // Debounce search term to avoid excessive filtering
+  const debouncedSearchTerm = useDebounce(searchTerm, 300);
 
   useEffect(() => {
     const fetchSources = async () => {
@@ -139,7 +143,7 @@ function SourceList() {
         // First filter by search term
         const matchesSearch = source.data.journalist_designation
           .toLowerCase()
-          .includes(searchTerm.toLowerCase());
+          .includes(debouncedSearchTerm.toLowerCase());
 
         if (!matchesSearch) {
           return false;
@@ -170,7 +174,7 @@ function SourceList() {
           return dateB - dateA; // Descending: newest first
         }
       });
-  }, [sources, searchTerm, filter, sortedAsc]);
+  }, [sources, debouncedSearchTerm, filter, sortedAsc]);
 
   const dropdownItems = useMemo(
     () => [
@@ -247,6 +251,7 @@ function SourceList() {
             placeholder={t("sourcelist.search.placeholder")}
             prefix={<Search size={18} />}
             value={searchTerm}
+            data-testid="source-search-input"
             onChange={handleSearchChange}
             className="flex-1 min-w-0 max-w-xs"
             allowClear


### PR DESCRIPTION
This pulls out the debouncing logic from https://github.com/freedomofpress/securedrop-client/pull/2627. Basically, it does this:

- Split `hooks.ts` into its own module, so we can more easily define different hooks separately
- Add a `useDebounce` hook
- Uses the `useDebounce` hook on the search field, so that it doesn't start filtering sources until the user hasn't typed for 300ms
