### PR TITLE
Suppress RUSTSEC-2025-0134

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,6 +1,8 @@
 [advisories]
 # advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]
-ignore = []
+ignore = [
+    "RUSTSEC-2025-0134" # rustls-pemfile is unmaintained (#2893)
+]
 
 # Output Configuration
 [output]


### PR DESCRIPTION
Already tracked as #2893.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
