### PR TITLE
[app] fix source not found error when deleting active source

### DIFF
--- a/app/src/renderer/features/sources/sourcesSlice.ts
+++ b/app/src/renderer/features/sources/sourcesSlice.ts
@@ -78,6 +78,11 @@ export const sourcesSlice = createSlice({
       .addCase(fetchSources.fulfilled, (state, action) => {
         state.loading = false;
         state.sources = action.payload;
+
+        // Update active source UUID in case of deletion
+        if (!state.sources.find((s) => s.uuid === state.activeSourceUuid)) {
+          state.activeSourceUuid = null;
+        }
       })
       .addCase(fetchSources.rejected, (state, action) => {
         state.loading = false;


### PR DESCRIPTION
Fixes #2796 

When the active source is deleted, the frontend still tries to fetch its conversation which results in a failed DB call. This PR fixes that by checking if `activeSourceUuid` is still in the list of sources whenever we fetch sources from the frontend. If it's been deleted, then we unset `activeSourceUuid`.

## Test plan
Repro initial bug:

- Run `app` with several sources 
- Select a given source `source_a` from the source list, opening its conversation view 
- Delete `source_a` (deleting the account)
- Trigger manual sync or some other re-render operation
- App console shows:
```
Error occurred in handler for 'getSourceWithItems': Error: Source with UUID 6d3a8b24-a7ec-4c8e-b646-36782b52d77e not found
    at DB.getSourceWithItems (/home/user/github/freedomofpress/securedrop-client/app/src/main/database/index.ts:593:13)
    at /home/user/github/freedomofpress/securedrop-client/app/src/main/index.ts:182:34
    at Session.<anonymous> (node:electron/js2c/browser_init:2:107040)
    at Session.emit (node:events:518:28)]
```

With fix:
- Run `app` with several sources 
- Select a given source `source_a` from the source list, opening its conversation view 
- Delete `source_a` (deleting the account)
- Trigger manual sync or some other re-render operation
- No error printed to console