### PR TITLE
Harden our usage of liquidjs

### DIFF
--- a/app/resources/templates/transcript.txt.liquid
+++ b/app/resources/templates/transcript.txt.liquid
@@ -8,7 +8,7 @@ Transcript:
 Source wrote:
 {{ item.plaintext }}
 {% when "reply" %}
-{{ item.data.journalist_uuid | getJournalistName }} replied:
+{{ journalists[item.data.journalist_uuid] | default: "Unknown journalist" }} replied:
 {% if not item.plaintext %}[Message is encrypted...]{% else %}{{ item.plaintext }}{% endif %}
 {% when "file" %}
 Source uploaded file: {% if not item.filename %}[encrypted file]{% else %}{{ item.filename | split: "/" | last}}{% endif %}

--- a/app/src/main/transcriber.test.ts
+++ b/app/src/main/transcriber.test.ts
@@ -121,7 +121,8 @@ describe("Transcriber Component Tests", () => {
 
   function createMockDB() {
     return {
-      getJournalistByID: vi.fn(),
+      getJournalists: vi.fn(),
+      getSourceWithItems: vi.fn(),
     } as unknown as DB;
   }
 
@@ -132,7 +133,7 @@ describe("Transcriber Component Tests", () => {
   it("should return a valid transcript with all message and replies", async () => {
     const db = createMockDB();
 
-    db.getJournalistByID = vi.fn(() => mockJournalist);
+    db.getJournalists = vi.fn(() => [mockJournalist]);
 
     const expectedSource: string = "Source: palpable disquiet";
     const expectedTranscript: string = `Transcript:
@@ -153,12 +154,10 @@ Interesting message there
     expect(output).toContain(expectedTranscript);
   });
 
-  it("should gracefully handle  errors when looking up journalists", async () => {
+  it("should gracefully handle unknown journalists", async () => {
     const db = createMockDB();
 
-    db.getJournalistByID = vi.fn(() => {
-      throw new Error("mocked error");
-    });
+    db.getJournalists = vi.fn(() => []);
 
     const expectedSource: string = "Source: palpable disquiet";
     const expectedTranscript: string = `Transcript:
@@ -182,12 +181,8 @@ Interesting message there
   it("should write a valid transcript file", async () => {
     const db = createMockDB();
 
-    db.getJournalistByID = vi.fn(() => {
-      return mockJournalist;
-    });
-    db.getSourceWithItems = vi.fn(() => {
-      return mockSourceWithItems;
-    });
+    db.getJournalists = vi.fn(() => [mockJournalist]);
+    db.getSourceWithItems = vi.fn(() => mockSourceWithItems);
 
     const expectedSource: string = "Source: palpable disquiet";
     const expectedTranscript: string = `Transcript:

--- a/app/src/main/transcriber.test.ts
+++ b/app/src/main/transcriber.test.ts
@@ -121,7 +121,8 @@ describe("Transcriber Component Tests", () => {
 
   function createMockDB() {
     return {
-      getJournalistByID: vi.fn(),
+      getJournalists: vi.fn(),
+      getSourceWithItems: vi.fn(),
     } as unknown as DB;
   }
 
@@ -132,7 +133,7 @@ describe("Transcriber Component Tests", () => {
   it("should return a valid transcript with all message and replies", async () => {
     const db = createMockDB();
 
-    db.getJournalistByID = vi.fn(() => mockJournalist);
+    db.getJournalists = vi.fn(() => [mockJournalist]);
 
     const expectedSource: string = "Source: palpable disquiet";
     const expectedTranscript: string = `Transcript:
@@ -153,12 +154,59 @@ Interesting message there
     expect(output).toContain(expectedTranscript);
   });
 
-  it("should gracefully handle  errors when looking up journalists", async () => {
+  it("should show [Message is encrypted...] when plaintext is null", async () => {
+    const db = createMockDB();
+    db.getJournalists = vi.fn(() => [mockJournalist]);
+
+    const sourceWithUnfetchedItems: SourceWithItems = {
+      ...mockSourceWithItems,
+      items: [
+        {
+          uuid: "message-unfetched",
+          data: {
+            kind: "message",
+            uuid: "message-unfetched",
+            source: "source-1",
+            size: 1024,
+            seen_by: [],
+            is_read: false,
+            interaction_count: 1,
+          },
+          fetch_progress: 0,
+          fetch_status: 0,
+          // @ts-expect-error FIXME the typing is wrong here, see https://github.com/freedomofpress/securedrop-client/issues/3347
+          plaintext: null,
+        },
+        {
+          uuid: "reply-unfetched",
+          data: {
+            kind: "reply",
+            uuid: "reply-unfetched",
+            source: "source-1",
+            size: 1024,
+            journalist_uuid: "journo-1",
+            is_deleted_by_source: false,
+            seen_by: [],
+            interaction_count: 1,
+          },
+          fetch_progress: 0,
+          fetch_status: 0,
+          // @ts-expect-error FIXME the typing is wrong here, see https://github.com/freedomofpress/securedrop-client/issues/3347
+          plaintext: null,
+        },
+      ],
+    };
+
+    const output: string = await renderTranscript(sourceWithUnfetchedItems, db);
+    // TODO: message should show [Message is encrypted...] like replies do
+    expect(output).toContain("Source wrote:\n\n");
+    expect(output).toContain("notsuperman replied:\n[Message is encrypted...]");
+  });
+
+  it("should gracefully handle unknown journalists", async () => {
     const db = createMockDB();
 
-    db.getJournalistByID = vi.fn(() => {
-      throw new Error("mocked error");
-    });
+    db.getJournalists = vi.fn(() => []);
 
     const expectedSource: string = "Source: palpable disquiet";
     const expectedTranscript: string = `Transcript:
@@ -182,12 +230,8 @@ Interesting message there
   it("should write a valid transcript file", async () => {
     const db = createMockDB();
 
-    db.getJournalistByID = vi.fn(() => {
-      return mockJournalist;
-    });
-    db.getSourceWithItems = vi.fn(() => {
-      return mockSourceWithItems;
-    });
+    db.getJournalists = vi.fn(() => [mockJournalist]);
+    db.getSourceWithItems = vi.fn(() => mockSourceWithItems);
 
     const expectedSource: string = "Source: palpable disquiet";
     const expectedTranscript: string = `Transcript:

--- a/app/src/main/transcriber.ts
+++ b/app/src/main/transcriber.ts
@@ -2,35 +2,49 @@ import { join } from "path";
 import fs from "fs";
 import { DB } from "./database";
 import { Storage } from "./storage";
-import { type SourceWithItems, Journalist } from "../types";
+import { type SourceWithItems } from "../types";
 
 import { Liquid } from "liquidjs";
+import transcriptTemplateContent from "../../resources/templates/transcript.txt.liquid?raw";
 
 export async function renderTranscript(data: SourceWithItems, db: DB) {
+  const transcriptTemplateName = "transcript.txt.liquid";
+
   const engine = new Liquid({
-    root: join(__dirname, "../../resources/templates"),
-    extname: ".liquid",
+    // Supplying templates as an in-memory map causes LiquidJS to replace its
+    // default fs implementation with MapFS, which only performs map lookups.
+    // The real filesystem is never accessible to the engine.
+    templates: { [transcriptTemplateName]: transcriptTemplateContent },
+    // Restrict property access to own properties only, preventing templates
+    // from traversing the prototype chain on context objects.
+    ownPropertyOnly: true,
+    // Disable dynamic partials ({% include someVariable %}) — our template
+    // does not use them, so there's no reason to leave that surface open.
+    dynamicPartials: false,
+    // Throw on unknown filters rather than silently skipping them.
+    strictFilters: true,
+    // Throw on undefined variables rather than silently rendering empty string.
+    strictVariables: true,
+    // Relax strictVariables inside if/unless/default so that a missing
+    // variable evaluates to false/null instead of throwing. This is needed
+    // for the template's {% if not item.plaintext %} guards and
+    // | default: "..." fallbacks.
+    lenientIf: true,
   });
 
-  engine.registerFilter("getJournalistName", function (uuid: string) {
-    const db: DB = this.context.get(["db"]) as DB;
-    try {
-      const journalist: Journalist = db.getJournalistByID(uuid);
-      return journalist.data.username || "Unknown journalist";
-    } catch (error) {
-      console.error("Error looking up journalist ", error);
-      return "Unknown journalist";
-    }
-  });
+  const journalists: Record<string, string> = {};
+  for (const journalist of db.getJournalists()) {
+    journalists[journalist.uuid] = journalist.data.username;
+  }
 
   const renderContext = {
     d: data,
-    db: db,
+    journalists,
   };
 
   try {
     const output: string = await engine.renderFile(
-      "transcript.txt.liquid",
+      transcriptTemplateName,
       renderContext,
     );
     return output;

--- a/app/src/main/transcriber.ts
+++ b/app/src/main/transcriber.ts
@@ -2,35 +2,51 @@ import { join } from "path";
 import fs from "fs";
 import { DB } from "./database";
 import { Storage } from "./storage";
-import { type SourceWithItems, Journalist } from "../types";
+import { type SourceWithItems } from "../types";
 
 import { Liquid } from "liquidjs";
+import transcriptTemplateContent from "../../resources/templates/transcript.txt.liquid?raw";
 
 export async function renderTranscript(data: SourceWithItems, db: DB) {
+  const transcriptTemplateName = "transcript.txt.liquid";
+
   const engine = new Liquid({
-    root: join(__dirname, "../../resources/templates"),
-    extname: ".liquid",
+    // Supplying templates as an in-memory map causes LiquidJS to replace its
+    // default fs implementation with MapFS, which only performs map lookups.
+    // The real filesystem is never accessible to the engine.
+    templates: { [transcriptTemplateName]: transcriptTemplateContent },
+    // Restrict property access to own properties only, preventing templates
+    // from traversing the prototype chain on context objects.
+    ownPropertyOnly: true,
+    // Disable dynamic partials ({% include someVariable %}) — our template
+    // does not use them, so there's no reason to leave that surface open.
+    dynamicPartials: false,
+    // Throw on unknown filters rather than silently skipping them.
+    strictFilters: true,
+    // Throw on undefined variables rather than silently rendering empty string.
+    strictVariables: true,
+    // Relax strictVariables inside if/unless/default so that a missing
+    // variable evaluates to false/null instead of throwing. This is needed
+    // for the template's {% if not item.plaintext %} guards and
+    // | default: "..." fallbacks.
+    lenientIf: true,
   });
 
-  engine.registerFilter("getJournalistName", function (uuid: string) {
-    const db: DB = this.context.get(["db"]) as DB;
-    try {
-      const journalist: Journalist = db.getJournalistByID(uuid);
-      return journalist.data.username || "Unknown journalist";
-    } catch (error) {
-      console.error("Error looking up journalist ", error);
-      return "Unknown journalist";
-    }
-  });
+  const journalists: Record<string, string> = {};
+  for (const journalist of db.getJournalists()) {
+    journalists[journalist.uuid] = journalist.data.username;
+  }
 
+  // The context should contain all data needed to render the template;
+  // the template should only do formatting and not any method calls.
   const renderContext = {
     d: data,
-    db: db,
+    journalists,
   };
 
   try {
     const output: string = await engine.renderFile(
-      "transcript.txt.liquid",
+      transcriptTemplateName,
       renderContext,
     );
     return output;


### PR DESCRIPTION
Recent liquidjs vulnerabilities reveal a few options to harden our usage of it. First, we can disable/enable a number of useful options we can benefit from.

CVE-2026-35525 and CVE-2026-39859 allowed bypassing the limited file paths that could be read. We can avoid these issues entirely by

  1) preloading templates via the `templates` map so liquidjs isn't
     doing any file lookups
2) having vite compile in the template so we don't need to do any file
     reads whatsoever

CVE-2026-39412 allowed bypassing the (now-enabled) ownPropertyOnly protection. Passing the entire `db` object into the template is a bit risky, since we just need it for journalist names, lets pass in a map of that so the template is purely rendering data and can't invoke DB lookups.

Heavily assisted by Claude.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] no actual user-facing changes, i.e. transcript export works exactly the same
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
