### PR TITLE
Remove duplicate "X" close button from deletion dialog

### DIFF
--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -318,6 +318,7 @@ function SourceList() {
       <Modal
         open={deleteModalOpen}
         data-testid="delete-modal"
+        closable={false}
         title={
           <span data-testid="delete-modal-title">
             {selectedSources.size === 1


### PR DESCRIPTION
We already have a "Cancel" button that does the exact same thing. The main motivation for this is to improve the tabbing order, which previously selected the "X" first and then moved into our buttons, now it'll just start with our buttons.

Refs #1897.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] open deletion dialog, hit <kbd>Tab</kbd>, it should focus on "Cancel". <kbd>Tab</kbd> again, move to delete conversation, then delete account.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
