### PR TITLE
Set an explicit timeout when we shell out to GPG

### DIFF
--- a/app/src/main/crypto.ts
+++ b/app/src/main/crypto.ts
@@ -6,6 +6,10 @@ import * as openpgp from "openpgp";
 import * as fs from "fs";
 import * as path from "path";
 import { PathBuilder, Storage, UnsafePathComponent } from "./storage";
+import { ms } from "../types";
+
+// Allow 3 minutes for decryption, which might need to wait for sd-gpg to start
+const SHELL_TIMEOUT = 180_000 as ms;
 
 export interface CryptoConfig {
   isQubes: boolean;
@@ -78,14 +82,17 @@ export class Crypto {
     }
   }
 
-  /**
-   * Get the environment for running GPG
-   */
-  private getGpgEnv(): NodeJS.ProcessEnv {
+  private getSpawnOptions() {
+    let env: NodeJS.ProcessEnv;
     if (this.isQubes && this.qubesGpgDomain) {
-      return { ...process.env, QUBES_GPG_DOMAIN: this.qubesGpgDomain };
+      env = { ...process.env, QUBES_GPG_DOMAIN: this.qubesGpgDomain };
+    } else {
+      env = process.env;
     }
-    return process.env;
+    return {
+      env: env,
+      timeout: SHELL_TIMEOUT,
+    };
   }
 
   /**
@@ -107,7 +114,7 @@ export class Crypto {
     cmd.push("--export", "--armor", this.submissionKeyFingerprint);
 
     return new Promise((resolve, reject) => {
-      const process = spawn(cmd[0], cmd.slice(1), { env: this.getGpgEnv() });
+      const process = spawn(cmd[0], cmd.slice(1), this.getSpawnOptions());
       let stdout = "";
       let stderr = "";
 
@@ -154,7 +161,7 @@ export class Crypto {
     cmd.push("--decrypt");
 
     return new Promise((resolve, reject) => {
-      const gpgProcess = spawn(cmd[0], cmd.slice(1), { env: this.getGpgEnv() });
+      const gpgProcess = spawn(cmd[0], cmd.slice(1), this.getSpawnOptions());
 
       let stdout = Buffer.alloc(0);
       let stderr = Buffer.alloc(0);
@@ -173,8 +180,10 @@ export class Crypto {
         stderr = Buffer.concat([stderr, chunk]);
       });
 
-      gpgProcess.on("close", async (code) => {
-        if (code !== 0) {
+      gpgProcess.on("close", async (code, signal) => {
+        if (signal) {
+          reject(new Error(`Process terminated with signal ${signal}`));
+        } else if (code !== 0) {
           const errorMessage = stderr.toString("utf8");
           reject(
             new CryptoError(
@@ -221,7 +230,7 @@ export class Crypto {
       const gpgOutputFile = fs.createWriteStream(tempGpgOutput);
       let stderr = Buffer.alloc(0);
 
-      const gpgProcess = spawn(cmd[0], cmd.slice(1), { env: this.getGpgEnv() });
+      const gpgProcess = spawn(cmd[0], cmd.slice(1), this.getSpawnOptions());
 
       // Stream GPG output directly to temporary file (no memory accumulation)
       gpgProcess.stdout.pipe(gpgOutputFile);
@@ -231,10 +240,12 @@ export class Crypto {
         stderr = Buffer.concat([stderr, chunk]);
       });
 
-      gpgProcess.on("close", async (code) => {
+      gpgProcess.on("close", async (code, signal) => {
         gpgOutputFile.end();
 
-        if (code !== 0) {
+        if (signal) {
+          reject(new Error(`Process terminated with signal ${signal}`));
+        } else if (code !== 0) {
           // Clean up temp directory on error
           fs.rmSync(tempDir.path, { recursive: true, force: true });
           const errorMessage = stderr.toString("utf8");


### PR DESCRIPTION
Unless sd-gpg is starting up, these should be relatively quick. Most of these operations already have much larger timeouts via the queue, but those include the download time as well, so these are narrower timeouts for just these actions to prevent it from hanging for a long time.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] visual review should be sufficient. Could do a basic smoke test if you want to.
* [x] verify no process shell outs were missed
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
