### PR TITLE
Enable security pragmas for app sqlite3 db

### DIFF
--- a/app/src/main/database/index.test.ts
+++ b/app/src/main/database/index.test.ts
@@ -59,6 +59,8 @@ describe("Database Component Tests", () => {
     expect(db).toBeDefined();
     expect(fs.existsSync(testDbPath)).toBe(true);
     expect(db["db"]!.pragma("journal_mode", { simple: true })).toBe("wal");
+    expect(db["db"]!.pragma("secure_delete", { simple: true })).toBe(1);
+    expect(db["db"]!.pragma("auto_vacuum", { simple: true })).toBe(1);
   });
 
   it("should handle database closure", () => {

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -168,6 +168,12 @@ export class DB {
     // Create or open the SQLite database
     const dbPath = path.join(dbDir, "db.sqlite");
     const db = new Database(dbPath, { nativeBinding: this.getBinaryPath() });
+
+    // enable security pragmas
+    db.pragma("secure_delete = ON");
+    db.pragma("auto_vacuum = FULL");
+
+    // WAL mode must be set after auto_vacuum
     db.pragma("journal_mode = WAL");
 
     // Set the database URL for migrations


### PR DESCRIPTION
Fixes #3109 

Explicitly sets `secure_delete = ON` and `auto_vacuum = FULL` pragmas during DB creation.

## Test plan

- [ ] CI is passing
- [ ] Application basic functionality is unchanged
- [ ] Run the app and then connect to the db via `sqlite3 ~/.config/SecureDrop/db.sqlite:
  - [ ] `PRAGMA secure_delete;` returns 1, `PRAGMA auto_vacuum` returns 1
