### PR TITLE
[app] populate message previews

### DIFF
--- a/app/scripts/test-data-generate.py
+++ b/app/scripts/test-data-generate.py
@@ -202,35 +202,11 @@ for _ in range(count):
         "has_attachment": has_attachment,
     }
 
-    # If any item is a message, set show_message_preview to True
-    show_message_preview = False
-    for item_row in item_rows:
-        if (
-            isinstance(item_row["data"], dict)
-            and item_row["data"].get("kind") is not None
-            and item_row["data"].get("kind", "") == "message"
-        ):
-            show_message_preview = True
-            break
-
-    # The message preview should be the most recent message's plaintext
-    message_preview = ""
-    for item_row in reversed(item_rows):
-        if (
-            isinstance(item_row["data"], dict)
-            and item_row["data"].get("kind") == "message"
-            and item_row.get("plaintext")
-        ):
-            message_preview = str(item_row.get("plaintext", ""))[:200]  # Limit to 200 characters
-            break
-
     # Create the source row SQL
     # Note: is_seen and has_attachment are generated columns, so we don't insert them directly
     source_row = {
         "uuid": source_uuid,
         "data": source_obj,
-        "show_message_preview": show_message_preview,
-        "message_preview": message_preview,
     }
     sql_lines.append(insert("sources", source_row))
 

--- a/app/src/main/database/migrations/20251112200039_drop_message_preview.sql
+++ b/app/src/main/database/migrations/20251112200039_drop_message_preview.sql
@@ -1,0 +1,174 @@
+-- migrate:up
+-- Recreate sources_projected view
+DROP VIEW sources_projected;
+
+CREATE VIEW
+    sources_projected AS
+WITH
+    -- Select latest starred value from pending_events
+    latest_starred AS (
+        SELECT
+            source_uuid,
+            CASE
+                WHEN type = 'source_starred' THEN true
+                WHEN type = 'source_unstarred' THEN false
+            END as starred_value
+        FROM
+            (
+                SELECT
+                    source_uuid,
+                    type,
+                    -- Order events to select most recent
+                    ROW_NUMBER() OVER (
+                        PARTITION BY
+                            source_uuid
+                        ORDER BY
+                            snowflake_id DESC
+                    ) AS rn
+                FROM
+                    pending_events
+                WHERE
+                    type IN ('source_starred', 'source_unstarred')
+                    AND source_uuid IS NOT NULL
+            ) latest
+        WHERE
+            rn = 1
+    )
+SELECT
+    sources.uuid,
+    -- project Starred/Unstarred event
+    CASE
+        WHEN latest_starred.starred_value IS NOT NULL THEN json_set (sources.data, '$.is_starred', starred_value)
+        ELSE sources.data
+    END AS data,
+    sources.version,
+    sources.has_attachment,
+    -- project Seen event
+    CASE
+        WHEN EXISTS (
+            SELECT
+                1
+            FROM
+                pending_events
+            WHERE
+                pending_events.source_uuid = sources.uuid
+                AND pending_events.type = 'item_seen'
+        ) THEN 1
+        ELSE sources.is_seen
+    END AS is_seen
+FROM
+    sources
+    LEFT JOIN latest_starred ON latest_starred.source_uuid = sources.uuid
+WHERE
+    -- project SourceDeleted event
+    NOT EXISTS (
+        SELECT
+            1
+        FROM
+            pending_events
+        WHERE
+            pending_events.source_uuid = sources.uuid
+            AND pending_events.type = 'source_deleted'
+    );
+
+ALTER TABLE sources
+DROP COLUMN message_preview;
+
+ALTER TABLE sources
+DROP COLUMN show_message_preview;
+
+-- Add sorted items view 
+CREATE VIEW
+    sorted_items AS
+SELECT
+    *,
+    ROW_NUMBER() OVER (
+        PARTITION BY
+            source_uuid
+        ORDER BY
+            interaction_count DESC
+    ) AS rn
+FROM
+    items_projected;
+
+-- migrate:down
+ALTER TABLE sources
+ADD COLUMN message_preview TEXT;
+
+ALTER TABLE sources
+ADD COLUMN show_message_preview INTEGER DEFAULT 0;
+
+DROP VIEW sources_projected;
+
+CREATE VIEW
+    sources_projected AS
+WITH
+    -- Select latest starred value from pending_events
+    latest_starred AS (
+        SELECT
+            source_uuid,
+            CASE
+                WHEN type = 'source_starred' THEN true
+                WHEN type = 'source_unstarred' THEN false
+            END as starred_value
+        FROM
+            (
+                SELECT
+                    source_uuid,
+                    type,
+                    -- Order events to select most recent
+                    ROW_NUMBER() OVER (
+                        PARTITION BY
+                            source_uuid
+                        ORDER BY
+                            snowflake_id DESC
+                    ) AS rn
+                FROM
+                    pending_events
+                WHERE
+                    type IN ('source_starred', 'source_unstarred')
+                    AND source_uuid IS NOT NULL
+            ) latest
+        WHERE
+            rn = 1
+    )
+SELECT
+    sources.uuid,
+    -- project Starred/Unstarred event
+    CASE
+        WHEN latest_starred.starred_value IS NOT NULL THEN json_set (sources.data, '$.is_starred', starred_value)
+        ELSE sources.data
+    END AS data,
+    sources.version,
+    sources.has_attachment,
+    sources.show_message_preview,
+    sources.message_preview,
+    -- project Seen event
+    CASE
+        WHEN EXISTS (
+            SELECT
+                1
+            FROM
+                pending_events
+            WHERE
+                pending_events.source_uuid = sources.uuid
+                AND pending_events.type = 'item_seen'
+        ) THEN 1
+        ELSE sources.is_seen
+    END AS is_seen
+FROM
+    sources
+    LEFT JOIN latest_starred ON latest_starred.source_uuid = sources.uuid
+WHERE
+    -- project SourceDeleted event
+    NOT EXISTS (
+        SELECT
+            1
+        FROM
+            pending_events
+        WHERE
+            pending_events.source_uuid = sources.uuid
+            AND pending_events.type = 'source_deleted'
+    );
+
+DROP VIEW sorted_items;

--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -64,6 +64,7 @@ function createMockDB() {
     completeFileItem: vi.fn(),
     setDownloadInProgress: vi.fn(),
     setDecryptionInProgress: vi.fn(),
+    setSourceMessagePreview: vi.fn(),
     failDownload: vi.fn(),
     failDecryption: vi.fn(),
     terminallyFailItem: vi.fn(),

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -124,6 +124,12 @@ export class TaskQueue {
           `Unexpected status ${nextStatus} for item ${item.id}, skipping...`,
         );
       }
+
+      // After decryption, update source message preview and
+      // post message to main thread
+      if (this.port) {
+        this.port.postMessage(this.db.getSource(metadata.source));
+      }
     } finally {
       // After every process tick, post message to main thread
       if (this.port) {

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -101,7 +101,12 @@ function spawnFetchWorker(mainWindow: BrowserWindow): Worker {
 
   worker.on("message", (result) => {
     console.debug("Message from worker: ", result);
-    mainWindow.webContents.send("item-update", result);
+    // Check if worker update is Source or Item
+    if ("messagePreview" in result) {
+      mainWindow.webContents.send("source-update", result);
+    } else {
+      mainWindow.webContents.send("item-update", result);
+    }
   });
 
   worker.on("error", (err) => {

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -105,6 +105,10 @@ const electronAPI = {
   onItemUpdate: (callback: (...args: any[]) => void) => {
     ipcRenderer.on("item-update", (_event, ...args) => callback(...args));
   },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onSourceUpdate: (callback: (...args: any[]) => void) => {
+    ipcRenderer.on("source-update", (_event, ...args) => callback(...args));
+  },
 };
 
 contextBridge.exposeInMainWorld("electronAPI", electronAPI);

--- a/app/src/renderer/features/sources/sourcesSlice.test.ts
+++ b/app/src/renderer/features/sources/sourcesSlice.test.ts
@@ -35,8 +35,7 @@ const mockSources: SourceType[] = [
     },
     isRead: false,
     hasAttachment: false,
-    showMessagePreview: false,
-    messagePreview: "",
+    messagePreview: null,
   },
   {
     uuid: "source-2",
@@ -53,8 +52,10 @@ const mockSources: SourceType[] = [
     },
     isRead: true,
     hasAttachment: true,
-    showMessagePreview: true,
-    messagePreview: "Hello from source 2",
+    messagePreview: {
+      kind: "message",
+      plaintext: "Hello from source 2",
+    },
   },
 ];
 

--- a/app/src/renderer/features/sources/sourcesSlice.ts
+++ b/app/src/renderer/features/sources/sourcesSlice.ts
@@ -38,6 +38,15 @@ export const sourcesSlice = createSlice({
     clearActiveSource: (state) => {
       state.activeSourceUuid = null;
     },
+    updateSource: (state, action) => {
+      const updatedSource: SourceType = action.payload;
+      state.sources = state.sources.map((source, _) => {
+        if (source.uuid === updatedSource.uuid) {
+          return updatedSource;
+        }
+        return source;
+      });
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -57,7 +66,7 @@ export const sourcesSlice = createSlice({
   },
 });
 
-export const { clearError, setActiveSource, clearActiveSource } =
+export const { clearError, setActiveSource, clearActiveSource, updateSource } =
   sourcesSlice.actions;
 export const selectSources = (state: RootState) => state.sources.sources;
 export const selectActiveSourceUuid = (state: RootState) =>

--- a/app/src/renderer/features/sync/syncSlice.test.ts
+++ b/app/src/renderer/features/sync/syncSlice.test.ts
@@ -24,8 +24,7 @@ const mockSources: SourceType[] = [
     },
     isRead: false,
     hasAttachment: false,
-    showMessagePreview: false,
-    messagePreview: "",
+    messagePreview: null,
   },
   {
     uuid: "source-2",
@@ -42,8 +41,10 @@ const mockSources: SourceType[] = [
     },
     isRead: true,
     hasAttachment: true,
-    showMessagePreview: true,
-    messagePreview: "Hello from source 2",
+    messagePreview: {
+      kind: "message",
+      plaintext: "Hello from source 2",
+    },
   },
 ];
 

--- a/app/src/renderer/locales/en.json
+++ b/app/src/renderer/locales/en.json
@@ -72,7 +72,8 @@
       }
     },
     "source": {
-      "encrypted": "encrypted...",
+      "encryptedFile": "Encrypted File",
+      "encryptedMessage": "Encrypted Message",
       "toggleStar": "Toggle star"
     }
   },

--- a/app/src/renderer/locales/fr.json
+++ b/app/src/renderer/locales/fr.json
@@ -72,7 +72,8 @@
       }
     },
     "source": {
-      "encrypted": "chiffré...",
+      "encryptedFile": "Fichier Crypté",
+      "encryptedMessage": "Message Crypté",
       "toggleStar": "Basculer le favori"
     }
   },

--- a/app/src/renderer/test-component-setup.tsx
+++ b/app/src/renderer/test-component-setup.tsx
@@ -50,6 +50,9 @@ beforeEach(() => {
       .fn()
       .mockRejectedValue(new Error("mock not implemented")),
     onItemUpdate: vi.fn().mockRejectedValue(new Error("mock not implemented")),
+    onSourceUpdate: vi
+      .fn()
+      .mockRejectedValue(new Error("mock not implemented")),
     getItem: vi.fn().mockRejectedValue(new Error("mock not implemented")),
     getSources: vi.fn().mockResolvedValue([
       {

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
@@ -116,8 +116,7 @@ describe("Sources Component", () => {
       },
       isRead: false,
       hasAttachment: false,
-      showMessagePreview: false,
-      messagePreview: "",
+      messagePreview: null,
     },
     {
       uuid: "source-2",
@@ -133,8 +132,10 @@ describe("Sources Component", () => {
       },
       isRead: true,
       hasAttachment: true,
-      showMessagePreview: true,
-      messagePreview: "Hello from Bob",
+      messagePreview: {
+        kind: "message",
+        plaintext: "Hello from Bob,",
+      },
     },
     {
       uuid: "source-3",
@@ -150,8 +151,7 @@ describe("Sources Component", () => {
       },
       isRead: false,
       hasAttachment: false,
-      showMessagePreview: false,
-      messagePreview: "",
+      messagePreview: null,
     },
     {
       uuid: "source-4",
@@ -167,8 +167,7 @@ describe("Sources Component", () => {
       },
       isRead: true,
       hasAttachment: false,
-      showMessagePreview: false,
-      messagePreview: "",
+      messagePreview: null,
     },
   ];
 
@@ -180,6 +179,7 @@ describe("Sources Component", () => {
     window.electronAPI = {
       getSources: vi.fn().mockResolvedValue(mockSources),
       syncMetadata: vi.fn().mockResolvedValue(undefined),
+      onSourceUpdate: vi.fn().mockResolvedValue(undefined),
     } as Partial<typeof window.electronAPI> as typeof window.electronAPI;
   });
 

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -11,10 +11,11 @@ import {
   fetchSources,
   selectSources,
   selectSourcesLoading,
+  updateSource,
 } from "../../../features/sources/sourcesSlice";
 import { fetchConversation } from "../../../features/conversation/conversationSlice";
 import Toolbar, { type filterOption } from "./SourceList/Toolbar";
-import { PendingEventType } from "../../../../types";
+import { PendingEventType, Source as SourceType } from "../../../../types";
 
 function SourceList() {
   const { sourceUuid: activeSourceUuid } = useParams<{ sourceUuid?: string }>();
@@ -47,6 +48,12 @@ function SourceList() {
 
   useEffect(() => {
     dispatch(fetchSources());
+  }, [dispatch]);
+
+  useEffect(() => {
+    window.electronAPI.onSourceUpdate((source: SourceType) => {
+      dispatch(updateSource(source));
+    });
   }, [dispatch]);
 
   // Calculate container height for react-window

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.test.tsx
@@ -37,8 +37,7 @@ const createMockSource = (overrides: Partial<SourceType> = {}): SourceType => ({
   },
   isRead: true,
   hasAttachment: false,
-  showMessagePreview: false,
-  messagePreview: "",
+  messagePreview: null,
   ...overrides,
 });
 
@@ -105,11 +104,8 @@ describe("Source Component", () => {
   });
 
   describe("message preview functionality", () => {
-    it("does not display message preview when showMessagePreview is false", () => {
-      const sourceWithoutPreview = createMockSource({
-        showMessagePreview: false,
-        messagePreview: "This should not be shown",
-      });
+    it("does not display message preview when messagePreview is undefined", () => {
+      const sourceWithoutPreview = createMockSource();
       renderWithProviders(
         <Source source={sourceWithoutPreview} {...defaultProps} />,
       );
@@ -118,10 +114,12 @@ describe("Source Component", () => {
       expect(messagePreview).toBeNull();
     });
 
-    it("displays 'encrypted...' when showMessagePreview is true but messagePreview is empty", () => {
+    it("displays 'Encrypted File' when messagePreview exists but plaintext is empty for file", () => {
       const sourceWithEmptyPreview = createMockSource({
-        showMessagePreview: true,
-        messagePreview: "",
+        messagePreview: {
+          kind: "file",
+          plaintext: null,
+        },
       });
       renderWithProviders(
         <Source source={sourceWithEmptyPreview} {...defaultProps} />,
@@ -129,14 +127,32 @@ describe("Source Component", () => {
 
       const messagePreview = screen.getByTestId("message-preview");
       expect(messagePreview).toBeDefined();
-      expect(messagePreview.textContent).toBe("encrypted...");
+      expect(messagePreview.textContent).toBe("Encrypted File");
     });
 
-    it("displays actual message preview when showMessagePreview is true and messagePreview has content", () => {
+    it("displays 'Encrypted Message' when messagePreview exists but plaintext is empty for file", () => {
+      const sourceWithEmptyPreview = createMockSource({
+        messagePreview: {
+          kind: "message",
+          plaintext: null,
+        },
+      });
+      renderWithProviders(
+        <Source source={sourceWithEmptyPreview} {...defaultProps} />,
+      );
+
+      const messagePreview = screen.getByTestId("message-preview");
+      expect(messagePreview).toBeDefined();
+      expect(messagePreview.textContent).toBe("Encrypted Message");
+    });
+
+    it("displays actual message preview when messagePreview is set and plaintext has content", () => {
       const testMessage = "This is a test message preview";
       const sourceWithPreview = createMockSource({
-        showMessagePreview: true,
-        messagePreview: testMessage,
+        messagePreview: {
+          kind: "message",
+          plaintext: testMessage,
+        },
       });
       renderWithProviders(
         <Source source={sourceWithPreview} {...defaultProps} />,
@@ -288,8 +304,7 @@ describe("Source Component", () => {
       },
       isRead: true,
       hasAttachment: false,
-      showMessagePreview: false,
-      messagePreview: "",
+      messagePreview: null,
     };
 
     const baseProps = {

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.tsx
@@ -124,18 +124,20 @@ const Source = memo(function Source({
               >
                 {designation}
               </h3>
-              {source.showMessagePreview && (
+              {source.messagePreview && (
                 <p
                   className={`text-xs truncate ${
                     isActive ? "text-white opacity-80" : "text-gray-500"
                   } ${
                     !source.isRead ? "font-medium" : "font-normal"
-                  } ${source.messagePreview === "" ? "italic" : ""}`}
+                  } ${!source.messagePreview.plaintext ? "italic" : ""}`}
                   data-testid="message-preview"
                 >
-                  {source.messagePreview === ""
-                    ? t("source.encrypted")
-                    : source.messagePreview}
+                  {!source.messagePreview.plaintext
+                    ? source.messagePreview.kind === "file"
+                      ? t("source.encryptedFile")
+                      : t("source.encryptedMessage")
+                    : source.messagePreview.plaintext}
                 </p>
               )}
             </div>

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -101,8 +101,12 @@ export type Source = {
   data: SourceMetadata;
   isRead: boolean;
   hasAttachment: boolean;
-  showMessagePreview: boolean;
-  messagePreview: string;
+  messagePreview: MessagePreview | null;
+};
+
+export type MessagePreview = {
+  kind: "message" | "reply" | "file";
+  plaintext: string | null;
 };
 
 export type SourceWithItems = {
@@ -135,8 +139,9 @@ export type SourceRow = {
   data: string; // JSON stringified SourceMetadata
   is_seen: boolean;
   has_attachment: boolean;
-  show_message_preview: boolean;
-  message_preview: string;
+  last_message_kind?: "message" | "reply" | "file";
+  last_message_plaintext?: string;
+  last_message_filename?: string;
 };
 
 export type Item = {


### PR DESCRIPTION
Fixes #2778

Populates message previews on sync. We attempt to populate the preview whenever source metadata is updated, or when we download + decrypt a new message.

Note: this is based off the branch from the encrypt replies PR: https://github.com/freedomofpress/securedrop-client/pull/2803

## Test plan
Opening the app from a fresh sync should now show message previews in the source list. On receiving new message or sending new replies, message preview should update in the source list view.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
