### PR TITLE
Update PR body created by backport.py

### DIFF
--- a/scripts/backport.py
+++ b/scripts/backport.py
@@ -37,17 +37,10 @@ if input("OK to push and create PR? [y/N]").lower() != "y":
     sys.exit()
 subprocess.check_call(["git", "push", "-u", remote, branch])
 body = f"""\
-## Status
-
-Ready for review
-
-## Description of Changes
-
 Backport of #{args.pr}.
 
 ## Testing
 
-* [ ] CI is passing
 * [ ] base is `{base}`
 * [ ] Only contains changes from #{args.pr}.
 """


### PR DESCRIPTION
We updated our conventions a while back to drop the "Status" section and we don't need an explicit "CI is passing" anymore.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
