### PR TITLE
[app] terminate worker before app shutdown

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -237,6 +237,8 @@ if (!gotTheLock) {
     return worker;
   }
 
+  let fetchWorker: Worker | null = null;
+
   // This method will be called when Electron has finished
   // initialization and is ready to create browser windows.
   // Some APIs can only be used after this event occurs.
@@ -403,7 +405,7 @@ if (!gotTheLock) {
             }
           }
           db.updateFetchStatus(itemUuid, fetchStatus);
-          fetchWorker.postMessage({
+          fetchWorker?.postMessage({
             authToken: authToken,
           } as AuthedRequest);
         },
@@ -428,7 +430,7 @@ if (!gotTheLock) {
             }
 
             // Trigger fetch worker for new replies
-            fetchWorker.postMessage({
+            fetchWorker?.postMessage({
               authToken: request.authToken,
             } as AuthedRequest);
           }
@@ -709,7 +711,7 @@ if (!gotTheLock) {
 
       const mainWindow = createWindow();
 
-      const fetchWorker = spawnFetchWorker(mainWindow);
+      fetchWorker = spawnFetchWorker(mainWindow);
     })
     .catch((error) => {
       console.error("Unhandled error during app startup:", error);
@@ -722,6 +724,9 @@ if (!gotTheLock) {
 
   app.on("before-quit", () => {
     db.close();
+    if (fetchWorker) {
+      void fetchWorker.terminate();
+    }
   });
 }
 


### PR DESCRIPTION
Fixes uncaught exception on app shutdown when the app shuts down before the worker process terminates

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
