### PR TITLE
app: allow download cancellation + message retry

### DIFF
--- a/app/src/renderer/locales/en.json
+++ b/app/src/renderer/locales/en.json
@@ -25,6 +25,8 @@
       "clickToOpen": "Click to open"
     },
     "itemEncrypted": "Message is encrypted...",
+    "messageFailed": "Failed to decrypt message",
+    "retryFetch": "Retry",
     "lastSourceActivity": "Last source activity",
     "you": "You",
     "unknown": "Unknown",

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item.tsx
@@ -48,7 +48,13 @@ const Item = memo(function ItemComponent({ item, designation }: ItemProps) {
 
   const kind = item.data.kind;
   if (kind === "message") {
-    return <Message item={item} designation={designation} />;
+    return (
+      <Message
+        item={item}
+        designation={designation}
+        onUpdate={onFetchStatusUpdate}
+      />
+    );
   }
   if (kind === "file") {
     return (

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
@@ -312,6 +312,14 @@ const InProgressFile = memo(function InProgressFile({
     });
   };
 
+  const cancelDownload = () => {
+    onUpdate({
+      item_uuid: item.uuid,
+      type: ItemUpdateType.FetchStatus,
+      fetch_status: FetchStatus.Initial,
+    });
+  };
+
   return (
     <div className="flex items-center justify-start">
       <LoaderCircle
@@ -338,15 +346,20 @@ const InProgressFile = memo(function InProgressFile({
           <p className="italic">
             {progressSize} {t("of")} {fileSize}
           </p>
-          {item.fetch_status === FetchStatus.DownloadInProgress ? (
-            <Button size="small" type="link" onClick={pauseDownload}>
-              {t("pause")}
+          <div className="flex gap-1">
+            {item.fetch_status === FetchStatus.DownloadInProgress ? (
+              <Button size="small" type="link" onClick={pauseDownload}>
+                {t("pause")}
+              </Button>
+            ) : (
+              <Button size="small" type="link" onClick={resumeDownload}>
+                {t("resume")}
+              </Button>
+            )}
+            <Button size="small" type="link" onClick={cancelDownload}>
+              {t("cancel")}
             </Button>
-          ) : (
-            <Button size="small" type="link" onClick={resumeDownload}>
-              {t("resume")}
-            </Button>
-          )}
+          </div>
         </div>
       </div>
     </div>

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.test.tsx
@@ -17,19 +17,30 @@ describe("Message Component Memoization", () => {
     },
     plaintext: "Hello, this is a message",
   };
+  const mockOnUpdate = vi.fn();
 
-  const cases: Array<[{ item: Item; designation: string }, number]> = [
+  const cases: Array<
+    [{ item: Item; designation: string; onUpdate: () => void }, number]
+  > = [
     // Initial render
-    [{ item: mockItem, designation: "Test Source" }, 1],
+    [{ item: mockItem, designation: "Test Source", onUpdate: mockOnUpdate }, 1],
     // Same props - should not re-render
-    [{ item: mockItem, designation: "Test Source" }, 1],
+    [{ item: mockItem, designation: "Test Source", onUpdate: mockOnUpdate }, 1],
     // Change designation - should re-render
-    [{ item: mockItem, designation: "Different Source" }, 2],
+    [
+      {
+        item: mockItem,
+        designation: "Different Source",
+        onUpdate: mockOnUpdate,
+      },
+      2,
+    ],
     // Change item plaintext - should re-render
     [
       {
         item: { ...mockItem, plaintext: "Different message" },
         designation: "Different Source",
+        onUpdate: mockOnUpdate,
       },
       3,
     ],
@@ -38,6 +49,7 @@ describe("Message Component Memoization", () => {
       {
         item: { ...mockItem, plaintext: undefined },
         designation: "Different Source",
+        onUpdate: mockOnUpdate,
       },
       4,
     ],

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.tsx
@@ -1,20 +1,43 @@
 import { memo } from "react";
-import type { Item } from "../../../../../../types";
+import {
+  FetchStatus,
+  ItemUpdateType,
+  type Item,
+  type ItemUpdate,
+} from "../../../../../../types";
 import { toTitleCase } from "../../../../../utils";
 import Avatar from "../../../../../components/Avatar";
 import { useTranslation } from "react-i18next";
+import { RotateCw } from "lucide-react";
+import { Button, Tooltip, theme } from "antd";
+import { ExclamationCircleTwoTone } from "@ant-design/icons";
 import "../Item.css";
 
 interface MessageProps {
   item: Item;
   designation: string;
+  onUpdate: (update: ItemUpdate) => void;
 }
 
-const Message = memo(function Message({ item, designation }: MessageProps) {
+const Message = memo(function Message({
+  item,
+  designation,
+  onUpdate,
+}: MessageProps) {
   const { t } = useTranslation("MainContent");
+  const { token } = theme.useToken();
   const titleCaseDesignation = toTitleCase(designation);
+  const isFailed = item.fetch_status === FetchStatus.FailedTerminal;
   const isEncrypted = !item.plaintext;
   const messageContent = item.plaintext || "";
+
+  const retryFetch = () => {
+    onUpdate({
+      item_uuid: item.uuid,
+      type: ItemUpdateType.FetchStatus,
+      fetch_status: FetchStatus.DownloadInProgress,
+    });
+  };
 
   return (
     <div
@@ -27,7 +50,27 @@ const Message = memo(function Message({ item, designation }: MessageProps) {
           <span className="author">{titleCaseDesignation}</span>
         </div>
         <div className="message-box whitespace-pre-wrap">
-          {isEncrypted ? (
+          {isFailed ? (
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <ExclamationCircleTwoTone
+                  twoToneColor={token.colorError}
+                  style={{ fontSize: 16 }}
+                />
+                <span className="italic text-gray-500">
+                  {t("messageFailed")}
+                </span>
+              </div>
+              <Tooltip title={t("retryFetch")}>
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<RotateCw size={14} />}
+                  onClick={retryFetch}
+                />
+              </Tooltip>
+            </div>
+          ) : isEncrypted ? (
             <span className="italic text-gray-500">{t("itemEncrypted")}</span>
           ) : (
             messageContent


### PR DESCRIPTION
Fixes #2984, Fixes #3002

- Adds a `cancel` option (in addition to `pause`) for in-progress downloads
- When a message terminally fails, show an error message + add option to retry

<img width="1920" height="1048" alt="Screenshot from 2026-01-29 12-23-56" src="https://github.com/user-attachments/assets/61164e6c-0c5b-4c31-852a-c96e65691796" />

<img width="1920" height="1048" alt="Screenshot from 2026-01-29 12-26-15" src="https://github.com/user-attachments/assets/b41fc825-3acd-40e3-9f86-955d0eb02340" />



## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
