### PR TITLE
Install xz-utils in diffoscope CI job for proper diffs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          apt-get update && apt-get install --yes diffoscope-minimal \
+          apt-get update && apt-get install --yes diffoscope-minimal xz-utils \
             --no-install-recommends
       - uses: actions/download-artifact@v7
         with:


### PR DESCRIPTION
Otherwise diffoscope will just give you a hexdump, which is mostly useless.

Refs #3219.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] visual review, same as https://github.com/freedomofpress/securedrop/commit/26ffd35d62511c24f57c6975653b18384703eec4

