### PR TITLE
app: Open files in sd-viewer dispVM

### DIFF
--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -101,6 +101,9 @@ const electronAPI = {
   getCSPNonce: logIpcCall<string>("getCSPNonce", () =>
     ipcRenderer.invoke("getCSPNonce"),
   ),
+  openFile: logIpcCall<void>("openFile", (itemUuid: string) =>
+    ipcRenderer.invoke("openFile", itemUuid),
+  ),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onItemUpdate: (callback: (...args: any[]) => void) => {
     ipcRenderer.on("item-update", (_event, ...args) => callback(...args));

--- a/app/src/renderer/test-component-setup.tsx
+++ b/app/src/renderer/test-component-setup.tsx
@@ -165,6 +165,7 @@ beforeEach(() => {
     addPendingItemsSeenBatch: vi.fn().mockResolvedValue([]),
     shouldAutoLogin: vi.fn().mockResolvedValue(false),
     clearClipboard: vi.fn().mockResolvedValue(null),
+    openFile: vi.fn().mockResolvedValue(undefined),
   } as ElectronAPI;
 });
 

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
@@ -335,7 +335,6 @@ const InProgressFile = memo(function InProgressFile({
   );
 });
 
-// TODO: implement download viewer
 const CompleteFile = memo(function CompleteFile({ item }: { item: Item }) {
   const filename = item.filename
     ? item.filename.substring(item.filename.lastIndexOf("/") + 1)
@@ -350,12 +349,25 @@ const CompleteFile = memo(function CompleteFile({ item }: { item: Item }) {
 
   const { Icon, color } = getFileIconAndColor(filename);
 
+  const handleOpenFile = async () => {
+    try {
+      await window.electronAPI.openFile(item.uuid);
+    } catch (error) {
+      console.error("Failed to open file:", error);
+    }
+  };
+
   return (
     <div className="flex items-center justify-start mt-2 mb-2">
       <Icon style={{ fontSize: 30, color }} className="file-icon" />
       <div className="ml-2">
         <Tooltip title={tooltipTitle}>
-          <Button size="small" type="link" className="file-namebtn">
+          <Button
+            size="small"
+            type="link"
+            className="file-namebtn"
+            onClick={handleOpenFile}
+          >
             {formattedFilename}
           </Button>
         </Tooltip>


### PR DESCRIPTION
The frontend asks the backend to open a specific UUID, and the backend looks it up and passes the filename to `qvm-open-in-vm`.

This unconditionally opens files in the sd-viewer dispVM, there is no exception for dev environments or otherwise (just like the client).

Fixes #2838.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] Need to test this in Qubes, so I rebased it on top of https://github.com/freedomofpress/securedrop-client/pull/2848, built debs, and then installed it in the sd-app VM. Start the app and verify that after a file is downloaded, you can click on it and it opens in a separate VM.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
