### PR TITLE
Fix typo in nightlies CI config

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           app-id: ${{ vars.FPF_BRANCH_UPDATER_APP_ID }}
           private-key: ${{ secrets.FPF_BRANCH_UPDATER_APP_PRIVKEY }}
-          repostiories: |
+          repositories: |
             build-logs
             securedrop-apt-test
       - name: Commit and push


### PR DESCRIPTION
See warning at e.g. https://github.com/freedomofpress/securedrop-client/actions/runs/18055974620/job/51385958151.

