### PR TITLE
Have securedrop-proxy depend on securedrop-arti

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -37,8 +37,7 @@ Description: Python module and qrexec service to store logs for SecureDrop Works
 
 Package: securedrop-proxy
 Architecture: any
-# TODO: add securedrop-arti once that's published
-Depends: ${misc:Depends}, ${shlibs:Depends}, libqubesdb, python3, python3-cryptography, python3-qubesdb
+Depends: ${misc:Depends}, ${shlibs:Depends}, securedrop-arti, libqubesdb, python3, python3-cryptography, python3-qubesdb
 Description: This is securedrop Qubes proxy service
  This package provides the network proxy on Qubes to talk to the SecureDrop server.
 


### PR DESCRIPTION
Probably needs https://github.com/freedomofpress/securedrop-apt-test/pull/284 before CI will pass.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
