### PR TITLE
Adjust non-production warning to avoid vertical scrollbar

### DIFF
--- a/app/src/renderer/App.tsx
+++ b/app/src/renderer/App.tsx
@@ -12,7 +12,7 @@ function App() {
   return (
     <>
       {!__IS_PRODUCTION__ && (
-        <div className="bg-red-800 text-white text-center p-1">
+        <div className="fixed bottom-1 left-1 z-50 bg-red-700 text-white text-xs font-bold py-1 px-4 leading-tight rounded">
           {t("nonProduction")}
         </div>
       )}


### PR DESCRIPTION
In dev mode, the "WARNING: non-production mode" bar at the top was bothering me because it forced a vertical scrollbar on the whole window. This adjusts the css for that warning div to make it fixed position in the bottom-left, as an overlay that's always there. I chose the bottom left so that it won't get in the way of UI components:

<img width="3000" height="1960" alt="image" src="https://github.com/user-attachments/assets/dcaea404-6615-4859-a0bd-934dbcd57f54" />


## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
