### PR TITLE
[app] move export status to types.ts

### DIFF
--- a/app/src/main/export.test.ts
+++ b/app/src/main/export.test.ts
@@ -5,13 +5,13 @@ import * as os from "os";
 import * as tar from "tar";
 import {
   ArchiveExporter,
-  PrintStatus,
   PrintExportError,
   PrintState,
   PrintStateMachine,
   ExportState,
   ExportStateMachine,
 } from "./export";
+import { PrintStatus } from "../types";
 
 // PrintStateMachine transitions
 describe("PrintStateMachine", () => {

--- a/app/src/main/export.ts
+++ b/app/src/main/export.ts
@@ -10,65 +10,15 @@ import * as path from "path";
 import { spawn, ChildProcess } from "child_process";
 import { promisify } from "util";
 import * as tar from "tar";
+import {
+  DeviceErrorStatus,
+  DeviceStatus,
+  ExportStatus,
+  PrintStatus,
+} from "../types";
 
 const mkdtemp = promisify(mkdtempCb);
 const chmodAsync = promisify(chmod);
-
-// All possible strings returned by the qrexec calls to sd-devices. These values come from
-// `print/status.py` and `disk/status.py` in `securedrop-export`
-// and must only be changed in coordination with changes released in that component.
-export type DeviceStatus = ExportStatus | PrintStatus | DeviceErrorStatus;
-
-export enum DeviceErrorStatus {
-  // Misc errors
-  CALLED_PROCESS_ERROR = "CALLED_PROCESS_ERROR",
-  ERROR_USB_CONFIGURATION = "ERROR_USB_CONFIGURATION",
-  UNEXPECTED_RETURN_STATUS = "UNEXPECTED_RETURN_STATUS",
-
-  // Client-side error only
-  ERROR_MISSING_FILES = "ERROR_MISSING_FILES", // All files meant for export are missing
-}
-
-export enum ExportStatus {
-  // Success
-  SUCCESS_EXPORT = "SUCCESS_EXPORT",
-
-  // Error
-  NO_DEVICE_DETECTED = "NO_DEVICE_DETECTED",
-  INVALID_DEVICE_DETECTED = "INVALID_DEVICE_DETECTED", // Multi partitioned, not encrypted, etc
-  MULTI_DEVICE_DETECTED = "MULTI_DEVICE_DETECTED", // Not currently supported
-  UNKNOWN_DEVICE_DETECTED = "UNKNOWN_DEVICE_DETECTED", // Badly-formatted USB or VeraCrypt/TC
-
-  DEVICE_LOCKED = "DEVICE_LOCKED", // One valid device detected, and it's locked
-  DEVICE_WRITABLE = "DEVICE_WRITABLE", // One valid device detected, and it's unlocked (and mounted)
-
-  ERROR_UNLOCK_LUKS = "ERROR_UNLOCK_LUKS",
-  ERROR_UNLOCK_GENERIC = "ERROR_UNLOCK_GENERIC",
-  ERROR_MOUNT = "ERROR_MOUNT", // Unlocked but not mounted
-
-  ERROR_EXPORT = "ERROR_EXPORT", // Could not write to disk
-
-  // Export succeeds but drives were not properly closed
-  ERROR_EXPORT_CLEANUP = "ERROR_EXPORT_CLEANUP",
-  ERROR_UNMOUNT_VOLUME_BUSY = "ERROR_UNMOUNT_VOLUME_BUSY",
-
-  DEVICE_ERROR = "DEVICE_ERROR", // Something went wrong while trying to check the device
-}
-
-export enum PrintStatus {
-  // Success
-  PRINT_PREFLIGHT_SUCCESS = "PRINTER_PREFLIGHT_SUCCESS",
-  TEST_SUCCESS = "PRINTER_TEST_SUCCESS",
-  PRINT_SUCCESS = "PRINTER_SUCCESS",
-
-  // Error
-  ERROR_PRINTER_NOT_FOUND = "ERROR_PRINTER_NOT_FOUND",
-  ERROR_PRINT = "ERROR_PRINT",
-  ERROR_UNPRINTABLE_TYPE = "ERROR_UNPRINTABLE_TYPE",
-  ERROR_MIMETYPE_UNSUPPORTED = "ERROR_MIMETYPE_UNSUPPORTED",
-  ERROR_MIMETYPE_DISCOVERY = "ERROR_MIMETYPE_DISCOVERY",
-  ERROR_UNKNOWN = "ERROR_GENERIC", // Unknown printer error, backwards-compatible
-}
 
 export class PrintExportError extends Error {
   status?: DeviceStatus;

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -220,3 +220,71 @@ export type ReplySentData = {
 export type FetchDownloadsMessage = {
   authToken: string;
 };
+
+/** Print + Export types */
+
+// All possible strings returned by the qrexec calls to sd-devices. These values come from
+// `print/status.py` and `disk/status.py` in `securedrop-export`
+// and must only be changed in coordination with changes released in that component.
+export type DeviceStatus =
+  | ExportStatus
+  | PrintStatus
+  | DeviceErrorStatus
+  | ArchiveStatus;
+
+export enum DeviceErrorStatus {
+  // Misc errors
+  CALLED_PROCESS_ERROR = "CALLED_PROCESS_ERROR",
+  ERROR_USB_CONFIGURATION = "ERROR_USB_CONFIGURATION",
+  UNEXPECTED_RETURN_STATUS = "UNEXPECTED_RETURN_STATUS",
+
+  // Client-side error only
+  ERROR_MISSING_FILES = "ERROR_MISSING_FILES", // All files meant for export are missing
+}
+
+export enum ExportStatus {
+  // Success
+  SUCCESS_EXPORT = "SUCCESS_EXPORT",
+
+  // Error
+  NO_DEVICE_DETECTED = "NO_DEVICE_DETECTED",
+  INVALID_DEVICE_DETECTED = "INVALID_DEVICE_DETECTED", // Multi partitioned, not encrypted, etc
+  MULTI_DEVICE_DETECTED = "MULTI_DEVICE_DETECTED", // Not currently supported
+  UNKNOWN_DEVICE_DETECTED = "UNKNOWN_DEVICE_DETECTED", // Badly-formatted USB or VeraCrypt/TC
+
+  DEVICE_LOCKED = "DEVICE_LOCKED", // One valid device detected, and it's locked
+  DEVICE_WRITABLE = "DEVICE_WRITABLE", // One valid device detected, and it's unlocked (and mounted)
+
+  ERROR_UNLOCK_LUKS = "ERROR_UNLOCK_LUKS",
+  ERROR_UNLOCK_GENERIC = "ERROR_UNLOCK_GENERIC",
+  ERROR_MOUNT = "ERROR_MOUNT", // Unlocked but not mounted
+
+  ERROR_EXPORT = "ERROR_EXPORT", // Could not write to disk
+
+  // Export succeeds but drives were not properly closed
+  ERROR_EXPORT_CLEANUP = "ERROR_EXPORT_CLEANUP",
+  ERROR_UNMOUNT_VOLUME_BUSY = "ERROR_UNMOUNT_VOLUME_BUSY",
+
+  DEVICE_ERROR = "DEVICE_ERROR", // Something went wrong while trying to check the device
+}
+
+export enum PrintStatus {
+  // Success
+  PRINT_PREFLIGHT_SUCCESS = "PRINTER_PREFLIGHT_SUCCESS",
+  TEST_SUCCESS = "PRINTER_TEST_SUCCESS",
+  PRINT_SUCCESS = "PRINTER_SUCCESS",
+
+  // Error
+  ERROR_PRINTER_NOT_FOUND = "ERROR_PRINTER_NOT_FOUND",
+  ERROR_PRINT = "ERROR_PRINT",
+  ERROR_UNPRINTABLE_TYPE = "ERROR_UNPRINTABLE_TYPE",
+  ERROR_MIMETYPE_UNSUPPORTED = "ERROR_MIMETYPE_UNSUPPORTED",
+  ERROR_MIMETYPE_DISCOVERY = "ERROR_MIMETYPE_DISCOVERY",
+  ERROR_UNKNOWN = "ERROR_GENERIC", // Unknown printer error, backwards-compatible
+}
+
+export enum ArchiveStatus {
+  ERROR_ARCHIVE_METADATA = "ERROR_ARCHIVE_METADATA",
+  ERROR_METADATA_PARSING = "ERROR_METADATA_PARSING",
+  ERROR_EXTRACTION = "ERROR_EXTRACTION",
+}


### PR DESCRIPTION
Split out from https://github.com/freedomofpress/securedrop-client/pull/2890 

Moves export types into `types.ts` to be accessible from components and backend.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
