### PR TITLE
Remove current year from messages.pot

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -1,6 +1,8 @@
 .PHONY: all
 all: help
 
+SHELL := /bin/bash
+
 # We prefer to use python3.11 if it's available, especially on arm64 based Macs,
 # but we're also OK with just python3 if that's all we've got
 PYTHON := $(if $(shell bash -c "command -v python3.11"), python3.11, python3)
@@ -143,6 +145,7 @@ $(POT): securedrop_client
 		--project="SecureDrop Client" \
 		--msgid-bugs-address=securedrop@freedom.press \
 		--copyright-holder="Freedom of the Press Foundation" \
+		--header-comment=$$'# Translations template for PROJECT.\n# This file is distributed under the same license as the PROJECT project.\n#' \
 		--add-comments="Translators:" \
 		--strip-comments \
 		--add-location=never \

--- a/client/securedrop_client/locale/messages.pot
+++ b/client/securedrop_client/locale/messages.pot
@@ -1,7 +1,5 @@
 # Translations template for SecureDrop Client.
-# Copyright (C) 2025 Freedom of the Press Foundation
 # This file is distributed under the same license as the SecureDrop Client project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 #, fuzzy
 msgid ""


### PR DESCRIPTION
This is pybabel boilerplate and bumping it each year is not actually how copyright works (c.f. <https://hynek.me/til/copyright-years/>), so let's just remove it entirely. No other file has a similar automated requirement it be updated after the new year.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] we're on board with the reasoning behind this
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
