### PR TITLE
Fix small memory leak in config_qubesdb.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ dependencies = [
  "anyhow",
  "bindgen",
  "futures-util",
+ "libc",
  "reqwest",
  "serde",
  "serde_json",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -11,6 +11,7 @@ qubesdb = []
 [dependencies]
 anyhow = {version = "1.0.75"}
 futures-util = "0.3.30"
+libc = "0.2"
 reqwest = { version = "0.12", features = ["gzip", "stream", "socks"] }
 serde = {version = "1.0.188", features = ["derive"]}
 serde_json = "1.0.107"


### PR DESCRIPTION
The pointer returned from qdb_read() needs to be explicitly freed.

Also add some more is_null() checks to be on the safe side.

Fixes #2954.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
