### PR TITLE
Raise dependabot cooldown to 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,14 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 5
+      default-days: 7
 
   - package-ecosystem: npm
     directory: "/app"
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 5
+      default-days: 7
     groups:
       frontend:
         patterns:
@@ -61,7 +61,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 5
+      default-days: 7
     allow:
       - dependency-type: "development"
   - package-ecosystem: "pip"
@@ -69,7 +69,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 5
+      default-days: 7
     allow:
       - dependency-type: "development"
     ignore:
@@ -83,7 +83,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 5
+      default-days: 7
     allow:
       - dependency-type: "development"
     groups:
@@ -95,7 +95,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 5
+      default-days: 7
     allow:
       - dependency-type: "development"
     groups:
@@ -107,7 +107,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 5
+      default-days: 7
     allow:
       - dependency-type: "development"
     groups:


### PR DESCRIPTION
This is what zizmor wants now. See also https://github.com/freedomofpress/securedrop-dev-docs/pull/291.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
