### PR TITLE
[export] set perms on implicitly created directories on archive extraction

### DIFF
--- a/export/securedrop_export/directory.py
+++ b/export/securedrop_export/directory.py
@@ -78,6 +78,11 @@ def safe_extractall(archive_file_path: str, dest_path: str) -> None:
 
         tar.extractall(dest_path)  # noqa: S202
 
+        # Ensure all directories (including implicitly created ones) have 0o700 permissions
+        # We check for path traversal above, so do not need to re-check here.
+        for file_info in tar.getmembers():
+            _check_all_permissions(Path(file_info.name).parent, dest_path)
+
 
 def relative_filepath(filepath: str | Path, base_dir: str | Path) -> Path:
     """

--- a/export/tests/test_directory.py
+++ b/export/tests/test_directory.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import tarfile
 import tempfile
 from pathlib import Path
 
@@ -80,3 +81,127 @@ class TestDirectory:
 
         # Returns without error
         assert directory._check_all_permissions(path, base) is None
+
+    def test_safe_extractall_implicitly_created_directories(self):
+        """Test that implicitly created parent directories have 0o700 permissions."""
+        # Create a temporary directory for the archive and extraction
+        archive_dir = tempfile.mkdtemp()
+        extract_dir = tempfile.mkdtemp()
+
+        try:
+            # Create a tar archive with nested files but without explicit directory entries
+            archive_path = os.path.join(archive_dir, "test.tar")
+            with tarfile.open(archive_path, "w") as tar:
+                # Create a file in a nested directory structure
+                file_path = os.path.join(archive_dir, "file.txt")
+                with open(file_path, "w") as f:
+                    f.write("test content")
+
+                # Add the file with a nested path but don't add parent directories explicitly
+                tar.add(file_path, arcname="level1/level2/level3/file.txt")
+
+            # Extract using safe_extractall
+            directory.safe_extractall(archive_path, extract_dir)
+
+            # Verify all implicitly created directories have 0o700 permissions
+            level1_path = os.path.join(extract_dir, "level1")
+            level2_path = os.path.join(extract_dir, "level1/level2")
+            level3_path = os.path.join(extract_dir, "level1/level2/level3")
+
+            for dir_path in [level1_path, level2_path, level3_path]:
+                stat_res = os.stat(dir_path).st_mode
+                masked = stat_res & 0o777
+                assert masked == 0o700, (
+                    f"Directory {dir_path} has permissions {oct(masked)}, expected 0o700"
+                )
+
+        finally:
+            shutil.rmtree(archive_dir)
+            shutil.rmtree(extract_dir)
+
+    def test_safe_extractall_multiple_nested_paths(self):
+        """Test that all implicitly created directories have correct perms with multiple paths."""
+        # Create a temporary directory for the archive and extraction
+        archive_dir = tempfile.mkdtemp()
+        extract_dir = tempfile.mkdtemp()
+
+        try:
+            # Create a tar archive with multiple nested files
+            archive_path = os.path.join(archive_dir, "test.tar")
+            with tarfile.open(archive_path, "w") as tar:
+                # Create multiple files with different nested paths
+                for i, nested_path in enumerate(
+                    [
+                        "dir1/subdir1/file1.txt",
+                        "dir1/subdir2/file2.txt",
+                        "dir2/subdir1/subsubdir/file3.txt",
+                    ]
+                ):
+                    file_path = os.path.join(archive_dir, f"file{i}.txt")
+                    with open(file_path, "w") as f:
+                        f.write(f"test content {i}")
+                    tar.add(file_path, arcname=nested_path)
+
+            # Extract using safe_extractall
+            directory.safe_extractall(archive_path, extract_dir)
+
+            # Verify all directories have 0o700 permissions
+            dirs_to_check = [
+                "dir1",
+                "dir1/subdir1",
+                "dir1/subdir2",
+                "dir2",
+                "dir2/subdir1",
+                "dir2/subdir1/subsubdir",
+            ]
+
+            for rel_dir in dirs_to_check:
+                dir_path = os.path.join(extract_dir, rel_dir)
+                stat_res = os.stat(dir_path).st_mode
+                masked = stat_res & 0o777
+                assert masked == 0o700, (
+                    f"Directory {dir_path} has permissions {oct(masked)}, expected 0o700"
+                )
+
+        finally:
+            shutil.rmtree(archive_dir)
+            shutil.rmtree(extract_dir)
+
+    def test_safe_extractall_explicit_and_implicit_directories(self):
+        """Test permissions when archive contains both explicit and implicit directory entries."""
+        # Create a temporary directory for the archive and extraction
+        archive_dir = tempfile.mkdtemp()
+        extract_dir = tempfile.mkdtemp()
+
+        try:
+            # Create a tar archive with both explicit directories and files in nested paths
+            archive_path = os.path.join(archive_dir, "test.tar")
+            with tarfile.open(archive_path, "w") as tar:
+                # Add an explicit directory entry with wrong permissions
+                explicit_dir = os.path.join(archive_dir, "explicit_dir")
+                os.makedirs(explicit_dir, mode=0o755)  # Wrong permissions
+                tar.add(explicit_dir, arcname="explicit_dir")
+
+                # Add a file in a nested path under the explicit directory
+                file_path = os.path.join(archive_dir, "file.txt")
+                with open(file_path, "w") as f:
+                    f.write("test content")
+                tar.add(file_path, arcname="explicit_dir/implicit_subdir/file.txt")
+
+            # Extract using safe_extractall
+            directory.safe_extractall(archive_path, extract_dir)
+
+            # Verify all directories have 0o700 permissions (including the explicit one)
+            explicit_dir_path = os.path.join(extract_dir, "explicit_dir")
+            implicit_subdir_path = os.path.join(extract_dir, "explicit_dir/implicit_subdir")
+
+            for dir_path in [explicit_dir_path, implicit_subdir_path]:
+                stat_res = os.stat(dir_path).st_mode
+                masked = stat_res & 0o777
+                assert masked == 0o700, (
+                    f"Directory {dir_path} has permissions {oct(masked)}, expected 0o700"
+                )
+
+        finally:
+            shutil.rmtree(archive_dir)
+            shutil.rmtree(extract_dir)


### PR DESCRIPTION
When extracting an archive in `sd-export`, we expect all directories to have `0o700` permissions. Archives may contain implicit directory entries, so  we should check all directory permissions (explicit + implicit) on extraction.

This also removes the need for the temporary directory hack in the `ArchiveExporter` Electron code that sets the permissions on these implicit directories.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
