### PR TITLE
Truncate previews in SQL in addition to CSS

### DIFF
--- a/app/.semgrep/custom-rules.yml
+++ b/app/.semgrep/custom-rules.yml
@@ -123,7 +123,8 @@ rules:
         - vuln
 
   # Rule: Ban ALL dynamic content in prepare() statements
-  # Only allow template literals with safe constants (FetchStatus, EventStatus).
+  # Only allow template literals with safe constants (FetchStatus, EventStatus,
+  # MESSAGE_PREVIEW_LENGTH).
   # Exception: selectWhereIn method uses TypeScript string literal types for safety.
   - id: better-sqlite3-ban-dynamic-content
     patterns:
@@ -131,6 +132,7 @@ rules:
       # Exclude safe constants
       - pattern-not: $DB.prepare(`...${FetchStatus.$FIELD}...`)
       - pattern-not: $DB.prepare(`...${EventStatus.$FIELD}...`)
+      - pattern-not: $DB.prepare(`...${MESSAGE_PREVIEW_LENGTH}...`)
       # Exclude selectWhereIn which is validated by using string literal types
       - pattern-not-inside: |
           selectWhereIn(...) {

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -30,6 +30,10 @@ import {
 } from "../../types";
 import { Crypto } from "../crypto";
 
+// Truncate message previews to 200 Unicode code points
+// at the database layer; CSS will handle the rest
+export const MESSAGE_PREVIEW_LENGTH = 200;
+
 interface KeyObject {
   [key: string]: object;
 }
@@ -237,7 +241,7 @@ export class DB {
         s.is_seen,
         s.has_attachment,
         i.kind AS last_message_kind,
-        i.plaintext AS last_message_plaintext,
+        substr(i.plaintext, 1, ${MESSAGE_PREVIEW_LENGTH}) AS last_message_plaintext,
         i.filename AS last_message_filename
       FROM sources_projected s
       LEFT JOIN sorted_items i
@@ -245,16 +249,16 @@ export class DB {
         AND i.rn = 1;
     `);
     this.selectSourceById = this.db.prepare(`
-      SELECT 
-        s.uuid, 
-        s.data, 
-        s.is_seen, 
+      SELECT
+        s.uuid,
+        s.data,
+        s.is_seen,
         s.has_attachment,
         i.kind AS last_message_kind,
-        i.plaintext AS last_message_plaintext,
+        substr(i.plaintext, 1, ${MESSAGE_PREVIEW_LENGTH}) AS last_message_plaintext,
         i.filename AS last_message_filename
       FROM sources_projected s
-      LEFT JOIN sorted_items i 
+      LEFT JOIN sorted_items i
         ON s.uuid = i.source_uuid AND i.rn = 1
       WHERE s.uuid = ?
     `);


### PR DESCRIPTION
Currently we render the entire message and solely truncate it in CSS. This is fine for small messages, but for pathologically large messages it forces the browser to render the entire message and then truncate it in CSS, just to render and update the SourceList.

We now truncate it in SQL so the CSS truncation has to do much less work.

Refs #3030.


## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

* [x] Create a source with multiple messages of 30k random emojis (you can use https://gist.github.com/legoktm/f8e10a84526df4629d1a2918e17787c0)
* [x] On main, observe that even switching between other sources that are not giant is slow
* [x] Check out this PR
* [x] Now switching between other sources that are not giant should be fast again. Loading the big source is still slow, but that'll be fixed in a follow-up.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
