### PR TITLE
Configure Electron fuses, document others

### DIFF
--- a/app/electron-builder.yml
+++ b/app/electron-builder.yml
@@ -16,6 +16,19 @@ extraResources:
   - from: src/main/database/migrations
     to: migrations
 npmRebuild: false
+electronFuses:
+  runAsNode: false
+  # We don't use cookies but if we enable this it's going to prompt for a keychain password
+  # enableCookieEncryption: false
+  enableNodeCliInspectArguments: false
+  enableNodeOptionsEnvironmentVariable: false
+  # TODO: once we switch to a custom protocol, we should disable file://
+  # grantFileProtocolExtraPrivileges: false
+  # We don't use custom V8 snapshots
+  # loadBrowserProcessSpecificV8Snapshot: false
+  # The asar stuff is only useful on Windows/macOS with codesigning
+  # enableEmbeddedAsarIntegrityValidation: false
+  # onlyLoadAppFromAsar: false
 linux:
   extraResources:
     - from: node_modules/@dbmate/linux-x64/bin/dbmate


### PR DESCRIPTION
* Enable two fuses that disable some node debugging/override options.
* Document why we don't enable others, like cookie encryption, ASAR validation, etc.
* Leave a TODO to flip the file:// protocol one, once we switch to a custom protocol.


## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] Use try-client-pr to verify production builds in SDW, do a smoke test that basic functionality all works.
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
