### PR TITLE
Set noImplicitAny in tsconfig

### DIFF
--- a/app/electron.vite.config.ts
+++ b/app/electron.vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig(({ mode }) => {
   const isDev = mode === "development";
   console.log(`Building in ${isDev ? "development" : "production"} mode`);
 
-  const mainVars = {};
+  const mainVars: Record<string, string> = {};
   if (isDev) {
     // Build the proxy: `make -C ../proxy build`
     try {

--- a/app/integration_tests/proxy.test.ts
+++ b/app/integration_tests/proxy.test.ts
@@ -33,7 +33,7 @@ describe("Test executing JSON proxy commands against httpbin", async () => {
       proxyCommand(1000),
     );
     expect(result.status).toEqual(200);
-    expect(result.headers["content-type"]).toEqual("application/json");
+    expect(result.headers.get("content-type")).toEqual("application/json");
   });
 
   it.for([200, 204, 404])(

--- a/app/integration_tests/proxy.test.ts
+++ b/app/integration_tests/proxy.test.ts
@@ -7,7 +7,7 @@ import {
   proxyStreamInner,
   proxyStreamRequest,
 } from "../src/main/proxy";
-import { ProxyCommand, ProxyJSONResponse, ms } from "../src/types";
+import { JSONObject, ProxyCommand, ProxyJSONResponse, ms } from "../src/types";
 
 const proxyCommand = (timeout: number): ProxyCommand => {
   return {
@@ -98,7 +98,7 @@ describe("Test executing JSON proxy commands against httpbin", async () => {
       proxyCommand(1000),
     );
     expect(result.status).toEqual(200);
-    expect(result.data!["args"]).toEqual({ foo: "bar" });
+    expect((result.data! as JSONObject)["args"]).toEqual({ foo: "bar" });
   });
 
   it("proxy subcommand terminates with SIGTERM on timeout", async () => {
@@ -146,7 +146,10 @@ describe("Test executing JSON proxy commands against httpbin", async () => {
       proxyCommand(1000),
     );
     expect(result.status).toEqual(200);
-    expect(result.data!["headers"]).toHaveProperty("X-Test-Header", "th");
+    expect((result.data! as JSONObject)["headers"]).toHaveProperty(
+      "X-Test-Header",
+      "th",
+    );
   });
 
   it("request with body", async () => {
@@ -162,7 +165,7 @@ describe("Test executing JSON proxy commands against httpbin", async () => {
       proxyCommand(1000),
     );
     expect(result.status).toEqual(200);
-    expect(result.data!["json"]).toEqual(input);
+    expect((result.data! as JSONObject)["json"]).toEqual(input);
   });
 });
 

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -19,11 +19,13 @@ import type {
   JournalistMetadata,
 } from "../../types";
 
-const sortKeys = (_, value) =>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const sortKeys = (_: string, value: any) =>
   value instanceof Object && !(value instanceof Array)
     ? Object.keys(value)
         .sort()
-        .reduce((sorted, key) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .reduce((sorted: Record<string, any>, key: string) => {
           sorted[key] = value[key];
           return sorted;
         }, {})
@@ -236,7 +238,7 @@ export class DB {
   getIndex(): Index {
     // NOTE: setting journalists to empty object for now, as implementing
     // journalist sync is still TODO.
-    const index = { sources: {}, items: {}, journalists: {} };
+    const index: Index = { sources: {}, items: {}, journalists: {} };
     for (const row of this.selectAllSourceVersion.iterate()) {
       index.sources[row.uuid] = row.version;
     }

--- a/app/src/main/proxy.test.ts
+++ b/app/src/main/proxy.test.ts
@@ -59,14 +59,14 @@ describe("Test executing proxy with JSON requests", () => {
     };
     const proxyExec = proxyJSONRequest({} as ProxyRequest, mockProxyCommand());
 
-    const respHeaders = {
-      Connection: "Keep-Alive",
-      "Content-Type": "text/html",
-    };
+    const respHeaders = new Map([
+      ["Connection", "Keep-Alive"],
+      ["Content-Type", "text/html"],
+    ]);
     const respStatus = 200;
     const response = {
       status: respStatus,
-      headers: respHeaders,
+      headers: Object.fromEntries(respHeaders),
       body: respData,
     };
     process.stdout?.emit("data", JSON.stringify(response));

--- a/app/src/main/proxy.ts
+++ b/app/src/main/proxy.ts
@@ -90,7 +90,9 @@ function parseJSONResponse(response: string): ProxyJSONResponse {
     error,
     data: body,
     status: status,
-    headers: result["headers"] || {},
+    headers: result["headers"]
+      ? new Map(Object.entries(result["headers"]))
+      : new Map(),
   };
 }
 

--- a/app/src/main/sync.test.ts
+++ b/app/src/main/sync.test.ts
@@ -77,7 +77,7 @@ describe("syncMetadata", () => {
         status: 304,
         error: false,
         data: null,
-        headers: {} as Map<string, string>,
+        headers: new Map(),
       },
     ]);
     const status = await syncModule.syncMetadata(db, "");
@@ -118,14 +118,14 @@ describe("syncMetadata", () => {
         status: 200,
         error: false,
         data: serverIndex,
-        headers: {} as Map<string, string>,
+        headers: new Map(),
       },
       // Metadata response
       {
         status: 200,
         error: false,
         data: metadata,
-        headers: {} as Map<string, string>,
+        headers: new Map(),
       },
     ]);
 
@@ -142,7 +142,7 @@ describe("syncMetadata", () => {
         status: 500,
         error: true,
         data: { msg: "fail" },
-        headers: {} as Map<string, string>,
+        headers: new Map(),
       },
     ]);
     await expect(syncModule.syncMetadata(db, "")).rejects.toMatch(
@@ -170,13 +170,13 @@ describe("syncMetadata", () => {
         status: 200,
         error: false,
         data: serverIndex,
-        headers: {} as Map<string, string>,
+        headers: new Map(),
       },
       {
         status: 500,
         error: true,
         data: { msg: "fail" },
-        headers: {} as Map<string, string>,
+        headers: new Map(),
       },
     ]);
 
@@ -277,13 +277,13 @@ describe("syncMetadata", () => {
         status: 200,
         error: false,
         data: serverIndex,
-        headers: {} as Map<string, string>,
+        headers: new Map(),
       },
       {
         status: 200,
         error: false,
         data: metadata,
-        headers: {} as Map<string, string>,
+        headers: new Map(),
       },
     ]);
 
@@ -350,13 +350,13 @@ describe("syncMetadata", () => {
         status: 200,
         error: false,
         data: serverIndex,
-        headers: {} as Map<string, string>,
+        headers: new Map(),
       },
       {
         status: 200,
         error: false,
         data: metadata,
-        headers: {} as Map<string, string>,
+        headers: new Map(),
       },
     ]);
 
@@ -395,13 +395,13 @@ describe("syncMetadata", () => {
         status: 200,
         error: false,
         data: serverIndex,
-        headers: {} as Map<string, string>,
+        headers: new Map(),
       },
       {
         status: 200,
         error: false,
         data: { sources: {}, items: {} } as MetadataResponse,
-        headers: {} as Map<string, string>,
+        headers: new Map(),
       },
     ]);
 

--- a/app/src/renderer/views/Inbox/MainContent.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent.test.tsx
@@ -87,7 +87,10 @@ describe("MainContent Component", () => {
   });
 
   // Helper function to render MainContent with router and Redux
-  const renderMainContent = (initialRoute = "/", conversationData = {}) => {
+  const renderMainContent = (
+    initialRoute = "/",
+    conversationData: Record<string, SourceWithItems> = {},
+  ) => {
     const sourceUuid = Object.keys(conversationData)[0];
     return renderWithProviders(
       <Routes>

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -3,7 +3,7 @@ export type ProxyRequest = {
   path_query: string;
   stream: boolean;
   body?: string;
-  headers: object;
+  headers: Record<string, string>;
 };
 
 export type ProxyCommand = {

--- a/app/tsconfig.node.json
+++ b/app/tsconfig.node.json
@@ -11,6 +11,7 @@
     "composite": true,
     "types": ["electron-vite/node"],
     "module": "esnext",
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "noImplicitAny": true
   }
 }

--- a/app/tsconfig.web.json
+++ b/app/tsconfig.web.json
@@ -18,6 +18,7 @@
     "paths": {
       "@renderer/*": ["src/renderer/*"]
     },
-    "types": ["vitest/globals", "@testing-library/jest-dom"]
+    "types": ["vitest/globals", "@testing-library/jest-dom"],
+    "noImplicitAny": true
   }
 }


### PR DESCRIPTION
This would've caught the missing react-window types and in general is a bit stricter on typing and closer to our strict mypy config.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
