### PR TITLE
Disable spellcheck in input fields

### DIFF
--- a/app/src/renderer/views/Inbox/Sidebar/SourceList/Toolbar.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList/Toolbar.tsx
@@ -126,6 +126,7 @@ const Toolbar = memo(function Toolbar({
         onChange={onSearchChange}
         className="flex-1 min-w-0 max-w-xs"
         allowClear
+        spellCheck={false}
       />
 
       <div className="flex items-center gap-1 flex-shrink-0">

--- a/app/src/renderer/views/SignIn.tsx
+++ b/app/src/renderer/views/SignIn.tsx
@@ -194,7 +194,11 @@ function SignInView() {
                 },
               ]}
             >
-              <Input data-testid="username-input" placeholder="neliebly" />
+              <Input
+                data-testid="username-input"
+                placeholder="neliebly"
+                spellCheck={false}
+              />
             </Form.Item>
 
             <Form.Item


### PR DESCRIPTION
We don't want to spellcheck usernames nor search queries. It is still enabled in the longer-form reply textarea for now.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] type "asdf " (note space afterwards) in search and no red dots appear underneath
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
