### PR TITLE
[app] set overflow: hidden on messages

### DIFF
--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.tsx
@@ -50,7 +50,7 @@ const Message = memo(function Message({
         <div className="flex items-center mb-1">
           <span className="author">{titleCaseDesignation}</span>
         </div>
-        <div className="message-box whitespace-pre-wrap">
+        <div className="message-box whitespace-pre-wrap overflow-hidden">
           {isFailed ? (
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Reply.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Reply.tsx
@@ -135,7 +135,7 @@ function Reply({ item }: ReplyProps) {
           <span className="author reply-author">{getAuthorDisplay()}</span>
         </div>
         <div
-          className={`reply-box whitespace-pre-wrap relative ${showStatusIcon ? "with-status-icon" : ""}`}
+          className={`reply-box whitespace-pre-wrap overflow-hidden relative ${showStatusIcon ? "with-status-icon" : ""}`}
         >
           {isEncrypted ? (
             <span className="italic text-gray-500">{t("itemEncrypted")}</span>


### PR DESCRIPTION
Fixes #3063 

<img width="1036" height="905" alt="image" src="https://github.com/user-attachments/assets/1069062b-64ff-48f4-be82-20909b976efc" />


## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
Test sending Zalgo text messages + verify that they do not overflow the message container

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
