### PR TITLE
[app] build:mac-demo builds demo dev version of the app for mac

### DIFF
--- a/app/electron-builder.yml
+++ b/app/electron-builder.yml
@@ -11,9 +11,30 @@ files:
   - "!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}"
 asarUnpack:
   - resources/**
+  - node_modules/better-sqlite3/**
 extraResources:
-  - from: node_modules/@dbmate/linux-x64/bin/dbmate
-    to: bin/dbmate
   - from: src/main/database/migrations
     to: migrations
 npmRebuild: false
+linux:
+  extraResources:
+    - from: node_modules/@dbmate/linux-x64/bin/dbmate
+      to: bin/dbmate
+mac:
+  target:
+    - dmg
+  category: public.app-category.productivity
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  entitlements: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.plist
+  extraResources:
+    - from: node_modules/@dbmate/darwin-arm64/bin/dbmate
+      to: bin/dbmate
+    - from: ../target/release/securedrop-proxy
+      to: bin/securedrop-proxy
+    - from: scripts/securedrop-test-key.asc
+      to: keys/securedrop-test-key.asc
+dmg:
+  sign: true
+  title: "${productName}-${version}"

--- a/app/electron.vite.config.ts
+++ b/app/electron.vite.config.ts
@@ -65,6 +65,20 @@ export default defineConfig(({ mode }) => {
       );
     }
     mainVars["import.meta.env.GNUPGHOME"] = JSON.stringify(gpgHome);
+  } else if (mode === "mac-demo") {
+    // Mac demo mode: proxy binary is bundled, GPG keyring is set up at runtime
+    if (!process.env.PROXY_ORIGIN) {
+      throw new Error(
+        "PROXY_ORIGIN environment variable is required for mac-demo mode",
+      );
+    }
+    mainVars["__PROXY_ORIGIN__"] = JSON.stringify(process.env.PROXY_ORIGIN);
+    mainVars["__PROXY_CMD__"] = '""'; // Determined at runtime from bundled binary
+    mainVars["__VITE_NONCE__"] = '""';
+    // Set test submission key fingerprint (GPG keyring created at runtime)
+    mainVars["import.meta.env.SD_SUBMISSION_KEY_FPR"] = JSON.stringify(
+      "65A1B5FF195B56353CC63DFFCC40EF1228271441",
+    );
   } else {
     // In production, PROXY_CMD is determined at runtime, and PROXY_ORIGIN is managed by the proxy VM
     mainVars["__PROXY_CMD__"] = '""'; // Empty string
@@ -102,7 +116,7 @@ export default defineConfig(({ mode }) => {
         assetsInlineLimit: 0, // Disable inlining assets as data URIs for strict CSP
       },
       html:
-        mode === "development"
+        mode === "development" || mode === "mac-demo"
           ? {
               cspNonce: viteNonce,
             }

--- a/app/package.json
+++ b/app/package.json
@@ -28,6 +28,7 @@
     "postinstall": "./scripts/download-sqlite-binaries.py",
     "build:unpack": "pnpm run build && electron-builder --dir",
     "build:linux": "pnpm run build && electron-builder --linux",
+    "build:mac-demo": "cargo build --release --manifest-path ../proxy/Cargo.toml && PROXY_ORIGIN=https://demo-journalist.securedrop.org electron-vite build --mode mac-demo && electron-builder --mac",
     "dbmate": "sh -c 'dbmate --url sqlite:$HOME/.config/SecureDrop/db.sqlite --migrations-dir ./src/main/database/migrations --schema-file ./src/main/database/schema.sql \"$@\"' _",
     "dbmate:check": "pnpm run dbmate up && pnpm run dbmate dump && git diff --exit-code ./src/main/database/schema.sql",
     "translator-screenshots": "electron-vite build --mode test && rm -rf ./screenshots && mkdir -p ./screenshots && node ./scripts/translator-screenshots/main.js",

--- a/app/src/main/config.ts
+++ b/app/src/main/config.ts
@@ -85,5 +85,5 @@ function readEnvironment(
   key: string,
   defaultValue?: string,
 ): string | undefined {
-  return import.meta.env[key] || defaultValue;
+  return import.meta.env[key] || process.env[key] || defaultValue;
 }

--- a/app/src/main/proxy.ts
+++ b/app/src/main/proxy.ts
@@ -1,4 +1,5 @@
 import child_process from "node:child_process";
+import path from "node:path";
 import { Writable } from "node:stream";
 
 import type {
@@ -237,8 +238,15 @@ function buildProxyCommand(
   let commandOptions: string[] = [];
   const env: Map<string, string> = new Map();
 
-  if (import.meta.env.MODE == "development" || import.meta.env.MODE == "test") {
+  if (
+    import.meta.env.MODE == "development" ||
+    import.meta.env.MODE == "test" ||
+    import.meta.env.MODE == "mac-demo"
+  ) {
     command = __PROXY_CMD__;
+    if (import.meta.env.MODE == "mac-demo") {
+      command = path.join(process.resourcesPath, "bin", "securedrop-proxy");
+    }
     env.set("SD_PROXY_ORIGIN", __PROXY_ORIGIN__);
     env.set("DISABLE_TOR", "yes");
   } else {


### PR DESCRIPTION
Fixes #2986 

Adds `build:mac-demo` which builds the Electron app pointed at the Demo server in development mode for macOS.

Needed changes for `mac-demo` mode are:

- Bundles `sd-proxy` binary
- Adds `gpg` to the app `PATH` 

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
