### PR TITLE
Avoid redownloading better-sqlite3 binaries if already present

### DIFF
--- a/app/scripts/download-sqlite-binaries.py
+++ b/app/scripts/download-sqlite-binaries.py
@@ -187,6 +187,19 @@ def download_and_extract_binary(runtime, base_path, args, verify_checksum=True):
     target_dir = base_path / f"Release-{runtime}"
     target_dir.mkdir(parents=True, exist_ok=True)
 
+    final_path = target_dir / "better_sqlite3.node"
+
+    # Check if file already exists
+    if final_path.exists():
+        print(f"Binary already exists: {final_path}")
+        if verify_checksum:
+            verify_node_checksum(final_path, runtime, args)
+            print(f"✓ Existing {runtime} binary checksum verified")
+            return final_path
+        else:
+            print(f"✓ Using existing {runtime} binary (checksum verification skipped)")
+            return final_path
+
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir)
         download_path = temp_path / filename
@@ -205,7 +218,6 @@ def download_and_extract_binary(runtime, base_path, args, verify_checksum=True):
             verify_node_checksum(node_file, runtime, args)
 
         # Copy to final location
-        final_path = target_dir / "better_sqlite3.node"
         shutil.copy2(node_file, final_path)
 
     print(f"✓ Successfully downloaded {runtime} binary")


### PR DESCRIPTION
If the file already exists locally, verify its checksum and then use it instead of downloading it against. If the checksum doesn't match, an exception is raised and it's up to the user to figure out what to do.

This was written by Claude and motivated by today's partial GH outage. This alone doesn't help with CI since we don't cache node_modules, but if this ends up being an issue again, that would be the next logical step.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] Running the script doesn't redownload the binaries.
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
