### PR TITLE
Enable the Electron sandbox

### DIFF
--- a/app/press.freedom.SecureDropApp.desktop
+++ b/app/press.freedom.SecureDropApp.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
 Name=SecureDrop App
-Exec=securedrop-app --no-sandbox
+Exec=securedrop-app
 Icon=utilities-terminal
 Type=Application

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -81,7 +81,7 @@ function createWindow(): BrowserWindow {
     autoHideMenuBar: true,
     webPreferences: {
       preload: join(__dirname, "../preload/index.js"),
-      sandbox: false,
+      sandbox: true,
       spellcheck: false,
     },
   });

--- a/debian/rules
+++ b/debian/rules
@@ -45,6 +45,14 @@ override_dh_installsystemd:
 	dh_installsystemd --name securedrop-proxy-onion-config
 	dh_installsystemd --name securedrop-mime-handling
 
+# chrome-sandbox must be setuid to create new namespaces; see
+# https://github.com/chromium/chromium/blob/836ab130/sandbox/linux/README.md#setuid2
+override_dh_fixperms:
+	dh_fixperms
+	if dh_listpackages | grep -q '^securedrop-app$$'; then \
+		chmod 4755 debian/securedrop-app/usr/lib/securedrop-app/linux-unpacked/chrome-sandbox; \
+	fi
+
 override_dh_shlibdeps:
 	if dh_listpackages | grep -q '^securedrop-app$$'; then \
 		dh_shlibdeps --exclude=securedrop-app; \

--- a/debian/securedrop-app.lintian-overrides
+++ b/debian/securedrop-app.lintian-overrides
@@ -34,5 +34,8 @@ securedrop-app: package-has-unnecessary-activation-of-ldconfig-trigger
 # We're not stripping debug symbols
 securedrop-app: unstripped-binary-or-object
 
+# chrome-sandbox needs to be setuid
+securedrop-app: elevated-privileges 4755 root/root [usr/lib/securedrop-app/linux-unpacked/chrome-sandbox]
+
 # Don't care
 securedrop-app: no-manual-page

--- a/scripts/build-debs-main.sh
+++ b/scripts/build-debs-main.sh
@@ -12,7 +12,7 @@ apt-get update && apt-get upgrade --yes
 
 # Make a copy of the source tree since we do destructive operations on it
 rsync --exclude=build --exclude=.git --exclude=__pycache__ --exclude=node_modules --exclude=target \
-    --exclude=htmlcov --exclude=app/dist --exclude=app/out \
+    --exclude=htmlcov --exclude=app/coverage --exclude=app/dist --exclude=app/out \
     -av /src/ /srv/securedrop-client
 cd /srv/securedrop-client
 


### PR DESCRIPTION
Despite what we expected, it works, even under the grsecurity kernel. We just need to update the packaging to ship it as a setuid file.

Also update the build script to ignore app/coverage if it exists.

Fixes #2785.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] Use try-client-pr to install this on Qubes and then verify all functionality works.
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
