### PR TITLE
Handle 403 errors gracefully

### DIFF
--- a/app/src/renderer/features/conversation/conversationSlice.test.ts
+++ b/app/src/renderer/features/conversation/conversationSlice.test.ts
@@ -256,6 +256,7 @@ describe("conversationSlice", () => {
         loading: false,
         error: null,
         lastFetchTime: null,
+        status: null,
       },
     };
 

--- a/app/src/renderer/features/journalists/journalistsSlice.test.ts
+++ b/app/src/renderer/features/journalists/journalistsSlice.test.ts
@@ -215,6 +215,7 @@ describe("journalistsSlice", () => {
         loading: false,
         error: null,
         lastFetchTime: null,
+        status: null,
       },
     };
 

--- a/app/src/renderer/features/session/sessionSlice.test.ts
+++ b/app/src/renderer/features/session/sessionSlice.test.ts
@@ -21,6 +21,7 @@ describe("sessionSlice", () => {
   const mockSessionState: SessionState = {
     status: SessionStatus.Auth,
     authData: mockAuthData,
+    errorMessage: undefined,
   };
 
   it("should have the correct initial state", () => {
@@ -30,13 +31,23 @@ describe("sessionSlice", () => {
 
   describe("setUnauth action", () => {
     it("should set the session state to unauth", () => {
-      const result = sessionReducer(mockSessionState, setUnauth());
+      const result = sessionReducer(mockSessionState, setUnauth(undefined));
       expect(result).toEqual(unauthSessionState);
     });
 
     it("should return unauth state when clearing already empty state", () => {
-      const result = sessionReducer(unauthSessionState, setUnauth());
+      const result = sessionReducer(unauthSessionState, setUnauth(undefined));
       expect(result).toEqual(unauthSessionState);
+    });
+
+    it("should set error message when provided", () => {
+      const errorMsg = "Your session expired. Please log in again.";
+      const result = sessionReducer(mockSessionState, setUnauth(errorMsg));
+      expect(result).toEqual({
+        status: SessionStatus.Unauth,
+        authData: undefined,
+        errorMessage: errorMsg,
+      });
     });
   });
 
@@ -67,6 +78,7 @@ describe("sessionSlice", () => {
       expect(result).toEqual({
         status: SessionStatus.Offline,
         authData: undefined,
+        errorMessage: undefined,
       });
     });
 
@@ -75,6 +87,7 @@ describe("sessionSlice", () => {
       expect(result).toEqual({
         status: SessionStatus.Offline,
         authData: undefined,
+        errorMessage: undefined,
       });
       expect(result.authData).toBeUndefined();
     });
@@ -83,6 +96,7 @@ describe("sessionSlice", () => {
       const offlineState: SessionState = {
         status: SessionStatus.Offline,
         authData: undefined,
+        errorMessage: undefined,
       };
       const result = sessionReducer(offlineState, setOffline());
       expect(result).toEqual(offlineState);

--- a/app/src/renderer/features/session/sessionSlice.ts
+++ b/app/src/renderer/features/session/sessionSlice.ts
@@ -19,11 +19,13 @@ interface AuthData {
 interface SessionState {
   status: SessionStatus;
   authData?: AuthData;
+  errorMessage?: string;
 }
 
 const unauthState: SessionState = {
   status: SessionStatus.Unauth,
   authData: undefined,
+  errorMessage: undefined,
 };
 
 export const sessionSlice = createSlice({
@@ -33,11 +35,20 @@ export const sessionSlice = createSlice({
     setAuth: (state, action: PayloadAction<AuthData>) => {
       state.authData = action.payload;
       state.status = SessionStatus.Auth;
+      state.errorMessage = undefined;
     },
-    setUnauth: () => unauthState,
+    setUnauth: (state, action: PayloadAction<string | undefined>) => {
+      state.status = SessionStatus.Unauth;
+      state.authData = undefined;
+      state.errorMessage = action.payload;
+    },
+    clearError: (state) => {
+      state.errorMessage = undefined;
+    },
     setOffline: (state) => {
       state.status = SessionStatus.Offline;
       state.authData = undefined;
+      state.errorMessage = undefined;
     },
   },
 });
@@ -45,6 +56,7 @@ export const sessionSlice = createSlice({
 export type { SessionState, AuthData };
 export { SessionStatus };
 export const unauthSessionState = unauthState;
-export const { setAuth, setUnauth, setOffline } = sessionSlice.actions;
+export const { setAuth, setUnauth, clearError, setOffline } =
+  sessionSlice.actions;
 export const getSessionState = (state: RootState) => state.session;
 export default sessionSlice.reducer;

--- a/app/src/renderer/features/sources/sourcesSlice.test.ts
+++ b/app/src/renderer/features/sources/sourcesSlice.test.ts
@@ -315,6 +315,7 @@ describe("sourcesSlice", () => {
           loading: false,
           error: null,
           lastFetchTime: null,
+          status: null,
         },
       };
 
@@ -341,6 +342,7 @@ describe("sourcesSlice", () => {
           loading: false,
           error: null,
           lastFetchTime: null,
+          status: null,
         },
       };
 
@@ -367,6 +369,7 @@ describe("sourcesSlice", () => {
           loading: false,
           error: null,
           lastFetchTime: null,
+          status: null,
         },
       };
 
@@ -397,6 +400,7 @@ describe("sourcesSlice", () => {
           loading: false,
           error: null,
           lastFetchTime: null,
+          status: null,
         },
       };
 

--- a/app/src/renderer/features/sync/syncSlice.ts
+++ b/app/src/renderer/features/sync/syncSlice.ts
@@ -8,11 +8,13 @@ import { SyncStatus } from "../../../types";
 export interface SyncState {
   error: string | null;
   lastFetchTime: number | null;
+  status: SyncStatus | null;
 }
 
 const initialState: SyncState = {
   error: null,
   lastFetchTime: null,
+  status: null,
 };
 
 // Async thunk for syncing metadata (sources, journalists, and active conversation)
@@ -42,7 +44,7 @@ export const syncMetadata = createAsyncThunk(
       }
     }
 
-    return;
+    return status;
   },
 );
 
@@ -53,11 +55,15 @@ export const syncSlice = createSlice({
     clearError: (state) => {
       state.error = null;
     },
+    clearStatus: (state) => {
+      state.status = null;
+    },
   },
   extraReducers: (builder) => {
     builder
-      .addCase(syncMetadata.fulfilled, (state) => {
+      .addCase(syncMetadata.fulfilled, (state, action) => {
         state.lastFetchTime = Date.now();
+        state.status = action.payload;
       })
       .addCase(syncMetadata.rejected, (state, action) => {
         state.error = action.error.message || "Failed to sync metadata";
@@ -65,8 +71,9 @@ export const syncSlice = createSlice({
   },
 });
 
-export const { clearError } = syncSlice.actions;
+export const { clearError, clearStatus } = syncSlice.actions;
 export const selectSyncError = (state: RootState) => state.sync.error;
+export const selectSyncStatus = (state: RootState) => state.sync.status;
 export const selectlastFetchTime = (state: RootState) =>
   state.sync.lastFetchTime;
 export default syncSlice.reducer;

--- a/app/src/renderer/locales/en.json
+++ b/app/src/renderer/locales/en.json
@@ -103,7 +103,8 @@
     "errors": {
       "network": "Could not reach the SecureDrop server. Please check your Internet and Tor connection and try again.",
       "credentials": "Those credentials didn't work. Please try again, and make sure to use a new two-factor code.",
-      "generic": "That didn't work. Please check everything and try again."
+      "generic": "That didn't work. Please check everything and try again.",
+      "sessionExpired": "Your session expired. Please log in again."
     },
     "version": "SecureDrop App v{{version}}"
   },

--- a/app/src/renderer/locales/fr.json
+++ b/app/src/renderer/locales/fr.json
@@ -103,7 +103,8 @@
     "errors": {
       "network": "Impossible de joindre le serveur SecureDrop. Veuillez vérifier votre connexion Internet et Tor, puis réessayer.",
       "credentials": "Ces identifiants n'ont pas fonctionné. Veuillez réessayer et assurez-vous d'utiliser un nouveau code d'authentification à deux facteurs.",
-      "generic": "Cela n'a pas fonctionné. Veuillez tout vérifier et réessayer."
+      "generic": "Cela n'a pas fonctionné. Veuillez tout vérifier et réessayer.",
+      "sessionExpired": "Votre session a expiré. Reconnectez-vous."
     },
     "version": "Application SecureDrop v{{version}}"
   },

--- a/app/src/renderer/views/Inbox.tsx
+++ b/app/src/renderer/views/Inbox.tsx
@@ -1,15 +1,24 @@
 import { useEffect, useCallback } from "react";
 import { useDispatch } from "react-redux";
+import { useTranslation } from "react-i18next";
 import type { AppDispatch } from "../store";
 import { fetchJournalists } from "../features/journalists/journalistsSlice";
-import { syncMetadata } from "../features/sync/syncSlice";
+import {
+  syncMetadata,
+  selectSyncStatus,
+  clearStatus,
+} from "../features/sync/syncSlice";
+import { setUnauth } from "../features/session/sessionSlice";
+import { SyncStatus } from "../../types";
 import { useAppSelector } from "../hooks";
 import Sidebar from "./Inbox/Sidebar";
 import MainContent from "./Inbox/MainContent";
 
 function InboxView() {
   const dispatch = useDispatch<AppDispatch>();
+  const { t } = useTranslation("SignIn");
   const session = useAppSelector((state) => state.session);
+  const syncStatus = useAppSelector(selectSyncStatus);
 
   const sync = useCallback(() => {
     if (session.authData && import.meta.env.MODE != "test") {
@@ -30,6 +39,14 @@ function InboxView() {
       clearInterval(syncInterval);
     };
   }, [sync]);
+
+  // Handle 403 Forbidden errors from sync
+  useEffect(() => {
+    if (syncStatus === SyncStatus.FORBIDDEN) {
+      dispatch(setUnauth(t("errors.sessionExpired")));
+      dispatch(clearStatus());
+    }
+  }, [syncStatus, dispatch, t]);
 
   useEffect(() => {
     dispatch(fetchJournalists());

--- a/app/src/renderer/views/Inbox/Sidebar/Account.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/Account.tsx
@@ -35,7 +35,7 @@ function Account() {
 
   const signOut = () => {
     console.log("signing out");
-    dispatch(setUnauth());
+    dispatch(setUnauth(undefined));
     navigate("/");
   };
 

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -46,6 +46,7 @@ export enum SyncStatus {
   NOT_MODIFIED = "not_modified",
   UPDATED = "updated",
   ERROR = "error",
+  FORBIDDEN = "forbidden",
 }
 
 // IPC request for operation requiring auth token


### PR DESCRIPTION
Send the user to the login screen with an error message. This matches the current Python client's behavior.

We add a new SyncStatus.FORBIDDEN response and internally now return statuses along with data (instead of e.g. `Index | null` where null is 304) so higher level code can return the correct status. Because the statuses are hardcoded in the type, using the wrong one is a type error.

Fixes #2787.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] Set up a local server and log into the app (do not use auto login), verify sync works
* [ ] Enter the server container by running e.g. `podman exec -it -u root securedrop-dev-0 bash`
* [ ] Get the redis password by running `tail /etc/redis/redis.conf`
* [ ] Run `redis-cli` and authenticate by typing `auth [password]`
* [ ] Get a list of active sessions by running `keys api*`
* [ ] Delete all those sessions by running `del [keys...]`
* [ ] Run sync in the app. You should now be sent to the login screen and see an error message
* [ ] Once you start typing in the login form, the error message should clear.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
