### PR TITLE
[app] README: add no-qubes instruction + openssl dependency

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -13,7 +13,8 @@ This is an Electron-based desktop application that provides a secure interface f
 - Node.js (v22 or later)
 - Rust toolchain (2021 edition or later; for the proxy component)
 - pnpm package manager
-- System packages `jq` and `pkg-config`
+- System packages `jq`, `pkg-config`, and `openssl`
+- Python and [Poetry](https://python-poetry.org/docs/#installing-with-the-official-installer)
 
 On a Debian Bookworm VM, we recommend installing Node and Rust via [nvm](https://github.com/nvm-sh/nvm) and [rustup](https://rustup.rs/), which installs them in your local `PATH`. You can then install `pnpm` via `npm install -g pnpm@latest`.
 
@@ -50,6 +51,13 @@ To enable autologin, run with:
 
 ```bash
 pnpm dev -- --login
+```
+
+If you are running on Qubes OS, you will need to pass in the `--no-qubes` flag in localdev. This ensures the app
+loads development configuration rather than attempting to read config values from QubesDB as expected in the production Qubes Workstation environment.
+
+```bash
+pnpm dev -- --no-qubes
 ```
 
 #### Run App Against Demo SecureDrop Server


### PR DESCRIPTION
Some improvements to the `README` based on feedback:

- Include instructions for adding `--no-qubes` flag when running on Qubes 
- `openssl` dependency

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
