### PR TITLE
Update rust toolchain to 1.90.0

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Install Rust-specific dependencies for sd-proxy
         run: apt-get install --yes build-essential curl libssl-dev pkg-config
       - name: Install Rust to build sd-proxy
-        uses: dtolnay/rust-toolchain@1.87.0
+        uses: dtolnay/rust-toolchain@1.90.0
       - name: Run integration tests
         working-directory: app
         run: NODE_ENV=ci VITE_HTTPBIN_URL=http://httpbin:80 pnpm integration-test
@@ -178,7 +178,7 @@ jobs:
       # n.b. because this runs on Ubuntu runner directly,
       # build-essential, curl, libssl-dev and pkg-config are already installed
       - name: Install Rust to build sd-proxy
-        uses: dtolnay/rust-toolchain@1.87.0
+        uses: dtolnay/rust-toolchain@1.90.0
       - name: Install ffmpeg for video recording
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
       - name: Run tests

--- a/.github/workflows/cargo-vet.yml
+++ b/.github/workflows/cargo-vet.yml
@@ -18,7 +18,7 @@ jobs:
     name: Vet Dependencies
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.87.0
+    container: rust:1.90.0
     env:
       CARGO_VET_VERSION: 0.10.0
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
   rust:
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.87.0
+    container: rust:1.90.0
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,7 +9,7 @@ jobs:
   rust-audit:
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.87.0
+    container: rust:1.90.0
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           persist-credentials: false
       # Install Rust, keep in sync with rust-toolchain.toml
-      - uses: dtolnay/rust-toolchain@1.87.0
+      - uses: dtolnay/rust-toolchain@1.90.0
         if: ${{ matrix.component == 'proxy' }}
       - name: Install dependencies
         run: |

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.90.0"

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -15,7 +15,7 @@ COPY qubes_42.sources /etc/apt/sources.list.d/
 RUN sed -i s/##VERSION_CODENAME##/${DISTRO}/ /etc/apt/sources.list.d/qubes_42.sources
 
 # Keep in sync with rust-toolchain.toml
-ENV RUST_VERSION 1.87.0
+ENV RUST_VERSION 1.90.0
 ENV RUSTUP_VERSION 1.28.2
 ENV RUSTUP_INIT_SHA256 20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c 
 ENV RUSTUP_HOME /opt/rustup


### PR DESCRIPTION
Fixes #2776

## Test plan
- [ ] CI is passing
- [ ] Rust version is updated across the board - including GHA workflows.
