### PR TITLE
[inbox] delete individual items

### DIFF
--- a/app/src/renderer/features/conversation/conversationSlice.ts
+++ b/app/src/renderer/features/conversation/conversationSlice.ts
@@ -2,6 +2,7 @@ import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import {
   Item,
   NONPROCESSABLE_FETCH_STATUSES,
+  PendingEventType,
   type SourceWithItems,
 } from "../../../types";
 import type { RootState } from "../../store";
@@ -106,6 +107,25 @@ export const updateItemFetchStatus = createAsyncThunk(
   },
 );
 
+export const deleteItem = createAsyncThunk(
+  "conversation/deleteItem",
+  async ({
+    sourceUuid,
+    itemUuid,
+  }: {
+    sourceUuid: string;
+    itemUuid: string;
+  }) => {
+    await window.electronAPI.addPendingItemEvent(
+      itemUuid,
+      PendingEventType.ItemDeleted,
+    );
+    const sourceWithItems =
+      await window.electronAPI.getSourceWithItems(sourceUuid);
+    return { sourceWithItems };
+  },
+);
+
 const conversationSlice = createSlice({
   name: "conversation",
   initialState,
@@ -190,6 +210,11 @@ const conversationSlice = createSlice({
             return item;
           });
         }
+        state.lastFetchTime = Date.now();
+      })
+      .addCase(deleteItem.fulfilled, (state, action) => {
+        const { sourceWithItems } = action.payload;
+        state.conversation = sourceWithItems;
         state.lastFetchTime = Date.now();
       });
   },

--- a/app/src/renderer/locales/en.json
+++ b/app/src/renderer/locales/en.json
@@ -45,7 +45,13 @@
     "pendingReplyTooltip": "The reply is pending and will be sent to the source in the next sync",
     "successReplyTooltip": "Reply sent successfully",
     "seenReplyTooltip": "Reply seen and deleted by source",
-    "alreadyRunning": "The SecureDrop Inbox is already running"
+    "alreadyRunning": "The SecureDrop Inbox is already running",
+    "deleteItemModal": {
+      "title": "Delete item?",
+      "content": "Are you sure you want to delete this item? Deleting is not reversible and will affect all users.",
+      "cancel": "Cancel",
+      "delete": "Delete"
+    }
   },
   "Sidebar": {
     "account": {

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item.css
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item.css
@@ -21,7 +21,7 @@
   background: var(--Colors-Background-bg-primary, #fff);
   padding: var(--spacing-md, 8px) var(--spacing-lg, 12px);
   max-width: 600px;
-  margin-right: 50px;
+  margin-right: 0px;
   word-wrap: break-word;
   word-break: break-word;
   overflow-wrap: anywhere;
@@ -37,7 +37,7 @@
   background: var(--Colors-Background-bg-brand-secondary, #dbeafe);
   padding: var(--spacing-md, 8px) var(--spacing-lg, 12px);
   max-width: 600px;
-  margin-left: 50px;
+  margin-left: 0px;
   word-wrap: break-word;
   word-break: break-word;
   overflow-wrap: anywhere;

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item.tsx
@@ -7,9 +7,15 @@ import "./Item.css";
 import Message from "./Item/Message";
 import File from "./Item/File";
 import { useAppDispatch } from "../../../../hooks";
-import { updateItemFetchStatus } from "../../../../features/conversation/conversationSlice";
+import {
+  updateItemFetchStatus,
+  deleteItem,
+} from "../../../../features/conversation/conversationSlice";
 
-import { memo, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { Modal } from "antd";
+
+import React, { memo, useCallback } from "react";
 
 interface ItemProps {
   item: Item;
@@ -18,6 +24,8 @@ interface ItemProps {
 
 const Item = memo(function ItemComponent({ item, designation }: ItemProps) {
   const dispatch = useAppDispatch();
+  const { t } = useTranslation("MainContent");
+  const [modal, contextHolder] = Modal.useModal();
 
   const onFetchStatusUpdate = useCallback(
     async (update: ItemUpdate) => {
@@ -34,31 +42,60 @@ const Item = memo(function ItemComponent({ item, designation }: ItemProps) {
     [dispatch, item.data.source],
   );
 
+  const onDeleteItem = useCallback(() => {
+    dispatch(
+      deleteItem({ sourceUuid: item.data.source ?? "", itemUuid: item.uuid }),
+    );
+  }, [dispatch, item.data.source, item.uuid]);
+
+  const onDeleteClick = useCallback(() => {
+    modal.confirm({
+      getContainer: () => document.getElementById("root") || document.body,
+      title: t("deleteItemModal.title"),
+      content: t("deleteItemModal.content"),
+      okText: t("deleteItemModal.delete"),
+      cancelText: t("deleteItemModal.cancel"),
+      okButtonProps: { danger: true },
+      icon: null,
+      onOk: onDeleteItem,
+    });
+  }, [modal, t, onDeleteItem]);
+
   const kind = item.data.kind;
+  let content: React.ReactNode = null;
   if (kind === "message") {
-    return (
+    content = (
       <Message
         kind="message"
         item={item}
         designation={designation}
         onUpdate={onFetchStatusUpdate}
+        onDelete={onDeleteClick}
       />
     );
-  }
-  if (kind === "file") {
-    return (
+  } else if (kind === "file") {
+    content = (
       <File
         item={item}
         designation={designation}
         onUpdate={onFetchStatusUpdate}
+        onDelete={onDeleteClick}
       />
     );
+  } else if (kind === "reply") {
+    content = <Message kind="reply" item={item} onDelete={onDeleteClick} />;
   }
-  if (kind === "reply") {
-    return <Message kind="reply" item={item} onUpdate={onFetchStatusUpdate} />;
+
+  if (content === null) {
+    return null;
   }
-  // Fallback
-  return null;
+
+  return (
+    <>
+      {contextHolder}
+      {content}
+    </>
+  );
 });
 
 export default Item;

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.test.tsx
@@ -5,6 +5,7 @@ import { FetchStatus, type Item } from "../../../../../../types";
 
 describe("File Component Memoization", () => {
   const mockOnUpdate = vi.fn();
+  const mockOnDelete = vi.fn();
   const mockItem: Item = {
     uuid: "item-1",
     data: {
@@ -24,18 +25,43 @@ describe("File Component Memoization", () => {
   };
 
   const cases: Array<
-    [{ item: Item; designation: string; onUpdate: () => void }, number]
+    [
+      {
+        item: Item;
+        designation: string;
+        onUpdate: () => void;
+        onDelete: () => void;
+      },
+      number,
+    ]
   > = [
     // Initial render
-    [{ item: mockItem, designation: "Test Source", onUpdate: mockOnUpdate }, 1],
+    [
+      {
+        item: mockItem,
+        designation: "Test Source",
+        onUpdate: mockOnUpdate,
+        onDelete: mockOnDelete,
+      },
+      1,
+    ],
     // Same props - should not re-render
-    [{ item: mockItem, designation: "Test Source", onUpdate: mockOnUpdate }, 1],
+    [
+      {
+        item: mockItem,
+        designation: "Test Source",
+        onUpdate: mockOnUpdate,
+        onDelete: mockOnDelete,
+      },
+      1,
+    ],
     // Change designation - should re-render
     [
       {
         item: mockItem,
         designation: "Different Source",
         onUpdate: mockOnUpdate,
+        onDelete: mockOnDelete,
       },
       2,
     ],
@@ -45,6 +71,7 @@ describe("File Component Memoization", () => {
         item: { ...mockItem, uuid: "item-2" },
         designation: "Different Source",
         onUpdate: mockOnUpdate,
+        onDelete: mockOnDelete,
       },
       3,
     ],
@@ -58,6 +85,7 @@ describe("File Component Memoization", () => {
         },
         designation: "Different Source",
         onUpdate: mockOnUpdate,
+        onDelete: mockOnDelete,
       },
       4,
     ],
@@ -70,6 +98,7 @@ describe("File Component Memoization", () => {
         },
         designation: "Different Source",
         onUpdate: mockOnUpdate,
+        onDelete: mockOnDelete,
       },
       5,
     ],

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
@@ -284,18 +284,6 @@ const File = memo(function File({
             className="w-80 file-box"
             style={fileBoxStyle}
             onClick={handleClick}
-            onMouseEnter={() =>
-              !disableFetch &&
-              (fetchStatus === FetchStatus.Initial ||
-                fetchStatus === FetchStatus.Cancelled) &&
-              setIsHovered(true)
-            }
-            onMouseLeave={() =>
-              !disableFetch &&
-              (fetchStatus === FetchStatus.Initial ||
-                fetchStatus === FetchStatus.Cancelled) &&
-              setIsHovered(false)
-            }
           >
             <FileInner
               disableFetch={disableFetch}
@@ -303,18 +291,20 @@ const File = memo(function File({
               onUpdate={onUpdate}
             />
           </div>
-          <div
-            className="flex-shrink-0 transition-opacity"
-            style={{ opacity: isHovered ? 1 : 0 }}
-          >
-            <Button
-              type="text"
-              size="small"
-              danger
-              icon={<Trash size={16} />}
-              onClick={onDelete}
-            />
-          </div>
+          {!disableFetch && (
+            <div
+              className="flex-shrink-0 transition-opacity"
+              style={{ opacity: isHovered ? 1 : 0 }}
+            >
+              <Button
+                type="text"
+                size="small"
+                danger
+                icon={<Trash size={16} />}
+                onClick={onDelete}
+              />
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
@@ -17,7 +17,7 @@ import "../Item.css";
 import "./File.css";
 
 import { useTranslation } from "react-i18next";
-import { File as FileIcon, Download, LoaderCircle } from "lucide-react";
+import { File as FileIcon, Download, LoaderCircle, Trash } from "lucide-react";
 import { Button, Tooltip, theme, Dropdown } from "antd";
 import type { MenuProps } from "antd";
 import {
@@ -130,6 +130,7 @@ interface FileProps {
   item: Item;
   designation: string;
   onUpdate: (update: ItemUpdate) => void;
+  onDelete: () => void;
 }
 
 function getFileIconAndColor(filename: string): {
@@ -193,7 +194,12 @@ function getFileIconAndColor(filename: string): {
   return { Icon: FileFilled, color: "#8C8C8C" };
 }
 
-const File = memo(function File({ item, designation, onUpdate }: FileProps) {
+const File = memo(function File({
+  item,
+  designation,
+  onUpdate,
+  onDelete,
+}: FileProps) {
   const { token } = theme.useToken();
   const titleCaseDesignation = toTitleCase(designation);
   const fetchStatus = item.fetch_status;
@@ -265,34 +271,50 @@ const File = memo(function File({ item, designation, onUpdate }: FileProps) {
     <div
       className="flex items-start mb-4 justify-start"
       data-testid={`item-${item.uuid}`}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
     >
       <Avatar designation={titleCaseDesignation ?? ""} isActive={false} />
       <div className="ml-3">
         <div className="flex items-center mb-1">
           <span className="author">{titleCaseDesignation ?? ""}</span>
         </div>
-        <div
-          className="w-80 file-box"
-          style={fileBoxStyle}
-          onClick={handleClick}
-          onMouseEnter={() =>
-            !disableFetch &&
-            (fetchStatus === FetchStatus.Initial ||
-              fetchStatus === FetchStatus.Cancelled) &&
-            setIsHovered(true)
-          }
-          onMouseLeave={() =>
-            !disableFetch &&
-            (fetchStatus === FetchStatus.Initial ||
-              fetchStatus === FetchStatus.Cancelled) &&
-            setIsHovered(false)
-          }
-        >
-          <FileInner
-            item={item}
-            onUpdate={onUpdate}
-            disableFetch={disableFetch}
-          />
+        <div className="flex items-center gap-1">
+          <div
+            className="w-80 file-box"
+            style={fileBoxStyle}
+            onClick={handleClick}
+            onMouseEnter={() =>
+              !disableFetch &&
+              (fetchStatus === FetchStatus.Initial ||
+                fetchStatus === FetchStatus.Cancelled) &&
+              setIsHovered(true)
+            }
+            onMouseLeave={() =>
+              !disableFetch &&
+              (fetchStatus === FetchStatus.Initial ||
+                fetchStatus === FetchStatus.Cancelled) &&
+              setIsHovered(false)
+            }
+          >
+            <FileInner
+              disableFetch={disableFetch}
+              item={item}
+              onUpdate={onUpdate}
+            />
+          </div>
+          <div
+            className="flex-shrink-0 transition-opacity"
+            style={{ opacity: isHovered ? 1 : 0 }}
+          >
+            <Button
+              type="text"
+              size="small"
+              danger
+              icon={<Trash size={16} />}
+              onClick={onDelete}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.test.tsx
@@ -32,6 +32,7 @@ describe("Message Component Memoization", () => {
     decrypted_size: null,
   };
   const mockOnUpdate = vi.fn();
+  const mockOnDelete = vi.fn();
 
   const cases: Array<
     [
@@ -40,6 +41,7 @@ describe("Message Component Memoization", () => {
         item: Item;
         designation: string;
         onUpdate: () => void;
+        onDelete: () => void;
       },
       number,
     ]
@@ -51,6 +53,7 @@ describe("Message Component Memoization", () => {
         item: mockItem,
         designation: "Test Source",
         onUpdate: mockOnUpdate,
+        onDelete: mockOnDelete,
       },
       1,
     ],
@@ -61,6 +64,7 @@ describe("Message Component Memoization", () => {
         item: mockItem,
         designation: "Test Source",
         onUpdate: mockOnUpdate,
+        onDelete: mockOnDelete,
       },
       1,
     ],
@@ -71,6 +75,7 @@ describe("Message Component Memoization", () => {
         item: mockItem,
         designation: "Different Source",
         onUpdate: mockOnUpdate,
+        onDelete: mockOnDelete,
       },
       2,
     ],
@@ -81,6 +86,7 @@ describe("Message Component Memoization", () => {
         item: { ...mockItem, plaintext: "Different message" },
         designation: "Different Source",
         onUpdate: mockOnUpdate,
+        onDelete: mockOnDelete,
       },
       3,
     ],
@@ -91,6 +97,7 @@ describe("Message Component Memoization", () => {
         item: { ...mockItem, plaintext: null },
         designation: "Different Source",
         onUpdate: mockOnUpdate,
+        onDelete: mockOnDelete,
       },
       4,
     ],
@@ -100,7 +107,7 @@ describe("Message Component Memoization", () => {
 });
 
 describe("Reply", () => {
-  const mockOnUpdate = vi.fn();
+  const mockOnDelete = vi.fn();
 
   const mockReplyItem: Item = {
     uuid: "reply-1",
@@ -166,7 +173,7 @@ describe("Reply", () => {
 
     it("should display journalist full name when available", () => {
       const { getByText } = renderWithProviders(
-        <Message kind="reply" item={mockReplyItem} onUpdate={mockOnUpdate} />,
+        <Message kind="reply" item={mockReplyItem} onDelete={mockOnDelete} />,
         { preloadedState: unauthState },
       );
 
@@ -186,7 +193,7 @@ describe("Reply", () => {
         <Message
           kind="reply"
           item={itemWithJournalist2}
-          onUpdate={mockOnUpdate}
+          onDelete={mockOnDelete}
         />,
         { preloadedState: unauthState },
       );
@@ -207,7 +214,7 @@ describe("Reply", () => {
         <Message
           kind="reply"
           item={itemWithJournalist3}
-          onUpdate={mockOnUpdate}
+          onDelete={mockOnDelete}
         />,
         { preloadedState: unauthState },
       );
@@ -228,7 +235,7 @@ describe("Reply", () => {
         <Message
           kind="reply"
           item={itemWithUnknownJournalist}
-          onUpdate={mockOnUpdate}
+          onDelete={mockOnDelete}
         />,
         { preloadedState: unauthState },
       );
@@ -252,7 +259,7 @@ describe("Reply", () => {
 
     it("should display journalist name", () => {
       const { getByText } = renderWithProviders(
-        <Message kind="reply" item={mockReplyItem} onUpdate={mockOnUpdate} />,
+        <Message kind="reply" item={mockReplyItem} onDelete={mockOnDelete} />,
         { preloadedState: offlineState },
       );
 
@@ -261,7 +268,7 @@ describe("Reply", () => {
 
     it("should not display 'You' even if journalist matches offline user", () => {
       const { queryByText, getByText } = renderWithProviders(
-        <Message kind="reply" item={mockReplyItem} onUpdate={mockOnUpdate} />,
+        <Message kind="reply" item={mockReplyItem} onDelete={mockOnDelete} />,
         { preloadedState: offlineState },
       );
 
@@ -290,7 +297,7 @@ describe("Reply", () => {
 
     it("should display 'You' when current user is the author", () => {
       const { getByText } = renderWithProviders(
-        <Message kind="reply" item={mockReplyItem} onUpdate={mockOnUpdate} />, // journalist_uuid is "journalist-1"
+        <Message kind="reply" item={mockReplyItem} onDelete={mockOnDelete} />, // journalist_uuid is "journalist-1"
         { preloadedState: authState },
       );
 
@@ -310,7 +317,7 @@ describe("Reply", () => {
         <Message
           kind="reply"
           item={itemFromOtherJournalist}
-          onUpdate={mockOnUpdate}
+          onDelete={mockOnDelete}
         />,
         { preloadedState: authState },
       );
@@ -338,7 +345,7 @@ describe("Reply", () => {
       };
 
       const { getByText, queryByText } = renderWithProviders(
-        <Message kind="reply" item={mockReplyItem} onUpdate={mockOnUpdate} />, // journalist_uuid is "journalist-1" (Daniel Ellsberg)
+        <Message kind="reply" item={mockReplyItem} onDelete={mockOnDelete} />, // journalist_uuid is "journalist-1" (Daniel Ellsberg)
         { preloadedState: authStateAsJournalist2 },
       );
 
@@ -359,7 +366,7 @@ describe("Reply", () => {
         <Message
           kind="reply"
           item={itemWithUnknownJournalist}
-          onUpdate={mockOnUpdate}
+          onDelete={mockOnDelete}
         />,
         { preloadedState: authState },
       );
@@ -384,7 +391,7 @@ describe("Reply", () => {
       };
 
       const { getByText } = renderWithProviders(
-        <Message kind="reply" item={mockReplyItem} onUpdate={mockOnUpdate} />,
+        <Message kind="reply" item={mockReplyItem} onDelete={mockOnDelete} />,
         { preloadedState: emptyJournalistsState },
       );
 
@@ -410,7 +417,7 @@ describe("Reply", () => {
       };
 
       const { getByText } = renderWithProviders(
-        <Message kind="reply" item={mockReplyItem} onUpdate={mockOnUpdate} />, // journalist_uuid is "journalist-1"
+        <Message kind="reply" item={mockReplyItem} onDelete={mockOnDelete} />, // journalist_uuid is "journalist-1"
         { preloadedState: emptyJournalistsAuthState },
       );
 
@@ -436,7 +443,7 @@ describe("Reply", () => {
       };
 
       const { getByText } = renderWithProviders(
-        <Message kind="reply" item={mockReplyItem} onUpdate={mockOnUpdate} />, // journalist_uuid is "journalist-1"
+        <Message kind="reply" item={mockReplyItem} onDelete={mockOnDelete} />, // journalist_uuid is "journalist-1"
         { preloadedState: loadingState },
       );
 
@@ -462,7 +469,7 @@ describe("Reply", () => {
       };
 
       const { getByText, queryByText } = renderWithProviders(
-        <Message kind="reply" item={mockReplyItem} onUpdate={mockOnUpdate} />, // journalist_uuid is "journalist-1"
+        <Message kind="reply" item={mockReplyItem} onDelete={mockOnDelete} />, // journalist_uuid is "journalist-1"
         { preloadedState: emptyJournalistsAuthState },
       );
 
@@ -514,7 +521,7 @@ describe("Reply", () => {
           <Message
             kind="reply"
             item={pendingReplyItem}
-            onUpdate={mockOnUpdate}
+            onDelete={mockOnDelete}
           />,
           { preloadedState: authState },
         );
@@ -544,7 +551,7 @@ describe("Reply", () => {
           <Message
             kind="reply"
             item={pendingReplyItem}
-            onUpdate={mockOnUpdate}
+            onDelete={mockOnDelete}
           />,
           { preloadedState: authState },
         );
@@ -574,7 +581,7 @@ describe("Reply", () => {
           <Message
             kind="reply"
             item={pendingReplyItem}
-            onUpdate={mockOnUpdate}
+            onDelete={mockOnDelete}
           />,
           { preloadedState: authState },
         );
@@ -604,7 +611,7 @@ describe("Reply", () => {
           <Message
             kind="reply"
             item={pendingReplyItem}
-            onUpdate={mockOnUpdate}
+            onDelete={mockOnDelete}
           />,
           { preloadedState: authState },
         );
@@ -631,7 +638,7 @@ describe("Reply", () => {
           <Message
             kind="reply"
             item={pendingReplyItem}
-            onUpdate={mockOnUpdate}
+            onDelete={mockOnDelete}
           />,
           { preloadedState: offlineState },
         );
@@ -658,7 +665,7 @@ describe("Reply", () => {
           <Message
             kind="reply"
             item={pendingReplyItem}
-            onUpdate={mockOnUpdate}
+            onDelete={mockOnDelete}
           />,
           { preloadedState: unauthState },
         );
@@ -688,7 +695,7 @@ describe("Reply", () => {
 
     it("should display plaintext message when available", () => {
       const { getByText } = renderWithProviders(
-        <Message kind="reply" item={mockReplyItem} onUpdate={mockOnUpdate} />,
+        <Message kind="reply" item={mockReplyItem} onDelete={mockOnDelete} />,
         { preloadedState: authState },
       );
 
@@ -703,7 +710,7 @@ describe("Reply", () => {
       };
 
       const { getByText } = renderWithProviders(
-        <Message kind="reply" item={fetchingReply} onUpdate={mockOnUpdate} />,
+        <Message kind="reply" item={fetchingReply} onDelete={mockOnDelete} />,
         { preloadedState: authState },
       );
 
@@ -718,7 +725,7 @@ describe("Reply", () => {
       };
 
       const { getByText } = renderWithProviders(
-        <Message kind="reply" item={fetchingReply} onUpdate={mockOnUpdate} />,
+        <Message kind="reply" item={fetchingReply} onDelete={mockOnDelete} />,
         { preloadedState: authState },
       );
 
@@ -733,7 +740,7 @@ describe("Reply", () => {
       };
 
       const { getByText } = renderWithProviders(
-        <Message kind="reply" item={decryptingReply} onUpdate={mockOnUpdate} />,
+        <Message kind="reply" item={decryptingReply} onDelete={mockOnDelete} />,
         { preloadedState: authState },
       );
 
@@ -751,7 +758,7 @@ describe("Reply", () => {
         <Message
           kind="reply"
           item={failedDownloadReply}
-          onUpdate={mockOnUpdate}
+          onDelete={mockOnDelete}
         />,
         { preloadedState: authState },
       );
@@ -770,7 +777,7 @@ describe("Reply", () => {
         <Message
           kind="reply"
           item={failedDecryptionReply}
-          onUpdate={mockOnUpdate}
+          onDelete={mockOnDelete}
         />,
         { preloadedState: authState },
       );
@@ -785,7 +792,7 @@ describe("Reply", () => {
       };
 
       const { getByText } = renderWithProviders(
-        <Message kind="reply" item={encryptedReply} onUpdate={mockOnUpdate} />,
+        <Message kind="reply" item={encryptedReply} onDelete={mockOnDelete} />,
         { preloadedState: authState },
       );
 
@@ -799,7 +806,7 @@ describe("Reply", () => {
       };
 
       const { getByText } = renderWithProviders(
-        <Message kind="reply" item={encryptedReply} onUpdate={mockOnUpdate} />,
+        <Message kind="reply" item={encryptedReply} onDelete={mockOnDelete} />,
         { preloadedState: authState },
       );
 
@@ -850,7 +857,7 @@ describe("Reply", () => {
         <Message
           kind="reply"
           item={pendingReplyItem}
-          onUpdate={mockOnUpdate}
+          onDelete={mockOnDelete}
         />,
         { preloadedState: authState },
       );
@@ -860,7 +867,7 @@ describe("Reply", () => {
 
     it("should not display pending icon for regular replies", () => {
       const { queryByTestId } = renderWithProviders(
-        <Message kind="reply" item={mockReplyItem} onUpdate={mockOnUpdate} />, // Has journalist_uuid
+        <Message kind="reply" item={mockReplyItem} onDelete={mockOnDelete} />, // Has journalist_uuid
         { preloadedState: authState },
       );
 
@@ -872,7 +879,7 @@ describe("Reply", () => {
         <Message
           kind="reply"
           item={pendingReplyItem}
-          onUpdate={mockOnUpdate}
+          onDelete={mockOnDelete}
         />,
         { preloadedState: authState },
       );
@@ -880,8 +887,6 @@ describe("Reply", () => {
       const icon = getByTestId("pending-reply-icon");
       expect(icon).toBeInTheDocument();
 
-      // Hover to show tooltip (note: actual tooltip rendering may vary in tests)
-      // The tooltip title is set, which is what matters for accessibility
       const tooltipContainer = icon.parentElement;
       expect(tooltipContainer).toBeInTheDocument();
     });
@@ -903,7 +908,7 @@ describe("Reply", () => {
         <Message
           kind="reply"
           item={pendingReplyItem}
-          onUpdate={mockOnUpdate}
+          onDelete={mockOnDelete}
         />,
         { preloadedState: offlineState },
       );
@@ -992,7 +997,7 @@ describe("Reply", () => {
         <Message
           kind="reply"
           item={pendingReplyItem}
-          onUpdate={mockOnUpdate}
+          onDelete={mockOnDelete}
         />,
         { preloadedState: authState },
       );
@@ -1004,7 +1009,7 @@ describe("Reply", () => {
 
     it("should show sent icon for synced replies not yet seen by source", () => {
       const { getByTestId, queryByTestId } = renderWithProviders(
-        <Message kind="reply" item={sentReplyItem} onUpdate={mockOnUpdate} />,
+        <Message kind="reply" item={sentReplyItem} onDelete={mockOnDelete} />,
         { preloadedState: authState },
       );
 
@@ -1015,7 +1020,7 @@ describe("Reply", () => {
 
     it("should show seen icon when source has seen the reply", () => {
       const { getByTestId, queryByTestId } = renderWithProviders(
-        <Message kind="reply" item={seenReplyItem} onUpdate={mockOnUpdate} />,
+        <Message kind="reply" item={seenReplyItem} onDelete={mockOnDelete} />,
         { preloadedState: authState },
       );
 
@@ -1034,7 +1039,7 @@ describe("Reply", () => {
       };
 
       const { getByTestId, queryByTestId } = renderWithProviders(
-        <Message kind="reply" item={notDeletedItem} onUpdate={mockOnUpdate} />,
+        <Message kind="reply" item={notDeletedItem} onDelete={mockOnDelete} />,
         { preloadedState: authState },
       );
 

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.tsx
@@ -52,6 +52,7 @@ const Message = memo(function Message(props: MessageProps) {
   const [isHovered, setIsHovered] = useState(false);
 
   const sessionState = useAppSelector(getSessionState);
+  const disableDelete = sessionState.status !== SessionStatus.Auth;
 
   const replyData = kind === "reply" ? (item.data as ReplyMetadata) : null;
   const syncState: ReplySyncState | null = replyData
@@ -205,18 +206,20 @@ const Message = memo(function Message(props: MessageProps) {
             <div className="message-box whitespace-pre-wrap overflow-hidden">
               {displayMessage()}
             </div>
-            <div
-              className="flex-shrink-0 transition-opacity"
-              style={{ opacity: isHovered ? 1 : 0 }}
-            >
-              <Button
-                type="text"
-                size="small"
-                danger
-                icon={<Trash size={16} />}
-                onClick={onDelete}
-              />
-            </div>
+            {!disableDelete && (
+              <div
+                className="flex-shrink-0 transition-opacity"
+                style={{ opacity: isHovered ? 1 : 0 }}
+              >
+                <Button
+                  type="text"
+                  size="small"
+                  danger
+                  icon={<Trash size={16} />}
+                  onClick={onDelete}
+                />
+              </div>
+            )}
           </div>
         </div>
       </div>
@@ -235,18 +238,20 @@ const Message = memo(function Message(props: MessageProps) {
           <span className="author reply-author">{authorDisplay}</span>
         </div>
         <div className="flex items-center gap-1">
-          <div
-            className="flex-shrink-0 transition-opacity"
-            style={{ opacity: isHovered ? 1 : 0 }}
-          >
-            <Button
-              type="text"
-              size="small"
-              danger
-              icon={<Trash size={16} />}
-              onClick={onDelete}
-            />
-          </div>
+          {!disableDelete && (
+            <div
+              className="flex-shrink-0 transition-opacity"
+              style={{ opacity: isHovered ? 1 : 0 }}
+            >
+              <Button
+                type="text"
+                size="small"
+                danger
+                icon={<Trash size={16} />}
+                onClick={onDelete}
+              />
+            </div>
+          )}
           <div className="reply-box whitespace-pre-wrap overflow-hidden relative with-status-icon">
             {displayMessage()}
             {statusIcon && (

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useState } from "react";
 import {
   FetchStatus,
   ItemUpdateType,
@@ -10,7 +10,14 @@ import { toTitleCase, formatJournalistName } from "../../../../../utils";
 import Avatar from "../../../../../components/Avatar";
 import TruncatedText from "../../../../../components/TruncatedText";
 import { useTranslation } from "react-i18next";
-import { Loader2, RotateCw, Clock, Check, CheckCheck } from "lucide-react";
+import {
+  Loader2,
+  RotateCw,
+  Trash,
+  Clock,
+  Check,
+  CheckCheck,
+} from "lucide-react";
 import { Button, Tooltip, theme } from "antd";
 import { ExclamationCircleTwoTone } from "@ant-design/icons";
 import {
@@ -30,17 +37,19 @@ type MessageProps =
       item: Item;
       designation: string;
       onUpdate: (update: ItemUpdate) => void;
+      onDelete: () => void;
     }
   | {
       kind: "reply";
       item: Item;
-      onUpdate: (update: ItemUpdate) => void;
+      onDelete: () => void;
     };
 
 const Message = memo(function Message(props: MessageProps) {
-  const { kind, item, onUpdate } = props;
+  const { kind, item, onDelete } = props;
   const { t } = useTranslation("MainContent");
   const { token } = theme.useToken();
+  const [isHovered, setIsHovered] = useState(false);
 
   const sessionState = useAppSelector(getSessionState);
 
@@ -60,7 +69,10 @@ const Message = memo(function Message(props: MessageProps) {
   );
 
   const retryFetch = () => {
-    onUpdate({
+    if (kind !== "message") {
+      return;
+    }
+    props.onUpdate({
       item_uuid: item.uuid,
       type: ItemUpdateType.FetchStatus,
       fetch_status: FetchStatus.DownloadInProgress,
@@ -181,14 +193,30 @@ const Message = memo(function Message(props: MessageProps) {
       <div
         className="flex items-start mb-4 justify-start"
         data-testid={`item-${item.uuid}`}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
       >
         <Avatar designation={authorDisplay} isActive={false} />
         <div className="ml-3">
           <div className="flex items-center mb-1">
             <span className="author">{authorDisplay}</span>
           </div>
-          <div className="message-box whitespace-pre-wrap overflow-hidden">
-            {displayMessage()}
+          <div className="flex items-center gap-1">
+            <div className="message-box whitespace-pre-wrap overflow-hidden">
+              {displayMessage()}
+            </div>
+            <div
+              className="flex-shrink-0 transition-opacity"
+              style={{ opacity: isHovered ? 1 : 0 }}
+            >
+              <Button
+                type="text"
+                size="small"
+                danger
+                icon={<Trash size={16} />}
+                onClick={onDelete}
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -199,22 +227,38 @@ const Message = memo(function Message(props: MessageProps) {
     <div
       className="flex items-start mb-4 justify-end"
       data-testid={`item-${item.uuid}`}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
     >
       <div>
         <div className="flex items-center justify-start mb-1 gap-1">
           <span className="author reply-author">{authorDisplay}</span>
         </div>
-        <div className="reply-box whitespace-pre-wrap overflow-hidden relative with-status-icon">
-          {displayMessage()}
-          {statusIcon && (
-            <Tooltip
-              title={statusIcon.tooltip}
-              placement="topRight"
-              styles={{ root: { position: "fixed" } }}
-            >
-              {statusIcon.icon}
-            </Tooltip>
-          )}
+        <div className="flex items-center gap-1">
+          <div
+            className="flex-shrink-0 transition-opacity"
+            style={{ opacity: isHovered ? 1 : 0 }}
+          >
+            <Button
+              type="text"
+              size="small"
+              danger
+              icon={<Trash size={16} />}
+              onClick={onDelete}
+            />
+          </div>
+          <div className="reply-box whitespace-pre-wrap overflow-hidden relative with-status-icon">
+            {displayMessage()}
+            {statusIcon && (
+              <Tooltip
+                title={statusIcon.tooltip}
+                placement="topRight"
+                styles={{ root: { position: "fixed" } }}
+              >
+                {statusIcon.icon}
+              </Tooltip>
+            )}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #741

Adds deletion of individual items in the application by showing deletion icon next to message/file/reply on hover.

IPC + backend support for item deletion were all already in place, so this just makes that accessible via the UI!

<img width="1180" height="979" alt="image" src="https://github.com/user-attachments/assets/dda6a14c-e560-4f36-8837-3462b2b9ca47" />


## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
