### PR TITLE
Raise server_tests timeouts to 30 seconds

### DIFF
--- a/app/server_tests/sourcelist.test.ts
+++ b/app/server_tests/sourcelist.test.ts
@@ -32,7 +32,7 @@ describe.sequential("source list functionality", () => {
 
   afterAll(async () => {
     await context.teardown();
-  }, 20000);
+  }, 30000);
 
   it("should log in and sync sources", async () => {
     // Log in with test credentials
@@ -49,7 +49,7 @@ describe.sequential("source list functionality", () => {
     await expect(
       context.page.getByText("Preservative Legislator"),
     ).toBeVisible();
-  }, 25000);
+  });
 
   it("should search sources by codename", async () => {
     // Get the search input
@@ -115,7 +115,7 @@ describe.sequential("source list functionality", () => {
     await context.page.waitForTimeout(500);
 
     expect(await getVisibleSourceCount()).toBe(0);
-  }, 15000);
+  });
 
   it("should search case-insensitively", async () => {
     const searchInput = context.page.getByTestId("source-search-input");
@@ -138,7 +138,7 @@ describe.sequential("source list functionality", () => {
 
     // Clear search
     await searchInput.clear();
-  }, 10000);
+  });
 
   it("should search by partial codename", async () => {
     const searchInput = context.page.getByTestId("source-search-input");
@@ -162,7 +162,7 @@ describe.sequential("source list functionality", () => {
 
     // Clear search
     await searchInput.clear();
-  }, 10000);
+  });
 
   it("should show Preservative Legislator as unread", async () => {
     // Get the Preservative Legislator source by UUID
@@ -175,7 +175,7 @@ describe.sequential("source list functionality", () => {
     // Check that the element has font-bold class (indicates unread)
     const classes = await preservativeLegislator.getAttribute("class");
     expect(classes).toContain("font-bold");
-  }, 5000);
+  });
 
   it("should filter to show only unread sources", async () => {
     await setFilter("unread");
@@ -197,7 +197,7 @@ describe.sequential("source list functionality", () => {
 
     // Verify all sources are visible again
     expect(await getVisibleSourceCount()).toBe(3);
-  }, 10000);
+  });
 
   it("should filter to show only read sources", async () => {
     await setFilter("read");
@@ -219,5 +219,5 @@ describe.sequential("source list functionality", () => {
 
     // Verify all sources are visible again
     expect(await getVisibleSourceCount()).toBe(3);
-  }, 10000);
+  });
 });

--- a/app/server_tests/sync.test.ts
+++ b/app/server_tests/sync.test.ts
@@ -74,7 +74,7 @@ describe.sequential("sync against a real server", () => {
 
   afterAll(async () => {
     await context.teardown();
-  }, 20000);
+  }, 30000);
 
   it("should start with a fresh empty database", async () => {
     // Wait for the sign-in page to load
@@ -107,7 +107,7 @@ describe.sequential("sync against a real server", () => {
     expect(Object.keys(index.journalists).length).toBe(0);
 
     db.close();
-  }, 10000);
+  });
 
   it("should successfully log in with valid credentials", async () => {
     // Navigate back to sign-in page
@@ -116,7 +116,7 @@ describe.sequential("sync against a real server", () => {
 
     // Log in with test credentials
     await context.login();
-  }, 10000);
+  });
 
   it("should verify logged-in journalist from Redux state", async () => {
     // Verify journalist info from Redux state
@@ -133,7 +133,7 @@ describe.sequential("sync against a real server", () => {
     expect(reduxState.session.authData.journalistUUID).toBe(
       "be726875-1290-49d4-922d-2fc0901c9266",
     );
-  }, 10000);
+  });
 
   it("should sync and populate database with sources", async () => {
     await context.runSync();
@@ -158,7 +158,7 @@ describe.sequential("sync against a real server", () => {
     expect(firstSyncVersion).toBe(EXPECTED_VERSION);
 
     db.close();
-  }, 15000);
+  });
 
   it("should be idempotent when syncing again", async () => {
     await context.runSync();
@@ -176,5 +176,5 @@ describe.sequential("sync against a real server", () => {
     expect(secondVersion).toBe(firstSyncVersion);
     expect(secondVersion).toBe(EXPECTED_VERSION);
     db.close();
-  }, 15000);
+  });
 });

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -73,6 +73,7 @@ export default defineConfig({
           name: "server", // Tests that require a running server
           include: ["server_tests/**/*.test.ts"],
           globals: true,
+          testTimeout: 30000, // 30s default timeout
         },
         define: {
           __PROXY_CMD__: JSON.stringify(sdProxyCmd),


### PR DESCRIPTION
It's failing in CI, so raise it to 30 seconds across the board. The individual tests no longer need timeouts, but we still need them for the hooks (beforeAll/afterAll).


## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
