### PR TITLE
Have update_version.sh update package.json

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "securedrop-app",
-  "version": "0.0.1",
+  "version": "0.18.0-rc1",
   "description": "Graphical desktop app for SecureDrop",
   "productName": "SecureDrop",
   "main": "./out/main/index.js",

--- a/update_version.sh
+++ b/update_version.sh
@@ -16,6 +16,7 @@ fi
 
 sed -i'' -r -e "s/^__version__ = \"(.*?)\"/__version__ = \"${NEW_VERSION}\"/" client/securedrop_client/__init__.py
 sed -i'' -r -e "s/^__version__ = \"(.*?)\"/__version__ = \"${NEW_VERSION}\"/" export/securedrop_export/__init__.py
+sed -i'' -r -e 's/"version": ".*?"/"version": "'"${NEW_VERSION}"'"/' app/package.json
 
 # Normalize version, convert any - to ~, e.g. 0.9.0-rc1 to 0.9.0~rc1
 DEB_VERSION=$(echo "$NEW_VERSION" | sed 's/-/~/g')


### PR DESCRIPTION

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] SecureDrop App now displays the correct version number
* [x] running `./update_version.sh <whatever>` correctly bumps package.json

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
