### PR TITLE
Backport "SecureDrop Client 0.17.2" changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.17.2
+
+* Update Rust `bytes` crate to 1.11.1 to address CVE-2026-25541 (#3069)
+* Miscellaneous:
+  * Remove current year from messages.pot
+
 ## 0.17.1
 
 This release closes a potential path traversal attack that could result in a

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,13 @@ securedrop-client (0.18.0~rc1) unstable; urgency=medium
 
   * see changelog.md
 
- -- SecureDrop Team <securedrop@freedom.press>  Mon, 24 Nov 2025 11:14:07 -0500
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 18 Feb 2026 13:32:44 -0500
+
+securedrop-client (0.17.2) unstable; urgency=medium
+
+  * see changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 04 Feb 2026 13:55:13 -0500
 
 securedrop-client (0.17.1) unstable; urgency=medium
 


### PR DESCRIPTION
(cherry picked from commit 76d1adb0947a14ce960503dff77597f057ced368)

Fixes #3071.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
visual review should be fine
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
