### PR TITLE
Clear clipboard in app after successful login

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -1,5 +1,5 @@
 import "source-map-support/register";
-import { app, BrowserWindow, ipcMain, session } from "electron";
+import { app, BrowserWindow, ipcMain, session, clipboard } from "electron";
 import { join } from "path";
 import { randomBytes } from "crypto";
 import { optimizer, is } from "@electron-toolkit/utils";
@@ -292,6 +292,12 @@ app.whenReady().then(() => {
 
   ipcMain.handle("getCSPNonce", async (_event): Promise<string> => {
     return cspNonce;
+  });
+
+  ipcMain.handle("clearClipboard", async (_event): Promise<void> => {
+    clipboard.clear();
+    clipboard.clear("selection");
+    return;
   });
 
   const mainWindow = createWindow();

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -109,6 +109,9 @@ const electronAPI = {
   onSourceUpdate: (callback: (...args: any[]) => void) => {
     ipcRenderer.on("source-update", (_event, ...args) => callback(...args));
   },
+  clearClipboard: logIpcCall<void>("clearClipboard", () =>
+    ipcRenderer.invoke("clearClipboard"),
+  ),
 };
 
 contextBridge.exposeInMainWorld("electronAPI", electronAPI);

--- a/app/src/renderer/test-component-setup.tsx
+++ b/app/src/renderer/test-component-setup.tsx
@@ -164,6 +164,7 @@ beforeEach(() => {
     addPendingItemEvent: vi.fn().mockResolvedValue(BigInt(789)),
     addPendingItemsSeenBatch: vi.fn().mockResolvedValue([]),
     shouldAutoLogin: vi.fn().mockResolvedValue(false),
+    clearClipboard: vi.fn().mockResolvedValue(null),
   } as ElectronAPI;
 });
 

--- a/app/src/renderer/views/SignIn.tsx
+++ b/app/src/renderer/views/SignIn.tsx
@@ -93,6 +93,9 @@ function SignInView() {
           } as AuthData),
         );
 
+        // Clear the clipboard in case they pasted their password
+        window.electronAPI.clearClipboard();
+
         // Redirect to home
         navigate("/");
       } catch (e) {


### PR DESCRIPTION
In case the user pasted a password from a vault VM, clear it off the local VM's clipboard.

Fixes #2844.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

* [ ] Copy something on your clipboard
* [ ] Run the app and login (whether manually or using auto login)
* [ ] Try pasting, it should be empty.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
