### PR TITLE
Unbreak Redux + React devtools extensions

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -147,6 +147,16 @@ function spawnFetchWorker(mainWindow: BrowserWindow): Worker {
 app.whenReady().then(() => {
   // Set strict Content Security Policy via HTTP header with nonce
   session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    // Don't set a CSP for devtools when we're in dev mode
+    if (
+      is.dev &&
+      process.env["NODE_ENV"] != "production" &&
+      (details.url.startsWith("devtools://") ||
+        details.url.startsWith("chrome-extension://"))
+    ) {
+      callback({ responseHeaders: details.responseHeaders });
+      return;
+    }
     let scriptSrc = "script-src 'self'";
     let styleSrc = `style-src 'self' 'nonce-${cspNonce}'`;
     let connectSrc = "";


### PR DESCRIPTION
Disable CSP headers on devtools:// and chrome-extensions:// since it unsurprisingly breaks the extensions.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

* [x] Launch the app and no longer see a bunch of console spam about how there was a CSP failure
* [x] Redux + React extensions will work again. Note that the React extension requires a second page load, so type `window.location.reload()` in the console and then the React extension will load (this is a preexisting issue).

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
