### PR TITLE
Disable compression of .debs when FAST=1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
           lfs: true
       - name: Build packages
         run: |
-          DEBIAN_VERSION=${{ matrix.debian_version }} WHAT=${{ matrix.what }} BUILDER=securedrop-builder FAST=1 ./scripts/build-debs.sh
+          DEBIAN_VERSION=${{ matrix.debian_version }} WHAT=${{ matrix.what }} BUILDER=securedrop-builder ./scripts/build-debs.sh
       - uses: actions/upload-artifact@v6
         id: upload
         with:

--- a/debian/rules
+++ b/debian/rules
@@ -66,3 +66,9 @@ override_dh_shlibdeps:
 
 override_dh_strip:
 	dh_strip --exclude=securedrop-app
+
+# Skip compression when FAST=1 to speed up local builds
+ifdef FAST
+override_dh_builddeb:
+	dh_builddeb -- -Znone
+endif

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -3,3 +3,4 @@ securedrop-client source: ancient-python-version-field
 securedrop-client source: custom-compression-in-debian-source-options
 securedrop-client source: debhelper-but-no-misc-depends
 securedrop-client source: missing-license-paragraph-in-dep5-copyright
+securedrop-client source: custom-compression-in-debian-rules


### PR DESCRIPTION
This basically turns the dh_builddebs step into an instantaneous one because it just needs to collect the files instead of compressing them.

Despite the file sizes being larger, this'll provide a speedup especially for the `try-client-pr` workflow because we're no longer compressing (at build time) and decompressing (at install time) the same packages.

Notably the FAST builds are no longer reproducible against non-FAST builds, so we can't use them in CI for that purpose. But they will still be reproducible against other FAST builds.

Refs #3097.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] Use `try-client-pr.py 3130` (this PR) and see that it builds and still installs correctly.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
