### PR TITLE
Implement conffile override hack for all packages

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -30,14 +30,12 @@ override_dh_strip_nondeterminism:
 	dh_strip_nondeterminism $@
 
 # Override debhelper's auto-generated files in `/etc/`
-# to force an exact replacement of the files we are modifying
-# there (specifically, `/etc/apt/sources.list.d/apt_freedom_press.sources`
-# for the keyring package and `/etc/udisks2/tcrypt.conf` for the
-# securedrop-export package).
+# to force an exact replacement of the files we are installing
 override_dh_installdeb:
 	dh_installdeb
-	cat /dev/null > ${CURDIR}/debian/securedrop-export/DEBIAN/conffiles
-	cat /dev/null > ${CURDIR}/debian/securedrop-keyring/DEBIAN/conffiles
+	for pkg in `dh_listpackages`; do \
+		cat /dev/null > ${CURDIR}/debian/$$pkg/DEBIAN/conffiles; \
+	done
 
 override_dh_installsystemd:
 	dh_installsystemd --name securedrop-log-server

--- a/debian/securedrop-app.lintian-overrides
+++ b/debian/securedrop-app.lintian-overrides
@@ -36,3 +36,6 @@ securedrop-app: unstripped-binary-or-object
 
 # Don't care
 securedrop-app: no-manual-page
+
+# We override conffile for /etc/
+securedrop-app: control-file-is-empty [conffiles]

--- a/debian/securedrop-client.lintian-overrides
+++ b/debian/securedrop-client.lintian-overrides
@@ -22,3 +22,7 @@ securedrop-client: script-not-executable
 # This is our virtualenv's interpreter
 securedrop-client: unusual-interpreter
 securedrop-client: wrong-path-for-interpreter
+
+# We override conffile for /etc/
+securedrop-client: control-file-is-empty [conffiles]
+securedrop-client: file-in-etc-not-marked-as-conffile

--- a/debian/securedrop-export.lintian-overrides
+++ b/debian/securedrop-export.lintian-overrides
@@ -23,11 +23,9 @@ securedrop-export: script-not-executable
 securedrop-export: unusual-interpreter
 securedrop-export: wrong-path-for-interpreter
 
-# This is intentional
-securedrop-export: file-in-etc-not-marked-as-conffile [etc/udisks2/tcrypt.conf]
-
-# This is intentional
+# We override conffile for /etc/
 securedrop-export: control-file-is-empty [conffiles]
+securedrop-export: file-in-etc-not-marked-as-conffile
 
 # Preset options are missing from deb-systemd-helper
 securedrop-export: maintainer-script-calls-systemctl

--- a/debian/securedrop-keyring.lintian-overrides
+++ b/debian/securedrop-keyring.lintian-overrides
@@ -2,16 +2,14 @@
 securedrop-keyring: extended-description-is-empty
 
 # This is intentional
-securedrop-keyring: file-in-etc-not-marked-as-conffile [etc/apt/sources.list.d/apt_freedom_press.sources]
-
-# This is intentional
 securedrop-keyring: package-installs-apt-sources [etc/apt/sources.list.d/apt_freedom_press.sources]
 
 # FIXME: section shouldn't be "unknown"
 securedrop-keyring: section-is-dh_make-template
 
-# This is intentional
+# We override conffile for /etc/
 securedrop-keyring: control-file-is-empty [conffiles]
+securedrop-keyring: file-in-etc-not-marked-as-conffile
 
 # FIXME: abbreviate
 securedrop-keyring: synopsis-too-long

--- a/debian/securedrop-log.lintian-overrides
+++ b/debian/securedrop-log.lintian-overrides
@@ -31,3 +31,7 @@ securedrop-log: script-not-executable
 # This is our virtualenv's interpreter
 securedrop-log: unusual-interpreter
 securedrop-log: wrong-path-for-interpreter
+
+# We override conffile for /etc/
+securedrop-log: control-file-is-empty [conffiles]
+securedrop-log: file-in-etc-not-marked-as-conffile

--- a/debian/securedrop-proxy.lintian-overrides
+++ b/debian/securedrop-proxy.lintian-overrides
@@ -33,3 +33,7 @@ securedrop-proxy: script-not-executable
 
 # This is our virtualenv's interpreter
 securedrop-proxy: unusual-interpreter
+
+# We override conffile for /etc/
+securedrop-proxy: control-file-is-empty [conffiles]
+securedrop-proxy: file-in-etc-not-marked-as-conffile

--- a/debian/securedrop-workstation-config.lintian-overrides
+++ b/debian/securedrop-workstation-config.lintian-overrides
@@ -18,3 +18,6 @@ securedrop-workstation-config: no-manual-page
 
 # FIXME: missing a python3 dependency
 securedrop-workstation-config: python3-script-but-no-python3-dep
+
+# We override conffile for /etc/
+securedrop-workstation-config: control-file-is-empty [conffiles]

--- a/debian/securedrop-workstation-viewer.lintian-overrides
+++ b/debian/securedrop-workstation-viewer.lintian-overrides
@@ -12,3 +12,6 @@ securedrop-workstation-viewer: synopsis-too-long
 
 # We're not shipping CDs, so this is fine
 securedrop-workstation-viewer: package-has-long-file-name
+
+# We override conffile for /etc/
+securedrop-workstation-viewer: control-file-is-empty [conffiles]


### PR DESCRIPTION
Normally dpkg treats files in /etc/ as "conffiles", in which the user can modify them and if so, their modifications will be preserved and future updates from the package won't be applied.

But given our managed system, we don't want that to happen and all of our /etc/ files should always be overridden with our new versions. Instead of hardcoding specific packages, let's just apply it everywhere, and it'll be a no-op if that package doesn't ship any /etc files.

Via lintian, this exposed that we were shipping files in /etc/ in -client, -log and -proxy without the conffiles hack applying.

Fixes #1979.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] Logic looks right
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
