### PR TITLE
Remove stock entries from paxctld.conf

### DIFF
--- a/workstation-config/paxctld.conf
+++ b/workstation-config/paxctld.conf
@@ -2,106 +2,11 @@
 # grub
 
 /usr/bin/grub-script-check	E
-/usr/bin/grub-bios-setup	E
 /usr/sbin/grub-mkdevicemap	E
 /usr/sbin/grub-probe		E
 
-# qemu
-/usr/bin/qemu-alpha		m
-/usr/bin/qemu-arm		m
-/usr/bin/qemu-armeb		m
-/usr/bin/qemu-cris		m
-/usr/bin/qemu-i386		m
-/usr/bin/qemu-m68k		m
-/usr/bin/qemu-microblaze	m
-/usr/bin/qemu-microblazeel	m
-/usr/bin/qemu-mips		m
-/usr/bin/qemu-mips64		m
-/usr/bin/qemu-mips64el		m
-/usr/bin/qemu-mipsel		m
-/usr/bin/qemu-mipsn32		m
-/usr/bin/qemu-mipsn32el		m
-/usr/bin/qemu-or32		m
-/usr/bin/qemu-ppc		m
-/usr/bin/qemu-ppc64		m
-/usr/bin/qemu-ppc64abi32	m
-/usr/bin/qemu-s390x		m
-/usr/bin/qemu-sh4		m
-/usr/bin/qemu-sh4eb		m
-/usr/bin/qemu-sparc		m
-/usr/bin/qemu-sparc32plus	m
-/usr/bin/qemu-sparc64		m
-/usr/bin/qemu-unicore32		m
-/usr/bin/qemu-x86_64		m
-
-/usr/bin/qemu-system-aarch64		m
-/usr/bin/qemu-system-alpha		m
-/usr/bin/qemu-system-arm		m
-/usr/bin/qemu-system-cris		m
-/usr/bin/qemu-system-i386		m
-/usr/bin/qemu-system-lm32		m
-/usr/bin/qemu-system-m68k		m
-/usr/bin/qemu-system-microblaze		m
-/usr/bin/qemu-system-microblazeel	m
-/usr/bin/qemu-system-mips		m
-/usr/bin/qemu-system-mips64		m
-/usr/bin/qemu-system-mips64el		m
-/usr/bin/qemu-system-mipsel		m
-/usr/bin/qemu-system-moxie		m
-/usr/bin/qemu-system-or32		m
-/usr/bin/qemu-system-ppc		m
-/usr/bin/qemu-system-ppc64		m
-/usr/bin/qemu-system-ppcemb		m
-/usr/bin/qemu-system-s390x		m
-/usr/bin/qemu-system-sh4		m
-/usr/bin/qemu-system-sh4eb		m
-/usr/bin/qemu-system-sparc		m
-/usr/bin/qemu-system-sparc64		m
-/usr/bin/qemu-system-unicore32		m
-/usr/bin/qemu-system-x86_64		m
-/usr/bin/qemu-system-xtensa		m
-/usr/bin/qemu-system-xtensaeb		m
-
-# skype
-/usr/lib/skype/skype		m
-/usr/lib32/skype/skype		m
-
-# steam
-/usr/lib32/ld-linux.so.2	m
-
-# node
-/usr/bin/node			m
-
-# chrome
-/opt/google/chrome/chrome-sandbox	m
-/opt/google/chrome/nacl_helper		m
-/opt/google/chrome/chrome		m
-
-# chromium
-/usr/lib/chromium-browser/chromium-browser m
-
-# firefox
-/usr/lib/firefox/firefox		m
-/usr/lib/firefox/plugin-container	m
-
-# webapp-container
-/usr/bin/webapp-container	m
-
-# oxide
-/usr/lib/x86_64-linux-gnu/oxide-qt/oxide-renderer m
-
-# valgrind
-/usr/bin/valgrind		m
-
-# python
-/usr/bin/python2.7		E
-/usr/bin/python3.5		E
-
 # java
 /usr/lib/jvm/java-17-openjdk-amd64/bin/java   m
-
-# openrc
-/lib/rc/bin/lsb2rcconf		E
 
 # libreoffice
 # Ubuntu doesn't seem to carry this patch:
@@ -115,5 +20,5 @@
 # See <https://github.com/freedomofpress/securedrop-client/issues/2037>
 /usr/bin/nautilus		m
 
-# Electron/Chromium
+# Electron/Chromium has a JIT for JavaScript and needs executable memory
 /usr/lib/securedrop-app/linux-unpacked/securedrop-app m


### PR DESCRIPTION
No one should be running qemu, skype, steam, chrome, chromium, firefox, webapp-container, oxide, valgrind, openrc, or outdated Python in any SDW virtual machine because none of those programs are installed!

Also improve documentation for why the Electron app needs an exemption.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] verify that the list of things being removed are in fact not installed in any SDW VM.
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
