### PR TITLE
Have dependabot upgrade better-sqlite3, node-abi with electron

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,11 @@ updates:
           - "antd"
           - "@ant-design*"
       electron:
-        patterns: ["*electron*"]
+        patterns:
+          - "*electron*"
+          # better-sqlite3/node-abi need to upgrade with electron
+          - "node-abi"
+          - "better-sqlite3"
       eslint:
         patterns: ["*eslint*"]
       vite:
@@ -33,6 +37,8 @@ updates:
           - "antd"
           - "@ant-design*"
           - "*electron*"
+          - "node-abi"
+          - "better-sqlite3"
           - "*eslint*"
           - "*vite*"
         dependency-type: "production"
@@ -43,6 +49,8 @@ updates:
           - "antd"
           - "@ant-design*"
           - "*electron*"
+          - "better-sqlite3"
+          - "node-abi"
           - "*eslint*"
           - "*vite*"
         dependency-type: "development"

--- a/app/package.json
+++ b/app/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
     "jsdom": "^27.2.0",
+    "node-abi": "^4.24.0",
     "otpauth": "^9.4.1",
     "prettier": "3.7.4",
     "testcontainers": "^11.9.0",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       jsdom:
         specifier: ^27.2.0
         version: 27.2.0(postcss@8.5.6)
+      node-abi:
+        specifier: ^4.24.0
+        version: 4.24.0
       otpauth:
         specifier: ^9.4.1
         version: 9.4.1
@@ -3783,6 +3786,10 @@ packages:
   node-abi@3.75.0:
     resolution: {integrity: sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==}
     engines: {node: '>=10'}
+
+  node-abi@4.24.0:
+    resolution: {integrity: sha512-u2EC1CeNe25uVtX3EZbdQ275c74zdZmmpzrHEQh2aIYqoVjlglfUpOX9YY85x1nlBydEKDVaSmMNhR7N82Qj8A==}
+    engines: {node: '>=22.12.0'}
 
   node-addon-api@1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
@@ -9168,6 +9175,10 @@ snapshots:
   node-abi@3.75.0:
     dependencies:
       semver: 7.7.3
+
+  node-abi@4.24.0:
+    dependencies:
+      semver: 7.7.2
 
   node-addon-api@1.7.2:
     optional: true


### PR DESCRIPTION
Because we download better-sqlite3 binaries based on the specific electron ABI, the two may need to be upgraded together.

Our download-sqlite-binaries.py script uses the node-abi package (maintained by Electron) to know which ABI is in use, which also needs to be updated alongside electron. Add it as a top-level dev dependency since we directly use it and because we want dependabot to explicitly update it.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
Nothing to test ahead of time, but once merged I expect https://github.com/freedomofpress/securedrop-client/pull/2876 to get an update and also include upgrades for node-abi and better-sqlite3 that make the PR pass (or at least get farther in CI, there might be other issues).
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
