### PR TITLE
Propagate SyncStatus.ERROR if an exception is thrown

### DIFF
--- a/app/src/renderer/features/sync/syncSlice.test.ts
+++ b/app/src/renderer/features/sync/syncSlice.test.ts
@@ -249,6 +249,16 @@ describe("syncSlice", () => {
       expect(mockGetSources).not.toHaveBeenCalled();
     });
 
+    it("sets ERROR status when sync thunk rejects", async () => {
+      mockSyncMetadata.mockRejectedValue(new Error("items.kind is immutable"));
+
+      await (store.dispatch as any)(syncMetadata(mockAuthData("test-token")));
+
+      const syncState = (store.getState() as any).sync;
+      expect(syncState.status).toBe(SyncStatus.ERROR);
+      expect(syncState.error).toBe("items.kind is immutable");
+    });
+
     it("handles non-Error rejection for syncMetadata", async () => {
       mockSyncMetadata.mockRejectedValue("String error");
 

--- a/app/src/renderer/features/sync/syncSlice.ts
+++ b/app/src/renderer/features/sync/syncSlice.ts
@@ -89,6 +89,7 @@ export const syncSlice = createSlice({
       })
       .addCase(syncMetadata.rejected, (state, action) => {
         state.error = action.error.message || "Failed to sync metadata";
+        state.status = SyncStatus.ERROR;
       });
   },
 });


### PR DESCRIPTION
If the promise is rejected, then we also need to update state.status to be ERROR.

Fixes #3177.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] Have `db.updateBatch()` throw an exception (i.e. manually add one in unconditionally)
* [ ] Launch the app, observe sync status is still OK
* [ ] Check out this PR
* [ ] Manually re-sync
* [ ] Observe that sync status is now warning (idk why ERROR maps to warning but that's pre-existing)
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
