### PR TITLE
Enable eslint-plugin-i18next

### DIFF
--- a/app/eslint.config.ts
+++ b/app/eslint.config.ts
@@ -5,6 +5,7 @@ import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
 import eslintConfigPrettier from "eslint-config-prettier/flat";
 import importPlugin from "eslint-plugin-import";
+import i18next from "eslint-plugin-i18next";
 
 export default tseslint.config(
   {
@@ -23,6 +24,7 @@ export default tseslint.config(
       reactHooks.configs["recommended-latest"],
       reactRefresh.configs.recommended,
       eslintConfigPrettier,
+      i18next.configs["flat/recommended"],
     ],
     files: ["**/*.ts", "**/*.tsx"],
     languageOptions: {

--- a/app/package.json
+++ b/app/package.json
@@ -53,6 +53,7 @@
     "eslint": "^9.29.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-import-resolver-typescript": "^4.4.4",
+    "eslint-plugin-i18next": "^6.1.3",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       eslint-import-resolver-typescript:
         specifier: ^4.4.4
         version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.29.0(jiti@2.5.1))
+      eslint-plugin-i18next:
+        specifier: ^6.1.3
+        version: 6.1.3
       eslint-plugin-import:
         specifier: ^2.32.0
         version: 2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.29.0(jiti@2.5.1))
@@ -2295,6 +2298,10 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
 
+  eslint-plugin-i18next@6.1.3:
+    resolution: {integrity: sha512-z/h4oBRd9wI1ET60HqcLSU6XPeAh/EPOrBBTyCdkWeMoYrWAaUVA+DOQkWTiNIyCltG4NTmy62SQisVXxoXurw==}
+    engines: {node: '>=18.10.0'}
+
   eslint-plugin-import@2.32.0:
     resolution: {integrity: sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==}
     engines: {node: '>=4'}
@@ -3910,6 +3917,10 @@ packages:
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
+
+  requireindex@1.1.0:
+    resolution: {integrity: sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==}
+    engines: {node: '>=0.10.5'}
 
   resedit@1.7.2:
     resolution: {integrity: sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==}
@@ -7172,6 +7183,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-plugin-i18next@6.1.3:
+    dependencies:
+      lodash: 4.17.21
+      requireindex: 1.1.0
+
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.29.0(jiti@2.5.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
@@ -9001,6 +9017,8 @@ snapshots:
       set-function-name: 2.0.2
 
   require-directory@2.1.1: {}
+
+  requireindex@1.1.0: {}
 
   resedit@1.7.2:
     dependencies:

--- a/app/src/renderer/App.test.tsx
+++ b/app/src/renderer/App.test.tsx
@@ -10,10 +10,12 @@ import type { SessionState, AuthData } from "./features/session/sessionSlice";
 
 // Mock the views components to make testing simpler
 vi.mock("./views/Inbox", () => ({
+  // eslint-disable-next-line i18next/no-literal-string
   default: () => <div data-testid="inbox-view">Inbox View</div>,
 }));
 
 vi.mock("./views/SignIn", () => ({
+  // eslint-disable-next-line i18next/no-literal-string
   default: () => <div data-testid="signin-view">Sign In View</div>,
 }));
 

--- a/app/src/renderer/views/Inbox/MainContent.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent.test.tsx
@@ -8,6 +8,7 @@ import { renderWithProviders } from "../../test-component-setup";
 // Mock components
 vi.mock("./MainContent/EmptyState", () => ({
   default: () => (
+    // eslint-disable-next-line i18next/no-literal-string
     <div data-testid="empty-state">Select a source to view conversation</div>
   ),
 }));


### PR DESCRIPTION
Catches untranslated strings in our tsx files, similar to the semgrep rules we had in the client.

For now I disabled the 3 failures in tests individually, but if we have more we can disable the rule in `*.test.tsx` entirely.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
