### PR TITLE
Document why electron-builder is pinned

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -37,6 +37,9 @@
   },
   "keywords": [],
   "license": "AGPL-3.0-or-later",
+  "//": {
+    "electron-builder": "pinned to 26.3.0 because of regressions: https://github.com/freedomofpress/securedrop-client/issues/2996"
+  },
   "devDependencies": {
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",
     "@electron-toolkit/eslint-config-ts": "^3.1.0",


### PR DESCRIPTION
This is less elegant than proper JSON5 comments, but still gets the job done.

Per https://stackoverflow.com/a/14221781 the top-level `//` key is safe to use for this purpose.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
