### PR TITLE
ci(`lint-and-build`): check that `schema.sql` is up to date with dbmate migrations

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -32,7 +32,8 @@ jobs:
             build-essential \
             git \
             make \
-            python3 python3-pip
+            python3 python3-pip \
+            sqlite3
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -53,6 +54,12 @@ jobs:
       - name: Lint
         working-directory: app
         run: pnpm lint
+      - name: Check that database schema is up to date
+        working-directory: app
+        run: |
+          mkdir -p "${HOME}/.config/SecureDrop"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          pnpm dbmate:check
       - name: Test (unit tests)
         working-directory: app
         run: pnpm test

--- a/app/package.json
+++ b/app/package.json
@@ -25,6 +25,7 @@
     "build:unpack": "pnpm run build && electron-builder --dir",
     "build:linux": "pnpm run build && electron-builder --linux",
     "dbmate": "sh -c 'dbmate --url sqlite:$HOME/.config/SecureDrop/db.sqlite --migrations-dir ./src/main/database/migrations --schema-file ./src/main/database/schema.sql \"$@\"' _",
+    "dbmate:check": "pnpm run dbmate up && pnpm run dbmate dump && git diff --exit-code ./src/main/database/schema.sql",
     "translator-screenshots": "electron-vite build --mode test && rm -rf ./screenshots && mkdir -p ./screenshots && node ./scripts/translator-screenshots/main.js",
     "test-data-generate": "./scripts/test-data-generate.py",
     "test-data-insert": "./scripts/test-data-insert.sh"


### PR DESCRIPTION
Closes #2963 by:
1. adding a `pnpm dbmate:check` command that checks that `pnpm up && pnpm dump` is a no-op; and
2. running that command in CI.

## Test plan
- [ ] CI passes.

Bonus:
1. Delete a migration file.
2. [ ] `pnpm drop && pnpm dbmate:check` returns nonzero with a diff.

## Checklist

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
