### PR TITLE
Temporarily suppress new failing eslint rule

### DIFF
--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.tsx
@@ -305,6 +305,8 @@ export const ExportWizard = memo(function ExportWizard({
   const filename = item.filename
     ? item.filename.substring(item.filename.lastIndexOf("/") + 1)
     : "";
+  // FIXME, should use dispatch() instead
+  // eslint-disable-next-line react-hooks/immutability
   context.filename = filename;
 
   // Reset state when wizard is closed


### PR DESCRIPTION
Merge collision between the export PR and eslint upgrade; this should be properly fixed but this will unbreak CI for now.
