### PR TITLE
Simplify onItemUpdate/onSourceUpdate event handlers

### DIFF
--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -105,13 +105,17 @@ const electronAPI = {
   openFile: logIpcCall<void>("openFile", (itemUuid: string) =>
     ipcRenderer.invoke("openFile", itemUuid),
   ),
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onItemUpdate: (callback: (...args: any[]) => void) => {
-    ipcRenderer.on("item-update", (_event, ...args) => callback(...args));
+  onItemUpdate: (callback: (item: Item) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, item: Item) =>
+      callback(item);
+    ipcRenderer.on("item-update", listener);
+    return () => ipcRenderer.removeListener("item-update", listener);
   },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onSourceUpdate: (callback: (...args: any[]) => void) => {
-    ipcRenderer.on("source-update", (_event, ...args) => callback(...args));
+  onSourceUpdate: (callback: (source: Source) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, source: Source) =>
+      callback(source);
+    ipcRenderer.on("source-update", listener);
+    return () => ipcRenderer.removeListener("source-update", listener);
   },
   clearClipboard: logIpcCall<void>("clearClipboard", () =>
     ipcRenderer.invoke("clearClipboard"),

--- a/app/src/renderer/test-component-setup.tsx
+++ b/app/src/renderer/test-component-setup.tsx
@@ -71,10 +71,8 @@ beforeEach(() => {
     updateFetchStatus: vi
       .fn()
       .mockRejectedValue(new Error("mock not implemented")),
-    onItemUpdate: vi.fn().mockRejectedValue(new Error("mock not implemented")),
-    onSourceUpdate: vi
-      .fn()
-      .mockRejectedValue(new Error("mock not implemented")),
+    onItemUpdate: vi.fn().mockReturnValue(() => {}),
+    onSourceUpdate: vi.fn().mockReturnValue(() => {}),
     getItem: vi.fn().mockRejectedValue(new Error("mock not implemented")),
     getSources: vi.fn().mockResolvedValue([
       {

--- a/app/src/renderer/views/Inbox.tsx
+++ b/app/src/renderer/views/Inbox.tsx
@@ -8,8 +8,10 @@ import {
   selectSyncStatus,
   clearStatus,
 } from "../features/sync/syncSlice";
+import { updateItem } from "../features/conversation/conversationSlice";
+import { updateSource } from "../features/sources/sourcesSlice";
 import { setUnauth } from "../features/session/sessionSlice";
-import { SyncStatus } from "../../types";
+import { SyncStatus, type Item, type Source } from "../../types";
 import { useAppSelector } from "../hooks";
 import Sidebar from "./Inbox/Sidebar";
 import MainContent from "./Inbox/MainContent";
@@ -50,6 +52,22 @@ function InboxView() {
 
   useEffect(() => {
     dispatch(fetchJournalists());
+  }, [dispatch]);
+
+  // Register IPC listeners for real-time updates from the main process
+  useEffect(() => {
+    const unsubscribeItem = window.electronAPI.onItemUpdate((item: Item) => {
+      dispatch(updateItem(item));
+    });
+    const unsubscribeSource = window.electronAPI.onSourceUpdate(
+      (source: Source) => {
+        dispatch(updateSource(source));
+      },
+    );
+    return () => {
+      unsubscribeItem();
+      unsubscribeSource();
+    };
   }, [dispatch]);
 
   return (

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item.tsx
@@ -8,12 +8,9 @@ import Message from "./Item/Message";
 import Reply from "./Item/Reply";
 import File from "./Item/File";
 import { useAppDispatch, useAppSelector } from "../../../../hooks";
-import {
-  updateItem,
-  updateItemFetchStatus,
-} from "../../../../features/conversation/conversationSlice";
+import { updateItemFetchStatus } from "../../../../features/conversation/conversationSlice";
 
-import { memo, useEffect, useCallback } from "react";
+import { memo, useCallback } from "react";
 
 interface ItemProps {
   item: Item;
@@ -23,12 +20,6 @@ interface ItemProps {
 const Item = memo(function ItemComponent({ item, designation }: ItemProps) {
   const dispatch = useAppDispatch();
   const session = useAppSelector((state) => state.session);
-
-  useEffect(() => {
-    window.electronAPI.onItemUpdate((item: Item) => {
-      dispatch(updateItem(item));
-    });
-  }, [dispatch]);
 
   const onFetchStatusUpdate = useCallback(
     async (update: ItemUpdate) => {

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -11,11 +11,10 @@ import {
   fetchSources,
   selectSources,
   selectSourcesLoading,
-  updateSource,
 } from "../../../features/sources/sourcesSlice";
 import { fetchConversation } from "../../../features/conversation/conversationSlice";
 import Toolbar, { type filterOption } from "./SourceList/Toolbar";
-import { PendingEventType, Source as SourceType } from "../../../../types";
+import { PendingEventType } from "../../../../types";
 
 function SourceList() {
   const { sourceUuid: activeSourceUuid } = useParams<{ sourceUuid?: string }>();
@@ -48,12 +47,6 @@ function SourceList() {
 
   useEffect(() => {
     dispatch(fetchSources());
-  }, [dispatch]);
-
-  useEffect(() => {
-    window.electronAPI.onSourceUpdate((source: SourceType) => {
-      dispatch(updateSource(source));
-    });
   }, [dispatch]);
 
   // Calculate container height for react-window


### PR DESCRIPTION
Instead of registering one handler per item/source, we can just register a global handler that updates the Redux store, and let Redux take care of updating the individual items/sources.

Notably this will address the console warning that appeared after login, which said: "Possible EventEmitter memory leak detected. 11 item-update listeners added."

This was mostly done by Claude.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

* [ ] launch with a fresh DB, as the sync happens, observe that the source list correctly updates from "Encrypted..." to the message text.
* [ ] When viewing a source, download a file and see that it transitions through the dowloading -> downloaded states correctly. Also send a reply and see that it to goes through pending -> sent.


## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
