### PR TITLE
Tests: incorrect use of `assert func.called_`

### DIFF
--- a/client/tests/test_logic.py
+++ b/client/tests/test_logic.py
@@ -2196,7 +2196,7 @@ def test_Controller_on_queue_cleared(homedir, config, mocker, session_maker):
     co.api = "not none"
     co.show_last_sync_timer = mocker.MagicMock()
     co.on_queue_cleared()
-    fail_draft_replies.called_once_with(co.session)
+    fail_draft_replies.assert_called_once_with(co.session)
 
 
 def test_Controller_on_queue_paused(homedir, config, mocker, session_maker):

--- a/export/tests/print/test_service.py
+++ b/export/tests/print/test_service.py
@@ -49,8 +49,8 @@ class TestPrint:
 
         # When the client can accept new status values, we will assert that the
         # above call results in Status.PRINT_SUCCESS
-        assert mock_setup.called_once()
-        assert mock_print.called_once()
+        mock_setup.assert_called_once()
+        mock_print.assert_called_once()
 
         patch_setup.stop()
         patch_print.stop()
@@ -64,7 +64,7 @@ class TestPrint:
 
         # When the client can accept new status values, we will assert that the
         # above call results in Status.PREFLIGHT_SUCCESS
-        assert mock_setup.called_once()
+        mock_setup.assert_called_once()
 
         patch_setup.stop()
 
@@ -79,8 +79,8 @@ class TestPrint:
         # When the client can accept new status values, we will assert that the
         # above call results in Status.TEST_SUCCESS
 
-        assert mock_setup.called_once()
-        assert mock_print.called_once()
+        mock_setup.assert_called_once()
+        mock_print.assert_called_once()
 
         patch_setup.stop()
         patch_print.stop()
@@ -203,14 +203,14 @@ class TestPrint:
         # Printer found
         with mock.patch("os.path.exists", return_value=True) as path_exists:
             self.service._check_printer_setup()  # No exception raised
-            assert path_exists.called_once_with(IPP_USB_CTRL_SOCKET)
+            path_exists.assert_called_once_with(IPP_USB_CTRL_SOCKET)
 
         # Printer not found
         with mock.patch("os.path.exists", return_value=False) as path_exists:
             with pytest.raises(ExportException) as ex:
                 self.service._check_printer_setup()
             assert ex.value.sdstatus is Status.ERROR_PRINTER_NOT_FOUND
-            assert path_exists.called_once_with(IPP_USB_CTRL_SOCKET)
+            path_exists.assert_called_once_with(IPP_USB_CTRL_SOCKET)
 
     def test__print_test_page_calls_method(self):
         p = mock.patch.object(self.service, "_print_file")


### PR DESCRIPTION
The mocked objects were getting an unexistent method called 'called_once_with'. Asserting a non-existent method's call resuls in True (a false positive).

These methods should be prefixed by `.assert_` instead. Confusingly, the method '.called' does exist in a mocked object...

Credit to python/cpython@1d4d677 that made this mistake apparent by failing tests (requires python3.13).

Fixes #2849

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
- [ ] tests pass
- [ ] Manual failure injection to confirm @deeplow's diagnosis that these calls were in fact not being checked
- [ ] (Optionally) run export / client tests with python3.13

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
