### PR TITLE
Reject control characters in paths

### DIFF
--- a/app/src/main/storage.test.ts
+++ b/app/src/main/storage.test.ts
@@ -62,6 +62,18 @@ describe("PathBuilder", () => {
         "Invalid path component: path/to/file",
       );
     });
+
+    it("should reject control characters", () => {
+      expect(() => builder.validate("file\x00name")).toThrow(
+        "Path component contains control characters",
+      );
+      expect(() => builder.validate("file\nname")).toThrow(
+        "Path component contains control characters",
+      );
+      expect(() => builder.validate("file\x7fname")).toThrow(
+        "Path component contains control characters",
+      );
+    });
   });
 
   describe("getSubBuilder", () => {

--- a/app/src/main/storage.ts
+++ b/app/src/main/storage.ts
@@ -38,6 +38,15 @@ export class PathBuilder {
     if (part.includes("/") || part === ".." || part === "." || part === "") {
       throw new Error(`Invalid path component: ${part}`);
     }
+    // Reject terminal control characters; the server strips them so they should
+    // only appear in the case of a compromised server. Alone they can't do much but
+    // in theory could exploit someone looking at logs in a terminal.
+    if (/\p{Cc}/u.test(part)) {
+      // n.b. JSON.stringify escapes the control characters
+      throw new Error(
+        `Path component contains control characters: ${JSON.stringify(part)}`,
+      );
+    }
     return part;
   }
 


### PR DESCRIPTION
These should never actually happen because the server sanitizes the filename using werkzeug's secure_filename(), which strips them.

So if there's a compromised or buggy server, reject these characters which alone can't exploit anything, but could e.g. interfere with someone examining logs.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
