### PR TITLE
Build securedrop-app for nightlies

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build packages
         run: |
           git config --global --add safe.directory '*'
-          NIGHTLY=1 DEBIAN_VERSION=${{ matrix.debian_version }} BUILDER=securedrop-builder \
+          NIGHTLY=1 WHAT=app DEBIAN_VERSION=${{ matrix.debian_version }} BUILDER=securedrop-builder \
             ./scripts/build-debs.sh
       - uses: actions/upload-artifact@v5
         id: upload


### PR DESCRIPTION
Fixes #2932.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
n/a
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
