### PR TITLE
Sleep before pushing nightlies

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -104,4 +104,6 @@ jobs:
           cp -v ../build-bookworm/*.deb workstation/bookworm-nightlies/
           git add .
           git diff-index --quiet HEAD || git commit -m "Automated SecureDrop workstation build"
+          # Sleep before we push so the token will have propagated across GitHub infra
+          sleep 5
           git push https://x-access-token:${GH_TOKEN}@github.com/${PKG_REPO}.git main


### PR DESCRIPTION
So that the token will have had time to propagate across the GitHub infra.

Refs https://github.com/freedomofpress/infrastructure/issues/6263.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
n/a
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
