### PR TITLE
Fix tests on computers with lots of cores

### DIFF
--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -5,6 +5,12 @@ import { resolve } from "path";
 export default defineConfig({
   plugins: [react()],
   test: {
+    pool: "forks",
+    poolOptions: {
+      forks: {
+        maxForks: 4,
+      },
+    },
     setupFiles: [
       "./src/test-setup.ts",
       "./src/renderer/test-component-setup.tsx",


### PR DESCRIPTION
I've developing on my fairly-powerful Framework laptop and I started hitting a problem where many tests in the `main` branch fail, even though they pass in CI. After a bunch of troubleshooting, I discovered it's because I have 16 cores, and vitest was spawning 15  parallel workers, and this was overwhelming something in my system, causing tests to timeout and fail.

If we cap the max number of parallel workers in vitest to 4, they all pass.

Here's the output of the test failures with too many parallel workers:

```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL   component  src/renderer/views/SignIn.test.tsx > SignInView Component > says title and version
Error: Test timed out in 5000ms.
If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
 ❯ src/renderer/views/SignIn.test.tsx:9:3
      7| 
      8| describe("SignInView Component", () => {
      9|   it("says title and version", async () => {
       |   ^
     10|     renderWithProviders(<SignInView />);
     11| 

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/4]⎯

 FAIL   component  src/renderer/views/Inbox/MainContent/Conversation.test.tsx > Conversation Component Memoization > should handle memoization correctly
Error: Test timed out in 5000ms.
If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
 ❯ src/renderer/views/Inbox/MainContent/Conversation.test.tsx:204:3
    202|   ];
    203| 
    204|   it(
       |   ^
    205|     "should handle memoization correctly",
    206|     testMemoization(Conversation, cases),

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/4]⎯

 FAIL   component  src/renderer/views/Inbox/MainContent/Conversation.test.tsx > Conversation new message indicator > restores indicator from previously seen history
Error: expect(element).toBeInTheDocument()

element could not be found in the document
 ❯ src/renderer/views/Inbox/MainContent/Conversation.test.tsx:513:7
    511|     expect(
    512|       await screen.findByTestId("new-messages-divider"),
    513|     ).toBeInTheDocument();
       |       ^
    514|   });
    515| 

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/4]⎯

 FAIL   component  src/renderer/views/Inbox/MainContent/Header/SourceMenu.test.tsx > SourceMenu Component > Memoization > should handle memoization correctly
Error: Test timed out in 5000ms.
If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
 ❯ src/renderer/views/Inbox/MainContent/Header/SourceMenu.test.tsx:73:5
     71|     ];
     72| 
     73|     it(
       |     ^
     74|       "should handle memoization correctly",
     75|       testMemoization(SourceMenu, cases),

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/4]⎯


 Test Files  3 failed | 39 passed (42)
      Tests  4 failed | 669 passed (673)
   Start at  10:44:10
   Duration  22.29s (transform 3.42s, setup 0ms, collect 85.44s, tests 127.66s, environment 31.71s, prepare 10.15s)

 ELIFECYCLE  Test failed. See above for more details.
```