### PR TITLE
[app] decrypt file submissions in fetch worker

### DIFF
--- a/app/src/main/fetch/bufferedWriter.test.ts
+++ b/app/src/main/fetch/bufferedWriter.test.ts
@@ -28,16 +28,6 @@ describe("BufferedWriter constructor", () => {
     });
   });
 
-  it("should return error if stream not closed", () => {
-    const writer = new BufferedWriter();
-    writer.write("data", "utf8", () => {});
-    const result = writer.getBuffer();
-    expect(result).toBeInstanceOf(Error);
-    expect((result as Error).message).toBe(
-      "Writable stream not yet closed, cannot return buffer",
-    );
-  });
-
   it("should return concatenated buffer after stream is closed", () => {
     const writer = new BufferedWriter();
     writer.write("foo", "utf8", () => {

--- a/app/src/main/fetch/bufferedWriter.ts
+++ b/app/src/main/fetch/bufferedWriter.ts
@@ -29,10 +29,7 @@ export class BufferedWriter extends Writable {
     callback();
   }
 
-  getBuffer(): Buffer | Error {
-    if (this.final) {
-      return Buffer.concat(this.buffer);
-    }
-    return new Error("Writable stream not yet closed, cannot return buffer");
+  getBuffer(): Buffer {
+    return Buffer.concat(this.buffer);
   }
 }

--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { PassThrough } from "stream";
+
+import { TaskQueue } from "./queue";
+import { CryptoError } from "../crypto";
 import { FetchStatus, ItemMetadata } from "../../types";
 import { DB } from "../database";
 import { BufferedWriter } from "./bufferedWriter";
-import fs from "fs";
 
 // Mocks
 const mockProxyStreamRequest = vi.hoisted(() => {
@@ -18,6 +24,7 @@ vi.mock("../proxy", async () => {
 
 const mockCrypto = {
   decryptMessage: vi.fn(),
+  decryptFile: vi.fn(),
 };
 vi.mock("../crypto", () => {
   return {
@@ -37,12 +44,9 @@ vi.mock("fs", () => ({
       readFile: vi.fn(),
       unlink: vi.fn(),
     },
-    createWriteStream: vi.fn(),
+    createWriteStream: vi.fn(() => new PassThrough()),
   },
 }));
-
-import { TaskQueue } from "./queue";
-import { CryptoError } from "../crypto";
 
 // Helper to create mock DB with specific methods
 function createMockDB() {
@@ -63,6 +67,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCrypto.decryptMessage.mockReset();
+    mockCrypto.decryptFile.mockReset();
   });
 
   describe("Message Processing", () => {
@@ -390,12 +395,176 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
     });
   });
 
-  // TODO: Add tests for file download and decryption
-  // Files are downloaded directly to disk and will need separate decryption logic
-  // Test scenarios:
-  // - File downloads successfully to disk
-  // - File download fails and retries successfully
-  // - File decryption (when implemented)
+  describe("File Processing", () => {
+    it("should download and decrypt a file successfully on first attempt", async () => {
+      const db = createMockDB();
+      const metadata = { kind: "file", source: "source1" };
+
+      db.getItemWithFetchStatus = vi.fn(
+        () =>
+          [metadata, FetchStatus.Initial, 0] as [
+            ItemMetadata,
+            FetchStatus,
+            number,
+          ],
+      );
+
+      // Mock successful download
+      mockProxyStreamRequest.mockResolvedValue({
+        complete: true,
+        bytesWritten: 100,
+      });
+
+      // Mock successful decryption
+      mockCrypto.decryptFile.mockResolvedValue({
+        filePath: "/securedrop/source1",
+        filename: "plaintext.txt",
+      });
+
+      const queue = new TaskQueue(db);
+      await queue.process({ id: "msg1" }, db);
+
+      // Verify download phase
+      expect(db.setDownloadInProgress).toHaveBeenCalledWith("msg1");
+      expect(mockProxyStreamRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path_query: "/api/v1/sources/source1/submissions/msg1/download",
+        }),
+        expect.any(PassThrough),
+        0,
+      );
+
+      // Verify decryption phase
+      const downloadPath = path.join(
+        os.tmpdir(),
+        "download",
+        "source1",
+        "msg1",
+        "encrypted.gpg",
+      );
+      expect(db.setDecryptionInProgress).toHaveBeenCalledWith("msg1");
+      expect(mockCrypto.decryptFile).toHaveBeenCalledWith(downloadPath);
+      expect(db.completeFileItem).toHaveBeenCalledWith(
+        "msg1",
+        "/securedrop/source1/plaintext.txt",
+      );
+    });
+
+    it("should download successfully but fail decryption, and retry decryption only", async () => {
+      const db = createMockDB();
+      const metadata = { kind: "file", source: "source1" };
+
+      // First attempt: Initial status, Second attempt: FailedDecryptionRetryable
+      db.getItemWithFetchStatus = vi
+        .fn()
+        .mockReturnValueOnce([metadata, FetchStatus.Initial, 0])
+        .mockReturnValueOnce([
+          metadata,
+          FetchStatus.FailedDecryptionRetryable,
+          0,
+        ]);
+
+      // Mock successful download
+      mockProxyStreamRequest.mockResolvedValue({
+        complete: true,
+        bytesWritten: 100,
+      });
+
+      // Mock decryption failure on first attempt
+      mockCrypto.decryptFile.mockRejectedValueOnce(
+        new CryptoError("Decryption failed"),
+      );
+
+      const queue = new TaskQueue(db);
+
+      // First attempt - should fail decryption
+      await expect(queue.process({ id: "msg1" }, db)).rejects.toThrow(
+        `Decryption failed`,
+      );
+
+      // Verify download was saved to disk
+      expect(fs.promises.mkdir).toHaveBeenCalled();
+      expect(fs.createWriteStream).toHaveBeenCalledWith(
+        expect.stringContaining("/encrypted.gpg"),
+      );
+
+      expect(db.setDownloadInProgress).toHaveBeenCalledWith("msg1");
+      expect(db.setDecryptionInProgress).toHaveBeenCalledWith("msg1");
+      expect(db.failDecryption).toHaveBeenCalledWith("msg1");
+
+      // Second attempt - retry from FailedDecryptionRetryable status
+      // Mock successful decryption this time
+      mockCrypto.decryptFile.mockResolvedValue({
+        filePath: "/securedrop/source1",
+        filename: "plaintext.txt",
+      });
+
+      await queue.process({ id: "msg1" }, db);
+
+      // Should only do decryption phase (no download)
+      expect(mockProxyStreamRequest).toHaveBeenCalledTimes(1); // Only called once (first attempt)
+      expect(db.completeFileItem).toHaveBeenCalledWith(
+        "msg1",
+        "/securedrop/source1/plaintext.txt",
+      );
+
+      // Should clean up the file after successful decryption
+      expect(fs.promises.unlink).toHaveBeenCalledWith(
+        expect.stringContaining("/encrypted.gpg"),
+      );
+    });
+
+    it("should fail download, retry download and decryption successfully", async () => {
+      const db = createMockDB();
+      const metadata = { kind: "file", source: "source1" };
+
+      // First attempt: Initial status, Second attempt: FailedDownloadRetryable
+      db.getItemWithFetchStatus = vi
+        .fn()
+        .mockReturnValueOnce([metadata, FetchStatus.Initial, 0])
+        .mockReturnValueOnce([
+          metadata,
+          FetchStatus.FailedDownloadRetryable,
+          50,
+        ]);
+
+      const queue = new TaskQueue(db);
+
+      // First attempt - download fails
+      mockProxyStreamRequest.mockResolvedValueOnce({
+        complete: false,
+        bytesWritten: 50,
+        error: new Error("Network error"),
+      });
+
+      await expect(queue.process({ id: "msg1" }, db)).rejects.toThrow(
+        "Unable to complete stream download",
+      );
+
+      expect(db.setDownloadInProgress).toHaveBeenCalledWith("msg1");
+      expect(db.setDownloadInProgress).toHaveBeenCalledWith("msg1", 50); // Progress update
+      expect(db.failDownload).toHaveBeenCalledWith("msg1");
+
+      // Second attempt - download and decrypt successfully
+      mockProxyStreamRequest.mockResolvedValueOnce({
+        complete: true,
+        bytesWritten: 100,
+      });
+
+      mockCrypto.decryptFile.mockResolvedValue({
+        filePath: "/securedrop/source1",
+        filename: "plaintext.txt",
+      });
+
+      await queue.process({ id: "msg1" }, db);
+
+      expect(mockProxyStreamRequest).toHaveBeenCalledTimes(2);
+      expect(db.completeFileItem).toHaveBeenCalledWith(
+        "msg1",
+        "/securedrop/source1/plaintext.txt",
+      );
+    });
+  });
 
   describe("Edge Cases and Error Handling", () => {
     it("should skip items that are already complete", async () => {

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -193,7 +193,7 @@ export class TaskQueue {
   ) {
     const crypto = Crypto.getInstance();
     if (!crypto) {
-      throw new Error("Crypto not initilaized in fetch worker, cannot decrypt");
+      throw new Error("Crypto not initialized in fetch worker, cannot decrypt");
     }
 
     // Set status to decryption in progress


### PR DESCRIPTION
Completes decryption implementation in fetch worker, decrypting file submissions as well.

Some slight refactoring of the logic just to clean up the three decryption pathways:

- [message/reply] Decrypting from in-memory buffer
- [message/reply] Retrying decryption from ciphertext saved to disk
- [file] Decrypting from download encrypted file

Also modifies the `BufferedWriter` implementation to always return a buffer and not throw errors to simplify handling. I think we don't really need to worry about the case where we `getBuffer()` and then write data afterwards, but open to having more error handling there if we want to keep that guarantee.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
