### PR TITLE
Have `<Ctrl+Delete>` trigger the source deletion dialog

### DIFF
--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
@@ -1,7 +1,8 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
 import { expect, describe, it, vi, beforeEach, afterEach } from "vitest";
 import userEvent from "@testing-library/user-event";
 import React from "react";
+import { Routes, Route } from "react-router";
 import SourceList from "./SourceList";
 import type { Source as SourceType } from "../../../../types";
 import { PendingEventType } from "../../../../types";
@@ -181,18 +182,29 @@ describe("Sources Component", () => {
   });
 
   // Helper function to render SourceList with Redux state
-  const renderSourceList = (sources = mockSources, loading = false) => {
-    return renderWithProviders(<SourceList />, {
-      preloadedState: {
-        sources: {
-          sources,
-          activeSourceUuid: null,
-          loading,
-          error: null,
-          conversationIndicators: {},
+  const renderSourceList = (
+    sources = mockSources,
+    loading = false,
+    initialRoute = "/",
+  ) => {
+    return renderWithProviders(
+      <Routes>
+        <Route path="/" element={<SourceList />} />
+        <Route path="/source/:sourceUuid" element={<SourceList />} />
+      </Routes>,
+      {
+        initialEntries: [initialRoute],
+        preloadedState: {
+          sources: {
+            sources,
+            activeSourceUuid: null,
+            loading,
+            error: null,
+            conversationIndicators: {},
+          },
         },
       },
-    });
+    );
   };
 
   describe("Default behavior", () => {
@@ -930,6 +942,144 @@ describe("Sources Component", () => {
         expect(checkbox1).not.toBeChecked();
         expect(checkbox2).not.toBeChecked();
       });
+    });
+  });
+
+  describe("Keyboard shortcut (Ctrl+Delete)", () => {
+    beforeEach(() => {
+      window.electronAPI.addPendingSourceEvent = vi
+        .fn()
+        .mockResolvedValue(BigInt(123));
+      window.electronAPI.getSourceWithItems = vi.fn().mockResolvedValue(null);
+    });
+
+    it("opens delete modal when Ctrl+Delete is pressed with an active source", async () => {
+      renderSourceList(mockSources, false, "/source/source-1");
+
+      await waitFor(() => {
+        expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+      });
+
+      // Press Ctrl+Delete
+      fireEvent.keyDown(document, { key: "Delete", ctrlKey: true });
+
+      // Modal should be open
+      await waitFor(() => {
+        expect(screen.getByTestId("delete-modal")).toBeInTheDocument();
+      });
+    });
+
+    it("does not disturb checkbox selection when other sources are checked", async () => {
+      renderSourceList(mockSources, false, "/source/source-1");
+
+      await waitFor(() => {
+        expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+      });
+
+      // Select a different source via checkbox
+      await userEvent.click(screen.getByTestId("source-checkbox-source-2"));
+      expect(screen.getByTestId("source-checkbox-source-2")).toBeChecked();
+
+      // Press Ctrl+Delete - modal opens for active source (source-1)
+      fireEvent.keyDown(document, { key: "Delete", ctrlKey: true });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("delete-modal")).toBeInTheDocument();
+      });
+
+      // Neither checkbox is affected — source-1 is not checked, source-2 stays checked
+      expect(screen.getByTestId("source-checkbox-source-1")).not.toBeChecked();
+      expect(screen.getByTestId("source-checkbox-source-2")).toBeChecked();
+    });
+
+    it("does not open delete modal when Ctrl+Delete is pressed with no active source", async () => {
+      renderSourceList();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+      });
+
+      // Press Ctrl+Delete with no active source
+      fireEvent.keyDown(document, { key: "Delete", ctrlKey: true });
+
+      // Modal should not be open
+      expect(screen.queryByTestId("delete-modal")).not.toBeInTheDocument();
+    });
+
+    it("does not affect checkbox selection when opening or cancelling the modal", async () => {
+      renderSourceList(mockSources, false, "/source/source-1");
+
+      await waitFor(() => {
+        expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+      });
+
+      // Checkbox starts unchecked
+      expect(screen.getByTestId("source-checkbox-source-1")).not.toBeChecked();
+
+      // Press Ctrl+Delete - modal opens but checkbox is untouched
+      fireEvent.keyDown(document, { key: "Delete", ctrlKey: true });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("delete-modal")).toBeInTheDocument();
+      });
+      expect(screen.getByTestId("source-checkbox-source-1")).not.toBeChecked();
+
+      // Cancel the modal - checkbox is still untouched
+      await userEvent.click(screen.getByTestId("delete-modal-cancel-button"));
+      expect(screen.getByTestId("source-checkbox-source-1")).not.toBeChecked();
+    });
+
+    it("does not open delete modal when Delete is pressed without Ctrl", async () => {
+      renderSourceList(mockSources, false, "/source/source-1");
+
+      await waitFor(() => {
+        expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+      });
+
+      // Press Delete without Ctrl
+      fireEvent.keyDown(document, { key: "Delete", ctrlKey: false });
+
+      // Modal should not be open
+      expect(screen.queryByTestId("delete-modal")).not.toBeInTheDocument();
+    });
+
+    it("does not trigger when typing in an input field", async () => {
+      renderSourceList(mockSources, false, "/source/source-1");
+
+      await waitFor(() => {
+        expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+      });
+
+      // Focus the search input and fire keydown on it
+      const searchInput = screen.getByTestId("source-search-input");
+      searchInput.focus();
+
+      // Press Ctrl+Delete while focused on input
+      fireEvent.keyDown(searchInput, { key: "Delete", ctrlKey: true });
+
+      // Modal should not be open
+      expect(screen.queryByTestId("delete-modal")).not.toBeInTheDocument();
+    });
+
+    it("does not re-trigger when modal is already open", async () => {
+      renderSourceList(mockSources, false, "/source/source-1");
+
+      await waitFor(() => {
+        expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+      });
+
+      // Open modal via keyboard shortcut
+      fireEvent.keyDown(document, { key: "Delete", ctrlKey: true });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("delete-modal")).toBeInTheDocument();
+      });
+
+      // Press Ctrl+Delete again - should not cause issues
+      fireEvent.keyDown(document, { key: "Delete", ctrlKey: true });
+
+      // Modal should still be open (not re-triggered)
+      expect(screen.getByTestId("delete-modal")).toBeInTheDocument();
     });
   });
 

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -67,6 +67,10 @@ function SourceList() {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [deleteModalLoading, setDeleteModalLoading] = useState(false);
+  // Sources targeted for deletion
+  const [pendingDeleteSources, setPendingDeleteSources] = useState<Set<string>>(
+    new Set(),
+  );
   const [deleteCounts, setDeleteCounts] = useState<{
     messages: number;
     files: number;
@@ -126,11 +130,13 @@ function SourceList() {
     [dispatch],
   );
 
-  const handleBulkDelete = useCallback(async () => {
-    if (selectedSources.size === 0) {
+  // Opens the delete confirmation modal for the given set of sources.
+  const openDeleteModal = useCallback(async (sources: Set<string>) => {
+    if (sources.size === 0) {
       return;
     }
 
+    setPendingDeleteSources(sources);
     setDeleteModalOpen(true);
     setDeleteModalLoading(true);
 
@@ -140,7 +146,7 @@ function SourceList() {
       let totalFiles = 0;
       let totalReplies = 0;
 
-      for (const sourceUuid of selectedSources) {
+      for (const sourceUuid of sources) {
         const sourceWithItems =
           await window.electronAPI.getSourceWithItems(sourceUuid);
         if (sourceWithItems) {
@@ -168,22 +174,56 @@ function SourceList() {
     } finally {
       setDeleteModalLoading(false);
     }
-  }, [selectedSources]);
+  }, []);
+
+  // Bulk delete button: opens modal for the currently checked sources
+  const handleBulkDelete = useCallback(async () => {
+    await openDeleteModal(new Set(selectedSources));
+  }, [selectedSources, openDeleteModal]);
+
+  // Keyboard shortcut: Ctrl+Delete deletes the current source if there is one
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!e.ctrlKey || e.key !== "Delete") {
+        return;
+      }
+      // Don't trigger if modal is already open
+      if (deleteModalOpen) {
+        return;
+      }
+      // Don't trigger when typing in an input or textarea
+      const target = e.target as HTMLElement;
+      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") {
+        return;
+      }
+
+      if (activeSourceUuid) {
+        e.preventDefault();
+        void openDeleteModal(new Set([activeSourceUuid]));
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [openDeleteModal, deleteModalOpen, activeSourceUuid]);
 
   const handleDeleteModalCancel = useCallback(() => {
+    setPendingDeleteSources(new Set());
     setDeleteModalOpen(false);
   }, []);
 
   const handleDeleteAction = useCallback(
     async (eventType: PendingEventType) => {
-      for (const sourceUuid of selectedSources) {
+      for (const sourceUuid of pendingDeleteSources) {
         await window.electronAPI.addPendingSourceEvent(sourceUuid, eventType);
       }
       // If we deleted an account and it was the currently active source, navigate away
       if (
         eventType === PendingEventType.SourceDeleted &&
         activeSourceUuid &&
-        selectedSources.has(activeSourceUuid)
+        pendingDeleteSources.has(activeSourceUuid)
       ) {
         navigate("/");
       }
@@ -196,12 +236,21 @@ function SourceList() {
       }
       // Update local state immediately with projected changes
       dispatch(fetchSources());
-      // Uncheck all boxes
-      setSelectedSources(new Set());
-      setAllSelected(false);
+      // Remove the deleted sources from the checkbox selection if they were checked
+      setSelectedSources((prev) => {
+        const next = new Set(prev);
+        for (const uuid of pendingDeleteSources) {
+          next.delete(uuid);
+        }
+        if (next.size === 0) {
+          setAllSelected(false);
+        }
+        return next;
+      });
+      setPendingDeleteSources(new Set());
       setDeleteModalOpen(false);
     },
-    [selectedSources, dispatch, activeSourceUuid, navigate],
+    [pendingDeleteSources, dispatch, activeSourceUuid, navigate],
   );
 
   const handleToggleSort = useCallback(() => {
@@ -304,10 +353,10 @@ function SourceList() {
         closable={false}
         title={
           <span data-testid="delete-modal-title">
-            {selectedSources.size === 1
+            {pendingDeleteSources.size === 1
               ? t("sourcelist.deleteDialog.single.message")
               : t("sourcelist.deleteDialog.multiple.message", {
-                  count: selectedSources.size,
+                  count: pendingDeleteSources.size,
                 })}
           </span>
         }
@@ -330,7 +379,7 @@ function SourceList() {
               handleDeleteAction(PendingEventType.SourceConversationDeleted)
             }
           >
-            {selectedSources.size === 1
+            {pendingDeleteSources.size === 1
               ? t("sourcelist.deleteDialog.single.keepAccountButton")
               : t("sourcelist.deleteDialog.multiple.keepAccountsButton")}
           </Button>,
@@ -341,7 +390,7 @@ function SourceList() {
             danger
             onClick={() => handleDeleteAction(PendingEventType.SourceDeleted)}
           >
-            {selectedSources.size === 1
+            {pendingDeleteSources.size === 1
               ? t("sourcelist.deleteDialog.single.deleteAccountButton")
               : t("sourcelist.deleteDialog.multiple.deleteAccountsButton")}
           </Button>,


### PR DESCRIPTION
If there is an active source and the user is not typing in a textbox, have the shortcut launch the deletion dialog.

Fixes #1897.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] Verify shortcut works if there is an active source. 
* [ ] Verify shortcut doesn't affect which sources are selected in the source list.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
