### PR TITLE
nightlies: Move sleep before build-logs push

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -102,12 +102,12 @@ jobs:
           cp -v ../build-*/*.buildinfo "buildinfo/$(date +%Y)"
           git add .
           git diff-index --quiet HEAD || git commit -m "Publishing buildinfo files for workstation nightlies"
+          # Sleep before we push so the token will have propagated across GitHub infra
+          sleep 5
           git push https://x-access-token:${GH_TOKEN}@github.com/${LOGS_REPO}.git main
           # Now the packages themselves
           cd ../securedrop-apt-test
           cp -v ../build-bookworm/*.deb workstation/bookworm-nightlies/
           git add .
           git diff-index --quiet HEAD || git commit -m "Automated SecureDrop workstation build"
-          # Sleep before we push so the token will have propagated across GitHub infra
-          sleep 5
           git push https://x-access-token:${GH_TOKEN}@github.com/${PKG_REPO}.git main


### PR DESCRIPTION
The push to build-logs also needs the same "sleep" protection to ensure that the token has propagated across the GitHub infra before being used.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
visual review is fine
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
