### PR TITLE
[app] paginate item fetch from conversation

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -36,6 +36,7 @@ import { Search } from "./search";
 // Truncate message previews to 200 Unicode code points
 // at the database layer; CSS will handle the rest
 export const MESSAGE_PREVIEW_LENGTH = 200;
+const DEFAULT_ITEM_LIMIT = 100;
 
 interface KeyObject {
   [key: string]: object;
@@ -129,7 +130,11 @@ export class DB {
 
   private selectAllSources: Statement<[], SourceRow>;
   private selectSourceById: Statement<[string], SourceRow>;
-  private selectItemsBySourceId: Statement<[string], ItemRow>;
+  private selectItemsBySourceId: Statement<[string, number], ItemRow>;
+  private selectItemsBySourceIdBefore: Statement<
+    [string, number, number],
+    ItemRow
+  >;
   private selectAllJournalists: Statement<[], JournalistRow>;
   private insertSourcePendingEvent: Statement<
     {
@@ -305,7 +310,14 @@ export class DB {
     this.selectItemsBySourceId = this.db.prepare(`
       SELECT uuid, data, plaintext, filename, fetch_status, fetch_progress, decrypted_size, is_read FROM items_projected
       WHERE source_uuid = ?
-      ORDER BY interaction_count ASC
+      ORDER BY interaction_count DESC
+      LIMIT ?
+    `);
+    this.selectItemsBySourceIdBefore = this.db.prepare(`
+      SELECT uuid, data, plaintext, filename, fetch_status, fetch_progress, decrypted_size FROM items_projected
+      WHERE source_uuid = ? AND interaction_count < ?
+      ORDER BY interaction_count DESC
+      LIMIT ?
     `);
     this.selectAllJournalists = this.db.prepare(`
       SELECT uuid, data FROM journalists
@@ -709,7 +721,14 @@ export class DB {
     });
   }
 
-  getSourceWithItems(sourceUuid: string): SourceWithItems {
+  getSourceWithItems(
+    sourceUuid: string,
+    options?: {
+      limit?: number;
+      beforeInteractionCount?: number;
+      journalistUuid?: string;
+    },
+  ): SourceWithItems {
     if (!this.db) {
       throw new Error("Database is not open");
     }
@@ -724,7 +743,25 @@ export class DB {
 
     const sourceData = JSON.parse(sourceRow.data);
 
-    const itemRows = this.selectItemsBySourceId.all(sourceUuid);
+    let limit = DEFAULT_ITEM_LIMIT;
+    if (options?.limit) {
+      limit = options?.limit;
+    }
+    // Fetch limit+1 rows to detect if there are more historical items
+    const fetchLimit = limit + 1;
+    let rows: ItemRow[];
+    if (options?.beforeInteractionCount) {
+      rows = this.selectItemsBySourceIdBefore.all(
+        sourceUuid,
+        options.beforeInteractionCount,
+        fetchLimit,
+      );
+    } else {
+      rows = this.selectItemsBySourceId.all(sourceUuid, fetchLimit);
+    }
+    const hasMoreHistoricalItems = rows.length > limit;
+    // Take at most `limit` rows (DESC order), then reverse to ASC for display
+    const itemRows = rows.slice(0, limit).reverse();
 
     const items = itemRows.map((row) => {
       const data = JSON.parse(row.data) as ItemMetadata;
@@ -742,10 +779,40 @@ export class DB {
       };
     });
 
+    // Return most recently seen message: all replies are seen, if journalistUuid is specified
+    // use seen_by field, otherwise fallback to the is_read field
+    const journalistUuid = options?.journalistUuid;
+    let maxSeenInteractionCount: number | null = null;
+    for (const item of items) {
+      const interaction = item.data.interaction_count ?? null;
+      if (interaction === null) {
+        continue;
+      }
+      let hasBeenSeen: boolean;
+      if (journalistUuid) {
+        hasBeenSeen = item.data.seen_by.includes(journalistUuid);
+      } else if (item.data.kind !== "reply") {
+        hasBeenSeen = item.data.is_read;
+      } else {
+        hasBeenSeen = true;
+      }
+      if (
+        hasBeenSeen &&
+        (maxSeenInteractionCount === null ||
+          interaction > maxSeenInteractionCount)
+      ) {
+        maxSeenInteractionCount = interaction;
+      }
+    }
+    // If nothing has been seen, return null
+    const lastSeenInteractionCount = maxSeenInteractionCount ?? null;
+
     return {
       uuid: sourceRow.uuid,
       data: sourceData as SourceMetadata,
       items,
+      hasMoreHistoricalItems,
+      lastSeenInteractionCount,
     };
   }
 

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -346,8 +346,16 @@ if (!gotTheLock) {
 
       ipcMain.handle(
         "getSourceWithItems",
-        async (_event, sourceUuid: string): Promise<SourceWithItems> => {
-          const sourceWithItems = db.getSourceWithItems(sourceUuid);
+        async (
+          _event,
+          sourceUuid: string,
+          options?: {
+            limit?: number;
+            beforeInteractionCount?: number;
+            journalistUuid?: string;
+          },
+        ): Promise<SourceWithItems> => {
+          const sourceWithItems = db.getSourceWithItems(sourceUuid, options);
           return sourceWithItems;
         },
       );

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -65,8 +65,14 @@ const electronAPI = {
   ),
   getSourceWithItems: logIpcCall<SourceWithItems>(
     "getSourceWithItems",
-    (sourceUuid: string) =>
-      ipcRenderer.invoke("getSourceWithItems", sourceUuid),
+    (
+      sourceUuid: string,
+      options?: {
+        limit?: number;
+        beforeInteractionCount?: number;
+        journalistUuid?: string;
+      },
+    ) => ipcRenderer.invoke("getSourceWithItems", sourceUuid, options),
   ),
   getItem: logIpcCall<Item | null>("getItem", (itemUuid: string) =>
     ipcRenderer.invoke("getItem", itemUuid),

--- a/app/src/renderer/features/conversation/conversationSlice.test.ts
+++ b/app/src/renderer/features/conversation/conversationSlice.test.ts
@@ -131,6 +131,8 @@ describe("conversationSlice", () => {
         loading: false,
         error: null,
         lastFetchTime: null,
+        hasMoreHistoricalItems: false,
+        olderItemsLoading: false,
       });
     });
   });
@@ -143,6 +145,8 @@ describe("conversationSlice", () => {
         loading: false,
         error: "Some error message",
         lastFetchTime: null,
+        hasMoreHistoricalItems: false,
+        olderItemsLoading: false,
       };
 
       const action = clearError();
@@ -162,6 +166,8 @@ describe("conversationSlice", () => {
         loading: false,
         error: null,
         lastFetchTime: 123456789,
+        hasMoreHistoricalItems: false,
+        olderItemsLoading: false,
       };
 
       const action = clearConversation();
@@ -176,7 +182,9 @@ describe("conversationSlice", () => {
     it("handles successful fetch", async () => {
       await (store.dispatch as any)(fetchConversation("source-1"));
 
-      expect(mockGetSourceWithItems).toHaveBeenCalledWith("source-1");
+      expect(mockGetSourceWithItems).toHaveBeenCalledWith("source-1", {
+        limit: 100,
+      });
       expect(mockGetSourceWithItems).toHaveBeenCalledTimes(1);
 
       const state = (store.getState() as any).conversation;
@@ -254,6 +262,8 @@ describe("conversationSlice", () => {
         loading: false,
         error: "Test error",
         lastFetchTime: 123456789,
+        hasMoreHistoricalItems: false,
+        olderItemsLoading: false,
       },
       sync: {
         error: null,

--- a/app/src/renderer/features/conversation/conversationSlice.ts
+++ b/app/src/renderer/features/conversation/conversationSlice.ts
@@ -8,6 +8,8 @@ export interface ConversationState {
   loading: boolean;
   error: string | null;
   lastFetchTime: number | null;
+  hasMoreHistoricalItems: boolean;
+  olderItemsLoading: boolean;
 }
 
 const initialState: ConversationState = {
@@ -15,15 +17,21 @@ const initialState: ConversationState = {
   loading: false,
   error: null,
   lastFetchTime: null,
+  hasMoreHistoricalItems: false,
+  olderItemsLoading: false,
 };
+
+const CONVERSATION_PAGE_SIZE = 100;
 
 export const fetchConversation = createAsyncThunk(
   "conversation/fetchConversation",
   async (sourceUuid: string, { dispatch }) => {
-    const sourceWithItems =
-      await window.electronAPI.getSourceWithItems(sourceUuid);
+    const sourceWithItems = await window.electronAPI.getSourceWithItems(
+      sourceUuid,
+      { limit: CONVERSATION_PAGE_SIZE },
+    );
 
-    // Mark all items in this conversation as seen via a single SourceConversationSeen event
+    // Mark all items in this conversation as seen
     const maxInteractionCount = sourceWithItems.items.reduce(
       (max, item) => Math.max(max, item.data.interaction_count ?? 0),
       0,
@@ -39,6 +47,42 @@ export const fetchConversation = createAsyncThunk(
     }
 
     return { sourceUuid, sourceWithItems };
+  },
+);
+
+export const fetchOlderConversationItems = createAsyncThunk(
+  "conversation/fetchOlderConversationItems",
+  async (sourceUuid: string, { getState, dispatch }) => {
+    const state = getState() as RootState;
+    const conversation = state.conversation.conversation;
+    if (!conversation || conversation.uuid !== sourceUuid) {
+      return null;
+    }
+
+    const oldestItem = conversation.items[0];
+    const beforeInteractionCount = oldestItem?.data.interaction_count;
+
+    const sourceWithItems = await window.electronAPI.getSourceWithItems(
+      sourceUuid,
+      { limit: CONVERSATION_PAGE_SIZE, beforeInteractionCount },
+    );
+
+    // Mark all older items in this conversation as seen
+    const maxInteractionCount = sourceWithItems.items.reduce(
+      (max, item) => Math.max(max, item.data.interaction_count ?? 0),
+      0,
+    );
+    if (maxInteractionCount > 0) {
+      const created = await window.electronAPI.addPendingSourceConversationSeen(
+        sourceUuid,
+        maxInteractionCount,
+      );
+      if (created) {
+        dispatch(fetchSources());
+      }
+    }
+
+    return sourceWithItems;
   },
 );
 
@@ -74,6 +118,8 @@ const conversationSlice = createSlice({
     clearConversation: (state) => {
       state.conversation = null;
       state.lastFetchTime = null;
+      state.hasMoreHistoricalItems = false;
+      state.olderItemsLoading = false;
     },
     updateItem: (state, action) => {
       const updatedItem: Item = action.payload;
@@ -98,11 +144,32 @@ const conversationSlice = createSlice({
         state.error = null;
         const { sourceWithItems } = action.payload;
         state.conversation = sourceWithItems;
+        state.hasMoreHistoricalItems =
+          sourceWithItems.hasMoreHistoricalItems ?? false;
         state.lastFetchTime = Date.now();
       })
       .addCase(fetchConversation.rejected, (state, action) => {
         state.loading = false;
         state.error = action.error.message || "Failed to fetch conversation";
+      })
+      .addCase(fetchOlderConversationItems.pending, (state) => {
+        state.olderItemsLoading = true;
+      })
+      .addCase(fetchOlderConversationItems.fulfilled, (state, action) => {
+        state.olderItemsLoading = false;
+        if (!action.payload || !state.conversation) {
+          return;
+        }
+        const { items, hasMoreHistoricalItems } = action.payload;
+        const existingUuids = new Set(
+          state.conversation.items.map((i) => i.uuid),
+        );
+        const olderItems = items.filter((i) => !existingUuids.has(i.uuid));
+        state.conversation.items = [...olderItems, ...state.conversation.items];
+        state.hasMoreHistoricalItems = hasMoreHistoricalItems ?? false;
+      })
+      .addCase(fetchOlderConversationItems.rejected, (state) => {
+        state.olderItemsLoading = false;
       })
       .addCase(updateItemFetchStatus.fulfilled, (state, action) => {
         const { item: updatedItem } = action.payload;
@@ -131,5 +198,9 @@ export const selectLastConversation = (state: RootState) =>
   state.conversation.conversation;
 export const selectConversationLoading = (state: RootState) =>
   state.conversation.loading;
+export const selectHasMoreHistoricalItems = (state: RootState) =>
+  state.conversation.hasMoreHistoricalItems;
+export const selectOlderItemsLoading = (state: RootState) =>
+  state.conversation.olderItemsLoading;
 
 export default conversationSlice.reducer;

--- a/app/src/renderer/features/journalists/journalistsSlice.test.ts
+++ b/app/src/renderer/features/journalists/journalistsSlice.test.ts
@@ -10,6 +10,7 @@ import journalistsReducer, {
   getJournalistsError,
   type JournalistsState,
 } from "./journalistsSlice";
+import type { RootState } from "../../store";
 
 // Mock electronAPI
 const mockElectronAPI = {
@@ -195,7 +196,7 @@ describe("journalistsSlice", () => {
   });
 
   describe("selectors", () => {
-    const mockRootState = {
+    const mockRootState: RootState = {
       journalists: loadedState,
       session: {} as any, // Mock other state slices
       sources: {
@@ -210,6 +211,8 @@ describe("journalistsSlice", () => {
         loading: false,
         error: null,
         lastFetchTime: null,
+        hasMoreHistoricalItems: false,
+        olderItemsLoading: false,
       },
       sync: {
         error: null,

--- a/app/src/renderer/features/sources/sourcesSlice.test.ts
+++ b/app/src/renderer/features/sources/sourcesSlice.test.ts
@@ -18,7 +18,9 @@ import sessionSlice, {
   SessionStatus,
   type SessionState,
 } from "../session/sessionSlice";
-import conversationSlice from "../conversation/conversationSlice";
+import conversationSlice, {
+  ConversationState,
+} from "../conversation/conversationSlice";
 
 // Mock data matching the structure from test-component-setup.tsx
 const mockSources: SourceType[] = [
@@ -288,11 +290,13 @@ describe("sourcesSlice", () => {
       authData: undefined,
     };
 
-    const mockConversationState = {
+    const mockConversationState: ConversationState = {
       conversation: null,
       loading: false,
       error: null,
       lastFetchTime: null,
+      hasMoreHistoricalItems: false,
+      olderItemsLoading: false,
     };
 
     it("selectSources returns sources array", () => {

--- a/app/src/renderer/features/sync/syncSlice.test.ts
+++ b/app/src/renderer/features/sync/syncSlice.test.ts
@@ -212,7 +212,9 @@ describe("syncSlice", () => {
       await (store.dispatch as any)(syncMetadata(mockAuthData("test-token")));
 
       // Should have called getSourceWithItems for the active source only
-      expect(mockGetSourceWithItems).toHaveBeenCalledWith(activeSourceUuid);
+      expect(mockGetSourceWithItems).toHaveBeenCalledWith(activeSourceUuid, {
+        limit: 100,
+      });
       expect(mockGetSourceWithItems).toHaveBeenCalledTimes(1);
 
       // Sources should be updated

--- a/app/src/renderer/views/Inbox/MainContent.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent.test.tsx
@@ -128,6 +128,8 @@ describe("MainContent Component", () => {
             loading: false,
             error: null,
             lastFetchTime: null,
+            hasMoreHistoricalItems: false,
+            olderItemsLoading: false,
           },
         },
       },
@@ -162,6 +164,8 @@ describe("MainContent Component", () => {
               loading: false,
               error: null,
               lastFetchTime: Date.now(),
+              hasMoreHistoricalItems: false,
+              olderItemsLoading: false,
             },
           },
         },
@@ -259,7 +263,9 @@ describe("MainContent Component", () => {
 
       // Wait for the effect to run
       await waitFor(() => {
-        expect(mockGetSourceWithItems).toHaveBeenCalledWith("source-1");
+        expect(mockGetSourceWithItems).toHaveBeenCalledWith("source-1", {
+          limit: 100,
+        });
       });
     });
   });
@@ -345,6 +351,8 @@ describe("MainContent Component", () => {
               loading: false,
               error: null,
               lastFetchTime: Date.now(),
+              hasMoreHistoricalItems: false,
+              olderItemsLoading: false,
             },
           },
         },
@@ -390,7 +398,7 @@ describe("MainContent Component", () => {
       await waitFor(() => {
         expect(
           (window as any).electronAPI.getSourceWithItems,
-        ).toHaveBeenCalledWith("source-2");
+        ).toHaveBeenCalledWith("source-2", { limit: 100 });
       });
 
       // Header should still show source-1's designation via fallback

--- a/app/src/renderer/views/Inbox/MainContent/Conversation.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation.test.tsx
@@ -495,17 +495,20 @@ describe("Conversation new message indicator", () => {
   const baseItems = [createMessageItem("item-1", 1)];
 
   it("restores indicator from previously seen history", async () => {
-    const source = withItems([
-      createMessageItem("item-1", 1, {
-        seenBy: ["journalist-1"],
-        isRead: true,
-      }),
-      createMessageItem("item-2", 2, {
-        seenBy: ["journalist-1"],
-        isRead: true,
-      }),
-      createMessageItem("item-3", 3),
-    ]);
+    const source: SourceWithItems = {
+      ...withItems([
+        createMessageItem("item-1", 1, {
+          seenBy: ["journalist-1"],
+          isRead: true,
+        }),
+        createMessageItem("item-2", 2, {
+          seenBy: ["journalist-1"],
+          isRead: true,
+        }),
+        createMessageItem("item-3", 3),
+      ]),
+      lastSeenInteractionCount: 2,
+    };
 
     const { store } = renderWithProviders(
       <Conversation sourceWithItems={source} />,
@@ -536,7 +539,7 @@ describe("Conversation new message indicator", () => {
     });
   });
 
-  it("renders divider when new items arrive and scrolls near them", async () => {
+  it("renders divider when new items arrive", async () => {
     const { rerender } = renderWithProviders(
       <Conversation sourceWithItems={withItems(baseItems)} />,
     );
@@ -566,10 +569,6 @@ describe("Conversation new message indicator", () => {
       },
     });
 
-    const offsetSpy = vi
-      .spyOn(HTMLElement.prototype, "offsetTop", "get")
-      .mockReturnValue(400);
-
     rerender(
       <Conversation
         sourceWithItems={withItems([
@@ -581,15 +580,6 @@ describe("Conversation new message indicator", () => {
     );
 
     await screen.findByTestId("new-messages-divider");
-
-    await waitFor(() => {
-      expect(scrollTopValue).toBe(200);
-    });
-
-    const renderedItems = screen.getAllByTestId(/item-/);
-    expect(renderedItems).toHaveLength(3);
-
-    offsetSpy.mockRestore();
   });
 
   it("does not render divider for new replies", async () => {

--- a/app/src/renderer/views/Inbox/MainContent/Conversation.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation.tsx
@@ -16,6 +16,9 @@ import {
 } from "../../../features/drafts/draftsSlice";
 import {
   fetchConversation,
+  fetchOlderConversationItems,
+  selectHasMoreHistoricalItems,
+  selectOlderItemsLoading,
   updateItemFetchStatus,
 } from "../../../features/conversation/conversationSlice";
 import { syncMetadata } from "../../../features/sync/syncSlice";
@@ -67,6 +70,8 @@ const Conversation = memo(function Conversation({
   const { t } = useTranslation("MainContent");
   const dispatch = useAppDispatch();
   const session = useAppSelector((state) => state.session);
+  const hasMoreHistoricalItems = useAppSelector(selectHasMoreHistoricalItems);
+  const olderItemsLoading = useAppSelector(selectOlderItemsLoading);
   const sourceUuid = sourceWithItems?.uuid ?? "";
   const savedDraft = useAppSelector(selectDraft(sourceUuid));
   const [form] = Form.useForm();
@@ -78,9 +83,11 @@ const Conversation = memo(function Conversation({
     dividerItemUuid,
     dynamicRowHeight,
     hasItems,
+    heightsReady,
     listRef,
     newItems,
     oldItems,
+    scrollElement,
   } = useConversationScroll(sourceWithItems);
 
   // Restore draft when switching sources (including initial mount)
@@ -213,6 +220,35 @@ const Conversation = memo(function Conversation({
     return rows;
   }, [oldItems, newItems, dividerIndex]);
 
+  // Load older messages when the user scrolls near the top
+  useEffect(() => {
+    if (!scrollElement) {
+      return;
+    }
+
+    const handleScroll = () => {
+      if (
+        scrollElement.scrollTop <= 50 &&
+        hasMoreHistoricalItems &&
+        !olderItemsLoading &&
+        sourceWithItems
+      ) {
+        dispatch(fetchOlderConversationItems(sourceWithItems.uuid));
+      }
+    };
+
+    scrollElement.addEventListener("scroll", handleScroll);
+    return () => {
+      scrollElement.removeEventListener("scroll", handleScroll);
+    };
+  }, [
+    dispatch,
+    hasMoreHistoricalItems,
+    olderItemsLoading,
+    scrollElement,
+    sourceWithItems,
+  ]);
+
   if (!sourceWithItems) {
     return null;
   }
@@ -231,7 +267,10 @@ const Conversation = memo(function Conversation({
             rowComponent={ConversationRow}
             rowProps={{ virtualRows, designation: designation || "" }}
             listRef={listRef}
-            style={{ height: "100%" }}
+            style={{
+              height: "100%",
+              visibility: heightsReady ? "visible" : "hidden",
+            }}
             className="pt-4"
           />
         ) : (

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/useConversationScroll.ts
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/useConversationScroll.ts
@@ -11,14 +11,19 @@ import type { ListImperativeAPI, DynamicRowHeight } from "react-window";
 
 const NEW_MESSAGE_SEEN_THRESHOLD = 12;
 
-type PendingScrollTarget = "divider" | "bottom" | null;
+type PendingScrollTarget =
+  | "bottom"
+  | { kind: "index"; rowIndex: number }
+  | null;
 
 export interface ConversationScrollState {
   listRef: (api: ListImperativeAPI | null) => void;
+  scrollElement: HTMLElement | null;
   dynamicRowHeight: DynamicRowHeight;
   dividerIndex: number | null;
   dividerItemUuid: string | null;
   hasItems: boolean;
+  heightsReady: boolean;
   oldItems: Item[];
   newItems: Item[];
   acknowledgeNewMessages: () => void;
@@ -31,7 +36,7 @@ export function useConversationScroll(
   const [listAPI, listRef] = useListCallbackRef();
   const sourceUuidRef = useRef<string | null>(null);
   const itemCountRef = useRef<number>(0);
-  const dividerUuidRef = useRef<string | null>(null);
+  const firstItemUuidRef = useRef<string | null>(null);
   const pendingScrollTargetRef = useRef<PendingScrollTarget>(null);
 
   const [_isAutoScrolling, setIsAutoScrollingState] = useState(false);
@@ -50,14 +55,24 @@ export function useConversationScroll(
     key: activeSourceUuid ?? undefined,
   });
 
-  const journalistUUID = useAppSelector(
-    (state) => state.session.authData?.journalistUUID ?? null,
-  );
-  const lastSeenInteractionCount = useAppSelector((state) =>
-    activeSourceUuid
-      ? selectConversationLastSeen(state, activeSourceUuid)
-      : undefined,
-  );
+  // Use heightsReady state to only set items to visible once the rows have
+  // been sized
+  const [heightsReady, setHeightsReady] = useState(false);
+  useEffect(() => {
+    // TODO: shouldn't set state in a hook
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setHeightsReady(false);
+
+    // First raf: initial render + useDynamicRowHeight measures row heights
+    const raf1 = requestAnimationFrame(() => {
+      // Second raf: rows are resized, so now we can display
+      const raf2 = requestAnimationFrame(() => {
+        setHeightsReady(true);
+      });
+      return () => cancelAnimationFrame(raf2);
+    });
+    return () => cancelAnimationFrame(raf1);
+  }, [activeSourceUuid]);
 
   const items = useMemo<Item[]>(
     () => (sourceWithItems ? sourceWithItems.items : []),
@@ -65,45 +80,14 @@ export function useConversationScroll(
   );
   const itemCount = items.length;
   const hasItems = itemCount > 0;
+  const lastSeenInteractionCount = useAppSelector((state) =>
+    activeSourceUuid
+      ? selectConversationLastSeen(state, activeSourceUuid)
+      : undefined,
+  );
   const latestInteractionCount = useMemo(() => {
     return sourceWithItems?.items.at(-1)?.data.interaction_count ?? null;
   }, [sourceWithItems?.items]);
-
-  const historicalLastSeenInteractionCount = useMemo(() => {
-    if (!sourceWithItems) {
-      return null;
-    }
-
-    let maxSeen: number | null = null;
-    for (const item of sourceWithItems.items) {
-      const interaction = item.data.interaction_count;
-      if (interaction == null) {
-        continue;
-      }
-
-      let hasBeenSeen = false;
-      if (journalistUUID) {
-        hasBeenSeen = item.data.seen_by.includes(journalistUUID);
-      } else if (item.data.kind !== "reply") {
-        hasBeenSeen = item.data.is_read;
-      } else {
-        hasBeenSeen = true;
-      }
-
-      if (!hasBeenSeen) {
-        continue;
-      }
-
-      if (maxSeen === null || interaction > maxSeen) {
-        maxSeen = interaction;
-      }
-    }
-
-    return maxSeen;
-  }, [journalistUUID, sourceWithItems]);
-
-  const initialLastSeenInteractionCount =
-    historicalLastSeenInteractionCount ?? latestInteractionCount;
 
   useEffect(() => {
     if (!sourceWithItems || lastSeenInteractionCount !== undefined) {
@@ -112,16 +96,20 @@ export function useConversationScroll(
     dispatch(
       initializeConversationIndicator({
         sourceUuid: sourceWithItems.uuid,
-        lastSeenInteractionCount: initialLastSeenInteractionCount,
+        // If lastSeenInteractionCount is null/undefined, fall back to latest interaction
+        // count so we show most recent message on first-time open.
+        lastSeenInteractionCount:
+          sourceWithItems.lastSeenInteractionCount ?? latestInteractionCount,
       }),
     );
   }, [
     dispatch,
-    initialLastSeenInteractionCount,
     lastSeenInteractionCount,
+    latestInteractionCount,
     sourceWithItems,
   ]);
 
+  // If there are new, unseen messages, get the UUID for the "new messages" divider
   const dividerItemUuid = useMemo(() => {
     if (!sourceWithItems) {
       return null;
@@ -147,31 +135,6 @@ export function useConversationScroll(
     return firstNewItem ? firstNewItem.uuid : null;
   }, [items, lastSeenInteractionCount, sourceWithItems]);
 
-  useEffect(() => {
-    if (!sourceWithItems) {
-      dividerUuidRef.current = null;
-      sourceUuidRef.current = null;
-      itemCountRef.current = 0;
-      pendingScrollTargetRef.current = null;
-      return;
-    }
-
-    const prevSourceUuid = sourceUuidRef.current;
-    const prevCount = itemCountRef.current;
-
-    if (prevSourceUuid !== sourceWithItems.uuid) {
-      pendingScrollTargetRef.current = dividerItemUuid ? "divider" : "bottom";
-    } else if (dividerItemUuid && dividerItemUuid !== dividerUuidRef.current) {
-      pendingScrollTargetRef.current = "divider";
-    } else if (itemCount > prevCount && !dividerItemUuid) {
-      pendingScrollTargetRef.current = "bottom";
-    }
-
-    sourceUuidRef.current = sourceWithItems.uuid;
-    itemCountRef.current = itemCount;
-    dividerUuidRef.current = dividerItemUuid;
-  }, [dividerItemUuid, itemCount, sourceWithItems]);
-
   const { oldItems, newItems } = useMemo(() => {
     if (!dividerItemUuid) {
       return { oldItems: items, newItems: [] as typeof items };
@@ -190,6 +153,48 @@ export function useConversationScroll(
 
   const dividerIndex = dividerItemUuid !== null ? oldItems.length : null;
 
+  // Set the scroll target:
+  // If switching to this conversation and there is a new messages divider,
+  // we scroll to the divider. If there are no new messages, we default to bottom.
+  // On historical load, we restore the scroll by centering the last visible row
+  useEffect(() => {
+    if (!sourceWithItems) {
+      sourceUuidRef.current = null;
+      itemCountRef.current = 0;
+      firstItemUuidRef.current = null;
+      pendingScrollTargetRef.current = null;
+      return;
+    }
+
+    const prevSourceUuid = sourceUuidRef.current;
+    const prevCount = itemCountRef.current;
+    const prevFirstItemUuid = firstItemUuidRef.current;
+    const newFirstItemUuid = sourceWithItems.items[0]?.uuid ?? null;
+
+    if (prevSourceUuid !== sourceWithItems.uuid) {
+      pendingScrollTargetRef.current = dividerIndex
+        ? { kind: "index", rowIndex: dividerIndex }
+        : "bottom";
+    } else if (itemCount > prevCount) {
+      if (
+        prevFirstItemUuid !== null &&
+        newFirstItemUuid !== prevFirstItemUuid
+      ) {
+        // On historical load (prepends items to top), restore the scroll
+        // position by scrolling to what was previously the first visible row.
+        const numPrepended = itemCount - prevCount;
+        pendingScrollTargetRef.current = {
+          kind: "index",
+          rowIndex: numPrepended,
+        };
+      }
+    }
+
+    sourceUuidRef.current = sourceWithItems.uuid;
+    itemCountRef.current = itemCount;
+    firstItemUuidRef.current = newFirstItemUuid;
+  }, [dividerIndex, dividerItemUuid, itemCount, sourceWithItems]);
+
   const scrollToRowWithRetry = useCallback(
     (index: number, align: "start" | "center" | "end", maxRetries: number) => {
       if (!listAPI) {
@@ -206,22 +211,6 @@ export function useConversationScroll(
     },
     [listAPI],
   );
-
-  const scrollToDivider = useCallback(() => {
-    if (dividerIndex === null) {
-      return false;
-    }
-    return scrollToRowWithRetry(dividerIndex, "center", 5);
-  }, [dividerIndex, scrollToRowWithRetry]);
-
-  const scrollToBottom = useCallback(() => {
-    const totalRows =
-      oldItems.length + (dividerIndex !== null ? 1 : 0) + newItems.length;
-    if (totalRows === 0) {
-      return false;
-    }
-    return scrollToRowWithRetry(totalRows - 1, "end", 5);
-  }, [oldItems.length, newItems.length, dividerIndex, scrollToRowWithRetry]);
 
   const scheduleAutoScrollReset = useCallback(() => {
     requestAnimationFrame(() => setIsAutoScrolling(false));
@@ -248,17 +237,27 @@ export function useConversationScroll(
       return;
     }
 
+    let rowIndex: number;
+    let align: "start" | "center" | "end";
+
+    if (target === "bottom") {
+      const totalRows =
+        oldItems.length + (dividerIndex !== null ? 1 : 0) + newItems.length;
+      if (totalRows === 0) {
+        return;
+      }
+      rowIndex = totalRows - 1;
+      align = "end";
+    } else {
+      rowIndex = target.rowIndex;
+      align = "center";
+    }
+
     // TODO: we shouldn't set state in an effect
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setIsAutoScrolling(true);
 
-    if (target === "divider" && dividerItemUuid && scrollToDivider()) {
-      pendingScrollTargetRef.current = null;
-      scheduleAutoScrollReset();
-      return;
-    }
-
-    if (target === "bottom" && scrollToBottom()) {
+    if (scrollToRowWithRetry(rowIndex, align, 5)) {
       pendingScrollTargetRef.current = null;
       scheduleAutoScrollReset();
       return;
@@ -266,13 +265,14 @@ export function useConversationScroll(
 
     setIsAutoScrolling(false);
   }, [
-    dividerItemUuid,
+    dividerIndex,
     hasItems,
     itemCount,
+    newItems.length,
+    oldItems.length,
     scheduleAutoScrollReset,
     setIsAutoScrolling,
-    scrollToBottom,
-    scrollToDivider,
+    scrollToRowWithRetry,
   ]);
 
   useEffect(() => {
@@ -296,10 +296,12 @@ export function useConversationScroll(
 
   return {
     listRef: listRef as (api: ListImperativeAPI | null) => void,
+    scrollElement: listAPI?.element ?? null,
     dynamicRowHeight,
     dividerIndex,
     dividerItemUuid,
     hasItems,
+    heightsReady,
     oldItems,
     newItems,
     acknowledgeNewMessages,

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -120,6 +120,8 @@ export type SourceWithItems = {
   uuid: string;
   data: SourceMetadata;
   items: Item[];
+  hasMoreHistoricalItems?: boolean;
+  lastSeenInteractionCount?: number | null;
 };
 
 export type Journalist = {


### PR DESCRIPTION
Fixes #3128 

Sets a default page size of 100 and only fetches historical pages when we scroll far enough back in the window. Presumably this is a large enough page size that almost all SecureDrop conversations will fall within one page, but it sets a cap to prevent performance impact in the event of an overly large or potentially spammy conversation.

Because we do not fetch the items in the frontend until the page is exhausted, the historical scroll behavior means that the scrollbar size adjusts as the historical pages are fetched. 

This also tries to simplify some of our scroll logic by:

- Returning the last seen interaction_count from `getSourceWithItems`
- Removing the autoscroll to new messages while a conversation is still active. While testing, it seemed like a counter-intuitive behavior to have the conversation autoscroll when still open, so now we just render the indicator but only jump to the indicator on switching from an old conversation

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

- Run a localdev SecureDrop server 
- Load some sources with large # of messages (`NUM_SOURCES=2 make dev-load-data SD_LOADDATA_ARGS="--messages-per-source 500" `)
- Start the SecureDrop client
- Download + decrypt for large message # may take some time (experience could be improved as noted in https://github.com/freedomofpress/securedrop-client/issues/3184)
- Once fetch is complete, select one of the large conversations. Initial behavior should be to fetch the first 100 messages to render
- Scrolling up in the window should show messages, and once 100 messages have been reached (top of scroll bar), the client should fetch more historical messages. This will result in the scrollbar becoming smaller + next history should load 
- Should be able to keep progressively scrolling back, with historical fetches + additional conversation items being added  every 100 messages. 

 - Send new messages in one of the large message sources
 - Opening the conversation should render the `new message indicator` within the scroll view.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
