### PR TITLE
Cache securedrop-proxy builds if FAST=1 set

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -14,6 +14,10 @@ override_dh_auto_install:
 	bash ./debian/setup-venv.sh export
 	bash ./debian/setup-venv.sh log
 	cargo build --release --locked --features qubesdb
+ifdef FAST
+	mkdir -p target/release
+	cp $${CARGO_TARGET_DIR}/release/securedrop-proxy target/release/
+endif
 	bash ./debian/build-app.sh
 	dh_auto_install
 	dh_apparmor --profile-name=usr.bin.securedrop-client -psecuredrop-client

--- a/scripts/build-debs.sh
+++ b/scripts/build-debs.sh
@@ -59,10 +59,18 @@ BUILD_DEST=$(mktemp -d)
 # Optionally build other packages in the future, default to "main" packages
 WHAT="${WHAT:-main}"
 
+FAST="${FAST:-}"
+FAST_CACHE_ARGUMENTS=""
+if [[ -n $FAST ]]; then
+    FAST_CACHE_ARGUMENTS="-v sd-client-builder-cache-${DEBIAN_VERSION}:/cache:Z --env CARGO_TARGET_DIR=/cache/rust"
+fi
+
 $OCI_BIN run --rm $OCI_RUN_ARGUMENTS \
     -v "${BUILDER}:/builder:Z" \
     -v "${BUILD_DEST}:/build:Z" \
+    $FAST_CACHE_ARGUMENTS \
     --env NIGHTLY="${NIGHTLY:-}" \
+    --env FAST="${FAST}" \
     --env WHAT="${WHAT}" \
     --entrypoint "/src/scripts/build-debs-main.sh" \
     $CONTAINER
@@ -72,7 +80,6 @@ ls "$BUILD_DEST"
 mkdir -p build
 cp ${BUILD_DEST}/* build/
 
-FAST="${FAST:-}"
 if [[ -z $FAST ]]; then
     CONTAINER2="fpf.local/sd-client-lintian"
     $OCI_BIN build scripts/lintian -t $CONTAINER2


### PR DESCRIPTION
When building debs, if FAST=1 is set, use a build cache for securedrop-proxy, to make it near instantaneous if there are no changes. If there are changes, it'll rebuild whatever is necessary.

These fast builds build in a separate CARGO_TARGET_DIR which is a persistent volume, and then copy the binary to the correct target/ folder, which is where the securedrop-proxy.install file looks for it.

Refs #3097.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

* [x] Run `FAST=1 make build-debs` twice; on the second run the Rust compilation step should say something like "   Finished `release` profile [optimized + debuginfo] target(s) in 2.73s" with a time in seconds, and not minutes.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
