### PR TITLE
Support autologin in app for developers

### DIFF
--- a/app/electron.vite.config.ts
+++ b/app/electron.vite.config.ts
@@ -63,6 +63,7 @@ export default defineConfig(({ mode }) => {
       plugins: [react(), tailwindcss()],
       define: {
         __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
+        __DEV_AUTO_LOGIN__: isDev,
       },
     },
   };

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -27,6 +27,7 @@ import workerPath from "./fetch/worker?modulePath";
 // Parse command line arguments
 const args = process.argv.slice(2);
 const noQubes = args.includes("--no-qubes");
+const shouldAutoLogin = args.includes("--login");
 
 // Create crypto config
 const cryptoConfig = noQubes ? { isQubes: false } : {};
@@ -179,6 +180,11 @@ app.whenReady().then(() => {
   ipcMain.handle("getSystemLanguage", async (_event): Promise<string> => {
     const systemLanguage = process.env.LANG || app.getLocale() || "en";
     return systemLanguage;
+  });
+
+  ipcMain.handle("shouldAutoLogin", async (_event): Promise<boolean> => {
+    // Only honor auto-login in development mode
+    return is.dev && shouldAutoLogin;
   });
 
   const mainWindow = createWindow();

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -67,6 +67,9 @@ const electronAPI = {
   getSystemLanguage: logIpcCall<string>("getSystemLanguage", () =>
     ipcRenderer.invoke("getSystemLanguage"),
   ),
+  shouldAutoLogin: logIpcCall<boolean>("shouldAutoLogin", () =>
+    ipcRenderer.invoke("shouldAutoLogin"),
+  ),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onItemUpdate: (callback: (...args: any[]) => void) => {
     ipcRenderer.on("item-update", (_event, ...args) => callback(...args));

--- a/app/src/renderer/test-component-setup.tsx
+++ b/app/src/renderer/test-component-setup.tsx
@@ -13,6 +13,7 @@ import type { ElectronAPI } from "../preload/index";
 
 // Mock global variables
 (global as any).__APP_VERSION__ = "6.6.6-test";
+(global as any).__DEV_AUTO_LOGIN__ = false;
 
 // extends Vitest's expect with jest-dom matchers
 expect.extend(matchers);
@@ -155,6 +156,7 @@ beforeEach(() => {
         },
       },
     ]),
+    shouldAutoLogin: vi.fn().mockResolvedValue(false),
   } as ElectronAPI;
 });
 

--- a/app/src/renderer/views/SignIn.dev.ts
+++ b/app/src/renderer/views/SignIn.dev.ts
@@ -1,0 +1,40 @@
+/**
+ * Development-only auto-login functionality.
+ * This file is only imported in development builds and will not be included in production.
+ */
+
+import { TOTP } from "otpauth";
+import type { FormInstance } from "antd";
+
+type FormValues = {
+  username: string;
+  passphrase: string;
+  oneTimeCode: string;
+};
+
+export async function performAutoLogin(
+  form: FormInstance<FormValues>,
+): Promise<void> {
+  const autoLoginEnabled = await window.electronAPI.shouldAutoLogin();
+  if (!autoLoginEnabled) {
+    return;
+  }
+
+  console.log("Auto-login enabled, filling credentials...");
+
+  const totp = new TOTP({
+    secret: "JHCOGO7VCER3EJ4L",
+  });
+  const oneTimeCode = totp.generate();
+
+  form.setFieldsValue({
+    username: "journalist",
+    passphrase: "correct horse battery staple profanity oil chewy",
+    oneTimeCode: oneTimeCode,
+  });
+
+  // Submit the form after a brief delay to allow UI to update
+  setTimeout(() => {
+    form.submit();
+  }, 1000);
+}

--- a/app/src/renderer/views/SignIn.tsx
+++ b/app/src/renderer/views/SignIn.tsx
@@ -1,7 +1,7 @@
 import { Button, Input, Form } from "antd";
 import type { FormProps } from "antd";
 import { Eye, EyeOff } from "lucide-react";
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 
@@ -147,6 +147,23 @@ function SignInView() {
     // Redirect to home
     navigate("/");
   };
+
+  // Dev-only auto-login: will be compiled out in production builds
+  if (__DEV_AUTO_LOGIN__) {
+    // Track execution to prevent double-triggering in React Strict Mode
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const autoLoginExecutedRef = useRef<boolean>(false);
+
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useEffect(() => {
+      if (!autoLoginExecutedRef.current) {
+        autoLoginExecutedRef.current = true;
+        import("./SignIn.dev").then(({ performAutoLogin }) => {
+          performAutoLogin(form);
+        });
+      }
+    }, [form]);
+  }
 
   return (
     <div

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -3,3 +3,4 @@
 declare const __APP_VERSION__: string;
 declare const __PROXY_ORIGIN__: string;
 declare const __PROXY_CMD__: string;
+declare const __DEV_AUTO_LOGIN__: boolean;


### PR DESCRIPTION
Port over the client's `--login` which automatically enters the test/dev credentials so you don't need to spend a lot of time (re)typing them over and over again.

Special care is taken to only make this functionality available in dev builds; it's guarded by `__DEV_AUTO_LOGIN__`, which is a constant that vite knows is false in prod builds and will compile it out. This can be verified by running, e.g.:

    grep "correct horse battery staple" out/renderer/assets/index-*.js

and finding nothing.

One slightly odd consequence of this setup is that if you explicitly sign out, you'll log back in automatically; presumably in that case avoid using the autologin behavior.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] start a server with `make dev` and then try `pnpm dev -- --login` and see that it works

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
