### PR TITLE
Disable eslint `no-explicit-any` rule in tests

### DIFF
--- a/app/eslint.config.ts
+++ b/app/eslint.config.ts
@@ -58,4 +58,16 @@ export default tseslint.config(
       },
     },
   },
+  {
+    files: [
+      "**/*.test.ts",
+      "**/*.test.tsx",
+      "tests/**/*",
+      "integration_tests/**/*",
+      "**/test-component-setup.tsx",
+    ],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+    },
+  },
 );

--- a/app/server_tests/sync.test.ts
+++ b/app/server_tests/sync.test.ts
@@ -127,7 +127,6 @@ describe.sequential("sync against a real server", () => {
   it("should verify logged-in journalist from Redux state", async () => {
     // Verify journalist info from Redux state
     const reduxState = await context.page.evaluate(() => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const store = (window as any).__REDUX_STORE__;
       if (!store) {
         throw new Error("Redux store not found on window object");

--- a/app/src/main/__tests__/crypto.gpg.test.ts
+++ b/app/src/main/__tests__/crypto.gpg.test.ts
@@ -75,7 +75,6 @@ describe("Crypto with Real GPG", () => {
 
   beforeEach(() => {
     // Reset singleton and create with test homedir
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (Crypto as any).instance = undefined;
     crypto = Crypto.initialize({
       isQubes: false,

--- a/app/src/main/__tests__/crypto.integration.test.ts
+++ b/app/src/main/__tests__/crypto.integration.test.ts
@@ -41,17 +41,13 @@ describe("Crypto Integration Tests", () => {
 
   beforeEach(() => {
     // Reset singleton instance for testing
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (Crypto as any).instance = undefined;
     vi.clearAllMocks();
     vi.unstubAllEnvs();
 
     // Mock fs functions needed by Storage
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (mockFs.realpathSync as any) = vi.fn((path) => path);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (mockFs.existsSync as any) = vi.fn(() => false);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (mockFs.mkdirSync as any) = vi.fn();
 
     // Mock process object for spawn

--- a/app/src/main/__tests__/crypto.unit.test.ts
+++ b/app/src/main/__tests__/crypto.unit.test.ts
@@ -17,7 +17,6 @@ describe("Crypto", () => {
   describe("getInstance and Qubes detection", () => {
     beforeEach(() => {
       // Reset singleton instance for testing
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (Crypto as any).instance = undefined;
     });
 
@@ -53,7 +52,6 @@ describe("Crypto", () => {
   describe("getInstance", () => {
     beforeEach(() => {
       // Reset singleton instance for testing
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (Crypto as any).instance = undefined;
     });
 
@@ -77,7 +75,6 @@ describe("Crypto", () => {
 
     beforeEach(() => {
       // Reset singleton instance for testing
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (Crypto as any).instance = undefined;
       crypto = Crypto.initialize({ journalistPublicKey: "", isQubes: false });
     });

--- a/app/src/main/database/index.test.ts
+++ b/app/src/main/database/index.test.ts
@@ -20,7 +20,6 @@ describe("Database Component Tests", () => {
   let crypto: Crypto;
 
   beforeAll(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (Crypto as any).instance = undefined;
     crypto = Crypto.initialize({
       isQubes: false,
@@ -76,7 +75,6 @@ describe("Database Method Tests", () => {
   let crypto: Crypto;
 
   beforeAll(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (Crypto as any).instance = undefined;
     crypto = Crypto.initialize({
       isQubes: false,

--- a/app/src/renderer/features/conversation/conversationSlice.test.ts
+++ b/app/src/renderer/features/conversation/conversationSlice.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { configureStore } from "@reduxjs/toolkit";
 import type { SourceWithItems } from "../../../types";

--- a/app/src/renderer/features/journalists/journalistsSlice.test.ts
+++ b/app/src/renderer/features/journalists/journalistsSlice.test.ts
@@ -197,7 +197,6 @@ describe("journalistsSlice", () => {
   describe("selectors", () => {
     const mockRootState = {
       journalists: loadedState,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       session: {} as any, // Mock other state slices
       sources: {
         sources: [],

--- a/app/src/renderer/features/sources/sourcesSlice.test.ts
+++ b/app/src/renderer/features/sources/sourcesSlice.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { configureStore } from "@reduxjs/toolkit";
 import type { Source as SourceType } from "../../../types";

--- a/app/src/renderer/features/sync/syncSlice.test.ts
+++ b/app/src/renderer/features/sync/syncSlice.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { configureStore } from "@reduxjs/toolkit";
 import { Source as SourceType, SyncStatus } from "../../../types";

--- a/app/src/renderer/test-component-setup.tsx
+++ b/app/src/renderer/test-component-setup.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable react-refresh/only-export-components */
 import { expect, afterEach, beforeEach, vi } from "vitest";
 import { cleanup, render, type RenderResult } from "@testing-library/react";

--- a/app/src/renderer/views/Inbox/MainContent.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent.test.tsx
@@ -85,7 +85,6 @@ describe("MainContent Component", () => {
     vi.clearAllMocks();
 
     // Mock electronAPI
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).electronAPI = {
       getSourceWithItems: vi.fn().mockResolvedValue(mockSourceWithItems),
     };
@@ -160,7 +159,6 @@ describe("MainContent Component", () => {
   describe("Source Not Found", () => {
     it("shows source not found when conversation is null", async () => {
       // Mock the API to return null/error for this source
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (window as any).electronAPI.getSourceWithItems = vi
         .fn()
         .mockRejectedValue(new Error("Source not found"));
@@ -204,7 +202,6 @@ describe("MainContent Component", () => {
       const mockGetSourceWithItems = vi
         .fn()
         .mockResolvedValue(mockSourceWithItems);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (window as any).electronAPI.getSourceWithItems = mockGetSourceWithItems;
 
       renderMainContent("/source/source-1");
@@ -227,7 +224,6 @@ describe("MainContent Component", () => {
       };
 
       // Mock the API to return the lowercase name
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (window as any).electronAPI.getSourceWithItems = vi
         .fn()
         .mockResolvedValue(sourceWithLowercaseName);
@@ -263,7 +259,6 @@ describe("MainContent Component", () => {
 
     it("handles empty conversations in Redux state", async () => {
       // Mock the API to not return any data
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (window as any).electronAPI.getSourceWithItems = vi
         .fn()
         .mockRejectedValue(new Error("Not found"));

--- a/app/src/renderer/views/SignIn.test.tsx
+++ b/app/src/renderer/views/SignIn.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { screen, waitFor } from "@testing-library/react";
 import { expect } from "vitest";
 import userEvent from "@testing-library/user-event";


### PR DESCRIPTION
It mostly just gets in the way and is okay to use in tests.


## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] rationale makes sense
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
