### PR TITLE
Implement better approach to sanitizing gzip-provided filename

### DIFF
--- a/client/securedrop_client/crypto.py
+++ b/client/securedrop_client/crypto.py
@@ -84,7 +84,10 @@ def read_gzip_header_filename(filename: str) -> str:
             original_filename = str(fb, "utf-8")
 
     check_path_traversal(original_filename)
-    return original_filename
+    name = Path(original_filename).name
+    if not name:
+        raise ValueError(f"Extracted filename is only a directory: {original_filename}")
+    return name
 
 
 class GpgHelper:


### PR DESCRIPTION
The approach in 90b8c4c was purely validation, we tried to see if it was a path traversal, and if not, allowed the string through. A better approach is to sanitize the path - we just expect a filename here, so that's exactly what we should return. Absent a bug in pathlib, calling `Path(...).name` guarantees no path traversals because it's just a filename and not a full path.

Fixes #

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
