### PR TITLE
docs: vertical-align environment diagrams for easier visual comparison

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -64,6 +64,7 @@ end
 end
 
 subgraph "staging/production environment"
+direction TB
 spKeychain --- spClient
 subgraph sd-app
 spData(("~/.securedrop_client")) --- spClient


### PR DESCRIPTION
Somewhere along the way, the `staging/production environment` subgraph stopped inheriting the graph-level `TD` attribute.  An explicit `direction TB` directive aligns the subgraphs so that they're easier to compare.