### PR TITLE
Auto-resize the textarea, up to 15 rows

### DIFF
--- a/app/src/renderer/views/Inbox/MainContent/Conversation.css
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation.css
@@ -2,6 +2,15 @@
   padding-right: 40px;
 }
 
+.conversation-textarea textarea {
+  field-sizing: content;
+  min-height: calc(1lh + 24px); /* 2 lines + padding */
+  max-height: calc(15lh + 24px); /* 15 lines + padding */
+  overflow-y: auto !important;
+  resize: none !important;
+  padding: 10px;
+}
+
 .conversation-send-btn {
   position: absolute;
   right: 10px;

--- a/app/src/renderer/views/Inbox/MainContent/Conversation.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation.tsx
@@ -227,7 +227,6 @@ const Conversation = memo(function Conversation({
               <Input.TextArea
                 data-testid="reply-textarea"
                 maxLength={MAX_REPLY_LENGTH}
-                rows={4}
                 placeholder={placeholderText}
                 className="w-full border border-gray-300 rounded-lg p-3 text-gray-900 resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 conversation-textarea"
                 onChange={(e) => setMessageValue(e.target.value)}


### PR DESCRIPTION
Fixes #3018

This removes the resize grip in the bottom-right, and instead auto-resizes based on what's typed into the message box, like with Slack. It starts with 1 line, and goes up to a max of 15 lines before a scroll bar appears in the textarea.

[Screencast From 2026-02-04 16-20-49.webm](https://github.com/user-attachments/assets/20f308f2-7ea6-4b28-9af8-93b63b4524d9)

Also note that I tried using Ant's [autoSize](https://ant.design/components/input#input-demo-autosize-textarea), but ran into a bunch of CSP inline style issues. This was simpler.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
