### PR TITLE
Backport 0.17.5 (security hotfix)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.17.5
+
+This release contains a low-priority security fix. We are not aware of any
+exploitation in the wild.
+
+* Fix path injection in `read_gzip_header_filename()` (CVE-2026-35465)
+
 ## 0.17.4
 
 This release contains multiple security fixes, all of which are low or

--- a/client/securedrop_client/crypto.py
+++ b/client/securedrop_client/crypto.py
@@ -84,6 +84,12 @@ def read_gzip_header_filename(filename: str) -> str:
             original_filename = str(fb, "utf-8")
 
     check_path_traversal(original_filename)
+
+    # Ensure this is a single file and not a path
+    if original_filename != Path(original_filename).name:
+        # Otherwise, treat it as an unrecoverable fault for this file:
+        raise ValueError("Unsafe file name; aborting further processing")
+
     return original_filename
 
 

--- a/client/tests/test_crypto_gzip.py
+++ b/client/tests/test_crypto_gzip.py
@@ -153,7 +153,24 @@ def test_path_traversal(tmp_path):
         f.write(original_name.encode("utf-8") + b"\000")
         f.write(gzip.compress(b"test content")[10:])
 
-    with pytest.raises(
-        ValueError, match="Unsafe file or directory name: '../../../../../etc/passwd'"
-    ):
+    with pytest.raises(ValueError, match=f"Unsafe file or directory name: '{original_name}'"):
+        read_gzip_header_filename(str(tmp_file))
+
+
+def test_overwrite_via_abs_path(tmp_path):
+    """Test that an absolute path in the gzip header filename is rejected."""
+    tmp_file = tmp_path / "test.gz"
+    original_name = "/home/user/.securedrop_client/svs.sqlite"
+
+    with open(tmp_file, "wb") as f:
+        f.write(GZIP_FILE_IDENTIFICATION)  # ID
+        f.write(GZIP_COMPRESSION_BYTES)  # Compression method
+        f.write(bytes([GZIP_FLAG_FILENAME]))  # Flags
+        f.write(b"\000\000\000\000")  # mtime
+        f.write(b"\000")  # XFL
+        f.write(b"\377")  # OS
+        f.write(original_name.encode("utf-8") + b"\000")
+        f.write(gzip.compress(b"test content")[10:])
+
+    with pytest.raises(ValueError, match="Unsafe file name; aborting further processing"):
         read_gzip_header_filename(str(tmp_file))

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,13 @@ securedrop-client (0.18.0~rc1) unstable; urgency=medium
 
   * see changelog.md
 
- -- SecureDrop Team <securedrop@freedom.press>  Mon, 06 Apr 2026 17:05:33 -0400
+ -- SecureDrop Team <securedrop@freedom.press>  Mon, 13 Apr 2026 17:05:33 -0400
+
+securedrop-client (0.17.5) unstable; urgency=medium
+
+  * see changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 09 Apr 2026 11:56:03 -0400
 
 securedrop-client (0.17.4) unstable; urgency=medium
 


### PR DESCRIPTION
Backports changes introduced in 0.17.5 and changelog.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
- [ ] changes include [everything in 0.17.5 release](https://github.com/freedomofpress/securedrop-client/compare/release/0.17.4..release/0.17.5)

## Checklist (not relevant)

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
