### PR TITLE
Have shellcheck ignore app/node_modules

### DIFF
--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -18,6 +18,7 @@ FILES=$(find "." \
         -o -path '*.yml' \
         -o -path '*/.mypy_cache/*' \
         -o -path './.git' \
+        -o -path './app/node_modules/*' \
         -o -path './build/*' \
         -o -path './target' \
      \) -prune \


### PR DESCRIPTION
Takes forever to scan and of course, there are (upstream) scripts in there that fail lint.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
