### PR TITLE
 feat(`syncMetadata`): skip initial sync if we're already at the version hinted at login

### DIFF
--- a/app/src/main/sync/index.test.ts
+++ b/app/src/main/sync/index.test.ts
@@ -708,6 +708,39 @@ describe("syncMetadata", () => {
   });
 });
 
+describe("shouldSkipSync", () => {
+  it("returns true when db version matches hinted version", () => {
+    const db = mockDB();
+    db.getVersion = vi.fn(() => "v5");
+    expect(syncModule.shouldSkipSync(db, "v5")).toBe(true);
+  });
+
+  it("returns false when versions match but there are pending events", () => {
+    const db = mockDB();
+    db.getVersion = vi.fn(() => "v5");
+    db.getPendingEvents = vi.fn(() => [{ type: "reply", data: "test" }] as any);
+    expect(syncModule.shouldSkipSync(db, "v5")).toBe(false);
+  });
+
+  it("returns false when db version differs from hinted version", () => {
+    const db = mockDB();
+    db.getVersion = vi.fn(() => "v5");
+    expect(syncModule.shouldSkipSync(db, "v6")).toBe(false);
+  });
+
+  it("returns false when hinted version is undefined", () => {
+    const db = mockDB();
+    db.getVersion = vi.fn(() => "v5");
+    expect(syncModule.shouldSkipSync(db, undefined)).toBe(false);
+  });
+
+  it("returns false on initial sync when db has no version", () => {
+    const db = mockDB();
+    db.getVersion = vi.fn(() => ""); // initial state
+    expect(syncModule.shouldSkipSync(db, "v1")).toBe(false);
+  });
+});
+
 describe("syncMetadata lock timeout", () => {
   let syncLock: Lock;
 

--- a/app/src/main/sync/index.ts
+++ b/app/src/main/sync/index.ts
@@ -212,6 +212,17 @@ function deleteItems(db: DB, itemIDs: string[]) {
   db.deleteItems(itemIDs);
 }
 
+// Returns true if the database is already at the hinted version and there are
+// no pending events to flush.  This check MAY be used immediately after login
+// to save a round trip.  However, since the hinted version is updated only at
+// login, this check MUST NOT be used to skip any other sync, or the client will
+// never update during this session!
+export function shouldSkipSync(db: DB, hintedVersion?: string): boolean {
+  const nothingIncoming = db.getVersion() === hintedVersion;
+  const nothingOutgoing = db.getPendingEvents().length === 0;
+  return nothingIncoming && nothingOutgoing;
+}
+
 // Executes metadata sync with SecureDrop server, updating
 // the current version and persisting updated source, reply,
 // and submission metadata to the DB.

--- a/app/src/renderer/features/conversation/conversationSlice.test.ts
+++ b/app/src/renderer/features/conversation/conversationSlice.test.ts
@@ -256,9 +256,9 @@ describe("conversationSlice", () => {
         lastFetchTime: 123456789,
       },
       sync: {
-        loading: false,
         error: null,
-        lastFetchTime: null,
+        lastSyncStarted: null,
+        lastSyncFinished: null,
         status: null,
       },
     };

--- a/app/src/renderer/features/journalists/journalistsSlice.test.ts
+++ b/app/src/renderer/features/journalists/journalistsSlice.test.ts
@@ -212,9 +212,9 @@ describe("journalistsSlice", () => {
         lastFetchTime: null,
       },
       sync: {
-        loading: false,
         error: null,
-        lastFetchTime: null,
+        lastSyncStarted: null,
+        lastSyncFinished: null,
         status: null,
       },
       drafts: { drafts: {} },

--- a/app/src/renderer/features/sources/sourcesSlice.test.ts
+++ b/app/src/renderer/features/sources/sourcesSlice.test.ts
@@ -312,9 +312,9 @@ describe("sourcesSlice", () => {
         },
         conversation: mockConversationState,
         sync: {
-          loading: false,
           error: null,
-          lastFetchTime: null,
+          lastSyncStarted: null,
+          lastSyncFinished: null,
           status: null,
         },
         drafts: { drafts: {} },
@@ -340,9 +340,9 @@ describe("sourcesSlice", () => {
         },
         conversation: mockConversationState,
         sync: {
-          loading: false,
           error: null,
-          lastFetchTime: null,
+          lastSyncStarted: null,
+          lastSyncFinished: null,
           status: null,
         },
         drafts: { drafts: {} },
@@ -368,9 +368,9 @@ describe("sourcesSlice", () => {
         },
         conversation: mockConversationState,
         sync: {
-          loading: false,
           error: null,
-          lastFetchTime: null,
+          lastSyncStarted: null,
+          lastSyncFinished: null,
           status: null,
         },
         drafts: { drafts: {} },
@@ -400,9 +400,9 @@ describe("sourcesSlice", () => {
         },
         conversation: mockConversationState,
         sync: {
-          loading: false,
           error: null,
-          lastFetchTime: null,
+          lastSyncStarted: null,
+          lastSyncFinished: null,
           status: null,
         },
       };

--- a/app/src/renderer/features/sync/syncSlice.ts
+++ b/app/src/renderer/features/sync/syncSlice.ts
@@ -4,17 +4,20 @@ import { fetchConversation } from "../conversation/conversationSlice";
 import { fetchJournalists } from "../journalists/journalistsSlice";
 import { fetchSources } from "../sources/sourcesSlice";
 import { SyncStatus } from "../../../types";
+import { setUnauth } from "../session/sessionSlice";
 import type { AuthData } from "../session/sessionSlice";
 
 export interface SyncState {
   error: string | null;
-  lastFetchTime: number | null;
+  lastSyncStarted: number | null;
+  lastSyncFinished: number | null;
   status: SyncStatus | null;
 }
 
 const initialState: SyncState = {
   error: null,
-  lastFetchTime: null,
+  lastSyncStarted: null,
+  lastSyncFinished: null,
   status: null,
 };
 
@@ -24,10 +27,21 @@ export const syncMetadata = createAsyncThunk(
   async (authData: AuthData, { getState, dispatch }) => {
     const hintedRecords =
       (authData.lastHintedSources || 0) + (authData.lastHintedItems || 0);
+
+    // Only pass the hinted version (to see if we're already up to date and can
+    // skip sync) if this is the very first sync after login.
+    const state = getState() as RootState;
+    const hintedVersion = state.sync.lastSyncStarted
+      ? undefined
+      : authData.lastHintedVersion;
+
+    dispatch(markSyncStarted());
+
     // Sync metadata with the server
     const status: SyncStatus = await window.electronAPI.syncMetadata({
       authToken: authData.token,
       hintedRecords,
+      hintedVersion,
     });
 
     // If there are updates from sync, fetch downstream state
@@ -62,11 +76,15 @@ export const syncSlice = createSlice({
     clearStatus: (state) => {
       state.status = null;
     },
+    markSyncStarted: (state) => {
+      state.lastSyncStarted = Date.now();
+    },
   },
   extraReducers: (builder) => {
     builder
+      .addCase(setUnauth, () => initialState)
       .addCase(syncMetadata.fulfilled, (state, action) => {
-        state.lastFetchTime = Date.now();
+        state.lastSyncFinished = Date.now();
         state.status = action.payload;
       })
       .addCase(syncMetadata.rejected, (state, action) => {
@@ -75,9 +93,9 @@ export const syncSlice = createSlice({
   },
 });
 
-export const { clearError, clearStatus } = syncSlice.actions;
+export const { clearError, clearStatus, markSyncStarted } = syncSlice.actions;
 export const selectSyncError = (state: RootState) => state.sync.error;
 export const selectSyncStatus = (state: RootState) => state.sync.status;
-export const selectlastFetchTime = (state: RootState) =>
-  state.sync.lastFetchTime;
+export const selectLastSyncFinished = (state: RootState) =>
+  state.sync.lastSyncFinished;
 export default syncSlice.reducer;

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -58,6 +58,7 @@ export enum SyncStatus {
 export type AuthedRequest = {
   authToken: string;
   hintedRecords?: number;
+  hintedVersion?: string;
 };
 
 // Re-export some types that are derived from zod schemas


### PR DESCRIPTION
Implements the optimization that originally motivated @legoktm's suggestion of freedomofpress/securedrop-client freedomofpress/securedrop#7689: If the client knows it's up to date with the server at login, it doesn't have to immediately ask again if it's up to date!


## Test plan

1. [ ] Initial sync completes against `make dev`, e.g.:
    ```
    172.17.0.1 - - [13/Feb/2026 06:57:42] "POST /api/v1/token HTTP/1.1" 200 -
    # Immediately:
    172.17.0.1 - - [13/Feb/2026 06:57:43] "GET /api/v2/index HTTP/1.1" 200 -
    # Rest of sync...
    ```
2. [ ] Subsequent login shows only:
    ```
    172.17.0.1 - - [13/Feb/2026 06:57:42] "POST /api/v1/token HTTP/1.1" 200 -
    # 1 minute later...
    172.17.0.1 - - [13/Feb/2026 06:57:43] "GET /api/v2/index HTTP/1.1" 304 -
    ```
3. [ ] Mutate some server state and log in again:
    ```
    172.17.0.1 - - [13/Feb/2026 06:57:42] "POST /api/v1/token HTTP/1.1" 200 -
    # Immediately:
    172.17.0.1 - - [13/Feb/2026 06:57:43] "GET /api/v2/index HTTP/1.1" 200 -
    # ...
    ```


## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
