### PR TITLE
[app] export unlock device fixes

### DIFF
--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.tsx
@@ -400,6 +400,9 @@ const UnlockDeviceState = memo(function UnlockDeviceState({
             id="passphrase"
             value={context.passphrase}
             onChange={handlePassphraseChange}
+            onPressEnter={() =>
+              dispatch({ type: "UNLOCK_DEVICE", payload: context.passphrase })
+            }
             placeholder={t("exportWizard.passphrase")}
             autoFocus
           />


### PR DESCRIPTION
Fixes #2927 and #2928 

- Adds `onPressEnter` handler to the passphrase input field to advance when hitting enter from the passphrase field 
- Correctly handles unlock device errors, allowing the user to retry the passphrase

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

- Run app on Qubes workstation
- Initiate export flow and progress to unlock device screen
- Enter an incorrect password (and press `Enter` key to proceed)
- App should return `Incorrect password` error state
- Enter a correct password
- Export should successfully complete

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
