### PR TITLE
Enable sourcemap for renderer build

### DIFF
--- a/app/electron.vite.config.ts
+++ b/app/electron.vite.config.ts
@@ -115,6 +115,7 @@ export default defineConfig(({ mode }) => {
       },
       build: {
         assetsInlineLimit: 0, // Disable inlining assets as data URIs for strict CSP
+        sourcemap: true,
       },
       html:
         mode === "development" || mode === "mac-demo"


### PR DESCRIPTION


## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] Run `pnpm build:unpack` and then `ls out/renderer/assets/` and you should see a `.map` file.
