### PR TITLE
File icons

### DIFF
--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
@@ -14,19 +14,170 @@ import "../Item.css";
 import "./File.css";
 
 import { useTranslation } from "react-i18next";
-import {
-  File as FileIcon,
-  Download,
-  LoaderCircle,
-  FileCheck2,
-  FileX2,
-} from "lucide-react";
+import { File as FileIcon, Download, LoaderCircle, FileX2 } from "lucide-react";
 import { Button, Tooltip } from "antd";
+import {
+  FilePdfFilled,
+  FileExcelFilled,
+  FileImageFilled,
+  FileWordFilled,
+  FileZipFilled,
+  FilePptFilled,
+  FileMarkdownFilled,
+  FileFilled,
+} from "@ant-design/icons";
+import FileVideoFilled from "./FileVideoFilled";
+import FileAudioFilled from "./FileAudioFilled";
+
+const EXCEL_EXTENSIONS = new Set([
+  ".xls",
+  ".xlsx",
+  ".xlsm",
+  ".xlsb",
+  ".xlt",
+  ".xltx",
+  ".xltm",
+  ".csv",
+  ".tsv",
+  ".ods",
+]);
+
+const IMAGE_EXTENSIONS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".bmp",
+  ".tif",
+  ".tiff",
+  ".svg",
+  ".svgz",
+  ".webp",
+  ".ico",
+  ".djvu",
+  ".heif",
+  ".heic",
+  ".avif",
+]);
+
+const WORD_EXTENSIONS = new Set([".doc", ".docx", ".rtf", ".odt", ".txt"]);
+
+const ARCHIVE_EXTENSIONS = new Set([
+  ".zip",
+  ".gz",
+  ".tgz",
+  ".tar",
+  ".bz2",
+  ".tbz",
+  ".xz",
+  ".txz",
+  ".7z",
+  ".rar",
+]);
+
+const POWERPOINT_EXTENSIONS = new Set([
+  ".ppt",
+  ".pptx",
+  ".pps",
+  ".ppsx",
+  ".odp",
+]);
+
+const VIDEO_EXTENSIONS = new Set([
+  ".mp4",
+  ".mov",
+  ".avi",
+  ".mkv",
+  ".wmv",
+  ".flv",
+  ".webm",
+  ".ogv",
+  ".m4v",
+  ".mpg",
+  ".mpeg",
+  ".3gp",
+  ".3g2",
+]);
+
+const AUDIO_EXTENSIONS = new Set([
+  ".mp3",
+  ".wav",
+  ".flac",
+  ".aac",
+  ".ogg",
+  ".oga",
+  ".m4a",
+  ".wma",
+  ".aif",
+  ".aiff",
+  ".opus",
+]);
 
 interface FileProps {
   item: Item;
   designation: string;
   onUpdate: (update: ItemUpdate) => void;
+}
+
+function getFileIconAndColor(filename: string): {
+  Icon: React.ComponentType<{
+    style?: React.CSSProperties;
+    className?: string;
+  }>;
+  color: string;
+} {
+  const normalizedFilename = filename.toLowerCase();
+  const lastDotIndex = normalizedFilename.lastIndexOf(".");
+  const extension =
+    lastDotIndex === -1 ? "" : normalizedFilename.substring(lastDotIndex);
+
+  // PDF
+  if (extension === ".pdf") {
+    return { Icon: FilePdfFilled, color: "#FF4D4F" };
+  }
+
+  // Excel
+  if (EXCEL_EXTENSIONS.has(extension)) {
+    return { Icon: FileExcelFilled, color: "#22B35E" };
+  }
+
+  // Image
+  if (IMAGE_EXTENSIONS.has(extension)) {
+    return { Icon: FileImageFilled, color: "#8C8C8C" };
+  }
+
+  // Word
+  if (WORD_EXTENSIONS.has(extension)) {
+    return { Icon: FileWordFilled, color: "#1677FF" };
+  }
+
+  // Zip
+  if (ARCHIVE_EXTENSIONS.has(extension)) {
+    return { Icon: FileZipFilled, color: "#FAB714" };
+  }
+
+  // PowerPoint
+  if (POWERPOINT_EXTENSIONS.has(extension)) {
+    return { Icon: FilePptFilled, color: "#FF6E31" };
+  }
+
+  // Video
+  if (VIDEO_EXTENSIONS.has(extension)) {
+    return { Icon: FileVideoFilled, color: "#FF4D4F" };
+  }
+
+  // Audio
+  if (AUDIO_EXTENSIONS.has(extension)) {
+    return { Icon: FileAudioFilled, color: "#8C8C8C" };
+  }
+
+  // Markdown
+  if ([".md", ".markdown"].includes(extension)) {
+    return { Icon: FileMarkdownFilled, color: "#8C8C8C" };
+  }
+
+  // Other
+  return { Icon: FileFilled, color: "#8C8C8C" };
 }
 
 function File({ item, designation, onUpdate }: FileProps) {
@@ -181,9 +332,11 @@ function CompleteFile(item: Item) {
   const formattedFilename = formatFilename(filename, filenameMaxLength, 6);
   const tooltipTitle = filename.length > filenameMaxLength ? filename : "";
 
+  const { Icon, color } = getFileIconAndColor(filename);
+
   return (
     <div className="flex items-center justify-start mt-2 mb-2">
-      <FileCheck2 size={30} strokeWidth={1} className="file-icon" />
+      <Icon style={{ fontSize: 30, color }} className="file-icon" />
       <div className="ml-2">
         <Tooltip title={tooltipTitle}>
           <Button size="small" type="link" className="file-namebtn">

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/FileAudioFilled.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/FileAudioFilled.tsx
@@ -1,0 +1,39 @@
+import { memo } from "react";
+
+interface FileAudioFilledProps {
+  size?: number;
+  color?: string;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+const FileAudioFilled = memo(function FileAudioFilled({
+  size,
+  color,
+  className,
+  style,
+}: FileAudioFilledProps) {
+  // Support both custom props and Ant Design style prop
+  const iconSize = size ?? (style?.fontSize as number) ?? 30;
+  const iconColor = color ?? (style?.color as string) ?? "#8C8C8C";
+
+  return (
+    <svg
+      width={iconSize}
+      height={iconSize}
+      viewBox="0 0 26 32"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M24.8071 8.025C25.0214 8.23929 25.1429 8.52857 25.1429 8.83214V30.8571C25.1429 31.4893 24.6321 32 24 32H1.14286C0.510715 32 0 31.4893 0 30.8571V1.14286C0 0.510714 0.510715 0 1.14286 0H16.3107C16.6143 0 16.9071 0.121429 17.1214 0.335714L24.8071 8.025ZM18.0346 14.2243C18.0571 14.303 18.0684 14.3844 18.0684 14.4662V16.1549C18.0683 16.5473 17.8081 16.8921 17.4308 17.0001L13.2311 18.1997V23.4144C13.2312 25.0734 11.9164 26.4341 10.2583 26.4909L10.1528 26.4927C8.82675 26.4927 7.64976 25.6434 7.23164 24.385C6.81353 23.1266 7.24827 21.7418 8.31062 20.9482C9.37297 20.1546 10.8242 20.1305 11.9123 20.8884L11.9118 15.4987H11.9404C12.0195 15.1984 12.2512 14.962 12.5499 14.8769L16.9475 13.6201C17.4146 13.4868 17.9012 13.7573 18.0346 14.2243ZM15.7857 2.63571L22.5071 9.35714H15.7857V2.63571Z"
+        fill={iconColor}
+      />
+    </svg>
+  );
+});
+
+export default FileAudioFilled;

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/FileVideoFilled.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/FileVideoFilled.tsx
@@ -1,0 +1,39 @@
+import { memo } from "react";
+
+interface FileVideoFilledProps {
+  size?: number;
+  color?: string;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+const FileVideoFilled = memo(function FileVideoFilled({
+  size,
+  color,
+  className,
+  style,
+}: FileVideoFilledProps) {
+  // Support both custom props and Ant Design style prop
+  const iconSize = size ?? (style?.fontSize as number) ?? 30;
+  const iconColor = color ?? (style?.color as string) ?? "#FF4D4F";
+
+  return (
+    <svg
+      width={iconSize}
+      height={iconSize}
+      viewBox="0 0 26 32"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M24.8071 8.025C25.0214 8.23929 25.1429 8.52857 25.1429 8.83214V30.8571C25.1429 31.4893 24.6321 32 24 32H1.14286C0.510715 32 0 31.4893 0 30.8571V1.14286C0 0.510714 0.510715 0 1.14286 0H16.3107C16.6143 0 16.9071 0.121429 17.1214 0.335714L24.8071 8.025ZM22.5071 9.35714L15.7857 2.63571V9.35714H22.5071ZM17.6473 20.6202L9.95058 26.0119C9.76965 26.1387 9.52022 26.0948 9.39347 25.9138C9.34635 25.8466 9.32108 25.7665 9.32108 25.6843V14.9009C9.32108 14.68 9.50017 14.5009 9.72108 14.5009C9.8032 14.5009 9.88332 14.5262 9.95058 14.5733L17.6473 19.965C17.8283 20.0917 17.8722 20.3412 17.7454 20.5221C17.7187 20.5603 17.6855 20.5935 17.6473 20.6202Z"
+        fill={iconColor}
+      />
+    </svg>
+  );
+});
+
+export default FileVideoFilled;


### PR DESCRIPTION
Fixes #2739

This branch is based on the PR branch for #2803, so we should merge that PR before this one. I also merged `main` into it. This is necessary because of the bug #2809.

The checks are currently failing because the lint in #2803 is failing. So I'm marking this as blocked until that PR is finished and merged. Then we should be able to merge that branch into this one, and the lint should succeed.

This PR checks the filename extension for downloaded files and uses an appropriate icon.

The figma document showed icons for several file types, but for some reason the icons for mp4-file and mp3-file did not appear to be standard [Ant Design Icons](https://ant.design/components/icon)? So I pulled the SVG from figma and made custom icons for these two, `FileVideoFilled.tsx` and `FileAudioFilled.tsx`.

Here are some screenshots:

<img width="399" height="610" alt="Screenshot 2025-11-11 at 5 04 25 PM" src="https://github.com/user-attachments/assets/c5f98a86-d010-44b7-bf5c-b2bfde078f8f" />
<img width="394" height="612" alt="Screenshot 2025-11-11 at 5 04 52 PM" src="https://github.com/user-attachments/assets/eba00276-bb06-45a2-a710-e6579b5d4cf4" />
<img width="395" height="605" alt="Screenshot 2025-11-11 at 5 05 18 PM" src="https://github.com/user-attachments/assets/3c1b1a7c-6817-46c5-8446-daf6668c37a7" />
<img width="395" height="248" alt="Screenshot 2025-11-11 at 5 05 28 PM" src="https://github.com/user-attachments/assets/62abe52c-5d35-4ff7-9418-35b3ff5a926f" />

## Test plan

To make it simpler to test, here are the test docs I used: https://drive.google.com/file/d/1R7wuSlDG0-NkIviXy40kp-ytKE0toU9N/view?usp=drive_link

Set up a dev server, load the source interface, create a new source, and upload each of these files. Then in the app, download and decrypt them all to see the icons.
