### PR TITLE
Bump liquidjs to 10.25.5

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -103,7 +103,7 @@
     "better-sqlite3": "^12.6.0",
     "blakejs": "^1.2.1",
     "dbmate": "^2.29.3",
-    "liquidjs": "^10.25.0",
+    "liquidjs": "^10.25.5",
     "openpgp": "^6.3.0",
     "source-map-support": "^0.5.21",
     "tar": "^7.5.8",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^2.29.3
         version: 2.29.3
       liquidjs:
-        specifier: ^10.25.0
-        version: 10.25.0
+        specifier: ^10.25.5
+        version: 10.25.5
       openpgp:
         specifier: ^6.3.0
         version: 6.3.0
@@ -3485,8 +3485,8 @@ packages:
     resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
     engines: {node: '>= 12.0.0'}
 
-  liquidjs@10.25.0:
-    resolution: {integrity: sha512-XpO7AiGULTG4xcTlwkcTI5JreFG7b6esLCLp+aUSh7YuQErJZEoUXre9u9rbdb0057pfWG4l0VursvLd5Q/eAw==}
+  liquidjs@10.25.5:
+    resolution: {integrity: sha512-GKiKeZjJDdVoQAu+S9rzkYsYnYhcep5W3WwZXgb5f+yq484P/k9JqamBbGYu+LBEixcUAXZr2jogdAIjB3ki1w==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -8977,7 +8977,7 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.30.1
       lightningcss-win32-x64-msvc: 1.30.1
 
-  liquidjs@10.25.0:
+  liquidjs@10.25.5:
     dependencies:
       commander: 10.0.1
 


### PR DESCRIPTION
Addresses the following vulnerabilities in `liquidjs`:

CVE-2026-35525, https://github.com/advisories/GHSA-56p5-8mhr-2fph
CVE-2026-39859, https://github.com/advisories/GHSA-v273-448j-v4qj
CVE-2026-39412, https://github.com/advisories/GHSA-rv5g-f82m-qrvv
CVE-2026-34166, https://github.com/advisories/GHSA-mmg9-6m6j-jqqx

- [x] Checked `liquidjs` 10.25.5 with GuardDog as per the [dependency update policy](https://developers.securedrop.org/en/latest/dependency_updates.html)

## Test plan
- [x] passes CI