### PR TITLE
Remove QUBES_ENV_SOURCED env var, to allow config tests to pass in Qubes

### DIFF
--- a/app/src/main/config.test.ts
+++ b/app/src/main/config.test.ts
@@ -13,6 +13,7 @@ describe("Config", () => {
     // Clear all environment variables that might affect tests
     delete process.env.QUBES_TEST;
     delete (import.meta.env as any).SD_SUBMISSION_KEY_FPR;
+    delete (import.meta.env as any).QUBES_ENV_SOURCED;
     delete (import.meta.env as any).QUBES_GPG_DOMAIN;
     delete (import.meta.env as any).GNUPGHOME;
     // Clear mock state


### PR DESCRIPTION
Removes `QUBES_ENV_SOURCED` environmental variable from imports for config tests, allowing the `Config > Qubes detection > does not detect Qubes when no QUBES_ env vars exist` test to pass when run in a Qubes VM.


## Test plan
- [ ] CI is passing
