### PR TITLE
app: Set umask so any files created are owner read/write-only

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -30,6 +30,11 @@ import { syncMetadata } from "./sync";
 import workerPath from "./fetch/worker?modulePath";
 import { Lock } from "./sync/lock";
 import { Config } from "./config";
+import { setUmask } from "./umask";
+
+// Set umask so any files written are owner-only read/write (600).
+// This must be done before we create any files or spawn any worker threads.
+setUmask();
 
 // Parse command line arguments
 const args = process.argv.slice(2);

--- a/app/src/main/umask.ts
+++ b/app/src/main/umask.ts
@@ -1,0 +1,13 @@
+/**
+ * Set the umask to restrict file permissions to owner-only access.
+ *
+ * This ensures that any files or directories created by the application
+ * have the following permissions:
+ * - Files: 0o600 (owner read/write only)
+ * - Directories: 0o700 (owner read/write/execute only)
+ *
+ * This is in a separate file to simplify testing.
+ */
+export function setUmask(): void {
+  process.umask(0o077);
+}


### PR DESCRIPTION
While nothing else should be running in the sd-app VM, we can limit exposure of the database and file contents a bit by locking down the permissions to 600. Using a umask is the simplest way to do that and what the client does.

Fixes #2845.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] Assuming you've run the client before, look at the permissions of `~/.config/SecureDrop/db.sqlite` and any file in `~/.config/SecureDrop/files/...`, and see that they're group and world readable.
* [ ] Now delete `~/.config/SecureDrop` and start up the app fresh, with this PR, login in and download a file
* [ ] Check the permissions again, you should see group/world have no permissions. E.g.:
```
user@dev ~/g/f/securedrop-client (main)> eza -l ~/.config/SecureDrop/db.sqlite
.rw------- 90k user  5 Dec 15:34 /home/user/.config/SecureDrop/db.sqlite
user@dev ~/g/f/securedrop-client (main)> eza -l ~/.config/SecureDrop/files/2cfa8af9-7125-4271-973b-ddbec82b0887/df0b3539-4fee-4387-baf2-7f1abfd577a4/
.rw------- 46 user  5 Dec 15:35 memo.txt
```
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
