### PR TITLE
Use dynamic timeouts for file downloads across the board

### DIFF
--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -95,7 +95,11 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
   describe("Message Processing", () => {
     it("should download and decrypt a message successfully on first attempt", async () => {
       const db = createMockDB();
-      const metadata = { kind: "message", source: "source1" } as ItemMetadata;
+      const metadata = {
+        kind: "message",
+        source: "source1",
+        size: 1000,
+      } as ItemMetadata;
 
       // Mock: item is in Initial status
       db.getItem = vi.fn(() => mockItem(metadata, FetchStatus.Initial, 0));
@@ -125,6 +129,8 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         }),
         expect.any(BufferedWriter),
         0,
+        undefined,
+        20000,
       );
 
       // Verify decryption phase
@@ -138,7 +144,11 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
 
     it("should download successfully but fail decryption, save to disk, and retry decryption only", async () => {
       const db = createMockDB();
-      const metadata = { kind: "message", source: "source1" } as ItemMetadata;
+      const metadata = {
+        kind: "message",
+        source: "source1",
+        size: 1000,
+      } as ItemMetadata;
 
       // First attempt: Initial status
       db.getItem = vi
@@ -208,7 +218,11 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
 
     it("should fail download, retry download and decryption successfully", async () => {
       const db = createMockDB();
-      const metadata = { kind: "message", source: "source1" } as ItemMetadata;
+      const metadata = {
+        kind: "message",
+        source: "source1",
+        size: 1000,
+      } as ItemMetadata;
 
       // First attempt: Initial status, Second attempt: FailedDownloadRetryable
       db.getItem = vi
@@ -261,7 +275,11 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
   describe("Reply Processing", () => {
     it("should download and decrypt a reply successfully on first attempt", async () => {
       const db = createMockDB();
-      const metadata = { kind: "reply", source: "source1" } as ItemMetadata;
+      const metadata = {
+        kind: "reply",
+        source: "source1",
+        size: 1000,
+      } as ItemMetadata;
 
       db.getItem = vi.fn(() => mockItem(metadata, FetchStatus.Initial, 0));
 
@@ -287,6 +305,8 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         }),
         expect.any(BufferedWriter),
         0,
+        undefined,
+        20000,
       );
 
       expect(db.completePlaintextItem).toHaveBeenCalledWith(
@@ -297,7 +317,11 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
 
     it("should download successfully but fail decryption, save to disk, and retry decryption only", async () => {
       const db = createMockDB();
-      const metadata = { kind: "reply", source: "source1" } as ItemMetadata;
+      const metadata = {
+        kind: "reply",
+        source: "source1",
+        size: 1000,
+      } as ItemMetadata;
 
       db.getItem = vi
         .fn()
@@ -351,7 +375,11 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
 
     it("should fail download, retry download and decryption successfully", async () => {
       const db = createMockDB();
-      const metadata = { kind: "reply", source: "source1" } as ItemMetadata;
+      const metadata = {
+        kind: "reply",
+        source: "source1",
+        size: 1000,
+      } as ItemMetadata;
 
       db.getItem = vi
         .fn()
@@ -402,6 +430,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         kind: "file",
         source: "source1",
         uuid: "file-uuid-1",
+        size: 1000000,
       } as ItemMetadata;
 
       db.getItem = vi.fn(() => mockItem(metadata, FetchStatus.Initial, 0));
@@ -428,6 +457,8 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         }),
         expect.any(PassThrough),
         0,
+        undefined,
+        55000,
       );
 
       // Verify decryption phase
@@ -457,6 +488,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         kind: "file",
         source: "source1",
         uuid: "file-uuid-2",
+        size: 1000000,
       } as ItemMetadata;
 
       // First attempt: Initial status, Second attempt: FailedDecryptionRetryable
@@ -521,6 +553,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         kind: "file",
         source: "source1",
         uuid: "file-uuid-3",
+        size: 1000000,
       } as ItemMetadata;
 
       db.getItem = vi
@@ -571,7 +604,11 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
   describe("Edge Cases and Error Handling", () => {
     it("should skip items that are already complete", async () => {
       const db = createMockDB();
-      const metadata = { kind: "message", source: "source1" } as ItemMetadata;
+      const metadata = {
+        kind: "message",
+        source: "source1",
+        size: 1000,
+      } as ItemMetadata;
 
       db.getItem = vi.fn(() => mockItem(metadata, FetchStatus.Complete, 0));
 
@@ -586,7 +623,11 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
 
     it("should skip items that are terminally failed", async () => {
       const db = createMockDB();
-      const metadata = { kind: "message", source: "source1" } as ItemMetadata;
+      const metadata = {
+        kind: "message",
+        source: "source1",
+        size: 1000,
+      } as ItemMetadata;
 
       db.getItem = vi.fn(() =>
         mockItem(metadata, FetchStatus.FailedTerminal, 0),
@@ -600,7 +641,11 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
 
     it("should skip items that are paused", async () => {
       const db = createMockDB();
-      const metadata = { kind: "message", source: "source1" } as ItemMetadata;
+      const metadata = {
+        kind: "message",
+        source: "source1",
+        size: 1000,
+      } as ItemMetadata;
 
       db.getItem = vi.fn(() => mockItem(metadata, FetchStatus.Paused, 0));
 
@@ -612,7 +657,11 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
 
     it("should handle server error responses during download", async () => {
       const db = createMockDB();
-      const metadata = { kind: "message", source: "source1" } as ItemMetadata;
+      const metadata = {
+        kind: "message",
+        source: "source1",
+        size: 1000,
+      } as ItemMetadata;
 
       db.getItem = vi.fn(() => mockItem(metadata, FetchStatus.Initial, 0));
 
@@ -633,7 +682,11 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
 
     it("should handle file read errors during decryption retry", async () => {
       const db = createMockDB();
-      const metadata = { kind: "message", source: "source1" } as ItemMetadata;
+      const metadata = {
+        kind: "message",
+        source: "source1",
+        size: 1000,
+      } as ItemMetadata;
 
       db.getItem = vi.fn(() =>
         mockItem(metadata, FetchStatus.FailedDecryptionRetryable, 0),

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -4,6 +4,7 @@ export type ProxyRequest = {
   stream?: boolean;
   body?: string;
   headers: Record<string, string>;
+  timeout?: number;
 };
 
 export type ProxyCommand = {


### PR DESCRIPTION
A fixed 5s timeout is too small for large file downloads over Tor, so use the same dynamic timeout calculation the client does.

Also raise the reply and message download timeouts to 20s to match the client as well.
    
And finally, we weren't passing the timeout into the proxy, so it was still using the default 10s.

Fixes #2924.


## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
