### PR TITLE
Upgrade to Electron 40 & nodejs 24

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           cache: pnpm
           cache-dependency-path: app/pnpm-lock.yaml
       - name: Install node dependencies
@@ -97,7 +97,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           cache: pnpm
           cache-dependency-path: app/pnpm-lock.yaml
       - name: Install node dependencies
@@ -151,7 +151,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           cache: pnpm
           cache-dependency-path: app/pnpm-lock.yaml
       - name: Install node dependencies
@@ -186,7 +186,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           cache: pnpm
           cache-dependency-path: app/pnpm-lock.yaml
       - name: Install node dependencies

--- a/app/README.md
+++ b/app/README.md
@@ -10,7 +10,7 @@ This is an Electron-based desktop application that provides a secure interface f
 
 ## Prerequisites
 
-- Node.js (v22 or later)
+- Node.js v24
 - Rust toolchain (2021 edition or later; for the proxy component)
 - pnpm package manager
 - System packages `jq`, `pkg-config`, and `openssl`

--- a/app/package.json
+++ b/app/package.json
@@ -9,6 +9,9 @@
     "email": "securedrop@freedom.press"
   },
   "homepage": "https://securedrop.org",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "start": "electron-vite preview",
     "dev": "electron-vite dev",
@@ -52,7 +55,7 @@
     "@types/react-window": "^1.8.8",
     "@vitejs/plugin-react": "^5.1.2",
     "@vitest/coverage-v8": "^3.2.4",
-    "electron": "39.2.7",
+    "electron": "40.0.0",
     "electron-builder": "<26.3.1",
     "electron-devtools-installer": "^4.0.0",
     "electron-vite": "^5.0.0",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -16,10 +16,10 @@ importers:
         version: 1.0.3(antd@5.29.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@electron-toolkit/preload':
         specifier: ^3.0.2
-        version: 3.0.2(electron@39.2.7)
+        version: 3.0.2(electron@40.0.0)
       '@electron-toolkit/utils':
         specifier: ^4.0.0
-        version: 4.0.0(electron@39.2.7)
+        version: 4.0.0(electron@40.0.0)
       '@reduxjs/toolkit':
         specifier: ^2.11.2
         version: 2.11.2(react-redux@9.2.0(@types/react@19.2.8)(react@19.2.3)(redux@5.0.1))(react@19.2.3)
@@ -34,7 +34,7 @@ importers:
         version: 3.8.12
       better-sqlite3:
         specifier: ^12.6.0
-        version: 12.6.0
+        version: 12.6.2
       blakejs:
         specifier: ^1.2.1
         version: 1.2.1
@@ -133,8 +133,8 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(jiti@2.6.1)(jsdom@27.2.0(postcss@8.5.6))(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.2))
       electron:
-        specifier: 39.2.7
-        version: 39.2.7
+        specifier: 40.0.0
+        version: 40.0.0
       electron-builder:
         specifier: <26.3.1
         version: 26.3.0(electron-builder-squirrel-windows@26.0.12)
@@ -1554,9 +1554,6 @@ packages:
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
-  '@types/node@22.19.7':
-    resolution: {integrity: sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==}
-
   '@types/node@24.10.1':
     resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
 
@@ -2052,8 +2049,8 @@ packages:
   better-queue@3.8.12:
     resolution: {integrity: sha512-D9KZ+Us+2AyaCz693/9AyjTg0s8hEmkiM/MB3i09cs4MdK1KgTSGJluXRYmOulR69oLZVo2XDFtqsExDt8oiLA==}
 
-  better-sqlite3@12.6.0:
-    resolution: {integrity: sha512-FXI191x+D6UPWSze5IzZjhz+i9MK9nsuHsmTX9bXVl52k06AfZ2xql0lrgIUuzsMsJ7Vgl5kIptvDgBLIV3ZSQ==}
+  better-sqlite3@12.6.2:
+    resolution: {integrity: sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
 
   bidi-js@1.0.3:
@@ -2500,8 +2497,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@39.2.7:
-    resolution: {integrity: sha512-KU0uFS6LSTh4aOIC3miolcbizOFP7N1M46VTYVfqIgFiuA2ilfNaOHLDS9tCMvwwHRowAsvqBrh9NgMXcTOHCQ==}
+  electron@40.0.0:
+    resolution: {integrity: sha512-UyBy5yJ0/wm4gNugCtNPjvddjAknMTuXR2aCHioXicH7aKRKGDBPp4xqTEi/doVcB3R+MN3wfU9o8d/9pwgK2A==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -4829,9 +4826,6 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -5510,17 +5504,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron-toolkit/preload@3.0.2(electron@39.2.7)':
+  '@electron-toolkit/preload@3.0.2(electron@40.0.0)':
     dependencies:
-      electron: 39.2.7
+      electron: 40.0.0
 
   '@electron-toolkit/tsconfig@2.0.0(@types/node@24.10.1)':
     dependencies:
       '@types/node': 24.10.1
 
-  '@electron-toolkit/utils@4.0.0(electron@39.2.7)':
+  '@electron-toolkit/utils@4.0.0(electron@40.0.0)':
     dependencies:
-      electron: 39.2.7
+      electron: 40.0.0
 
   '@electron/asar@3.2.18':
     dependencies:
@@ -5641,7 +5635,7 @@ snapshots:
 
   '@electron/universal@2.0.1':
     dependencies:
-      '@electron/asar': 3.2.18
+      '@electron/asar': 3.4.1
       '@malept/cross-spawn-promise': 2.0.0
       debug: 4.4.3
       dir-compare: 4.2.0
@@ -6461,10 +6455,6 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@22.19.7':
-    dependencies:
-      undici-types: 6.21.0
-
   '@types/node@24.10.1':
     dependencies:
       undici-types: 7.16.0
@@ -7132,7 +7122,7 @@ snapshots:
       node-eta: 0.9.0
       uuid: 9.0.1
 
-  better-sqlite3@12.6.0:
+  better-sqlite3@12.6.2:
     dependencies:
       bindings: 1.5.0
       prebuild-install: empty-package@file:empty-package
@@ -7721,10 +7711,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@39.2.7:
+  electron@40.0.0:
     dependencies:
       '@electron/get': 2.0.3
-      '@types/node': 22.19.7
+      '@types/node': 24.10.1
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -10507,8 +10497,6 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@5.26.5: {}
-
-  undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
 

--- a/app/scripts/sqlite-checksums.json
+++ b/app/scripts/sqlite-checksums.json
@@ -1,10 +1,10 @@
 {
-  "better-sqlite3-v12.6.0-electron-v140-darwin-arm64.node": "5ef9eb0727fae9e887802d4fc5aab3ae2abbae2fa22c37d340e5bda3d33b82cc",
-  "better-sqlite3-v12.6.0-electron-v140-darwin-x64.node": "5ef9eb0727fae9e887802d4fc5aab3ae2abbae2fa22c37d340e5bda3d33b82cc",
-  "better-sqlite3-v12.6.0-electron-v140-linux-arm64.node": "5ef9eb0727fae9e887802d4fc5aab3ae2abbae2fa22c37d340e5bda3d33b82cc",
-  "better-sqlite3-v12.6.0-electron-v140-linux-x64.node": "5ef9eb0727fae9e887802d4fc5aab3ae2abbae2fa22c37d340e5bda3d33b82cc",
-  "better-sqlite3-v12.6.0-node-v127-darwin-arm64.node": "e6a901e119c2bdf391d93bc86830898e4c430dbfbe04a0d63ce4dd800a822997",
-  "better-sqlite3-v12.6.0-node-v127-darwin-x64.node": "e6a901e119c2bdf391d93bc86830898e4c430dbfbe04a0d63ce4dd800a822997",
-  "better-sqlite3-v12.6.0-node-v127-linux-arm64.node": "e6a901e119c2bdf391d93bc86830898e4c430dbfbe04a0d63ce4dd800a822997",
-  "better-sqlite3-v12.6.0-node-v127-linux-x64.node": "e6a901e119c2bdf391d93bc86830898e4c430dbfbe04a0d63ce4dd800a822997"
+  "better-sqlite3-v12.6.2-electron-v143-darwin-arm64.node": "ca99f36d13643334c367a2d52a07e6eff50d431342e2c3648b4b47eb52876ed7",
+  "better-sqlite3-v12.6.2-electron-v143-darwin-x64.node": "15b8c57a250d79f1d0afe9f8ce9a913fb0be25e80042fc532435104040867f4e",
+  "better-sqlite3-v12.6.2-electron-v143-linux-arm64.node": "3234b08c0e54b3bca398889277f1acf3651e9a1d6582eff87bf2827808d2d8b3",
+  "better-sqlite3-v12.6.2-electron-v143-linux-x64.node": "0a9876cc0c893c9d1c09c9e1db2b34b61acd1cea4fb592c5a4a5f4d0da52ca95",
+  "better-sqlite3-v12.6.2-node-v137-darwin-arm64.node": "f4ab8ddc57768a1342fad1a948c7ff943fe553ebd73671054cd58c1f7cd33021",
+  "better-sqlite3-v12.6.2-node-v137-darwin-x64.node": "94360f9f3d8d924f161e8a93ab5599f9d4954950c8e1105b0991d5a3108e28bb",
+  "better-sqlite3-v12.6.2-node-v137-linux-arm64.node": "145193b7aad7e02d51ae9c6376c81de1e05af4af9cf9c7097b5eb38d4b22f036",
+  "better-sqlite3-v12.6.2-node-v137-linux-x64.node": "0ce99d60cc96c6aeea33438748d6c0a8d585f8dec24a10dbe5c68dcaed29ef83"
 }

--- a/debian/securedrop-app.lintian-overrides
+++ b/debian/securedrop-app.lintian-overrides
@@ -3,7 +3,6 @@ securedrop-app: embedded-library freetype [usr/lib/securedrop-app/securedrop-app
 securedrop-app: embedded-library lcms2 [usr/lib/securedrop-app/securedrop-app]
 securedrop-app: embedded-library libjpeg [usr/lib/securedrop-app/securedrop-app]
 securedrop-app: embedded-library libjsoncpp [usr/lib/securedrop-app/securedrop-app]
-securedrop-app: embedded-library libpng [usr/lib/securedrop-app/securedrop-app]
 securedrop-app: embedded-library openjpeg [usr/lib/securedrop-app/securedrop-app]
 securedrop-app: embedded-library srtp [usr/lib/securedrop-app/securedrop-app]
 securedrop-app: embedded-library tiff [usr/lib/securedrop-app/securedrop-app]

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get --yes upgrade && apt-get install --yes build-essen
 
 COPY qubes_42.sources /etc/apt/sources.list.d/
 RUN sed -i s/##VERSION_CODENAME##/${DISTRO}/ /etc/apt/sources.list.d/qubes_42.sources
-COPY nodesource-node22.sources /etc/apt/sources.list.d/
+COPY nodesource-node24.sources /etc/apt/sources.list.d/
 
 # Keep in sync with rust-toolchain.toml
 ENV RUST_VERSION 1.90.0

--- a/scripts/nodesource-node24.sources
+++ b/scripts/nodesource-node24.sources
@@ -1,5 +1,5 @@
 Types: deb
-URIs: https://deb.nodesource.com/node_22.x
+URIs: https://deb.nodesource.com/node_24.x
 Suites: nodistro
 Components: main
 Signed-By:


### PR DESCRIPTION
Fixes #3000.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] Install nodejs 24 locally, verify `pnpm lint` + `pnpm test` work. If you're not using e.g. nvm, on Fedora I installed `node-24` and switched to it with [update-alternatives](https://beko.famkos.net/2024/06/12/updating-default-nodejs-version-on-fedora/).
* [ ] Smoke test basic functionality, including login, offline mode, sync, print/export

There's a new error/warning like:
```
[9652:0127/111126.745434:ERROR:dbus/object_proxy.cc:573] Failed to call method: org.freedesktop.systemd1.Manager.StartTransientUnit: object_path= /org/freedesktop/systemd1: org.freedesktop.systemd1.UnitExists: Unit app-org.chromium.Chromium-9652.scope was already loaded or has a fragment file.
```
but as far as I can tell there's no negative effects. Everything in Qubes works fine.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
