### PR TITLE
[app] add seen state when source deletes reply

### DIFF
--- a/app/src/renderer/locales/en.json
+++ b/app/src/renderer/locales/en.json
@@ -36,7 +36,8 @@
     "you": "You",
     "unknown": "Unknown",
     "pendingReplyTooltip": "The reply is pending and will be sent to the source in the next sync",
-    "successReplyTooltip": "Reply sent successfully"
+    "successReplyTooltip": "Reply sent successfully",
+    "seenReplyTooltip": "Reply seen and deleted by source"
   },
   "Sidebar": {
     "account": {

--- a/app/src/renderer/locales/fr.json
+++ b/app/src/renderer/locales/fr.json
@@ -32,7 +32,8 @@
     "you": "Vous",
     "unknown": "Inconnu",
     "pendingReplyTooltip": "La réponse est en attente et sera envoyée à la source lors de la prochaine synchronisation",
-    "successReplyTooltip": "Réponse envoyée avec succès"
+    "successReplyTooltip": "Réponse envoyée avec succès",
+    "seenReplyTooltip": "La réponse a été vue par la source"
   },
   "Sidebar": {
     "account": {

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Reply.css
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Reply.css
@@ -12,20 +12,10 @@
   color: rgba(0, 0, 0, 0.45);
 }
 
-.success-reply-icon {
+.sent-reply-icon {
   color: rgba(0, 0, 0, 0.45);
-  /* NOTE: Keep the 3s duration in sync with the timeout in Reply.tsx */
-  animation: fadeOut 3s ease-in-out forwards;
 }
 
-@keyframes fadeOut {
-  0% {
-    opacity: 1;
-  }
-  70% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-  }
+.seen-reply-icon {
+  color: rgba(0, 0, 0, 0.45);
 }


### PR DESCRIPTION
Fixes #889
Fixes #3035

Admittedly this experience confused me a bit, but in the source interface the UI prompts sources to delete replies from the journalist when they have been seen. We surface this via `is_deleted_by_source` in the `ReplyMetadata` but had no indicator for it in the UI. 

This makes the icon in the bottom-right of the reply box persistent and in a state of `pending`, `sent`, or `seen` (when it has been deleted by source).

<img width="1036" height="905" alt="image" src="https://github.com/user-attachments/assets/c2338030-18ea-4a3b-a361-d0e9882489f4" />


## Test plan

- Create a source account + send a submission message
- Send replies as a journalist to the source
- Verify they are `pending` and then `sent` in the UI
- From the source interface, delete one or more journalist replies
- Sync, and then verify they are now `seen` in the UI

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
