### PR TITLE
Add whonix-config package back

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,7 @@ jobs:
           - log
           - proxy
           - qubesdb-tools
+          - whonix-config
         debian_version:
           - bookworm
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository contains multiple components, including:
 * `log`: centralized logging
 * `qubesdb-tools`: tools for configuring non-Qubes-aware applications from
   QubesDB
+* `whonix-config`: Whonix configuration for SecureDrop
 * `proxy`: restricted HTTP proxy
 * `workstation-config`: configuration for SecureDrop Workstation templates
 

--- a/debian/control
+++ b/debian/control
@@ -49,6 +49,14 @@ Description: Tools for configuring non-Qubes-aware applications from QubesDB.
  This package provides tools for configuring non-Qubes-aware applications from
  QubesDB.
 
+Package: securedrop-whonix-config
+Section: admin
+Architecture: all
+# FIXME: s/tor/anon-gw-anonymizer-config/ (requires Whonix repositories in piuparts)
+Depends: ${misc:Depends}, securedrop-qubesdb-tools, tor
+Description: Whonix configuration for SecureDrop.
+ This package configures Whonix/Tor for SecureDrop.
+
 Package: securedrop-workstation-config
 Architecture: all
 Depends: python3-qubesdb, rsyslog, mailcap, apparmor, nautilus, securedrop-keyring, xfce4-terminal

--- a/debian/rules
+++ b/debian/rules
@@ -39,6 +39,7 @@ override_dh_installdeb:
 override_dh_installsystemd:
 	dh_installsystemd --name securedrop-log-server
 	dh_installsystemd --name securedrop-logging-disabled
+	dh_installsystemd --name securedrop-whonix-config
 	dh_installsystemd --name securedrop-proxy-onion-config
 	dh_installsystemd --name securedrop-arti
 	dh_installsystemd --name securedrop-mime-handling

--- a/debian/securedrop-whonix-config.install
+++ b/debian/securedrop-whonix-config.install
@@ -1,0 +1,1 @@
+whonix-config/app_journalist.auth_private.tmpl /usr/share/securedrop-whonix-config

--- a/debian/securedrop-whonix-config.lintian-overrides
+++ b/debian/securedrop-whonix-config.lintian-overrides
@@ -1,0 +1,2 @@
+# We don't care
+securedrop-whonix-config: package-has-long-file-name

--- a/debian/securedrop-whonix-config.securedrop-whonix-config.service
+++ b/debian/securedrop-whonix-config.securedrop-whonix-config.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=SecureDrop Whonix configuration
+ConditionPathExists=/var/run/qubes-service/securedrop-whonix-config
+
+# Both Qubes's qubes-qrexec-agent (for QubesDB) and Whonix's
+# anon-gw-anonymizer-config (for configuration directories) must
+# have started *before* this service for it to run successfully,
+# since it's a one-shot operation rather than a long-lived service.
+Requires=anon-gw-anonymizer-config.service
+After=anon-gw-anonymizer-config.service
+Requires=qubes-qrexec-agent.service
+After=qubes-qrexec-agent.service
+
+Before=tor.service
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/usr/bin/template-from-qubesdb /usr/share/securedrop-whonix-config/app_journalist.auth_private.tmpl /var/lib/tor/authdir/app-journalist.auth_private
+ExecStartPost=bash -c "chown debian-tor:debian-tor /var/lib/tor/authdir/app-journalist.auth_private && chmod 0600 /var/lib/tor/authdir/app-journalist.auth_private"
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/whonix-config/app_journalist.auth_private.tmpl
+++ b/whonix-config/app_journalist.auth_private.tmpl
@@ -1,0 +1,1 @@
+${SD_HIDSERV_HOSTNAME}:descriptor:x25519:${SD_HIDSERV_KEY}


### PR DESCRIPTION
Partially reverts d5fdbb4 and d175066 in order to restore the whonix-config package. This will be fully removed in a future release [1] but for now it will be kept, should there be any need to re-enable it.

This is mandatory, given that in its current form, [the workstation changes](https://github.com/freedomofpress/securedrop-workstation/pull/1414/files) meant to accompany this release do not remove `sd-whonix` nor its salt states. This means that the package `whonix-config` [is still expected to exist](https://github.com/freedomofpress/securedrop-workstation/blob/f6ecf68b46d3800128d4e9e7605bb5ead59b20f4/securedrop_salt/sd-whonix-config.sls).

[1]: https://github.com/freedomofpress/securedrop-client/milestone/24

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

1. Deploy with workstation before the merging of https://github.com/freedomofpress/securedrop-workstation/pull/1414
2. Install securedrop-proxy-**0.16.0**  in `sd-small-bookworm-template`, shut down template and restart `sd-proxy`.
3. Install built whonix-config package in `whonix-gateway-17`
4. Client is able to connect to server

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
