### PR TITLE
Have eslint require braces with control statements

### DIFF
--- a/app/eslint.config.ts
+++ b/app/eslint.config.ts
@@ -37,6 +37,7 @@ export default tseslint.config(
       },
     },
     rules: {
+      curly: ["error", "all"],
       "@typescript-eslint/no-unused-vars": [
         "error",
         {

--- a/app/src/main/__tests__/crypto.integration.test.ts
+++ b/app/src/main/__tests__/crypto.integration.test.ts
@@ -204,7 +204,9 @@ describe("Crypto Integration Tests", () => {
       } as never);
 
       mockFs.unlink.mockImplementation((_path, callback) => {
-        if (callback) callback(null);
+        if (callback) {
+          callback(null);
+        }
       });
 
       mockFs.existsSync.mockReturnValue(true);

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -415,7 +415,9 @@ export class DB {
     column: "snowflake_id",
     values: (string | number)[],
   ): T[] {
-    if (values.length === 0) return [];
+    if (values.length === 0) {
+      return [];
+    }
 
     // Build placeholders (?, ?, ?, ...)
     const placeholders = values.map(() => "?").join(", ");
@@ -589,10 +591,15 @@ export class DB {
 
   // Helper function for truthy values
   private isTruthy(value: unknown): boolean {
-    if (typeof value === "boolean") return value;
-    if (typeof value === "number") return value !== 0;
-    if (typeof value === "string")
+    if (typeof value === "boolean") {
+      return value;
+    }
+    if (typeof value === "number") {
+      return value !== 0;
+    }
+    if (typeof value === "string") {
       return value.toLowerCase() === "true" || value === "1";
+    }
     return Boolean(value);
   }
 

--- a/app/src/main/export.ts
+++ b/app/src/main/export.ts
@@ -170,8 +170,9 @@ export class ExportStateMachine implements StateMachine<
           if (
             event.status === ExportStatus.ERROR_UNLOCK_GENERIC ||
             event.status === ExportStatus.ERROR_UNLOCK_LUKS
-          )
+          ) {
             next = ExportState.ExportPreflightComplete;
+          }
         }
         break;
     }
@@ -375,10 +376,11 @@ export class ArchiveExporter {
         .map((l) => l.trim())
         .filter(Boolean);
       const last = lines.length > 0 ? lines[lines.length - 1] : "";
-      if (!last)
+      if (!last) {
         throw new PrintExportError(
           "No final line in sd-devices status response",
         );
+      }
 
       if (Object.values(ExportStatus).includes(last as ExportStatus)) {
         return last as ExportStatus;

--- a/app/src/renderer/test-component-setup.tsx
+++ b/app/src/renderer/test-component-setup.tsx
@@ -24,7 +24,9 @@ global.ResizeObserver = class {
     this.callback = callback;
   }
   observe(target: Element) {
-    if (this.observedTargets.has(target)) return;
+    if (this.observedTargets.has(target)) {
+      return;
+    }
     this.observedTargets.add(target);
     setTimeout(() => {
       this.callback(

--- a/app/src/renderer/utils.ts
+++ b/app/src/renderer/utils.ts
@@ -164,7 +164,9 @@ export function formatJournalistName(journalist: JournalistMetadata): string {
  * Pretty-print file size in human-readable format
  */
 export function prettyPrintBytes(bytes: number): string {
-  if (bytes <= 0) return "0 B";
+  if (bytes <= 0) {
+    return "0 B";
+  }
   const k = 1024;
   const sizes = ["B", "KB", "MB", "GB", "TB", "PB"];
   const i = Math.floor(Math.log(bytes) / Math.log(k));
@@ -186,7 +188,9 @@ export function formatFilename(
   maxLength: number,
   endLength: number,
 ): string {
-  if (filename.length <= maxLength) return filename;
+  if (filename.length <= maxLength) {
+    return filename;
+  }
 
   const dotIndex = filename.lastIndexOf(".");
   const hasExtension = dotIndex > 0 && dotIndex < filename.length - 1;

--- a/app/src/renderer/views/Inbox/MainContent/Conversation.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation.tsx
@@ -87,7 +87,9 @@ const Conversation = memo(function Conversation({
 
   const handleSubmit = useCallback(
     async (values: { message: string }) => {
-      if (!sourceWithItems || !values.message?.trim()) return;
+      if (!sourceWithItems || !values.message?.trim()) {
+        return;
+      }
 
       // Clear the form immediately for better UX
       form.resetFields();
@@ -149,7 +151,9 @@ const Conversation = memo(function Conversation({
 
   // Keyboard shortcut: Ctrl+D initiates download for all files
   const downloadAllFiles = useCallback(() => {
-    if (!sourceWithItems || !session.authData?.token) return;
+    if (!sourceWithItems || !session.authData?.token) {
+      return;
+    }
 
     const token = session.authData.token;
     sourceWithItems.items.forEach((item) => {
@@ -183,7 +187,9 @@ const Conversation = memo(function Conversation({
     };
   }, [downloadAllFiles]);
 
-  if (!sourceWithItems) return null;
+  if (!sourceWithItems) {
+    return null;
+  }
 
   return (
     <div className="flex flex-col h-full w-full min-h-0">


### PR DESCRIPTION
This helps with writing secure code in that you can't accidentally add a statement that you intend to be in the control flow block, like was seen in the "goto fail" bug[1].

Also it makes future modifications easier to review since they don't need to add extra braces.

[1] https://en.wikipedia.org/wiki/Unreachable_code#goto_fail_bug

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

* [ ] visual review that there was nothing left outside the braces that should be inside.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
