### PR TITLE
Run piuparts in Trixie for compatibility with ubuntu-latest runner's docker.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,14 +162,23 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+
       - uses: actions/download-artifact@v7
         with:
           path: build
           pattern: "build-main-${{ matrix.debian_version }}"
           merge-multiple: True
+
+      - name: Configure Docker to use overlay2
+        run: |
+          sudo systemctl stop docker
+          echo '{"storage-driver": "overlay2"}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl start docker
+
       - name: Run piuparts
         run: |
-          # We need to run it as docker-in-docker
+          # We need to run it as docker-in-docker, & for docker.io compatibility
+          # with ubuntu-latest's docker we use Trixie for the nested container.
           docker run \
             -v "/var/lib/docker:/var/lib/docker" \
             -v "/var/run/docker.sock:/var/run/docker.sock" \
@@ -179,4 +188,4 @@ jobs:
             -v "/$(pwd)/.github/workflows/piuparts:/piuparts" \
             -e DISTRO=${{ matrix.debian_version }} \
             -e PACKAGE=${{ matrix.package }} \
-            debian:${{ matrix.debian_version }} bash /piuparts/run-piuparts.sh
+            debian:trixie bash /piuparts/run-piuparts.sh

--- a/.github/workflows/piuparts/run-piuparts.sh
+++ b/.github/workflows/piuparts/run-piuparts.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 # Runs inside the container
+
 apt-get update && apt-get install --yes piuparts docker.io
 
 # Move things in this folder so the docker build can find them


### PR DESCRIPTION
Fixes broken docker-in-docker piuparts task in CI build by:
- runing piuparts in a trixie container so that it gets a compatible version of docker.io to the ubuntu-latest host docker versoin
- forcing use of the `overlay2` storage driver in said host.

## Test plan
- [ ] CI is passing
