### PR TITLE
Split sync functionality into its own Redux slice

### DIFF
--- a/app/src/main/sync.test.ts
+++ b/app/src/main/sync.test.ts
@@ -150,7 +150,7 @@ describe("syncMetadata", () => {
     );
   });
 
-  it("handles error from syncSources", async () => {
+  it("handles error from syncMetadata", async () => {
     // getIndex returns new index
     const serverIndex: Index = {
       sources: {

--- a/app/src/renderer/features/conversation/conversationSlice.test.ts
+++ b/app/src/renderer/features/conversation/conversationSlice.test.ts
@@ -224,7 +224,6 @@ describe("conversationSlice", () => {
         activeSourceUuid: null,
         loading: false,
         error: null,
-        lastSyncTime: null,
       },
       journalists: {
         journalists: [],
@@ -240,7 +239,7 @@ describe("conversationSlice", () => {
       sync: {
         loading: false,
         error: null,
-        lastSyncTime: null,
+        lastFetchTime: null,
       },
     };
 

--- a/app/src/renderer/features/conversation/conversationSlice.test.ts
+++ b/app/src/renderer/features/conversation/conversationSlice.test.ts
@@ -237,6 +237,11 @@ describe("conversationSlice", () => {
         error: "Test error",
         lastFetchTime: 123456789,
       },
+      sync: {
+        loading: false,
+        error: null,
+        lastSyncTime: null,
+      },
     };
 
     it("selectConversation returns conversation for matching UUID", () => {

--- a/app/src/renderer/features/journalists/journalistsSlice.test.ts
+++ b/app/src/renderer/features/journalists/journalistsSlice.test.ts
@@ -204,7 +204,6 @@ describe("journalistsSlice", () => {
         activeSourceUuid: null,
         loading: false,
         error: null,
-        lastSyncTime: null,
       },
       conversation: {
         conversation: null,
@@ -215,7 +214,7 @@ describe("journalistsSlice", () => {
       sync: {
         loading: false,
         error: null,
-        lastSyncTime: null,
+        lastFetchTime: null,
       },
     };
 

--- a/app/src/renderer/features/journalists/journalistsSlice.test.ts
+++ b/app/src/renderer/features/journalists/journalistsSlice.test.ts
@@ -212,6 +212,11 @@ describe("journalistsSlice", () => {
         error: null,
         lastFetchTime: null,
       },
+      sync: {
+        loading: false,
+        error: null,
+        lastSyncTime: null,
+      },
     };
 
     it("getJournalistsState should return the entire journalists state", () => {

--- a/app/src/renderer/features/sources/sourcesSlice.test.ts
+++ b/app/src/renderer/features/sources/sourcesSlice.test.ts
@@ -97,7 +97,6 @@ describe("sourcesSlice", () => {
         activeSourceUuid: null,
         loading: false,
         error: null,
-        lastSyncTime: null,
       });
     });
   });
@@ -110,7 +109,6 @@ describe("sourcesSlice", () => {
         activeSourceUuid: null,
         loading: false,
         error: "Some error message",
-        lastSyncTime: null,
       };
 
       const action = clearError();
@@ -120,7 +118,6 @@ describe("sourcesSlice", () => {
       expect(newState.sources).toEqual([]);
       expect(newState.activeSourceUuid).toBeNull();
       expect(newState.loading).toBe(false);
-      expect(newState.lastSyncTime).toBeNull();
     });
   });
 
@@ -131,7 +128,6 @@ describe("sourcesSlice", () => {
         activeSourceUuid: null,
         loading: false,
         error: null,
-        lastSyncTime: null,
       };
 
       const action = setActiveSource("source-1");
@@ -148,7 +144,6 @@ describe("sourcesSlice", () => {
         activeSourceUuid: "source-1",
         loading: false,
         error: null,
-        lastSyncTime: null,
       };
 
       const action = clearActiveSource();
@@ -168,7 +163,6 @@ describe("sourcesSlice", () => {
       expect(state.sources).toEqual(mockSources);
       expect(state.loading).toBe(false);
       expect(state.error).toBeNull();
-      expect(state.lastSyncTime).toBeGreaterThan(0);
     });
 
     it("handles fetch error", async () => {
@@ -183,7 +177,6 @@ describe("sourcesSlice", () => {
       expect(state.sources).toEqual([]);
       expect(state.loading).toBe(false);
       expect(state.error).toBe(errorMessage);
-      expect(state.lastSyncTime).toBeNull();
     });
 
     it("sets loading state during fetch", async () => {
@@ -231,7 +224,6 @@ describe("sourcesSlice", () => {
           activeSourceUuid: null,
           loading: false,
           error: null,
-          lastSyncTime: 123456789,
         },
         journalists: {
           journalists: [],
@@ -242,7 +234,7 @@ describe("sourcesSlice", () => {
         sync: {
           loading: false,
           error: null,
-          lastSyncTime: null,
+          lastFetchTime: null,
         },
       };
 
@@ -257,7 +249,6 @@ describe("sourcesSlice", () => {
           activeSourceUuid: "source-1",
           loading: false,
           error: null,
-          lastSyncTime: 123456789,
         },
         journalists: {
           journalists: [],
@@ -268,7 +259,7 @@ describe("sourcesSlice", () => {
         sync: {
           loading: false,
           error: null,
-          lastSyncTime: null,
+          lastFetchTime: null,
         },
       };
 
@@ -283,7 +274,6 @@ describe("sourcesSlice", () => {
           activeSourceUuid: null,
           loading: true,
           error: null,
-          lastSyncTime: null,
         },
         journalists: {
           journalists: [],
@@ -294,7 +284,7 @@ describe("sourcesSlice", () => {
         sync: {
           loading: false,
           error: null,
-          lastSyncTime: null,
+          lastFetchTime: null,
         },
       };
 
@@ -385,27 +375,6 @@ describe("sourcesSlice", () => {
       const state = (store.getState() as any).sources;
       expect(state.error).toBeNull();
       expect(state.sources).toEqual(mockSources);
-    });
-
-    it("updates lastSyncTime on successful operations", async () => {
-      const beforeTime = Date.now();
-
-      await (store.dispatch as any)(fetchSources());
-
-      const afterTime = Date.now();
-      const state = (store.getState() as any).sources;
-
-      expect(state.lastSyncTime).toBeGreaterThanOrEqual(beforeTime);
-      expect(state.lastSyncTime).toBeLessThanOrEqual(afterTime);
-    });
-
-    it("does not update lastSyncTime on failed operations", async () => {
-      mockGetSources.mockRejectedValue(new Error("Failed"));
-
-      await (store.dispatch as any)(fetchSources());
-
-      const state = (store.getState() as any).sources;
-      expect(state.lastSyncTime).toBeNull();
     });
   });
 });

--- a/app/src/renderer/features/sources/sourcesSlice.ts
+++ b/app/src/renderer/features/sources/sourcesSlice.ts
@@ -1,8 +1,6 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import type { RootState } from "../../store";
 import type { Source as SourceType } from "../../../types";
-import { fetchConversation } from "../conversation/conversationSlice";
-import { fetchJournalists } from "../journalists/journalistsSlice";
 
 export interface SourcesState {
   sources: SourceType[];
@@ -26,32 +24,6 @@ export const fetchSources = createAsyncThunk(
   async () => {
     const sources = await window.electronAPI.getSources();
     return sources;
-  },
-);
-
-// Async thunk for syncing sources (calls sync then fetches)
-export const syncSources = createAsyncThunk(
-  "sources/syncSources",
-  async (authToken: string | undefined, { getState, dispatch }) => {
-    // Sync metadata with the server
-    await window.electronAPI.syncMetadata({ authToken });
-
-    // Fetch updated sources
-    const newSources = await window.electronAPI.getSources();
-
-    // Fetch updated journalists
-    dispatch(fetchJournalists());
-
-    // Get the active source from Redux state
-    const state = getState() as RootState;
-    const activeSourceUuid = state.sources.activeSourceUuid;
-
-    // If there's an active source, fetch its conversation
-    if (activeSourceUuid) {
-      dispatch(fetchConversation(activeSourceUuid));
-    }
-
-    return newSources;
   },
 );
 
@@ -84,20 +56,6 @@ export const sourcesSlice = createSlice({
       .addCase(fetchSources.rejected, (state, action) => {
         state.loading = false;
         state.error = action.error.message || "Failed to fetch sources";
-      })
-      // syncSources
-      .addCase(syncSources.pending, (state) => {
-        state.loading = true;
-        state.error = null;
-      })
-      .addCase(syncSources.fulfilled, (state, action) => {
-        state.loading = false;
-        state.sources = action.payload;
-        state.lastSyncTime = Date.now();
-      })
-      .addCase(syncSources.rejected, (state, action) => {
-        state.loading = false;
-        state.error = action.error.message || "Failed to sync sources";
       });
   },
 });

--- a/app/src/renderer/features/sources/sourcesSlice.ts
+++ b/app/src/renderer/features/sources/sourcesSlice.ts
@@ -7,7 +7,6 @@ export interface SourcesState {
   activeSourceUuid: string | null;
   loading: boolean;
   error: string | null;
-  lastSyncTime: number | null;
 }
 
 const initialState: SourcesState = {
@@ -15,7 +14,6 @@ const initialState: SourcesState = {
   activeSourceUuid: null,
   loading: false,
   error: null,
-  lastSyncTime: null,
 };
 
 // Async thunk for fetching sources
@@ -51,7 +49,6 @@ export const sourcesSlice = createSlice({
       .addCase(fetchSources.fulfilled, (state, action) => {
         state.loading = false;
         state.sources = action.payload;
-        state.lastSyncTime = Date.now();
       })
       .addCase(fetchSources.rejected, (state, action) => {
         state.loading = false;

--- a/app/src/renderer/features/sync/syncSlice.test.ts
+++ b/app/src/renderer/features/sync/syncSlice.test.ts
@@ -1,0 +1,272 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { configureStore } from "@reduxjs/toolkit";
+import type { Source as SourceType } from "../../../types";
+import syncSlice, { syncMetadata } from "./syncSlice";
+import sourcesSlice from "../sources/sourcesSlice";
+import sessionSlice from "../session/sessionSlice";
+import conversationSlice from "../conversation/conversationSlice";
+
+// Mock data matching the structure from test-component-setup.tsx
+const mockSources: SourceType[] = [
+  {
+    uuid: "source-1",
+    data: {
+      fingerprint: "ABCD1234EFGH5678IJKL9012MNOP3456QRST7890",
+      is_starred: false,
+      journalist_designation: "multiplicative conditionality",
+      last_updated: "2024-01-15T10:30:00Z",
+      public_key:
+        "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v1\n...\n-----END PGP PUBLIC KEY BLOCK-----",
+      uuid: "source-1",
+    },
+    isRead: false,
+    hasAttachment: false,
+    showMessagePreview: false,
+    messagePreview: "",
+  },
+  {
+    uuid: "source-2",
+    data: {
+      fingerprint: "1234ABCD5678EFGH9012IJKL3456MNOP7890QRST",
+      is_starred: true,
+      journalist_designation: "piezoelectric crockery",
+      last_updated: "2024-01-14T15:45:00Z",
+      public_key:
+        "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v1\n...\n-----END PGP PUBLIC KEY BLOCK-----",
+      uuid: "source-2",
+    },
+    isRead: true,
+    hasAttachment: true,
+    showMessagePreview: true,
+    messagePreview: "Hello from source 2",
+  },
+];
+
+describe("syncSlice", () => {
+  let store: ReturnType<typeof configureStore>;
+  const mockGetSources = vi.fn();
+  const mockSyncMetadata = vi.fn();
+
+  beforeEach(() => {
+    // Create a test store with sources, session, conversations, and sync slices for proper typing
+    store = configureStore({
+      reducer: {
+        sources: sourcesSlice,
+        session: sessionSlice,
+        conversation: conversationSlice,
+        sync: syncSlice,
+      },
+    });
+
+    // Reset mocks
+    vi.clearAllMocks();
+
+    // Mock electronAPI
+    (window as any).electronAPI = {
+      getSources: mockGetSources,
+      syncMetadata: mockSyncMetadata,
+      getSourceWithItems: vi.fn().mockResolvedValue({
+        uuid: "source-1",
+        data: mockSources[0].data,
+        items: [],
+      }),
+    };
+
+    // Default mock implementations
+    mockGetSources.mockResolvedValue(mockSources);
+    mockSyncMetadata.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("syncMetadata async thunk", () => {
+    it("handles successful sync with auth token", async () => {
+      const authToken = "test-auth-token";
+      const action = syncMetadata(authToken);
+      await (store.dispatch as any)(action);
+
+      expect(mockSyncMetadata).toHaveBeenCalledWith({ authToken });
+      expect(mockSyncMetadata).toHaveBeenCalledTimes(1);
+      expect(mockGetSources).toHaveBeenCalledTimes(1);
+
+      const syncState = (store.getState() as any).sync;
+      const sourcesState = (store.getState() as any).sources;
+      expect(sourcesState.sources).toEqual(mockSources);
+      expect(syncState.loading).toBe(false);
+      expect(syncState.error).toBeNull();
+      expect(syncState.lastSyncTime).toBeGreaterThan(0);
+    });
+
+    it("handles sync failure without auth token", async () => {
+      const errorMessage = "Authentication required";
+      mockSyncMetadata.mockRejectedValue(new Error(errorMessage));
+
+      await (store.dispatch as any)(syncMetadata(undefined));
+
+      expect(mockSyncMetadata).toHaveBeenCalledWith({ authToken: undefined });
+      expect(mockGetSources).not.toHaveBeenCalled();
+
+      const syncState = (store.getState() as any).sync;
+      const sourcesState = (store.getState() as any).sources;
+      expect(sourcesState.sources).toEqual([]);
+      expect(syncState.loading).toBe(false);
+      expect(syncState.error).toBe(errorMessage);
+    });
+
+    it("handles sync metadata error", async () => {
+      const errorMessage = "Failed to sync metadata";
+      mockSyncMetadata.mockRejectedValue(new Error(errorMessage));
+
+      const action = syncMetadata("test-token");
+      await (store.dispatch as any)(action);
+
+      expect(mockSyncMetadata).toHaveBeenCalledTimes(1);
+      expect(mockGetSources).not.toHaveBeenCalled();
+
+      const syncState = (store.getState() as any).sync;
+      const sourcesState = (store.getState() as any).sources;
+      expect(sourcesState.sources).toEqual([]);
+      expect(syncState.loading).toBe(false);
+      expect(syncState.error).toBe(errorMessage);
+    });
+
+    it("handles getSources error after successful sync", async () => {
+      const errorMessage = "Failed to get sources";
+      mockGetSources.mockRejectedValue(new Error(errorMessage));
+
+      const action = syncMetadata("test-token");
+      await (store.dispatch as any)(action);
+
+      expect(mockSyncMetadata).toHaveBeenCalledTimes(1);
+      expect(mockGetSources).toHaveBeenCalledTimes(1);
+
+      const syncState = (store.getState() as any).sync;
+      const sourcesState = (store.getState() as any).sources;
+      expect(sourcesState.sources).toEqual([]);
+      expect(syncState.loading).toBe(false);
+      expect(syncState.error).toBeNull(); // Sync succeeded, sources fetch failed
+      expect(sourcesState.error).toBe(errorMessage); // Error is in sources slice
+    });
+
+    it("sets loading state during sync", async () => {
+      // Create promises that we can control
+      let resolveSyncMetadata!: () => void;
+      let resolveGetSources!: (value: SourceType[]) => void;
+
+      const syncMetadataPromise = new Promise<void>((resolve) => {
+        resolveSyncMetadata = resolve;
+      });
+      const getSourcesPromise = new Promise<SourceType[]>((resolve) => {
+        resolveGetSources = resolve;
+      });
+
+      mockSyncMetadata.mockReturnValue(syncMetadataPromise);
+      mockGetSources.mockReturnValue(getSourcesPromise);
+
+      const action = syncMetadata("test-token");
+      const dispatchPromise = (store.dispatch as any)(action);
+
+      // Check loading state is true while pending
+      expect((store.getState() as any).sync.loading).toBe(true);
+      expect((store.getState() as any).sync.error).toBeNull();
+
+      // Resolve both promises
+      resolveSyncMetadata!();
+      resolveGetSources!(mockSources);
+      await dispatchPromise;
+
+      // Check loading state is false after completion
+      expect((store.getState() as any).sync.loading).toBe(false);
+    });
+
+    it("fetches conversation for active source during sync", async () => {
+      const activeSourceUuid = "source-1";
+
+      // Set up store with active source
+      store = configureStore({
+        reducer: {
+          sources: sourcesSlice,
+          session: sessionSlice,
+          conversation: conversationSlice,
+          sync: syncSlice,
+        },
+        preloadedState: {
+          sources: {
+            sources: [],
+            activeSourceUuid: activeSourceUuid,
+            loading: false,
+            error: null,
+            lastSyncTime: null,
+          },
+          sync: {
+            loading: false,
+            error: null,
+            lastSyncTime: null,
+          },
+        },
+      });
+
+      // Mock getSourceWithItems for the active conversation
+      const mockGetSourceWithItems = vi.fn();
+      (window as any).electronAPI.getSourceWithItems = mockGetSourceWithItems;
+      mockGetSourceWithItems.mockResolvedValue({
+        uuid: activeSourceUuid,
+        data: mockSources[0].data,
+        items: [],
+      });
+
+      await (store.dispatch as any)(syncMetadata("test-token"));
+
+      // Should have called getSourceWithItems for the active source only
+      expect(mockGetSourceWithItems).toHaveBeenCalledWith(activeSourceUuid);
+      expect(mockGetSourceWithItems).toHaveBeenCalledTimes(1);
+
+      // Sources should be updated
+      const sourcesState = (store.getState() as any).sources;
+      expect(sourcesState.sources).toEqual(mockSources);
+    });
+
+    it("does not fetch conversations when no active source", async () => {
+      const mockGetSourceWithItems = vi.fn();
+      (window as any).electronAPI.getSourceWithItems = mockGetSourceWithItems;
+
+      await (store.dispatch as any)(syncMetadata("test-token"));
+
+      // Should NOT have called getSourceWithItems since no active source
+      expect(mockGetSourceWithItems).not.toHaveBeenCalled();
+
+      // Sources should still be updated in the store
+      const sourcesState = (store.getState() as any).sources;
+      expect(sourcesState.sources).toEqual(mockSources);
+    });
+
+    it("handles network timeout error during sync", async () => {
+      mockSyncMetadata.mockRejectedValue(new Error("Network timeout"));
+
+      await (store.dispatch as any)(syncMetadata("valid-token"));
+
+      const syncState = (store.getState() as any).sync;
+      const sourcesState = (store.getState() as any).sources;
+      expect(syncState.error).toBe("Network timeout");
+      expect(sourcesState.sources).toEqual([]);
+      expect(syncState.loading).toBe(false);
+
+      // syncMetadata should be called but getSources should not be called due to network failure
+      expect(mockSyncMetadata).toHaveBeenCalledTimes(1);
+      expect(mockGetSources).not.toHaveBeenCalled();
+    });
+
+    it("handles non-Error rejection for syncMetadata", async () => {
+      mockSyncMetadata.mockRejectedValue("String error");
+
+      const action = syncMetadata("test-token");
+      await (store.dispatch as any)(action);
+
+      const syncState = (store.getState() as any).sync;
+      expect(syncState.error).toBe("String error");
+    });
+  });
+});

--- a/app/src/renderer/features/sync/syncSlice.test.ts
+++ b/app/src/renderer/features/sync/syncSlice.test.ts
@@ -97,7 +97,7 @@ describe("syncSlice", () => {
       expect(sourcesState.sources).toEqual(mockSources);
       expect(syncState.loading).toBe(false);
       expect(syncState.error).toBeNull();
-      expect(syncState.lastSyncTime).toBeGreaterThan(0);
+      expect(syncState.lastFetchTime).toBeGreaterThan(0);
     });
 
     it("handles sync failure without auth token", async () => {
@@ -199,12 +199,12 @@ describe("syncSlice", () => {
             activeSourceUuid: activeSourceUuid,
             loading: false,
             error: null,
-            lastSyncTime: null,
+            lastFetchTime: null,
           },
           sync: {
             loading: false,
             error: null,
-            lastSyncTime: null,
+            lastFetchTime: null,
           },
         },
       });

--- a/app/src/renderer/features/sync/syncSlice.ts
+++ b/app/src/renderer/features/sync/syncSlice.ts
@@ -7,13 +7,13 @@ import { fetchSources } from "../sources/sourcesSlice";
 export interface SyncState {
   loading: boolean;
   error: string | null;
-  lastSyncTime: number | null;
+  lastFetchTime: number | null;
 }
 
 const initialState: SyncState = {
   loading: false,
   error: null,
-  lastSyncTime: null,
+  lastFetchTime: null,
 };
 
 // Async thunk for syncing metadata (sources, journalists, and active conversation)
@@ -58,7 +58,7 @@ export const syncSlice = createSlice({
       })
       .addCase(syncMetadata.fulfilled, (state) => {
         state.loading = false;
-        state.lastSyncTime = Date.now();
+        state.lastFetchTime = Date.now();
       })
       .addCase(syncMetadata.rejected, (state, action) => {
         state.loading = false;
@@ -70,5 +70,6 @@ export const syncSlice = createSlice({
 export const { clearError } = syncSlice.actions;
 export const selectSyncLoading = (state: RootState) => state.sync.loading;
 export const selectSyncError = (state: RootState) => state.sync.error;
-export const selectLastSyncTime = (state: RootState) => state.sync.lastSyncTime;
+export const selectlastFetchTime = (state: RootState) =>
+  state.sync.lastFetchTime;
 export default syncSlice.reducer;

--- a/app/src/renderer/features/sync/syncSlice.ts
+++ b/app/src/renderer/features/sync/syncSlice.ts
@@ -1,0 +1,74 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import type { RootState } from "../../store";
+import { fetchConversation } from "../conversation/conversationSlice";
+import { fetchJournalists } from "../journalists/journalistsSlice";
+import { fetchSources } from "../sources/sourcesSlice";
+
+export interface SyncState {
+  loading: boolean;
+  error: string | null;
+  lastSyncTime: number | null;
+}
+
+const initialState: SyncState = {
+  loading: false,
+  error: null,
+  lastSyncTime: null,
+};
+
+// Async thunk for syncing metadata (sources, journalists, and active conversation)
+export const syncMetadata = createAsyncThunk(
+  "sync/syncMetadata",
+  async (authToken: string | undefined, { getState, dispatch }) => {
+    // Sync metadata with the server
+    await window.electronAPI.syncMetadata({ authToken });
+
+    // Fetch updated sources
+    dispatch(fetchSources());
+
+    // Fetch updated journalists
+    dispatch(fetchJournalists());
+
+    // Get the active source from Redux state
+    const state = getState() as RootState;
+    const activeSourceUuid = state.sources.activeSourceUuid;
+
+    // If there's an active source, fetch its conversation
+    if (activeSourceUuid) {
+      dispatch(fetchConversation(activeSourceUuid));
+    }
+
+    return;
+  },
+);
+
+export const syncSlice = createSlice({
+  name: "sync",
+  initialState,
+  reducers: {
+    clearError: (state) => {
+      state.error = null;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(syncMetadata.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(syncMetadata.fulfilled, (state) => {
+        state.loading = false;
+        state.lastSyncTime = Date.now();
+      })
+      .addCase(syncMetadata.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.error.message || "Failed to sync metadata";
+      });
+  },
+});
+
+export const { clearError } = syncSlice.actions;
+export const selectSyncLoading = (state: RootState) => state.sync.loading;
+export const selectSyncError = (state: RootState) => state.sync.error;
+export const selectLastSyncTime = (state: RootState) => state.sync.lastSyncTime;
+export default syncSlice.reducer;

--- a/app/src/renderer/store.ts
+++ b/app/src/renderer/store.ts
@@ -3,12 +3,14 @@ import sessionSlice from "./features/session/sessionSlice";
 import journalistsSlice from "./features/journalists/journalistsSlice";
 import sourcesSlice from "./features/sources/sourcesSlice";
 import conversationSlice from "./features/conversation/conversationSlice";
+import syncSlice from "./features/sync/syncSlice";
 
 const rootReducer = combineReducers({
   session: sessionSlice,
   journalists: journalistsSlice,
   sources: sourcesSlice,
   conversation: conversationSlice,
+  sync: syncSlice,
 });
 
 export const setupStore = (preloadedState?: Partial<RootState>) => {

--- a/app/src/renderer/views/Inbox/Sidebar/Account.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/Account.tsx
@@ -8,7 +8,7 @@ import {
   setUnauth,
   SessionStatus,
 } from "../../../features/session/sessionSlice";
-import { syncSources } from "../../../features/sources/sourcesSlice";
+import { syncMetadata } from "../../../features/sync/syncSlice";
 import { getJournalistById } from "../../../features/journalists/journalistsSlice";
 import { formatJournalistName } from "../../../utils";
 
@@ -47,7 +47,7 @@ function Account() {
 
   const sync = () => {
     console.log("syncing metadata");
-    dispatch(syncSources(session.authData?.token));
+    dispatch(syncMetadata(session.authData?.token));
   };
 
   return (

--- a/app/src/renderer/views/Inbox/Sidebar/Account.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/Account.tsx
@@ -27,7 +27,6 @@ function Account() {
 
   // Get the current journalist's display name
   const getCurrentJournalistName = () => {
-    console.log(session.authData?.journalistUUID);
     if (currentJournalist) {
       return formatJournalistName(currentJournalist.data);
     }

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
@@ -188,7 +188,6 @@ describe("Sources Component", () => {
           activeSourceUuid: null,
           loading,
           error: null,
-          lastSyncTime: Date.now(),
         },
       },
     });


### PR DESCRIPTION
I spoke with @vickiniu and we decided that it made sense to split the sync functionality into its own Redux slice. Before, in the `sourcesSlice` slice, `syncSources` triggered the metadata sync. But this synced sources, journalists, and the active conversation, if there was one.

This PR creates a new `syncSlice` and moves the `syncSources` logic into it, but renames it `syncMetadata`.

All of the functionality should remain the same.
