### PR TITLE
fix(`pending_events`): cascade deletion from sources and items

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -140,7 +140,6 @@ export class DB {
     void
   >;
   private deletePendingEvent: Statement<{ snowflake_id: string }, void>;
-  private deletePendingEventsBySource: Statement<{ source_uuid: string }, void>;
   private selectPendingEvents: Statement<[], PendingEventRow>;
 
   constructor(crypto: Crypto, dbDir?: string) {
@@ -283,9 +282,6 @@ export class DB {
         `);
     this.deletePendingEvent = this.db.prepare(
       `DELETE FROM pending_events WHERE snowflake_id = @snowflake_id`,
-    );
-    this.deletePendingEventsBySource = this.db.prepare(
-      `DELETE FROM pending_events WHERE source_uuid = @source_uuid`,
     );
     this.selectPendingEvents = this.db.prepare(`
       SELECT snowflake_id, source_uuid, item_uuid, type, data FROM pending_events
@@ -456,8 +452,6 @@ export class DB {
       return item.uuid;
     });
     this.deleteItems(itemUuids);
-    // Delete any pending events for this source (TODO: `ON DELETE CASCADE`)
-    this.deletePendingEventsBySource.run({ source_uuid: sourceUuid });
     // Then, delete the source
     this.deleteSource.run({ uuid: sourceUuid });
   }
@@ -872,7 +866,6 @@ export class DB {
 
   getPendingEvents(): PendingEvent[] {
     const rows: PendingEventRow[] = this.selectPendingEvents.all();
-    const staleEvents: string[] = [];
     const pendingEvents = rows.map((r) => {
       let target: SourceTarget | ItemTarget;
       if (r.source_uuid) {
@@ -880,11 +873,9 @@ export class DB {
           uuid: r.source_uuid,
         });
         if (!source) {
-          console.warn(
-            `Skipping stale event for nonexistent source ${r.source_uuid}`,
+          throw new Error(
+            `Invariant violation: pending event references nonexistent source ${r.source_uuid}`,
           );
-          staleEvents.push(r.snowflake_id);
-          return null;
         }
         target = {
           source_uuid: r.source_uuid,
@@ -895,11 +886,9 @@ export class DB {
           uuid: r.item_uuid,
         });
         if (!item) {
-          console.warn(
-            `Skipping stale event for nonexistent item ${r.item_uuid}`,
+          throw new Error(
+            `Invariant violation: pending event references nonexistent item ${r.item_uuid}`,
           );
-          staleEvents.push(r.snowflake_id);
-          return null;
         }
         target = {
           item_uuid: r.item_uuid,
@@ -914,14 +903,7 @@ export class DB {
       };
     });
 
-    if (staleEvents.length > 0) {
-      console.info(`Purging ${staleEvents.length} stale event(s)`);
-    }
-    for (const id of staleEvents) {
-      this.deletePendingEvent.run({ snowflake_id: id });
-    }
-
-    return pendingEvents.filter((e): e is PendingEvent => e !== null);
+    return pendingEvents;
   }
 
   // Takes pending events and their statuses from the server and applies

--- a/app/src/main/database/migrations/20260107234838_cascade_deletion_to_events.sql
+++ b/app/src/main/database/migrations/20260107234838_cascade_deletion_to_events.sql
@@ -1,0 +1,40 @@
+-- migrate:up
+DROP TABLE pending_events;
+CREATE TABLE pending_events (
+        snowflake_id TEXT PRIMARY KEY,
+        -- See `schema.md` for details on how these foreign-key relationships
+        -- work over the lifecycles of sources and items versus their pending
+        -- events.
+        source_uuid TEXT REFERENCES sources (uuid) ON DELETE CASCADE,
+        item_uuid TEXT REFERENCES items (uuid) on DELETE CASCADE,
+        type TEXT NOT NULL,
+        -- additional event data
+        data json,
+        -- only one of source_uuid OR item_uuid is set
+        CHECK (
+            NOT (
+                source_uuid IS NOT NULL
+                AND item_uuid IS NOT NULL
+            )
+        )
+    );
+
+-- migrate:down
+DROP TABLE pending_events;
+CREATE TABLE pending_events (
+        snowflake_id TEXT PRIMARY KEY,
+        source_uuid TEXT REFERENCES sources (uuid),
+        -- pending items may not exist in the items table, so
+        -- we don't add the fkey constraint
+        item_uuid TEXT,
+        type TEXT NOT NULL,
+        -- additional event data
+        data json,
+        -- only one of source_uuid OR item_uuid is set
+        CHECK (
+            NOT (
+                source_uuid IS NOT NULL
+                AND item_uuid IS NOT NULL
+            )
+        )
+    );

--- a/app/src/main/database/schema.md
+++ b/app/src/main/database/schema.md
@@ -1,0 +1,64 @@
+## Source lifecycle versus `pending_events.source_uuid` foreign-key relationship
+
+A source must exist locally before other events (including deletion) can be
+created for it.
+
+All events (including deletion) for a source will be deleted when the source is
+deleted.
+
+```mermaid
+sequenceDiagram
+
+box client database
+participant sources
+participant items
+participant pending_events
+end
+participant server
+
+server ->> sources: uuid
+activate sources
+
+Note over sources: ...
+activate pending_events
+pending_events -->> server: DeleteSource(uuid)
+server ->> sources: DeleteSource(uuid)
+deactivate sources
+sources ->> pending_events: ON DELETE CASCADE
+deactivate pending_events
+```
+
+## Item lifecycle versus `pending_events.item_uuid` foreign-key relationship
+
+An item must exist locally (including via `ReplySent`) before other events
+(including deletion) can be created for it.
+
+All events (including deletion) for an item will be deleted when the item is
+deleted.
+
+```mermaid
+sequenceDiagram
+
+box client database
+participant sources
+participant items
+participant pending_events
+end
+participant server
+
+opt reply sent
+pending_events -->> server: ReplySent(uuid)
+server ->> pending_events: ReplySent(uuid)
+end
+
+server ->> items: uuid
+activate items
+
+Note over items: ...
+activate pending_events
+pending_events -->> server: DeleteItem(uuid)
+server ->> items: DeleteItem(uuid)
+deactivate items
+items ->> pending_events: ON DELETE CASCADE
+deactivate pending_events
+```


### PR DESCRIPTION
Fixes #2905.  Under some race conditions (especially during development and testing), a target (source or item) may no longer exist when an event is submitted for it.  Rather than submitting such an event with an empty version, which will be rejected by the server, ~~skip it~~ make the race condition itself impossible by enforcing foreign-key relationships with cascading deletion:
* `pending_events.source_uuid` → `sources.uuid`
* `pending_events.item_uuid` → `items.uuid`


## Test plan

1. Run `make dev`
2. Sync the app against the development server
3. Stop the development server
4. Click in and out of sources to generate some `item_seen` events
5. Restart the development server
6. Sync (log back in if necessary)
7. [ ] From the app, observe no `invalid event: version must have 64 hex digits` errors
8. [ ] From the server, observe no HTTP errors corresponding to rejected events


## Checklist

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations