### PR TITLE
Add explicit dependency on qubes-gpg-split

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,12 +13,12 @@ X-Python3-Version: >= 3.5
 
 Package: securedrop-app
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, qubes-gpg-split
 Description: SecureDrop App for journalists
 
 Package: securedrop-client
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, python3, python3-pyqt5, python3-pyqt5.qtsvg, python3-qubesdb, desktop-file-utils
+Depends: ${shlibs:Depends}, ${misc:Depends}, python3, python3-pyqt5, python3-pyqt5.qtsvg, python3-qubesdb, desktop-file-utils, qubes-gpg-split
 Description: securedrop client for qubes workstation
 
 Package: securedrop-export
@@ -35,6 +35,7 @@ Description: Submission export scripts for SecureDrop Workstation
 
 Package: securedrop-gpg-config
 Architecture: all
+Depends: qubes-gpg-split
 Description: Configures a GPG backend for use in the Qubes split-GPG context
 
 Package: securedrop-keyring


### PR DESCRIPTION
We can reasonably be sure that this is already present in the template but lets add it explicitly.

Follow-up to #3096 now that https://github.com/QubesOS/updates-status/issues/6397 is in the stable repos.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
Should be a no-op in practice.
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
