### PR TITLE
Add missing dependencies to securedrop-app package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,11 @@ Source: securedrop-client
 Section: unknown
 Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Build-Depends: debhelper-compat (= 11), dh-apparmor, dh-exec, python3-venv, libssl-dev, pkg-config, libclang-dev, qubesdb-dev, nodejs
+Build-Depends: debhelper-compat (= 11), dh-apparmor, dh-exec, python3-venv, libssl-dev, pkg-config, libclang-dev, qubesdb-dev, nodejs,
+ libasound2, libatk-bridge2.0-0, libatk1.0-0, libatspi2.0-0, libcairo2,
+ libcups2, libdbus-1-3, libexpat1, libgbm1, libglib2.0-0, libgtk-3-0,
+ libnspr4, libnss3, libpango-1.0-0, libx11-6, libxcb1, libxcomposite1,
+ libxdamage1, libxext6, libxfixes3, libxkbcommon0, libxrandr2
 Standards-Version: 3.9.8
 Homepage: https://github.com/freedomofpress/securedrop-client
 X-Python3-Version: >= 3.5

--- a/debian/rules
+++ b/debian/rules
@@ -56,7 +56,8 @@ override_dh_fixperms:
 	chmod 4755 debian/securedrop-app/usr/lib/securedrop-app/chrome-sandbox
 
 override_dh_shlibdeps:
-	dh_shlibdeps --exclude=securedrop-app
+	dh_shlibdeps -psecuredrop-app -ldebian/securedrop-app/usr/lib/securedrop-app
+	dh_shlibdeps --remaining-packages --exclude=securedrop-app
 
 override_dh_strip:
 	dh_strip --exclude=securedrop-app


### PR DESCRIPTION
We rely on dh_shlibdeps to find the dependencies, all of which need to be specified in Build-Depends, which dh_shlibdeps will then apply to the relevant subpackage.

If Electron introduces a new dependency, the build will fail until it's added. But if a dependency is no longer needed, it'll still pass.

Fixes #3082.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] `make build-debs` works, and `dpkg --info build/securedrop-app_0.18.0~rc1+bookworm_amd64.deb` shows dependencies
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
