### PR TITLE
[app] allow null entries in batch response to handle deletion

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -472,7 +472,7 @@ export class DB {
 
   // Updates source versions in DB. Should be run in a transaction that also
   // updates the global index version.
-  updateSources(sources: { [uuid: string]: SourceMetadata }) {
+  updateSources(sources: { [uuid: string]: SourceMetadata | null }) {
     Object.keys(sources).forEach((sourceid: string) => {
       const metadata = sources[sourceid];
       if (metadata) {
@@ -492,7 +492,7 @@ export class DB {
 
   // Updates item versions in DB. Should be run in a transaction that also
   // updates the global index version.
-  updateItems(items: { [uuid: string]: ItemMetadata }) {
+  updateItems(items: { [uuid: string]: ItemMetadata | null }) {
     Object.keys(items).forEach((itemid: string) => {
       const metadata = items[itemid];
       if (metadata) {
@@ -520,7 +520,7 @@ export class DB {
   // Updates journalist metadata in DB. Should be run in a transaction that also
   // updates the global index version.
   private updateJournalists(journalists: {
-    [uuid: string]: JournalistMetadata;
+    [uuid: string]: JournalistMetadata | null;
   }) {
     Object.keys(journalists).forEach((id: string) => {
       const metadata = journalists[id];

--- a/app/src/schemas.ts
+++ b/app/src/schemas.ts
@@ -74,9 +74,9 @@ export const IndexSchema = z.object({
 
 // Metadata, maps UUIDs to full metadata objects
 export const BatchResponseSchema = z.object({
-  sources: z.record(UUIDSchema, SourceMetadataSchema),
-  items: z.record(UUIDSchema, ItemMetadataSchema),
-  journalists: z.record(UUIDSchema, JournalistMetadataSchema),
+  sources: z.record(UUIDSchema, SourceMetadataSchema.nullable()),
+  items: z.record(UUIDSchema, ItemMetadataSchema.nullable()),
+  journalists: z.record(UUIDSchema, JournalistMetadataSchema.nullable()),
   events: z.record(z.string(), z.tuple([z.number(), z.string().nullable()])),
 });
 


### PR DESCRIPTION
Fixes #2819 

On delete, the batch response contains `null` for the items/sources/etc that are deleted. Update our zod schema to accept nullable values.

## Test plan
Initiating a source conversation delete should successfully execute in the client without errors.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
