### PR TITLE
Implement virtual scrolling

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -81,6 +81,7 @@
     "react-i18next": "^15.6.1",
     "react-redux": "^9.2.0",
     "react-router": "^7.8.1",
+    "react-window": "^1.8.11",
     "source-map-support": "^0.5.21",
     "tailwindcss": "^4.1.12"
   },

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       react-router:
         specifier: ^7.8.1
         version: 7.8.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react-window:
+        specifier: ^1.8.11
+        version: 1.8.11(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -3169,6 +3172,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  memoize-one@5.2.1:
+    resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -3845,6 +3851,13 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
+
+  react-window@1.8.11:
+    resolution: {integrity: sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==}
+    engines: {node: '>8.0.0'}
+    peerDependencies:
+      react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react@19.1.1:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
@@ -8164,6 +8177,8 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  memoize-one@5.2.1: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -8899,6 +8914,13 @@ snapshots:
       react: 19.1.1
       set-cookie-parser: 2.7.1
     optionalDependencies:
+      react-dom: 19.1.1(react@19.1.1)
+
+  react-window@1.8.11(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+    dependencies:
+      '@babel/runtime': 7.28.3
+      memoize-one: 5.2.1
+      react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
   react@19.1.1: {}

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor } from "@testing-library/react";
 import { expect, describe, it, vi, beforeEach, afterEach } from "vitest";
 import userEvent from "@testing-library/user-event";
+import React from "react";
 import SourceList from "./SourceList";
 import type { Source as SourceType } from "../../../../types";
 import type { SourceProps } from "./SourceList/Source";
@@ -12,9 +13,20 @@ vi.mock("react-window", () => ({
     children: ItemRenderer,
     itemCount,
     height,
-    itemSize,
     className,
-  }: any) => (
+  }: {
+    children: ({
+      index,
+      style,
+    }: {
+      index: number;
+      style: React.CSSProperties;
+    }) => React.ReactNode;
+    itemCount: number;
+    height: number;
+    itemSize?: number; // Optional since we don't use it in the mock
+    className: string;
+  }) => (
     <div
       data-testid="virtualized-list"
       data-item-count={itemCount}

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
@@ -6,7 +6,29 @@ import type { Source as SourceType } from "../../../../types";
 import type { SourceProps } from "./SourceList/Source";
 import { renderWithProviders } from "../../../test-component-setup";
 
-// Mock the Source component to simplify testing the main Sources component logic
+// Mock react-window to render all items instead of virtualizing
+vi.mock("react-window", () => ({
+  FixedSizeList: ({
+    children: ItemRenderer,
+    itemCount,
+    height,
+    itemSize,
+    className,
+  }: any) => (
+    <div
+      data-testid="virtualized-list"
+      data-item-count={itemCount}
+      style={{ height }}
+      className={className}
+    >
+      {Array.from({ length: itemCount }, (_, index) => (
+        <div key={index}>{ItemRenderer({ index, style: {} })}</div>
+      ))}
+    </div>
+  ),
+}));
+
+// Mock the Source component
 vi.mock("./SourceList/Source", () => ({
   default: ({
     source,
@@ -17,17 +39,28 @@ vi.mock("./SourceList/Source", () => ({
     onClick,
   }: SourceProps) => (
     <div
+      className={`flex items-center px-4 py-3 border-b border-gray-100 cursor-pointer transition-colors duration-150 ease-in-out
+        ${isActive ? "bg-blue-500 text-white hover:bg-blue-600" : "hover:bg-gray-50"}
+        ${isSelected && !isActive ? "bg-blue-25" : ""}
+      `}
       data-testid={`source-${source.uuid}`}
       data-selected={isSelected}
       data-active={isActive}
       onClick={() => onClick(source.uuid)}
     >
+      {/* Checkbox - using input to match test expectations */}
       <input
         type="checkbox"
         data-testid={`source-checkbox-${source.uuid}`}
         checked={isSelected}
-        onChange={(e) => onSelect(source.uuid, e.target.checked)}
+        onChange={(e) => {
+          e.stopPropagation();
+          onSelect(source.uuid, e.target.checked);
+        }}
+        onClick={(e) => e.stopPropagation()}
       />
+
+      {/* Star button */}
       <button
         data-testid={`star-button-${source.uuid}`}
         onClick={(e) => {
@@ -35,9 +68,16 @@ vi.mock("./SourceList/Source", () => ({
           onToggleStar(source.uuid, source.data.is_starred);
         }}
       >
-        {source.data.is_starred ? "star" : "no-star"}
+        {source.data.is_starred ? "★" : "☆"}
       </button>
-      <span data-testid={`source-designation-${source.uuid}`}>
+
+      {/* Source designation */}
+      <span
+        data-testid={`source-designation-${source.uuid}`}
+        className={`text-sm truncate ${
+          isActive ? "text-white" : "text-gray-900"
+        } ${!source.isRead ? "font-bold" : "font-medium"}`}
+      >
         {source.data.journalist_designation}
       </span>
     </div>

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.test.tsx
@@ -50,7 +50,9 @@ describe("Source Component", () => {
       const unreadSource = createMockSource({ isRead: false });
       renderWithProviders(<Source source={unreadSource} {...defaultProps} />);
 
-      const designation = screen.getByTestId("source-designation");
+      const designation = screen.getByTestId(
+        "source-designation-test-uuid-123",
+      );
       expect(designation.className).toContain("font-bold");
       expect(designation.className).not.toContain("font-medium");
     });
@@ -59,7 +61,9 @@ describe("Source Component", () => {
       const readSource = createMockSource({ isRead: true });
       renderWithProviders(<Source source={readSource} {...defaultProps} />);
 
-      const designation = screen.getByTestId("source-designation");
+      const designation = screen.getByTestId(
+        "source-designation-test-uuid-123",
+      );
       expect(designation.className).toContain("font-medium");
       expect(designation.className).not.toContain("font-bold");
     });
@@ -141,7 +145,7 @@ describe("Source Component", () => {
       );
 
       const checkbox = screen.getByTestId(
-        "source-checkbox",
+        "source-checkbox-test-uuid-123",
       ) as HTMLInputElement;
       expect(checkbox.checked).toBe(true);
     });
@@ -153,7 +157,7 @@ describe("Source Component", () => {
       );
 
       const checkbox = screen.getByTestId(
-        "source-checkbox",
+        "source-checkbox-test-uuid-123",
       ) as HTMLInputElement;
       expect(checkbox.checked).toBe(false);
     });
@@ -165,7 +169,7 @@ describe("Source Component", () => {
         <Source source={source} {...defaultProps} isSelected={false} />,
       );
 
-      const checkbox = screen.getByTestId("source-checkbox");
+      const checkbox = screen.getByTestId("source-checkbox-test-uuid-123");
       await user.click(checkbox);
 
       expect(mockOnSelect).toHaveBeenCalledWith("test-uuid-123", true);
@@ -238,7 +242,9 @@ describe("Source Component", () => {
       });
       renderWithProviders(<Source source={source} {...defaultProps} />);
 
-      const designation = screen.getByTestId("source-designation");
+      const designation = screen.getByTestId(
+        "source-designation-test-uuid-123",
+      );
       expect(designation.textContent).toBe("Unique Source Name"); // toTitleCase applied
     });
   });

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.tsx
@@ -46,6 +46,9 @@ const Source = memo(function Source({
         ${isSelected && !isActive ? "bg-blue-25" : ""}
 `}
       onClick={() => onClick(source.uuid)}
+      data-testid={`source-${source.uuid}`}
+      data-selected={isSelected}
+      data-active={isActive}
     >
       {/* Checkbox */}
       <Checkbox
@@ -60,7 +63,7 @@ const Source = memo(function Source({
             ? "text-white [&_.ant-checkbox-inner]:bg-white [&_.ant-checkbox-inner]:border-white [&_.ant-checkbox-checked_.ant-checkbox-inner]:bg-white [&_.ant-checkbox-checked_.ant-checkbox-inner]:border-white"
             : ""
         }
-        data-testid="source-checkbox"
+        data-testid={`source-checkbox-${source.uuid}`}
       />
 
       {/* Star button */}
@@ -83,6 +86,7 @@ const Source = memo(function Source({
             e.stopPropagation();
             onToggleStar(source.uuid, source.data.is_starred);
           }}
+          data-testid={`star-button-${source.uuid}`}
         />
       </Tooltip>
 
@@ -98,7 +102,7 @@ const Source = memo(function Source({
                 className={`text-sm truncate ${
                   isActive ? "text-white" : "text-gray-900"
                 } ${!source.isRead ? "font-bold" : "font-medium"}`}
-                data-testid="source-designation"
+                data-testid={`source-designation-${source.uuid}`}
               >
                 {designation}
               </h3>


### PR DESCRIPTION
This PR fixes the performance issues which have been plaguing the app so far by using [virtual scrolling](https://medium.com/@swatikpl44/virtual-scrolling-in-react-6028f700da6b). It adds the [react-window](https://www.npmjs.com/package/react-window) dependency to simplify the implementation of it. We may want to also implement this for conversation views, though those may be more complex because each item might have different heights.

Basically, rather than rendering all 1000 sources to the DOM (including all of their child components), this only renders the sources that are visible at the time based on the scrollbar position. So instead of rendering 1000 sources, it renders maybe 15 or so, depending on the window height. And as you scroll, it deletes the ones that are out of view and renders the new one that are in view.

Here's a video, recorded in Qubes, with 1000 sources.

[output.webm](https://github.com/user-attachments/assets/f34c0edd-264e-4eaf-a244-8483bb94999d)

Fixes #2616.
