### PR TITLE
Trigger sync immediately after queuing a pending reply

### DIFF
--- a/app/src/renderer/views/Inbox/MainContent/Conversation.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation.test.tsx
@@ -160,6 +160,9 @@ describe("Conversation Component Reply Submission", () => {
 
     // Note: Form clearing is handled by form.resetFields() but may not reflect
     // immediately in the test DOM. The important part is that the IPC was called.
+    // Note: syncMetadata auto-trigger is not tested here because it's disabled
+    // in test mode (import.meta.env.MODE === "test"). Server tests verify the
+    // end-to-end sync behavior.
   });
 
   it("should not submit reply when message is empty", async () => {

--- a/app/src/renderer/views/Inbox/MainContent/Conversation.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation.tsx
@@ -12,6 +12,7 @@ import {
   fetchConversation,
   updateItemFetchStatus,
 } from "../../../features/conversation/conversationSlice";
+import { syncMetadata } from "../../../features/sync/syncSlice";
 import useConversationScroll from "./Conversation/useConversationScroll";
 import "./Conversation.css";
 import { FetchStatus } from "../../../../types";
@@ -84,6 +85,11 @@ const Conversation = memo(function Conversation({
         // Update local state immediately with projected changes
         dispatch(fetchSources());
         dispatch(fetchConversation(sourceWithItems.uuid));
+
+        // Trigger sync to send the pending reply to the server
+        if (session.authData && import.meta.env.MODE !== "test") {
+          dispatch(syncMetadata(session.authData.token));
+        }
       } catch (error) {
         console.error("Failed to send reply:", error);
         // Restore the message on error
@@ -91,7 +97,14 @@ const Conversation = memo(function Conversation({
         setMessageValue(values.message);
       }
     },
-    [acknowledgeNewMessages, dispatch, dividerItemUuid, form, sourceWithItems],
+    [
+      acknowledgeNewMessages,
+      dispatch,
+      dividerItemUuid,
+      form,
+      session.authData,
+      sourceWithItems,
+    ],
   );
 
   // Keyboard shortcut: Ctrl+Enter sends reply


### PR DESCRIPTION
Replies are the main place where we don't implicitly show the finished state and instead have a pending indicator. We can reduce the amount of time a reply is pending by syncing it to the server as soon as it is queued.

Refs #2792.

This was written by Claude Code. 

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] send a reply, see in e.g. the server logs that a sync happens immediately after and the reply is no longer pending.
* [ ] no errors in offline mode, it still stays pending until you go online 
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
