### PR TITLE
Add a .desktop file for SecureDrop App

### DIFF
--- a/app/press.freedom.SecureDropApp.desktop
+++ b/app/press.freedom.SecureDropApp.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=SecureDrop App
+Exec=securedrop-app --no-sandbox
+Icon=utilities-terminal
+Type=Application

--- a/debian/securedrop-app.install
+++ b/debian/securedrop-app.install
@@ -1,1 +1,2 @@
 app/dist/linux-unpacked/ /usr/lib/securedrop-app
+app/press.freedom.SecureDropApp.desktop usr/share/applications/


### PR DESCRIPTION
Same as the client but with a different command.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] Use `./scripts/try-client-pr.py --app 2865` to install this into the workstation
* [x] from dom0, run `qvm-run --service sd-app qubes.StartApp+press.freedom.SecureDropApp`, which should launch the app!
* [x] this desktop file is basically the same as the client's
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
