### PR TITLE
feat(`sync)`: pin to API minor version 2.3

### DIFF
--- a/app/src/main/sync/index.ts
+++ b/app/src/main/sync/index.ts
@@ -8,6 +8,7 @@ import {
 } from "../../types";
 import { DB } from "../database";
 import {
+  API_MINOR_VERSION,
   IndexSchema,
   BatchResponseSchema,
   BatchRequestSchema,
@@ -28,6 +29,7 @@ async function getServerIndex(
       "Content-Type": "application/json",
       Authorization: `Token ${authToken}`,
       "If-None-Match": currentVersion,
+      Prefer: `securedrop=${API_MINOR_VERSION}`,
     },
   })) as ProxyJSONResponse;
 
@@ -62,6 +64,7 @@ async function submitBatch(
       Accept: "application/json",
       "Content-Type": "application/json",
       Authorization: `Token ${authToken}`,
+      Prefer: `securedrop=${API_MINOR_VERSION}`,
     },
     body: JSON.stringify(BatchRequestSchema.parse(request)),
   })) as ProxyJSONResponse;

--- a/app/src/schemas.ts
+++ b/app/src/schemas.ts
@@ -4,6 +4,11 @@
 
 import { z } from "zod";
 
+// Bump this constant when this file has been updated to reflect a new minor
+// version of the v2 Journalist API with new request/response shapes.  See the
+// constant of the same name in freedomofpress/securedrop for possible values.
+export const API_MINOR_VERSION = 3; // 2.x
+
 export const UUIDSchema = z.uuid({ version: "v4" });
 
 // Response from /api/v1/token


### PR DESCRIPTION
Closes #2830 and closes #2608 by sending `Prefer: securedrop=x`, where `x` is the minor version `2.x` of the Journalist API the app expects for its request/response schemas.

## Test plan

- [x] Server tests pass unmodified.
- [ ] When the app is run with this patch, sync fails and spews Zod errors:
    ```patch
    --- a/app/src/schemas.ts
    +++ b/app/src/schemas.ts
    @@ -7,7 +7,7 @@ import { z } from "zod";
     // Bump this constant when this file has been updated to reflect a new minor
     // version of the v2 Journalist API with new request/response shapes.  See the
     // constant of the same name in freedomofpress/securedrop for possible values.
    -export const API_MINOR_VERSION = 3; // 2.x
    +export const API_MINOR_VERSION = 1; // 2.x
     
     export const UUIDSchema = z.uuid({ version: "v4" });
    ```

## Checklist

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
