### PR TITLE
[app] add export dialog components

### DIFF
--- a/app/src/renderer/locales/en.json
+++ b/app/src/renderer/locales/en.json
@@ -112,6 +112,31 @@
     "pause": "Pause",
     "resume": "Resume",
     "of": "of",
-    "filenameTooltip": "Filename available after downloading"
+    "filenameTooltip": "Filename available after downloading",
+    "exportFile": "Export file",
+    "printFile": "Print file",
+    "exportWizard": {
+      "title": "Export File",
+      "preparingExport": "Preparing to export.",
+      "readyExport": "Ready to export.",
+      "understandRisks": "Understand the risks before exporting files",
+      "malwareTitle": "Malware",
+      "malwareWarning": "This workstation lets you open files securely. If you open files on another computer, any embedded malware may spread to your computer or network. If you are unsure how to manage this risk, please print the file, or contact your administrator.",
+      "anonymityTitle": "Anonymity",
+      "anonymityWarning": "Files submitted by sources may contain information or hidden metadata that identifies who they are. To protect your sources, please consider redacting files before working with them on network-connected computers.",
+      "exportInstructions": "Please insert one of the export drives provisioned specifically for the SecureDrop Workstation.\nIf you're using a VeraCrypt drive, unlock it manually before proceeding.",
+      "unlock": "Enter passphrase for USB drive",
+      "passphrase": "Passphrase",
+      "pleaseWait": "Please wait...",
+      "beCareful": "Remember to be careful when working with files outside of your Workstation machine",
+      "exportSuccess": "Export Successful",
+      "exportFailed": "Export Failed",
+      "unknownError": "Unknown error occurred",
+      "cancel": "Cancel",
+      "back": "Back",
+      "continue": "Continue",
+      "close": "Close",
+      "done": "Done"
+    }
   }
 }

--- a/app/src/renderer/locales/fr.json
+++ b/app/src/renderer/locales/fr.json
@@ -112,6 +112,31 @@
     "pause": "Pause",
     "resume": "Reprendre",
     "of": "de",
-    "filenameTooltip": "Nom de fichier disponible après le téléchargement"
+    "filenameTooltip": "Nom de fichier disponible après le téléchargement",
+    "exportFile": "Exporter le fichier",
+    "printFile": "Imprimer le fichier",
+    "exportWizard": {
+      "title": "Exporter le fichier",
+      "preparingExport": "Préparation de l'exportation.",
+      "readyExport": "Prêt à exporter.",
+      "understandRisks": "Comprendre les risques avant d'exporter des fichiers",
+      "malwareTitle": "Logiciels malveillants",
+      "malwareWarning": "Cette station de travail vous permet d'ouvrir des fichiers en toute sécurité. Si vous ouvrez des fichiers sur un autre ordinateur, tout logiciel malveillant intégré peut se propager à votre ordinateur ou réseau. Si vous n'êtes pas sûr de savoir comment gérer ce risque, veuillez imprimer le fichier ou contacter votre administrateur.",
+      "anonymityTitle": "Anonymat",
+      "anonymityWarning": "Les fichiers soumis par les sources peuvent contenir des informations ou des métadonnées cachées qui les identifient. Pour protéger vos sources, veuillez envisager de caviarder les fichiers avant de travailler avec eux sur des ordinateurs connectés au réseau.",
+      "exportInstructions": "Veuillez insérer l'un des lecteurs d'exportation fournis spécifiquement pour le poste de travail SecureDrop.\nSi vous utilisez un lecteur VeraCrypt, déverrouillez-le manuellement avant de continuer.",
+      "unlock": "Entrer la phrase de passe pour le lecteur USB",
+      "passphrase": "Phrase de passe",
+      "pleaseWait": "Veuillez patienter...",
+      "beCareful": "N'oubliez pas d'être prudent lorsque vous travaillez avec des fichiers en dehors de votre poste de travail",
+      "exportSuccess": "Exportation réussie",
+      "exportFailed": "Échec de l'exportation",
+      "unknownError": "Erreur inconnue survenue",
+      "cancel": "Annuler",
+      "back": "Retour",
+      "continue": "Continuer",
+      "close": "Fermer",
+      "done": "Terminé"
+    }
   }
 }

--- a/app/src/renderer/test-component-setup.tsx
+++ b/app/src/renderer/test-component-setup.tsx
@@ -32,6 +32,28 @@ Object.defineProperty(window, "matchMedia", {
   }),
 });
 
+// Mock window.getComputedStyle for Ant components (Modal uses this)
+Object.defineProperty(window, "getComputedStyle", {
+  writable: true,
+  value: () => ({
+    getPropertyValue: () => "",
+    paddingLeft: "0px",
+    paddingRight: "0px",
+    paddingTop: "0px",
+    paddingBottom: "0px",
+    marginLeft: "0px",
+    marginRight: "0px",
+    marginTop: "0px",
+    marginBottom: "0px",
+    borderLeftWidth: "0px",
+    borderRightWidth: "0px",
+    borderTopWidth: "0px",
+    borderBottomWidth: "0px",
+    width: "0px",
+    height: "0px",
+  }),
+});
+
 afterEach(() => {
   cleanup();
 });

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.test.tsx
@@ -1,0 +1,725 @@
+import { screen, waitFor } from "@testing-library/react";
+import { expect, describe, it, vi, beforeEach, afterEach } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { ExportWizard } from "./Export";
+import { FetchStatus, type Item } from "../../../../../../types";
+import { renderWithProviders } from "../../../../../test-component-setup";
+
+describe("ExportWizard Component", () => {
+  const mockItem: Item = {
+    uuid: "test-item-uuid",
+    data: {
+      uuid: "test-item-uuid",
+      kind: "file",
+      seen_by: [],
+      size: 1024,
+      source: "source-1",
+      is_read: false,
+      interaction_count: 0,
+    },
+    fetch_status: FetchStatus.Complete,
+    filename: "/path/to/testfile.pdf",
+  };
+
+  const mockOnClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("Initial State", () => {
+    it("renders nothing when not open", () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={false} onClose={mockOnClose} />,
+      );
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("renders the modal when open", async () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+    });
+
+    it("displays preflight state with risk warnings on initial open", async () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Preparing to export.")).toBeInTheDocument();
+        expect(
+          screen.getByText("Understand the risks before exporting files"),
+        ).toBeInTheDocument();
+        expect(screen.getByText("Malware")).toBeInTheDocument();
+        expect(screen.getByText("Anonymity")).toBeInTheDocument();
+      });
+    });
+
+    it("displays the filename in preflight state", async () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("testfile.pdf")).toBeInTheDocument();
+      });
+    });
+
+    it("shows Continue and Cancel buttons in preflight state", async () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      await waitFor(() => {
+        const continueButton = screen.getByRole("button", {
+          name: /continue/i,
+        });
+        const cancelButton = screen.getByRole("button", { name: /cancel/i });
+
+        expect(continueButton).toBeInTheDocument();
+        expect(continueButton).toBeDisabled(); // Disabled during preflight
+        expect(cancelButton).toBeInTheDocument();
+      });
+    });
+
+    it("prevents modal from being closed during preflight state", async () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      await waitFor(() => {
+        const dialog = screen.getByRole("dialog");
+        expect(dialog).toBeInTheDocument();
+      });
+
+      // Modal should not have a close button during preflight
+      const closeButton = screen.queryByRole("button", { name: /close/i });
+      expect(closeButton).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Preflight State Machine", () => {
+    it("automatically transitions from PREFLIGHT to PREFLIGHT_COMPLETE after delay", async () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      // Initially in PREFLIGHT state
+      await waitFor(() => {
+        expect(screen.getByText("Preparing to export.")).toBeInTheDocument();
+      });
+
+      // Wait for auto-transition (1.5 seconds + buffer)
+      await waitFor(
+        () => {
+          const continueButton = screen.getByRole("button", {
+            name: /continue/i,
+          });
+          expect(continueButton).not.toBeDisabled();
+        },
+        { timeout: 2000 },
+      );
+    });
+
+    it("shows loading spinner during preflight", async () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      await waitFor(() => {
+        // Check for spinner by checking if there's an element with animate-spin class
+        const spinner = document.querySelector(".animate-spin");
+        expect(spinner).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Ready State", () => {
+    it("transitions to READY state after preflight complete and clicking Continue", async () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      // Wait for preflight to complete
+      await waitFor(
+        () => {
+          const continueButton = screen.getByRole("button", {
+            name: /continue/i,
+          });
+          expect(continueButton).not.toBeDisabled();
+        },
+        { timeout: 2000 },
+      );
+
+      // Click Continue
+      const continueButton = screen.getByRole("button", { name: /continue/i });
+      await userEvent.click(continueButton);
+
+      // Should now be in READY state
+      await waitFor(() => {
+        expect(screen.getByText("Ready to export.")).toBeInTheDocument();
+        expect(
+          screen.getByText(/Please insert one of the export drives/i),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows Back, Continue, and Cancel buttons in READY state", async () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      // Wait and click Continue to reach READY state
+      await waitFor(
+        async () => {
+          const continueButton = screen.getByRole("button", {
+            name: /continue/i,
+          });
+          expect(continueButton).not.toBeDisabled();
+          await userEvent.click(continueButton);
+        },
+        { timeout: 2000 },
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Ready to export.")).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole("button", { name: /back/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /continue/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /cancel/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("goes back to PREFLIGHT_COMPLETE when Back button is clicked in READY state", async () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      // Reach READY state
+      await waitFor(
+        async () => {
+          const continueButton = screen.getByRole("button", {
+            name: /continue/i,
+          });
+          expect(continueButton).not.toBeDisabled();
+          await userEvent.click(continueButton);
+        },
+        { timeout: 2000 },
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Ready to export.")).toBeInTheDocument();
+      });
+
+      // Click Back
+      const backButton = screen.getByRole("button", { name: /back/i });
+      await userEvent.click(backButton);
+
+      // Should be back at PREFLIGHT_COMPLETE (which shows same content as PREFLIGHT but enabled button)
+      await waitFor(() => {
+        expect(screen.getByText("Preparing to export.")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Unlock Device State", () => {
+    it("transitions to UNLOCK_DEVICE state when Continue clicked in READY state", async () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      // Reach READY state
+      await waitFor(
+        async () => {
+          const continueButton = screen.getByRole("button", {
+            name: /continue/i,
+          });
+          expect(continueButton).not.toBeDisabled();
+          await userEvent.click(continueButton);
+        },
+        { timeout: 2000 },
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Ready to export.")).toBeInTheDocument();
+      });
+
+      // Click Continue again to go to unlock
+      const continueButton = screen.getByRole("button", { name: /continue/i });
+      await userEvent.click(continueButton);
+
+      // Should now be in UNLOCK_DEVICE state
+      await waitFor(() => {
+        expect(
+          screen.getByText("Enter passphrase for USB drive"),
+        ).toBeInTheDocument();
+        expect(screen.getByLabelText("Passphrase")).toBeInTheDocument();
+      });
+    });
+
+    it("displays passphrase input field in unlock state", async () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      // Navigate to UNLOCK_DEVICE state
+      await waitFor(
+        async () => {
+          const continueButton = screen.getByRole("button", {
+            name: /continue/i,
+          });
+          expect(continueButton).not.toBeDisabled();
+          await userEvent.click(continueButton);
+        },
+        { timeout: 2000 },
+      );
+
+      await waitFor(async () => {
+        const continueButton = screen.getByRole("button", {
+          name: /continue/i,
+        });
+        await userEvent.click(continueButton);
+      });
+
+      await waitFor(async () => {
+        const continueButton = screen.getByRole("button", {
+          name: /continue/i,
+        });
+        await userEvent.click(continueButton);
+      });
+
+      await waitFor(() => {
+        const passphraseInput = screen.getByLabelText("Passphrase");
+        expect(passphraseInput).toBeInTheDocument();
+        expect(passphraseInput).toHaveAttribute("type", "password");
+      });
+    });
+
+    it("disables Continue button when passphrase is empty", async () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      // Navigate to UNLOCK_DEVICE state
+      await waitFor(
+        async () => {
+          const continueButton = screen.getByRole("button", {
+            name: /continue/i,
+          });
+          expect(continueButton).not.toBeDisabled();
+          await userEvent.click(continueButton);
+        },
+        { timeout: 2000 },
+      );
+
+      await waitFor(async () => {
+        const continueButton = screen.getByRole("button", {
+          name: /continue/i,
+        });
+        await userEvent.click(continueButton);
+      });
+
+      await waitFor(async () => {
+        const continueButton = screen.getByRole("button", {
+          name: /continue/i,
+        });
+        await userEvent.click(continueButton);
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Enter passphrase for USB drive"),
+        ).toBeInTheDocument();
+      });
+
+      const continueButton = screen.getByRole("button", { name: /continue/i });
+      expect(continueButton).toBeDisabled();
+    });
+
+    it("enables Continue button when passphrase is entered", async () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      // Navigate to UNLOCK_DEVICE state
+      await waitFor(
+        async () => {
+          const continueButton = screen.getByRole("button", {
+            name: /continue/i,
+          });
+          expect(continueButton).not.toBeDisabled();
+          await userEvent.click(continueButton);
+        },
+        { timeout: 2000 },
+      );
+
+      await waitFor(async () => {
+        const continueButton = screen.getByRole("button", {
+          name: /continue/i,
+        });
+        await userEvent.click(continueButton);
+      });
+
+      await waitFor(async () => {
+        const continueButton = screen.getByRole("button", {
+          name: /continue/i,
+        });
+        await userEvent.click(continueButton);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Passphrase")).toBeInTheDocument();
+      });
+
+      // Type passphrase
+      const passphraseInput = screen.getByLabelText("Passphrase");
+      await userEvent.type(passphraseInput, "test-passphrase-123");
+
+      // Continue button should now be enabled
+      const continueButton = screen.getByRole("button", { name: /continue/i });
+      expect(continueButton).not.toBeDisabled();
+    });
+
+    it("goes back to READY state when Back button is clicked in UNLOCK_DEVICE state", async () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      // Navigate to UNLOCK_DEVICE state
+      await waitFor(
+        async () => {
+          const continueButton = screen.getByRole("button", {
+            name: /continue/i,
+          });
+          expect(continueButton).not.toBeDisabled();
+          await userEvent.click(continueButton);
+        },
+        { timeout: 2000 },
+      );
+
+      await waitFor(async () => {
+        const continueButton = screen.getByRole("button", {
+          name: /continue/i,
+        });
+        await userEvent.click(continueButton);
+      });
+
+      await waitFor(async () => {
+        const continueButton = screen.getByRole("button", {
+          name: /continue/i,
+        });
+        await userEvent.click(continueButton);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Passphrase")).toBeInTheDocument();
+      });
+
+      // Click Back
+      const backButton = screen.getByRole("button", { name: /back/i });
+      await userEvent.click(backButton);
+
+      // Should be back at READY state
+      await waitFor(() => {
+        expect(screen.getByText("Ready to export.")).toBeInTheDocument();
+      });
+    });
+  });
+
+  // TODO(vicki): add tests for EXPORTING state when API call is implemented
+
+  describe("Success State", () => {
+    it("transitions to SUCCESS state after successful export", async () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      // Navigate through all states to trigger export
+      await waitFor(
+        async () => {
+          const continueButton = screen.getByRole("button", {
+            name: /continue/i,
+          });
+          expect(continueButton).not.toBeDisabled();
+          await userEvent.click(continueButton);
+        },
+        { timeout: 2000 },
+      );
+
+      await waitFor(async () => {
+        const continueButton = screen.getByRole("button", {
+          name: /continue/i,
+        });
+        await userEvent.click(continueButton);
+      });
+
+      await waitFor(async () => {
+        const continueButton = screen.getByRole("button", {
+          name: /continue/i,
+        });
+        await userEvent.click(continueButton);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Passphrase")).toBeInTheDocument();
+      });
+
+      const passphraseInput = screen.getByLabelText("Passphrase");
+      await userEvent.type(passphraseInput, "test-passphrase");
+
+      const continueButton = screen.getByRole("button", { name: /continue/i });
+      await userEvent.click(continueButton);
+
+      // Wait for success state
+      await waitFor(() => {
+        expect(screen.getByText("Export Successful")).toBeInTheDocument();
+        expect(
+          screen.getByText(
+            /Remember to be careful when working with files outside/i,
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("shows only Done button in success state", async () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      // Navigate to SUCCESS state
+      await waitFor(
+        async () => {
+          const continueButton = screen.getByRole("button", {
+            name: /continue/i,
+          });
+          expect(continueButton).not.toBeDisabled();
+          await userEvent.click(continueButton);
+        },
+        { timeout: 2000 },
+      );
+
+      await waitFor(async () => {
+        const continueButton = screen.getByRole("button", {
+          name: /continue/i,
+        });
+        await userEvent.click(continueButton);
+      });
+
+      await waitFor(async () => {
+        const continueButton = screen.getByRole("button", {
+          name: /continue/i,
+        });
+        await userEvent.click(continueButton);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Passphrase")).toBeInTheDocument();
+      });
+
+      const passphraseInput = screen.getByLabelText("Passphrase");
+      await userEvent.type(passphraseInput, "test-passphrase");
+
+      const continueButton = screen.getByRole("button", { name: /continue/i });
+      await userEvent.click(continueButton);
+
+      await waitFor(() => {
+        expect(screen.getByText("Export Successful")).toBeInTheDocument();
+      });
+
+      // Should only have Done button
+      expect(screen.getByRole("button", { name: /done/i })).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /continue/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /back/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /cancel/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("calls onClose when Done button is clicked", async () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      // Navigate to SUCCESS state
+      await waitFor(
+        async () => {
+          const continueButton = screen.getByRole("button", {
+            name: /continue/i,
+          });
+          expect(continueButton).not.toBeDisabled();
+          await userEvent.click(continueButton);
+        },
+        { timeout: 2000 },
+      );
+
+      await waitFor(async () => {
+        const continueButton = screen.getByRole("button", {
+          name: /continue/i,
+        });
+        await userEvent.click(continueButton);
+      });
+
+      await waitFor(async () => {
+        const continueButton = screen.getByRole("button", {
+          name: /continue/i,
+        });
+        await userEvent.click(continueButton);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Passphrase")).toBeInTheDocument();
+      });
+
+      const passphraseInput = screen.getByLabelText("Passphrase");
+      await userEvent.type(passphraseInput, "test-passphrase");
+
+      const continueButton = screen.getByRole("button", { name: /continue/i });
+      await userEvent.click(continueButton);
+
+      await waitFor(() => {
+        expect(screen.getByText("Export Successful")).toBeInTheDocument();
+      });
+
+      const doneButton = screen.getByRole("button", { name: /done/i });
+      await userEvent.click(doneButton);
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Cancel Functionality", () => {
+    it("calls onClose when Cancel button is clicked", async () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      // Wait for modal to open
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+
+      // Wait for preflight to complete
+      await waitFor(
+        () => {
+          const continueButton = screen.getByRole("button", {
+            name: /continue/i,
+          });
+          expect(continueButton).not.toBeDisabled();
+        },
+        { timeout: 2000 },
+      );
+
+      const cancelButton = screen.getByRole("button", { name: /cancel/i });
+      await userEvent.click(cancelButton);
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("resets wizard state when modal is closed and reopened", async () => {
+      const { rerender } = renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      // Navigate to READY state
+      await waitFor(
+        async () => {
+          const continueButton = screen.getByRole("button", {
+            name: /continue/i,
+          });
+          expect(continueButton).not.toBeDisabled();
+          await userEvent.click(continueButton);
+        },
+        { timeout: 2000 },
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Ready to export.")).toBeInTheDocument();
+      });
+
+      // Close the modal
+      rerender(
+        <ExportWizard item={mockItem} open={false} onClose={mockOnClose} />,
+      );
+
+      // Reopen the modal
+      rerender(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      // Should be back at initial PREFLIGHT state
+      await waitFor(() => {
+        expect(screen.getByText("Preparing to export.")).toBeInTheDocument();
+        expect(
+          screen.getByText("Understand the risks before exporting files"),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("ElectronAPI Integration", () => {
+    it("successfully completes export flow (stub implementation)", async () => {
+      renderWithProviders(
+        <ExportWizard item={mockItem} open={true} onClose={mockOnClose} />,
+      );
+
+      // Navigate through all states to trigger export
+      await waitFor(
+        async () => {
+          const continueButton = screen.getByRole("button", {
+            name: /continue/i,
+          });
+          expect(continueButton).not.toBeDisabled();
+          await userEvent.click(continueButton);
+        },
+        { timeout: 2000 },
+      );
+
+      await waitFor(async () => {
+        const continueButton = screen.getByRole("button", {
+          name: /continue/i,
+        });
+        await userEvent.click(continueButton);
+      });
+
+      await waitFor(async () => {
+        const continueButton = screen.getByRole("button", {
+          name: /continue/i,
+        });
+        await userEvent.click(continueButton);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Passphrase")).toBeInTheDocument();
+      });
+
+      const passphraseInput = screen.getByLabelText("Passphrase");
+      await userEvent.type(passphraseInput, "test-passphrase");
+
+      const continueButton = screen.getByRole("button", { name: /continue/i });
+      await userEvent.click(continueButton);
+
+      // Wait for success state (export API call is TODO/stubbed currently)
+      await waitFor(() => {
+        expect(screen.getByText("Export Successful")).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.tsx
@@ -1,0 +1,481 @@
+import { memo, useReducer, useEffect } from "react";
+import { type Item } from "../../../../../../types";
+import "../Item.css";
+import "./File.css";
+
+import { useTranslation } from "react-i18next";
+import { LoaderCircle, FileX2, Inbox, Unlock } from "lucide-react";
+import { Button, Modal, Input } from "antd";
+
+type ExportState =
+  | "PREFLIGHT"
+  | "PREFLIGHT_COMPLETE"
+  | "READY"
+  | "UNLOCK_DEVICE"
+  | "EXPORTING"
+  | "SUCCESS"
+  | "ERROR";
+
+type ExportAction =
+  | { type: "PREFLIGHT_COMPLETE" }
+  | { type: "START_EXPORT" }
+  | { type: "UNLOCK_DEVICE"; payload: string }
+  | { type: "SET_PASSPHRASE"; payload: string }
+  | { type: "GO_BACK" }
+  | { type: "EXPORT_SUCCESS" }
+  | { type: "EXPORT_ERROR"; payload: string }
+  | { type: "CANCEL" };
+
+interface ExportContext {
+  state: ExportState;
+  filename: string;
+  passphrase: string;
+  errorMessage: string;
+}
+
+const initialContext: ExportContext = {
+  state: "PREFLIGHT",
+  filename: "",
+  passphrase: "",
+  errorMessage: "",
+};
+
+function exportReducer(
+  context: ExportContext,
+  action: ExportAction,
+): ExportContext {
+  switch (context.state) {
+    case "PREFLIGHT":
+      switch (action.type) {
+        case "PREFLIGHT_COMPLETE":
+          return {
+            ...context,
+            state: "PREFLIGHT_COMPLETE",
+          };
+        case "CANCEL":
+          return initialContext;
+        default:
+          return context;
+      }
+
+    case "PREFLIGHT_COMPLETE":
+      switch (action.type) {
+        case "START_EXPORT":
+          return {
+            ...context,
+            state: "READY",
+          };
+        case "CANCEL":
+          return initialContext;
+        default:
+          return context;
+      }
+
+    case "READY":
+      switch (action.type) {
+        case "START_EXPORT":
+          return { ...context, state: "UNLOCK_DEVICE" };
+        case "GO_BACK":
+          return { ...context, state: "PREFLIGHT_COMPLETE" };
+        case "CANCEL":
+          return initialContext;
+        default:
+          return context;
+      }
+
+    case "UNLOCK_DEVICE":
+      switch (action.type) {
+        case "SET_PASSPHRASE":
+          return { ...context, passphrase: action.payload };
+        case "UNLOCK_DEVICE":
+          return { ...context, state: "EXPORTING" };
+        case "GO_BACK":
+          return { ...context, state: "READY", passphrase: "" };
+        case "CANCEL":
+          return initialContext;
+        default:
+          return context;
+      }
+
+    case "EXPORTING":
+      switch (action.type) {
+        case "EXPORT_SUCCESS":
+          return { ...context, state: "SUCCESS" };
+        case "EXPORT_ERROR":
+          return {
+            ...context,
+            state: "ERROR",
+            errorMessage: action.payload,
+          };
+        default:
+          return context;
+      }
+
+    case "SUCCESS":
+    case "ERROR":
+      // Terminal states
+      switch (action.type) {
+        case "CANCEL":
+          return initialContext;
+        default:
+          return context;
+      }
+
+    default:
+      return context;
+  }
+}
+
+interface StateComponentProps {
+  context: ExportContext;
+  dispatch: React.Dispatch<ExportAction>;
+  filename: string;
+  t: (key: string) => string;
+}
+
+const PreflightState = memo(function PreflightState({
+  context,
+  t,
+}: StateComponentProps) {
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-4">
+        {context.state === "PREFLIGHT" ? (
+          <LoaderCircle
+            className={"animate-spin text-blue-500"}
+            size={24}
+            strokeWidth={1}
+          />
+        ) : (
+          <Inbox size={24} className="text-blue-500" />
+        )}
+        <div className="ml-3">
+          <h3 className="text-lg font-semibold">
+            {t("exportWizard.preparingExport")}
+          </h3>
+          <p className="text-gray-600">{context.filename}</p>
+        </div>
+      </div>
+      <hr className="my-4 border-gray-300" />
+      <div className="space-y-4">
+        <h3 className="text-md font-semibold">
+          {t("exportWizard.understandRisks")}
+        </h3>
+        <div>
+          <p className="font-semibold">{t("exportWizard.malwareTitle")}</p>
+          <p className="text-gray-600">{t("exportWizard.malwareWarning")}</p>
+        </div>
+        <div>
+          <p className="font-semibold">{t("exportWizard.anonymityTitle")}</p>
+          <p className="text-gray-600">{t("exportWizard.anonymityWarning")}</p>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+const ReadyState = memo(function ReadyState({
+  context,
+  t,
+}: StateComponentProps) {
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-4">
+        <Inbox size={24} className="text-blue-500" />
+        <div className="ml-3">
+          <h3 className="text-lg font-semibold">
+            {t("exportWizard.readyExport")}
+          </h3>
+          <p className="text-gray-600">{context.filename}</p>
+        </div>
+      </div>
+      <hr className="my-4 border-gray-300" />
+      <div className="space-y-4">
+        <p>{t("exportWizard.exportInstructions")}</p>
+      </div>
+    </div>
+  );
+});
+
+const UnlockDeviceState = memo(function UnlockDeviceState({
+  context,
+  dispatch,
+  t,
+}: StateComponentProps) {
+  const handlePassphraseChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch({ type: "SET_PASSPHRASE", payload: e.target.value });
+  };
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-4">
+        <Unlock size={24} className="text-blue-500" />
+        <div className="ml-3">
+          <h3 className="text-lg font-semibold">{t("exportWizard.unlock")}</h3>
+        </div>
+      </div>
+      <hr className="my-4 border-gray-300" />
+      <div className="space-y-4">
+        <div>
+          <label htmlFor="passphrase" className="block font-medium mb-2">
+            {t("exportWizard.passphrase")}
+          </label>
+          <Input.Password
+            id="passphrase"
+            value={context.passphrase}
+            onChange={handlePassphraseChange}
+            placeholder={t("exportWizard.passphrase")}
+            autoFocus
+          />
+        </div>
+      </div>
+    </div>
+  );
+});
+
+const ExportingState = memo(function ExportingState({
+  t,
+}: StateComponentProps) {
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-4">
+        <Inbox size={24} className="text-blue-500" />
+        <div className="ml-3">
+          <h3 className="text-lg font-semibold">
+            {t("exportWizard.pleaseWait")}
+          </h3>
+        </div>
+      </div>
+      <hr className="my-4 border-gray-300" />
+      <div className="space-y-4">
+        <h3 className="text-md font-semibold">{t("exportWizard.beCareful")}</h3>
+      </div>
+    </div>
+  );
+});
+
+const SuccessState = memo(function SuccessState({ t }: StateComponentProps) {
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-4">
+        <Inbox size={24} className="text-blue-500" />
+        <div className="ml-3">
+          <h3 className="text-lg font-semibold">
+            {t("exportWizard.exportSuccess")}
+          </h3>
+        </div>
+      </div>
+      <hr className="my-4 border-gray-300" />
+      <div className="space-y-4">
+        <h3 className="text-md font-semibold">{t("exportWizard.beCareful")}</h3>
+      </div>
+    </div>
+  );
+});
+
+const ErrorState = memo(function ErrorState({
+  context,
+  t,
+}: StateComponentProps) {
+  return (
+    <div className="text-center py-8">
+      <FileX2 className="mx-auto mb-4 text-red-500" size={48} strokeWidth={2} />
+      <h3 className="text-lg font-semibold mb-2 text-red-600">
+        {t("exportWizard.exportFailed")}
+      </h3>
+      <p className="text-gray-600">{context.errorMessage}</p>
+    </div>
+  );
+});
+
+interface ExportWizardProps {
+  item: Item;
+  open: boolean;
+  onClose: () => void;
+}
+
+export const ExportWizard = memo(function ExportWizard({
+  item,
+  open,
+  onClose,
+}: ExportWizardProps) {
+  const { t } = useTranslation("Item");
+  const [context, dispatch] = useReducer(exportReducer, initialContext);
+
+  const filename = item.filename
+    ? item.filename.substring(item.filename.lastIndexOf("/") + 1)
+    : "";
+  context.filename = filename;
+
+  // Reset state when wizard is closed
+  useEffect(() => {
+    if (!open) {
+      dispatch({ type: "CANCEL" });
+    }
+  }, [open]);
+
+  // TODO(vicki): remove once we trigger preflight for real
+  // Simulate preflight progression
+  useEffect(() => {
+    if (context.state === "PREFLIGHT") {
+      const timer = setTimeout(() => {
+        dispatch({ type: "PREFLIGHT_COMPLETE" });
+      }, 1500); // 1.5 second delay
+
+      return () => clearTimeout(timer);
+    }
+    return;
+  }, [context.state]);
+
+  // Handle export logic
+  useEffect(() => {
+    if (context.state === "EXPORTING") {
+      const performExport = async () => {
+        try {
+          // TODO(vicki): call export from backend
+          dispatch({ type: "EXPORT_SUCCESS" });
+        } catch (error) {
+          console.error("Failed to export file:", error);
+          const errorMessage =
+            error instanceof Error
+              ? error.message
+              : t("exportWizard.unknownError");
+          dispatch({ type: "EXPORT_ERROR", payload: errorMessage });
+        }
+      };
+      performExport();
+    }
+  }, [context.state, item.uuid, t]);
+
+  const handleClose = () => {
+    dispatch({ type: "CANCEL" });
+    onClose();
+  };
+
+  const renderStateComponent = () => {
+    const stateProps = { context, dispatch, filename, t };
+
+    switch (context.state) {
+      case "PREFLIGHT":
+        return <PreflightState {...stateProps} />;
+      case "PREFLIGHT_COMPLETE":
+        return <PreflightState {...stateProps} />;
+      case "READY":
+        return <ReadyState {...stateProps} />;
+      case "UNLOCK_DEVICE":
+        return <UnlockDeviceState {...stateProps} />;
+      case "EXPORTING":
+        return <ExportingState {...stateProps} />;
+      case "SUCCESS":
+        return <SuccessState {...stateProps} />;
+      case "ERROR":
+        return <ErrorState {...stateProps} />;
+      default:
+        return null;
+    }
+  };
+
+  const renderFooter = () => {
+    switch (context.state) {
+      case "PREFLIGHT":
+        return [
+          <Button key="continue" type="primary" disabled>
+            {t("exportWizard.continue")}
+          </Button>,
+          <Button key="cancel" onClick={handleClose}>
+            {t("exportWizard.cancel")}
+          </Button>,
+        ];
+
+      case "PREFLIGHT_COMPLETE":
+        return [
+          <Button
+            key="continue"
+            type="primary"
+            onClick={() => {
+              dispatch({ type: "START_EXPORT" });
+            }}
+          >
+            {t("exportWizard.continue")}
+          </Button>,
+          <Button key="cancel" onClick={handleClose}>
+            {t("exportWizard.cancel")}
+          </Button>,
+        ];
+
+      case "READY":
+        return [
+          <Button key="back" onClick={() => dispatch({ type: "GO_BACK" })}>
+            {t("exportWizard.back")}
+          </Button>,
+          <Button
+            key="export"
+            type="primary"
+            onClick={() => dispatch({ type: "START_EXPORT" })}
+          >
+            {t("exportWizard.continue")}
+          </Button>,
+          <Button key="cancel" onClick={handleClose}>
+            {t("exportWizard.cancel")}
+          </Button>,
+        ];
+
+      case "UNLOCK_DEVICE":
+        return [
+          <Button key="back" onClick={() => dispatch({ type: "GO_BACK" })}>
+            {t("exportWizard.back")}
+          </Button>,
+          <Button
+            key="export"
+            type="primary"
+            disabled={!context.passphrase}
+            onClick={() =>
+              dispatch({ type: "UNLOCK_DEVICE", payload: context.passphrase })
+            }
+          >
+            {t("exportWizard.continue")}
+          </Button>,
+          <Button key="cancel" onClick={handleClose}>
+            {t("exportWizard.cancel")}
+          </Button>,
+        ];
+
+      case "EXPORTING":
+        // No buttons during export
+        return null;
+
+      case "SUCCESS":
+        return [
+          <Button key="close" onClick={handleClose}>
+            {t("exportWizard.done")}
+          </Button>,
+        ];
+
+      case "ERROR":
+        return [
+          <Button key="close" onClick={handleClose}>
+            {t("exportWizard.close")}
+          </Button>,
+        ];
+
+      default:
+        return null;
+    }
+  };
+
+  const isNonClosableState =
+    context.state === "EXPORTING" || context.state === "PREFLIGHT";
+
+  return (
+    <Modal
+      open={open}
+      onCancel={handleClose}
+      footer={renderFooter()}
+      width={600}
+      closable={!isNonClosableState}
+      maskClosable={!isNonClosableState}
+    >
+      {renderStateComponent()}
+    </Modal>
+  );
+});

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useState } from "react";
 import {
   FetchStatus,
   ItemUpdate,
@@ -15,7 +15,14 @@ import "../Item.css";
 import "./File.css";
 
 import { useTranslation } from "react-i18next";
-import { File as FileIcon, Download, LoaderCircle, FileX2 } from "lucide-react";
+import {
+  File as FileIcon,
+  Download,
+  LoaderCircle,
+  FileX2,
+  Printer,
+  Upload,
+} from "lucide-react";
 import { Button, Tooltip } from "antd";
 import {
   FilePdfFilled,
@@ -29,6 +36,7 @@ import {
 } from "@ant-design/icons";
 import FileVideoFilled from "./FileVideoFilled";
 import FileAudioFilled from "./FileAudioFilled";
+import { ExportWizard } from "./Export";
 
 const EXCEL_EXTENSIONS = new Set([
   ".xls",
@@ -336,6 +344,9 @@ const InProgressFile = memo(function InProgressFile({
 });
 
 const CompleteFile = memo(function CompleteFile({ item }: { item: Item }) {
+  const { t } = useTranslation("Item");
+  const [exportWizardOpen, setExportWizardOpen] = useState(false);
+
   const filename = item.filename
     ? item.filename.substring(item.filename.lastIndexOf("/") + 1)
     : "";
@@ -357,24 +368,66 @@ const CompleteFile = memo(function CompleteFile({ item }: { item: Item }) {
     }
   };
 
-  return (
-    <div className="flex items-center justify-start mt-2 mb-2">
-      <Icon style={{ fontSize: 30, color }} className="file-icon" />
-      <div className="ml-2">
-        <Tooltip title={tooltipTitle}>
-          <Button
-            size="small"
-            type="link"
-            className="file-namebtn"
-            onClick={handleOpenFile}
-          >
-            {formattedFilename}
-          </Button>
-        </Tooltip>
+  const handleExportClick = () => {
+    setExportWizardOpen(true);
+  };
 
-        <p className="italic">{fileSize}</p>
+  const handlePrintClick = async () => {
+    console.log("Implement print wizard");
+  };
+
+  const handleExportWizardClose = () => {
+    setExportWizardOpen(false);
+    // Note: ExportWizard handles state cleanup via its useEffect when open changes
+  };
+
+  return (
+    <>
+      <div className="flex items-center justify-between mt-2 mb-2">
+        <div className="flex items-center">
+          <Icon style={{ fontSize: 30, color }} className="file-icon" />
+          <div className="ml-2">
+            <Tooltip title={tooltipTitle}>
+              <Button
+                size="small"
+                type="link"
+                className="file-namebtn"
+                onClick={handleOpenFile}
+              >
+                {formattedFilename}
+              </Button>
+            </Tooltip>
+
+            <p className="italic">{fileSize}</p>
+          </div>
+        </div>
+
+        <div className="flex gap-1">
+          <Tooltip title={t("exportFile")}>
+            <Button
+              type="text"
+              size="small"
+              icon={<Upload size={18} />}
+              onClick={handleExportClick}
+            />
+          </Tooltip>
+          <Tooltip title={t("printFile")}>
+            <Button
+              type="text"
+              size="small"
+              icon={<Printer size={18} />}
+              onClick={handlePrintClick}
+            />
+          </Tooltip>
+        </div>
       </div>
-    </div>
+
+      <ExportWizard
+        item={item}
+        open={exportWizardOpen}
+        onClose={handleExportWizardClose}
+      />
+    </>
   );
 });
 


### PR DESCRIPTION
Part of #2864 

Adds components for the export wizard. Currently not hooked up at all to the Electron backend. Implementation follows a similar state machine model to the backend implementation for export.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
