### PR TITLE
Test `nightlies.yml` whenever workflow is edited

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -5,11 +5,14 @@ on:
   push:
     branches:
       - main
+  pull_request:  # To test changes in this workflow
+    paths:
+      - '.github/workflows/nightlies.yml'
 
 # Only allow one job to run at a time because we're pushing to git repos;
 # the string value doesn't matter, just that it's a fixed string.
 concurrency:
-  group: "just-one-please"
+  group: "just-one-please-${{ github.ref }}"
 
 permissions:
   contents: read
@@ -51,6 +54,7 @@ jobs:
           if-no-files-found: error
 
   commit-and-push:
+    if: ${{ github.ref == 'refs/heads/main' }} # Skip when testing workflow
     runs-on: ubuntu-latest
     container: debian:bookworm
     needs:


### PR DESCRIPTION
Some issues have been caused in the past due to workflow changes that affected the nightlies. This triggers a limited nightly run whenever `nightlies.yml` is edited.

Ports the workstation PR https://github.com/freedomofpress/securedrop-workstation/pull/1546/ to this repo. Fixes #3014

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
