### PR TITLE
[app] pending_events: fix multiple starred events bug

### DIFF
--- a/app/src/main/database/index.test.ts
+++ b/app/src/main/database/index.test.ts
@@ -188,7 +188,7 @@ describe("pending_events update projected views", () => {
     expect(sourceWithItems.items.length).toEqual(3);
   });
 
-  it("pending Starred event should star source", () => {
+  it("pending Starred event should star sources", () => {
     // Insert three sources
     db.updateSources({
       source1: mockSourceMetadata("source1"),
@@ -201,10 +201,11 @@ describe("pending_events update projected views", () => {
     }
 
     db.addPendingSourceEvent("source1", PendingEventType.Starred);
+    db.addPendingSourceEvent("source2", PendingEventType.Starred);
 
     sources = db.getSources();
     for (const source of sources) {
-      if (source.uuid === "source1") {
+      if (source.uuid === "source1" || source.uuid === "source2") {
         expect(source.data.is_starred).toBeTruthy();
         continue;
       }
@@ -212,7 +213,7 @@ describe("pending_events update projected views", () => {
     }
   });
 
-  it("pending Unstarred event should star source", () => {
+  it("pending Unstarred event should unstar source", () => {
     // Insert three sources
     db.updateSources({
       source1: mockSourceMetadata("source1", true),
@@ -225,10 +226,11 @@ describe("pending_events update projected views", () => {
     }
 
     db.addPendingSourceEvent("source1", PendingEventType.Unstarred);
+    db.addPendingSourceEvent("source2", PendingEventType.Unstarred);
 
     sources = db.getSources();
     for (const source of sources) {
-      if (source.uuid === "source1") {
+      if (source.uuid === "source1" || source.uuid === "source2") {
         expect(source.data.is_starred).toBeFalsy();
         continue;
       }

--- a/app/src/main/database/migrations/20250930191810_create_pending_events_table.sql
+++ b/app/src/main/database/migrations/20250930191810_create_pending_events_table.sql
@@ -28,21 +28,27 @@ WITH
             CASE
                 WHEN type = 5 THEN true -- Starred
                 WHEN type = 6 THEN false -- Unstarred
-            END AS starred_value
+            END as starred_value
         FROM
             (
                 SELECT
                     source_uuid,
-                    type
+                    type,
+                    -- Order events to select most recent
+                    ROW_NUMBER() OVER (
+                        PARTITION BY
+                            source_uuid
+                        ORDER BY
+                            snowflake_id DESC
+                    ) AS rn
                 FROM
                     pending_events
                 WHERE
-                    type in (5, 6) -- Starred or Unstarred 
-                ORDER BY
-                    snowflake_id DESC
-                LIMIT
-                    1
-            )
+                    type IN (5, 6) -- Starred or Unstarred
+                    AND source_uuid IS NOT NULL
+            ) latest
+        WHERE
+            rn = 1
     )
 SELECT
     sources.uuid,


### PR DESCRIPTION
Fixes bug where starring/unstarring multiple sources doesn't reflect in the pending_events due to a bug in our query selecting for the latest event. Adds test cases also to verify that starring/unstarring multiple sources projects correctly