### PR TITLE
Fix cancellation and pause/resume

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -625,11 +625,8 @@ export class DB {
   }
 
   public updateFetchStatus(itemUuid: string, fetchStatus: number) {
-    // When resetting to Initial or DownloadInProgress, also reset fetch_progress
-    if (
-      fetchStatus === FetchStatus.Initial ||
-      fetchStatus === FetchStatus.DownloadInProgress
-    ) {
+    // When cancelling, reset fetch_progress so the next download starts fresh
+    if (fetchStatus === FetchStatus.Cancelled) {
       this.updateItemFetchStatusWithReset.run({
         uuid: itemUuid,
         fetch_status: fetchStatus,

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -1288,7 +1288,7 @@ describe("Datastore Method Tests", () => {
   });
 
   describe("updateFetchStatus", () => {
-    it("should reset fetch_progress to 0 when updating to Initial status", () => {
+    it("should reset fetch_progress to 0 when cancelling", () => {
       db.updateSources({
         source1: mockSourceMetadata("source1"),
       });
@@ -1303,16 +1303,16 @@ describe("Datastore Method Tests", () => {
       let item = db.getItem("item1");
       expect(item?.fetch_progress).toBe(50000);
 
-      // Now update status to Initial (simulating Cancel)
-      db.updateFetchStatus("item1", FetchStatus.Initial);
+      // User cancels
+      db.updateFetchStatus("item1", FetchStatus.Cancelled);
 
       // Verify progress was reset to 0
       item = db.getItem("item1");
-      expect(item?.fetch_status).toBe(FetchStatus.Initial);
+      expect(item?.fetch_status).toBe(FetchStatus.Cancelled);
       expect(item?.fetch_progress).toBe(0);
     });
 
-    it("should reset fetch_progress to 0 when updating to DownloadInProgress status", () => {
+    it("should preserve fetch_progress when updating to DownloadInProgress status", () => {
       db.updateSources({
         source1: mockSourceMetadata("source1"),
       });
@@ -1320,22 +1320,22 @@ describe("Datastore Method Tests", () => {
         item1: mockItemMetadata("item1", "source1", "file"),
       });
 
-      // Simulate a failed download with progress
+      // Simulate a paused download with progress
       db.setDownloadInProgress("item1", 100000);
-      db.failDownload("item1");
+      db.pauseItem("item1");
 
-      // Verify progress was preserved during failure
+      // Verify progress was preserved during pause
       let item = db.getItem("item1");
       expect(item?.fetch_progress).toBe(100000);
-      expect(item?.fetch_status).toBe(FetchStatus.FailedDownloadRetryable);
+      expect(item?.fetch_status).toBe(FetchStatus.Paused);
 
-      // Now update status to DownloadInProgress (simulating Retry)
+      // Now resume (Paused -> DownloadInProgress)
       db.updateFetchStatus("item1", FetchStatus.DownloadInProgress);
 
-      // Verify progress was reset to 0
+      // Verify progress is preserved so download can resume from where it left off
       item = db.getItem("item1");
       expect(item?.fetch_status).toBe(FetchStatus.DownloadInProgress);
-      expect(item?.fetch_progress).toBe(0);
+      expect(item?.fetch_progress).toBe(100000);
     });
 
     it("should NOT reset fetch_progress when updating to other statuses", () => {
@@ -1373,11 +1373,11 @@ describe("Datastore Method Tests", () => {
       let item = db.getItem("item1");
       expect(item?.fetch_status).toBe(FetchStatus.FailedTerminal);
 
-      // Reset to Initial (Cancel) should reset progress
-      db.updateFetchStatus("item1", FetchStatus.Initial);
+      // Cancel should reset progress
+      db.updateFetchStatus("item1", FetchStatus.Cancelled);
 
       item = db.getItem("item1");
-      expect(item?.fetch_status).toBe(FetchStatus.Initial);
+      expect(item?.fetch_status).toBe(FetchStatus.Cancelled);
       expect(item?.fetch_progress).toBe(0);
 
       // Now it can be processed again

--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -148,7 +148,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         }),
         expect.any(BufferedWriter),
         0,
-        undefined, // abortSignal
+        expect.any(AbortSignal), // abortSignal
         20000, // timeout
         expect.any(Function), // onProgress
       );
@@ -328,7 +328,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         }),
         expect.any(BufferedWriter),
         0,
-        undefined, // abortSignal
+        expect.any(AbortSignal), // abortSignal
         20000, // timeout
         expect.any(Function), // onProgress
       );
@@ -459,7 +459,9 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         size: 1000000,
       } as ItemMetadata;
 
-      db.getItem = vi.fn(() => mockItem(metadata, FetchStatus.Initial, 0));
+      db.getItem = vi.fn(() =>
+        mockItem(metadata, FetchStatus.DownloadInProgress, 0),
+      );
 
       // Mock successful download
       mockProxyStreamRequest.mockResolvedValue({
@@ -484,7 +486,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         }),
         expect.any(PassThrough),
         0,
-        undefined, // abortSignal
+        expect.any(AbortSignal), // abortSignal
         55000, // timeout
         expect.any(Function), // onProgress
       );
@@ -518,8 +520,9 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         uuid: "file-uuid-progress",
       } as ItemMetadata;
 
-      // Always return an item in Initial state for simplicity
-      db.getItem = vi.fn(() => mockItem(metadata, FetchStatus.Initial, 0));
+      db.getItem = vi.fn(() =>
+        mockItem(metadata, FetchStatus.DownloadInProgress, 0),
+      );
       db.getSource = vi.fn(() => ({}) as never);
 
       // Mock crypto decryption success
@@ -575,10 +578,12 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         size: 1000000,
       } as ItemMetadata;
 
-      // First attempt: Initial status, Second attempt: FailedDecryptionRetryable
+      // First attempt: DownloadInProgress status, Second attempt: FailedDecryptionRetryable
       db.getItem = vi
         .fn()
-        .mockReturnValueOnce(mockItem(metadata, FetchStatus.Initial, 0))
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.DownloadInProgress, 0),
+        )
         .mockReturnValueOnce(
           mockItem(metadata, FetchStatus.FailedDecryptionRetryable, 0),
         );
@@ -606,6 +611,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
       expect(fs.promises.mkdir).toHaveBeenCalled();
       expect(fs.createWriteStream).toHaveBeenCalledWith(
         expect.stringContaining("/encrypted.gpg"),
+        expect.any(Object),
       );
 
       expect(db.setDownloadInProgress).toHaveBeenCalledWith("msg1");
@@ -643,7 +649,9 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
 
       db.getItem = vi
         .fn()
-        .mockReturnValueOnce(mockItem(metadata, FetchStatus.Initial, 0))
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.DownloadInProgress, 0),
+        )
         .mockReturnValueOnce(
           mockItem(metadata, FetchStatus.FailedDownloadRetryable, 30),
         );
@@ -688,7 +696,12 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
   });
 
   describe("Edge Cases and Error Handling", () => {
-    it("should skip items that are already complete", async () => {
+    it.each([
+      { status: FetchStatus.Complete, label: "complete" },
+      { status: FetchStatus.FailedTerminal, label: "terminally failed" },
+      { status: FetchStatus.Paused, label: "paused" },
+      { status: FetchStatus.Cancelled, label: "cancelled" },
+    ])("should skip items that are $label", async ({ status }) => {
       const db = createMockDB();
       const metadata = {
         kind: "message",
@@ -696,49 +709,14 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         size: 1000,
       } as ItemMetadata;
 
-      db.getItem = vi.fn(() => mockItem(metadata, FetchStatus.Complete, 0));
+      db.getItem = vi.fn(() => mockItem(metadata, status, 0));
 
       const queue = new TaskQueue(db);
       await queue.process({ id: "msg1" }, db);
 
-      // Should not perform any operations
       expect(mockProxyStreamRequest).not.toHaveBeenCalled();
       expect(db.setDownloadInProgress).not.toHaveBeenCalled();
       expect(db.setDecryptionInProgress).not.toHaveBeenCalled();
-    });
-
-    it("should skip items that are terminally failed", async () => {
-      const db = createMockDB();
-      const metadata = {
-        kind: "message",
-        source: "source1",
-        size: 1000,
-      } as ItemMetadata;
-
-      db.getItem = vi.fn(() =>
-        mockItem(metadata, FetchStatus.FailedTerminal, 0),
-      );
-
-      const queue = new TaskQueue(db);
-      await queue.process({ id: "msg1" }, db);
-
-      expect(mockProxyStreamRequest).not.toHaveBeenCalled();
-    });
-
-    it("should skip items that are paused", async () => {
-      const db = createMockDB();
-      const metadata = {
-        kind: "message",
-        source: "source1",
-        size: 1000,
-      } as ItemMetadata;
-
-      db.getItem = vi.fn(() => mockItem(metadata, FetchStatus.Paused, 0));
-
-      const queue = new TaskQueue(db);
-      await queue.process({ id: "msg1" }, db);
-
-      expect(mockProxyStreamRequest).not.toHaveBeenCalled();
     });
 
     it("should handle server error responses during download", async () => {
@@ -1006,7 +984,9 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
       // First attempt: download fails partway through
       db.getItem = vi
         .fn()
-        .mockReturnValueOnce(mockItem(metadata, FetchStatus.Initial, 0));
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.DownloadInProgress, 0),
+        );
 
       mockProxyStreamRequest.mockResolvedValueOnce({
         complete: false,
@@ -1053,7 +1033,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         }),
         expect.anything(),
         0, // Should start from 0, not 100000000
-        undefined, // abortSignal
+        expect.any(AbortSignal), // abortSignal
         expect.any(Number), // timeout
         expect.any(Function), // onProgress
       );
@@ -1061,124 +1041,133 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
       expect(db.completeFileItem).toHaveBeenCalled();
     });
 
-    it("should start fresh download after cancel (status reset to Initial)", async () => {
+    it("should resume from actual file size on disk, not DB progress", async () => {
       const db = createMockDB();
       const metadata = {
         kind: "file",
         source: "source1",
-        size: 200000000, // 200MB file
+        size: 100000000, // 100MB
         uuid: "file1",
       } as ItemMetadata;
 
-      // First attempt: download fails
+      // DB thinks 60MB was written, but only 50MB is on disk
       db.getItem = vi
         .fn()
-        .mockReturnValueOnce(mockItem(metadata, FetchStatus.Initial, 0));
+        .mockReturnValue(
+          mockItem(metadata, FetchStatus.DownloadInProgress, 60000000),
+        );
 
-      mockProxyStreamRequest.mockResolvedValueOnce({
-        complete: false,
-        bytesWritten: 50000000, // 50MB downloaded
-        error: new Error("Timeout"),
+      (fs.promises.stat as ReturnType<typeof vi.fn>).mockResolvedValue({
+        size: 50000000,
       });
 
-      const queue = new TaskQueue(db);
-
-      await expect(queue.process({ id: "file1" }, db)).rejects.toThrow(
-        "Unable to complete stream download",
-      );
-
-      expect(db.failDownload).toHaveBeenCalledWith("file1");
-
-      // Simulate user clicking "Cancel" - status reset to Initial with progress=0
-      vi.clearAllMocks();
-
-      db.getItem = vi.fn().mockReturnValue(
-        // Progress is 0 because updateFetchStatus reset it when going to Initial
-        mockItem(metadata, FetchStatus.Initial, 0),
-      );
-
-      // Now user clicks download again
       mockProxyStreamRequest.mockResolvedValueOnce({
         complete: true,
-        bytesWritten: 200000000,
+        bytesWritten: 50000000,
         sha256sum: FILE_ETAG,
       });
 
       mockCrypto.decryptFile.mockResolvedValue({
         decryptedFilePath: "/tmp/decrypted/file.txt",
-        decryptedSize: 195000000,
-      });
-
-      await queue.process({ id: "file1" }, db);
-
-      // Should start from 0
-      expect(mockProxyStreamRequest).toHaveBeenCalledWith(
-        expect.objectContaining({
-          path_query: "/api/v1/sources/source1/submissions/file1/download",
-        }),
-        expect.anything(),
-        0, // Fresh start from 0
-        undefined, // abortSignal
-        expect.any(Number), //timeout
-        expect.any(Function), // onProgress
-      );
-
-      expect(db.completeFileItem).toHaveBeenCalled();
-    });
-
-    it("should fail gracefully and allow retry for message downloads", async () => {
-      const db = createMockDB();
-      const metadata = {
-        kind: "message",
-        source: "source1",
-        size: 5000,
-      } as ItemMetadata;
-
-      // First attempt fails
-      db.getItem = vi
-        .fn()
-        .mockReturnValueOnce(mockItem(metadata, FetchStatus.Initial, 0));
-
-      mockProxyStreamRequest.mockResolvedValueOnce({
-        complete: false,
-        bytesWritten: 2500,
-        error: new Error("Network error"),
+        decryptedSize: 95000000,
       });
 
       const queue = new TaskQueue(db);
+      await queue.process({ id: "file1" }, db);
 
-      await expect(queue.process({ id: "msg1" }, db)).rejects.toThrow(
-        "Unable to complete stream download",
+      // Should resume from the actual file size (50MB), not the DB value (60MB)
+      expect(mockProxyStreamRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        50000000,
+        expect.any(AbortSignal),
+        expect.any(Number),
+        expect.any(Function),
       );
+    });
 
-      expect(db.failDownload).toHaveBeenCalledWith("msg1");
+    it("should start from 0 when progress > 0 but the file is missing on disk", async () => {
+      const db = createMockDB();
+      const metadata = {
+        kind: "file",
+        source: "source1",
+        size: 100000000,
+        uuid: "file1",
+      } as ItemMetadata;
 
-      // Retry after status reset
-      vi.clearAllMocks();
+      // DB has progress, but the partial file is gone
+      db.getItem = vi
+        .fn()
+        .mockReturnValue(
+          mockItem(metadata, FetchStatus.DownloadInProgress, 50000000),
+        );
+
+      const enoentError = Object.assign(new Error("ENOENT"), {
+        code: "ENOENT",
+      });
+      (fs.promises.stat as ReturnType<typeof vi.fn>)
+        .mockRejectedValueOnce(enoentError) // partial file missing on resume check
+        .mockResolvedValue({ size: 100000000 }); // post-decryption stat
+
+      mockProxyStreamRequest.mockResolvedValueOnce({
+        complete: true,
+        bytesWritten: 100000000,
+        sha256sum: FILE_ETAG,
+      });
+
+      mockCrypto.decryptFile.mockResolvedValue({
+        decryptedFilePath: "/tmp/decrypted/file.txt",
+        decryptedSize: 95000000,
+      });
+
+      const queue = new TaskQueue(db);
+      await queue.process({ id: "file1" }, db);
+
+      // File missing → resume from 0
+      expect(mockProxyStreamRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        0,
+        expect.any(AbortSignal),
+        expect.any(Number),
+        expect.any(Function),
+      );
+    });
+
+    it("should not call failDownload or proceed to decryption when a download is cancelled", async () => {
+      const db = createMockDB();
+      const metadata = {
+        kind: "file",
+        source: "source1",
+        size: 200000000,
+        uuid: "file1",
+      } as ItemMetadata;
 
       db.getItem = vi
         .fn()
         .mockReturnValue(mockItem(metadata, FetchStatus.DownloadInProgress, 0));
 
-      const encryptedBuffer = Buffer.from("encrypted message");
-      const decryptedContent = "Hello, world!";
-      vi.spyOn(BufferedWriter.prototype, "getBuffer").mockReturnValue(
-        encryptedBuffer,
+      // Simulate an in-progress download that gets aborted mid-stream
+      mockProxyStreamRequest.mockImplementation(
+        async (_req, _writer, _offset, _abortSignal: AbortSignal) => {
+          // Abort during the download
+          queue.cancelDownload("file1");
+          // proxyStreamRequest returns incomplete when the signal fires
+          return {
+            complete: false,
+            bytesWritten: 10000000,
+            error: new Error("aborted"),
+          } as ProxyStreamResponse;
+        },
       );
-      mockCrypto.decryptMessage.mockResolvedValue(decryptedContent);
 
-      mockProxyStreamRequest.mockResolvedValueOnce({
-        complete: true,
-        bytesWritten: 5000,
-        sha256sum: etagFor(encryptedBuffer),
-      });
+      const queue = new TaskQueue(db);
+      // Should resolve cleanly, not throw
+      await queue.process({ id: "file1" }, db);
 
-      await queue.process({ id: "msg1" }, db);
-
-      expect(db.completePlaintextItem).toHaveBeenCalledWith(
-        "msg1",
-        decryptedContent,
-      );
+      expect(db.failDownload).not.toHaveBeenCalled();
+      expect(db.setDecryptionInProgress).not.toHaveBeenCalled();
+      expect(mockCrypto.decryptFile).not.toHaveBeenCalled();
     });
   });
 

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -31,6 +31,14 @@ export type ItemFetchTask = {
 
 type DownloadResult = Buffer | string;
 
+// Thrown when a download is intentionally aborted (paused or cancelled by the user).
+// This is not an error condition and should not cause the item to be marked as failed.
+class DownloadCancelledError extends Error {
+  constructor() {
+    super("Download was cancelled");
+  }
+}
+
 export class TaskQueue {
   db: DB;
   messageQueue: Queue;
@@ -38,6 +46,7 @@ export class TaskQueue {
   authToken?: string;
   port?: MessagePort;
   storage: Storage;
+  activeDownloads: Map<string, AbortController> = new Map();
 
   constructor(
     db: DB,
@@ -71,6 +80,14 @@ export class TaskQueue {
 
   getAuthToken(): string {
     return this.authToken ? this.authToken : "";
+  }
+
+  // Aborts any in-progress download for the given item.
+  cancelDownload(itemId: string) {
+    const controller = this.activeDownloads.get(itemId);
+    if (controller) {
+      controller.abort();
+    }
   }
 
   // Queries the database for all items that need to be downloaded and queues
@@ -151,11 +168,12 @@ export class TaskQueue {
         fetch_progress: progress,
       } = dbItem;
 
-      // Skip items that are complete, terminally failed, paused, or not scheduled
+      // Skip items that are complete, terminally failed, paused, or cancelled
       if (
         status == FetchStatus.Complete ||
         status == FetchStatus.FailedTerminal ||
-        status == FetchStatus.Paused
+        status == FetchStatus.Paused ||
+        status == FetchStatus.Cancelled
       ) {
         console.debug("Item task is not in an processable state, skipping...");
         return;
@@ -169,7 +187,20 @@ export class TaskQueue {
         status === FetchStatus.DownloadInProgress ||
         status === FetchStatus.FailedDownloadRetryable
       ) {
-        downloadResult = await this.download(item, db, metadata, progress || 0);
+        try {
+          downloadResult = await this.download(
+            item,
+            db,
+            metadata,
+            progress || 0,
+          );
+        } catch (e) {
+          if (e instanceof DownloadCancelledError) {
+            // Download was intentionally paused or cancelled — not a failure
+            return;
+          }
+          throw e;
+        }
         nextStatus = FetchStatus.DecryptionInProgress;
       }
 
@@ -199,17 +230,14 @@ export class TaskQueue {
     }
   };
 
-  private async download(
+  private async prepareDownload(
     item: ItemFetchTask,
-    db: DB,
     metadata: ItemMetadata,
     progress: number,
-  ): Promise<DownloadResult> {
-    console.debug(`Starting download for ${metadata.kind} ${item.id}`);
-    db.setDownloadInProgress(item.id);
-
+  ): Promise<{ path: string; writer: Writable; progress: number }> {
     let downloadFilePath: string = "";
     let downloadWriter: Writable;
+    let resumeProgress = 0;
 
     if (metadata.kind === "message" || metadata.kind === "reply") {
       // For messages/replies: use BufferedWriter (in-memory only)
@@ -219,10 +247,69 @@ export class TaskQueue {
       downloadFilePath = this.storage.downloadFilePath(metadata, item);
       const downloadDir = path.dirname(downloadFilePath);
       await fs.promises.mkdir(downloadDir, { recursive: true });
-      downloadWriter = fs.createWriteStream(downloadFilePath);
+      if (progress > 0) {
+        // Re-read the resume position from disk — it's the source of truth,
+        // in case the DB is out of sync with what was actually written.
+        try {
+          const stats = await fs.promises.stat(downloadFilePath);
+          resumeProgress = stats.size;
+        } catch (error: unknown) {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+            throw error;
+          }
+          // File doesn't exist, start from the beginning
+        }
+      }
+      // If we have some progress to resume, append from where the file ends,
+      // otherwise truncate and start anew.
+      downloadWriter = fs.createWriteStream(downloadFilePath, {
+        flags: resumeProgress > 0 ? "a" : "w",
+      });
     } else {
       throw new Error(`Unsupported item kind: ${metadata.kind}`);
     }
+    return {
+      path: downloadFilePath,
+      writer: downloadWriter,
+      progress: resumeProgress,
+    };
+  }
+
+  private async download(
+    item: ItemFetchTask,
+    db: DB,
+    metadata: ItemMetadata,
+    progress: number,
+  ): Promise<DownloadResult> {
+    console.debug(`Starting download for ${metadata.kind} ${item.id}`);
+    const abortController = new AbortController();
+    this.activeDownloads.set(item.id, abortController);
+    try {
+      db.setDownloadInProgress(item.id);
+      return await this.innerDownload(
+        item,
+        db,
+        metadata,
+        progress,
+        abortController,
+      );
+    } finally {
+      this.activeDownloads.delete(item.id);
+    }
+  }
+
+  private async innerDownload(
+    item: ItemFetchTask,
+    db: DB,
+    metadata: ItemMetadata,
+    originalProgress: number,
+    abortController: AbortController,
+  ): Promise<DownloadResult> {
+    const {
+      path: downloadFilePath,
+      writer: downloadWriter,
+      progress,
+    } = await this.prepareDownload(item, metadata, originalProgress);
 
     const queryPath = `/api/v1/sources/${metadata.source}/${metadata.kind == "reply" ? "replies" : "submissions"}/${item.id}/download`;
     const downloadRequest: ProxyRequest = {
@@ -254,8 +341,10 @@ export class TaskQueue {
       const now = Date.now();
       const totalBytesWritten = progress + bytesWritten;
 
-      // Always update the database with current progress
-      db.setDownloadInProgress(item.id, totalBytesWritten);
+      // Don't override the DB status if the download has been cancelled
+      if (!abortController.signal.aborted) {
+        db.setDownloadInProgress(item.id, totalBytesWritten);
+      }
 
       // Throttle UI updates to avoid overwhelming the renderer
       if (
@@ -271,7 +360,7 @@ export class TaskQueue {
       downloadRequest,
       downloadWriter,
       progress,
-      undefined, // abortSignal
+      abortController.signal,
       timeout,
       onProgress,
     );
@@ -287,6 +376,12 @@ export class TaskQueue {
     downloadResponse = downloadResponse as ProxyStreamResponse;
 
     if (!downloadResponse.complete) {
+      // If the abort signal was triggered, the download was intentionally
+      // stopped by the user (pause or cancel) — don't mark the item as failed
+      if (abortController.signal.aborted) {
+        throw new DownloadCancelledError();
+      }
+
       const bytesWritten = progress + downloadResponse.bytesWritten;
       db.setDownloadInProgress(item.id, bytesWritten);
       db.failDownload(item.id);

--- a/app/src/main/fetch/worker.ts
+++ b/app/src/main/fetch/worker.ts
@@ -25,6 +25,15 @@ const crypto = Crypto.initialize(workerData.cryptoConfig);
 const db = new Datastore(crypto, new Storage());
 const q = new TaskQueue(db, port);
 
-port.on("message", (message: AuthedRequest) => {
-  q.queueFetches(message);
+type CancelMessage = {
+  type: "cancel";
+  itemId: string;
+};
+
+port.on("message", (message: AuthedRequest | CancelMessage) => {
+  if ("type" in message && message.type === "cancel") {
+    q.cancelDownload(message.itemId);
+  } else {
+    q.queueFetches(message as AuthedRequest);
+  }
 });

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -7,7 +7,7 @@ import {
   session,
   clipboard,
 } from "electron";
-import { join, dirname, delimiter } from "path";
+import { join, delimiter } from "path";
 import { randomBytes } from "crypto";
 
 import { optimizer, is } from "@electron-toolkit/utils";
@@ -398,31 +398,13 @@ if (!gotTheLock) {
           fetchStatus: number,
           authToken: string,
         ) => {
-          // When resetting to Initial or DownloadInProgress, clean up partial download files
+          // If the user is pausing or cancelling, abort any in-progress download
+          // before updating the DB so the worker doesn't overwrite the new status
           if (
-            fetchStatus === FetchStatus.Initial ||
-            fetchStatus === FetchStatus.DownloadInProgress
+            fetchStatus === FetchStatus.Paused ||
+            fetchStatus === FetchStatus.Cancelled
           ) {
-            const item = db.getItem(itemUuid);
-            if (item && item.data.kind === "file") {
-              const storage = new Storage();
-              const downloadDir = storage.downloadFilePath(item.data, {
-                id: itemUuid,
-              });
-              // Delete the entire download directory for this item
-              const dirPath = dirname(downloadDir);
-              try {
-                fs.rmSync(dirPath, { recursive: true, force: true });
-                console.debug(
-                  `Cleaned up partial download directory: ${dirPath}`,
-                );
-              } catch (err) {
-                console.warn(
-                  `Failed to clean up partial download directory ${dirPath}:`,
-                  err,
-                );
-              }
-            }
+            fetchWorker?.postMessage({ type: "cancel", itemId: itemUuid });
           }
           db.updateFetchStatus(itemUuid, fetchStatus);
           fetchWorker?.postMessage({

--- a/app/src/renderer/views/Inbox/MainContent/Conversation.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation.tsx
@@ -192,7 +192,8 @@ const Conversation = memo(function Conversation({
     sourceWithItems.items.forEach((item) => {
       if (
         item.data.kind === "file" &&
-        item.fetch_status === FetchStatus.Initial
+        (item.fetch_status === FetchStatus.Initial ||
+          item.fetch_status === FetchStatus.Cancelled)
       ) {
         dispatch(
           updateItemFetchStatus({

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
@@ -197,6 +197,7 @@ const File = memo(function File({ item, designation, onUpdate }: FileProps) {
   let FileInner;
   switch (fetchStatus) {
     case FetchStatus.Initial:
+    case FetchStatus.Cancelled:
       FileInner = InitialFile;
       break;
     case FetchStatus.DownloadInProgress:
@@ -217,7 +218,10 @@ const File = memo(function File({ item, designation, onUpdate }: FileProps) {
   }
 
   const handleClick = () => {
-    if (fetchStatus === FetchStatus.Initial) {
+    if (
+      fetchStatus === FetchStatus.Initial ||
+      fetchStatus === FetchStatus.Cancelled
+    ) {
       onUpdate({
         item_uuid: item.uuid,
         type: ItemUpdateType.FetchStatus,
@@ -227,15 +231,18 @@ const File = memo(function File({ item, designation, onUpdate }: FileProps) {
   };
 
   // Apply error border color using theme token when in failed state
-  // Apply hover background color for initial state
+  // Apply hover background color for initial state (or cancelled)
   const fileBoxStyle = {
     ...(fetchStatus === FetchStatus.FailedTerminal
       ? { borderColor: token.colorErrorBorder }
       : undefined),
-    ...(fetchStatus === FetchStatus.Initial && isHovered
+    ...((fetchStatus === FetchStatus.Initial ||
+      fetchStatus === FetchStatus.Cancelled) &&
+    isHovered
       ? { backgroundColor: token.colorFillQuaternary }
       : undefined),
-    ...(fetchStatus === FetchStatus.Initial
+    ...(fetchStatus === FetchStatus.Initial ||
+    fetchStatus === FetchStatus.Cancelled
       ? { cursor: "pointer" }
       : undefined),
     transition: "background-color 0.2s ease",
@@ -256,10 +263,14 @@ const File = memo(function File({ item, designation, onUpdate }: FileProps) {
           style={fileBoxStyle}
           onClick={handleClick}
           onMouseEnter={() =>
-            fetchStatus === FetchStatus.Initial && setIsHovered(true)
+            (fetchStatus === FetchStatus.Initial ||
+              fetchStatus === FetchStatus.Cancelled) &&
+            setIsHovered(true)
           }
           onMouseLeave={() =>
-            fetchStatus === FetchStatus.Initial && setIsHovered(false)
+            (fetchStatus === FetchStatus.Initial ||
+              fetchStatus === FetchStatus.Cancelled) &&
+            setIsHovered(false)
           }
         >
           <FileInner item={item} onUpdate={onUpdate} />
@@ -342,7 +353,7 @@ const InProgressFile = memo(function InProgressFile({
     onUpdate({
       item_uuid: item.uuid,
       type: ItemUpdateType.FetchStatus,
-      fetch_status: FetchStatus.Initial,
+      fetch_status: FetchStatus.Cancelled,
     });
   };
 
@@ -531,7 +542,7 @@ const FailedFile = memo(function FailedFile({ item, onUpdate }: FileViewProps) {
     onUpdate({
       item_uuid: item.uuid,
       type: ItemUpdateType.FetchStatus,
-      fetch_status: FetchStatus.Initial,
+      fetch_status: FetchStatus.Cancelled,
     });
   };
 

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -202,6 +202,8 @@ export enum FetchStatus {
   FailedDecryptionRetryable = 6,
   // Exceeded max retries, considered terminally failed
   FailedTerminal = 7,
+  // User explicitly cancelled the download
+  Cancelled = 8,
 }
 
 // EventStatus codes returned from the server


### PR DESCRIPTION
Neither pause nor resume were working, this mostly fixes that.
    
First, we now inject an AbortController to the underlying
securedrop-proxy process, so we can cleanly terminate it when asked to
pause or cancel a download.

Transitioning into the "Initial" + "DownloadInProgress" states would
delete any previous file before starting a new download. This
effectively broke resuming, since it would reset the state, plus it
caused some race conditions on cancellation, in which it was both
complete and cancelled, so it advanced to decryption, but by that point
the file had been deleted and now it fails again.

On top of that fs.createWriteStream() was already truncating the file,
breaking resume but also making the delete a bit useless. We now rely on
that property of truncating or appending instead of deleting when
cancelling.

There was some confusion in the "Initial" state being used for both a
download that hasn't started and one that is being cancelled. I created
a new explicit Cancelled state that in the frontend mostly looks like
Initial, but has different backend behavior.

Fixes #3206.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] Have a server with a 100MB file
* [x] Use try-client-pr to fetch this on SDW and then use the Inbox to download that 100MB file and try starting download, pausing, then resuming, then cancel, etc. And it should do what you expect.
   * [x] Rarely I saw cancellation turning into "download failed" but I think that's acceptable just because that still lets you retry.
* [x] Also try running `pkill -9 securedrop-pr` in sd-proxy while a download is going and see that the auto-resume still works.

Also:
* [x] Start a download, pause it midway
* [x] Find the partially downloaded file in /tmp/download/{journalist uuid}/{file uuid}/encrypted.gpg and delete it
* [x] Resume the download, observe that progress correctly resets to 0 and starts from scratch.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
