### PR TITLE
[app] separate message and file download queues

### DIFF
--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -724,31 +724,75 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
   });
 
   describe("Queue Integration", () => {
-    it("should queue items for processing", () => {
+    it("should queue messages to messageQueue and files to fileQueue", () => {
       const db = createMockDB();
-      db.getItemsToProcess = vi.fn(() => ["item1", "item2"]);
+      db.getItemsToProcess = vi.fn(() => ["message1", "file1", "reply1"]);
+      db.getItem = vi.fn((id) => {
+        if (id === "message1") {
+          return mockItem(
+            {
+              kind: "message",
+              source: "source1",
+              uuid: "message1",
+            } as ItemMetadata,
+            FetchStatus.Initial,
+          );
+        }
+        if (id === "reply1") {
+          return mockItem(
+            {
+              kind: "reply",
+              source: "source1",
+              uuid: "reply1",
+            } as ItemMetadata,
+            FetchStatus.Initial,
+          );
+        }
+        if (id === "file1") {
+          return mockItem(
+            {
+              kind: "file",
+              source: "source1",
+              uuid: "file1",
+              size: 1000,
+            } as ItemMetadata,
+            FetchStatus.Initial,
+          );
+        }
+        return null;
+      });
 
       const queue = new TaskQueue(db);
-      vi.spyOn(queue.queue, "push");
+      vi.spyOn(queue.messageQueue, "push");
+      vi.spyOn(queue.fileQueue, "push");
 
       queue.queueFetches({ authToken: "test-token" });
 
       expect(db.getItemsToProcess).toHaveBeenCalled();
-      expect(queue.queue.push).toHaveBeenCalledTimes(2);
+      // 2 messages/replies should go to messageQueue
+      expect(queue.messageQueue.push).toHaveBeenCalledTimes(2);
+      // 1 file should go to fileQueue
+      expect(queue.fileQueue.push).toHaveBeenCalledTimes(1);
       expect(queue.authToken).toBe("test-token");
     });
 
     it("should handle queue errors with failDownload", () => {
       const db = createMockDB();
       db.getItemsToProcess = vi.fn(() => ["item1"]);
+      db.getItem = vi.fn(() =>
+        mockItem(
+          { kind: "message", source: "source1", uuid: "item1" } as ItemMetadata,
+          FetchStatus.Initial,
+        ),
+      );
 
       const queue = new TaskQueue(db);
-      vi.spyOn(queue.queue, "push");
+      vi.spyOn(queue.messageQueue, "push");
 
       queue.queueFetches({ authToken: "test-token" });
 
       // Simulate the error callback that gets passed to queue.push
-      const pushCall = vi.mocked(queue.queue.push).mock.calls[0];
+      const pushCall = vi.mocked(queue.messageQueue.push).mock.calls[0];
       expect(pushCall).toBeDefined();
       expect(pushCall[1]).toBeTypeOf("function");
 

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -30,7 +30,8 @@ type DownloadResult = Buffer | string;
 
 export class TaskQueue {
   db: DB;
-  queue: Queue;
+  messageQueue: Queue;
+  fileQueue: Queue;
   authToken?: string;
   port?: MessagePort;
   storage: Storage;
@@ -41,9 +42,24 @@ export class TaskQueue {
     overrideTaskFn?: (task: ItemFetchTask, db: DB) => void,
   ) {
     this.db = db;
-    this.queue = createQueue(
+    this.messageQueue = createQueue(
+      "message-queue",
       db,
       overrideTaskFn ? overrideTaskFn : this.process,
+      // Max timeout: 1s for messages
+      1_000,
+      port,
+    );
+    this.fileQueue = createQueue(
+      "file-queue",
+      db,
+      overrideTaskFn ? overrideTaskFn : this.process,
+      // Max timeout per task attempt. For the maximum file size of 500MB, the
+      // worst-case download timeout is ~4.2 hours (based on 50 KB/s over Tor).
+      // We set this to 2 hours as a reasonable per-attempt limit, relying on the
+      // 5 retries below to handle worst-case large file downloads. Each retry gets
+      // a fresh timeout, so total potential time is 2 hours × 6 attempts = 12 hours.
+      7_200_000, // 2 hours in milliseconds
       port,
     );
     this.port = port;
@@ -84,6 +100,11 @@ export class TaskQueue {
 
   // Queries the database for all items that need to be downloaded and queues
   // up download tasks to be processed.
+  // Routes items to the appropriate queue:
+  // - Messages/replies go to messageQueue
+  // - Files go to fileQueue
+  // This allows messages to be fetched while files are downloading, since that
+  // may be a long-running process
   queueFetches(message: AuthedRequest) {
     this.authToken = message.authToken;
     try {
@@ -95,9 +116,22 @@ export class TaskQueue {
         const task: ItemFetchTask = {
           id: itemUUID,
         };
-        this.queue.push(task, (err, _result) => {
+
+        const item = this.db.getItem(itemUUID);
+        if (!item) {
+          continue;
+        }
+
+        const queue =
+          item.data.kind === "file" ? this.fileQueue : this.messageQueue;
+
+        queue.push(task, (err, _result) => {
           if (err) {
-            console.error("Error executing fetch download task: ", task, err);
+            console.error(
+              `Error executing fetch download task in queue: `,
+              task,
+              err,
+            );
             this.db.failDownload(task.id);
             if (this.port) {
               this.port.postMessage(this.db.getItem(task.id));
@@ -395,8 +429,10 @@ export class TaskQueue {
 }
 
 function createQueue(
+  name: string,
   db: DB,
   taskFn: (task: ItemFetchTask, db: DB) => void,
+  maxTimeout: number,
   port?: MessagePort,
 ): Queue {
   const q: Queue = new Queue(
@@ -410,12 +446,7 @@ function createQueue(
     },
     {
       batchSize: 1,
-      // Queue timeout per task attempt. For the maximum file size of 500MB, the
-      // worst-case download timeout is ~4.2 hours (based on 50 KB/s over Tor).
-      // We set this to 2 hours as a reasonable per-attempt limit, relying on the
-      // 5 retries below to handle worst-case large file downloads. Each retry gets
-      // a fresh timeout, so total potential time is 2 hours × 6 attempts = 12 hours.
-      maxTimeout: 7_200_000, // 2 hours in milliseconds
+      maxTimeout: maxTimeout,
       maxRetries: 5,
       id: "id",
       // Merge handles tasks scheduled with the same ID
@@ -430,12 +461,12 @@ function createQueue(
   );
 
   q.on("error", (error) => {
-    console.error("Error from queue: ", error);
+    console.error(`Error from ${name}: `, error);
   });
 
   q.on("task_failed", (taskId, errorMessage) => {
     console.error(
-      "Task failed and exceeded retry attempts, removing from queue: ",
+      `Task failed and exceeded retry attempts in ${name}, removing from queue: `,
       taskId,
       errorMessage,
     );


### PR DESCRIPTION
Fixes #2968 

Creates separate download queues for files vs messages. Now that we've added more realistic timeouts for large file downloads, those may take a long time to run. We don't want message fetching to be blocked while large file downloads are in process, so we handle them in a separate queue.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

(easier to test on Qubes with Tor latency)

- Create a very large file submission
- Initiate file download (shoudl take on order of minutes)
- While file download is in progress, send new message submissions
- Message submissions should still be fetched + decrypted

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
