### PR TITLE
Add support for sd-printers in Inbox

### DIFF
--- a/app/integration_tests/export-archive.test.ts
+++ b/app/integration_tests/export-archive.test.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import * as tar from "tar";
-import { ArchiveExporter } from "../src/main/export";
+import { ArchiveExporter, EXPORT_QUBE } from "../src/main/export";
 import { execSync } from "child_process";
 
 // Test Export Archive creation with securedrop_export
@@ -25,7 +25,7 @@ describe("Export Archive Tests", () => {
 
   describe("Metadata validation", () => {
     it("should create tarball with metadata.json at root", async () => {
-      const exporter = new ArchiveExporter();
+      const exporter = new ArchiveExporter(EXPORT_QUBE);
       const metadata = { device: "disk", foo: "bar" };
 
       const archivePath = await exporter.createArchive({
@@ -48,7 +48,7 @@ describe("Export Archive Tests", () => {
     });
 
     it("should include encryption_key in metadata when provided", async () => {
-      const exporter = new ArchiveExporter();
+      const exporter = new ArchiveExporter(EXPORT_QUBE);
       const passphrase = "test-passphrase-123";
       const metadata = {
         device: "disk",
@@ -74,7 +74,7 @@ describe("Export Archive Tests", () => {
 
   describe("File path structure", () => {
     it("should place single file under export_data/", async () => {
-      const exporter = new ArchiveExporter();
+      const exporter = new ArchiveExporter(EXPORT_QUBE);
       const testFile = path.join(archiveDir, "document.txt");
       fs.writeFileSync(testFile, "test content");
 
@@ -100,7 +100,7 @@ describe("Export Archive Tests", () => {
     });
 
     it("should place multiple files flat under export_data with parent prefix", async () => {
-      const exporter = new ArchiveExporter();
+      const exporter = new ArchiveExporter(EXPORT_QUBE);
 
       // Create files with proper directory structure
       const sourceDir = path.join(tmpDir, "source");
@@ -143,7 +143,7 @@ describe("Export Archive Tests", () => {
     });
 
     it("should handle transcript.txt same as other files", async () => {
-      const exporter = new ArchiveExporter();
+      const exporter = new ArchiveExporter(EXPORT_QUBE);
 
       // Create multiple files including transcript.txt
       const sourceDir = path.join(tmpDir, "source");
@@ -190,7 +190,7 @@ describe("Export Archive Tests", () => {
 
   describe("Path security validations (safe_extractall requirements)", () => {
     it("should only contain relative paths", async () => {
-      const exporter = new ArchiveExporter();
+      const exporter = new ArchiveExporter(EXPORT_QUBE);
       const testFile = path.join(archiveDir, "test.txt");
       fs.writeFileSync(testFile, "content");
 
@@ -219,7 +219,7 @@ describe("Export Archive Tests", () => {
     });
 
     it("should not contain path traversal sequences", async () => {
-      const exporter = new ArchiveExporter();
+      const exporter = new ArchiveExporter(EXPORT_QUBE);
       const testFile = path.join(archiveDir, "test.txt");
       fs.writeFileSync(testFile, "content");
 
@@ -259,7 +259,7 @@ describe("Export Archive Tests", () => {
     });
 
     it("should resolve to within extraction directory when extracted", async () => {
-      const exporter = new ArchiveExporter();
+      const exporter = new ArchiveExporter(EXPORT_QUBE);
       const testFile = path.join(archiveDir, "test.txt");
       fs.writeFileSync(testFile, "content");
 
@@ -298,7 +298,7 @@ describe("Export Archive Tests", () => {
 
   describe("File permissions", () => {
     it("should create tarball that extracts with proper permissions", async () => {
-      const exporter = new ArchiveExporter();
+      const exporter = new ArchiveExporter(EXPORT_QUBE);
       const testFile = path.join(archiveDir, "test.txt");
       fs.writeFileSync(testFile, "content");
 
@@ -332,7 +332,7 @@ describe("Export Archive Tests", () => {
 
   describe("Python safe_extractall compatibility", () => {
     it("should successfully extract with Python safe_extractall", async () => {
-      const exporter = new ArchiveExporter();
+      const exporter = new ArchiveExporter(EXPORT_QUBE);
       const testFile = path.join(archiveDir, "document.txt");
       fs.writeFileSync(testFile, "test content");
 
@@ -396,7 +396,7 @@ print('SUCCESS')
     });
 
     it("should extract multiple files with Python safe_extractall", async () => {
-      const exporter = new ArchiveExporter();
+      const exporter = new ArchiveExporter(EXPORT_QUBE);
 
       // Create multiple files
       const sourceDir = path.join(tmpDir, "source");
@@ -473,7 +473,7 @@ print('SUCCESS')
 
   describe("Edge cases", () => {
     it("should handle files with special characters in names", async () => {
-      const exporter = new ArchiveExporter();
+      const exporter = new ArchiveExporter(EXPORT_QUBE);
       const testFile = path.join(archiveDir, "file with spaces.txt");
       fs.writeFileSync(testFile, "content");
 
@@ -497,7 +497,7 @@ print('SUCCESS')
     });
 
     it("should create valid tarball with no files (metadata only)", async () => {
-      const exporter = new ArchiveExporter();
+      const exporter = new ArchiveExporter(EXPORT_QUBE);
 
       const archivePath = await exporter.createArchive({
         archiveDir,

--- a/app/src/main/export.test.ts
+++ b/app/src/main/export.test.ts
@@ -10,6 +10,7 @@ import {
   PrintStateMachine,
   ExportState,
   ExportStateMachine,
+  EXPORT_QUBE,
 } from "./export";
 import { PrintStatus } from "../types";
 
@@ -79,7 +80,11 @@ describe("ExportStateMachine", () => {
 
 // ArchiveExporter.parseStatus
 describe("ArchiveExporter", () => {
-  class TestExporter extends ArchiveExporter {}
+  class TestExporter extends ArchiveExporter {
+    constructor() {
+      super(EXPORT_QUBE);
+    }
+  }
 
   it("should parse known status from processStderr", () => {
     const exporter = new TestExporter();
@@ -121,7 +126,7 @@ describe("ArchiveExporter", () => {
     });
 
     it("creates an archive with metadata.json only", async () => {
-      const exporter = new ArchiveExporter();
+      const exporter = new ArchiveExporter(EXPORT_QUBE);
       const archiveFilename = "test-archive.tar.gz";
       const metadata = { foo: "bar" };
 
@@ -145,7 +150,7 @@ describe("ArchiveExporter", () => {
     });
 
     it("creates an archive with metadata.json and one file", async () => {
-      const exporter = new ArchiveExporter();
+      const exporter = new ArchiveExporter(EXPORT_QUBE);
       const archiveFilename = "test-archive2.tar.gz";
       const metadata = { foo: "bar" };
       const fileContent = "hello world";
@@ -180,7 +185,7 @@ describe("ArchiveExporter", () => {
     });
 
     it("creates an archive with multiple files and correct structure", async () => {
-      const exporter = new ArchiveExporter();
+      const exporter = new ArchiveExporter(EXPORT_QUBE);
       const archiveFilename = "test-archive3.tar.gz";
       const metadata = { foo: "bar" };
 
@@ -230,7 +235,7 @@ describe("ArchiveExporter", () => {
     });
 
     it("creates an archive with sourceName and files under source directory", async () => {
-      const exporter = new ArchiveExporter();
+      const exporter = new ArchiveExporter(EXPORT_QUBE);
       const archiveFilename = "test-archive5.tar.gz";
       const metadata = { foo: "bar" };
 
@@ -303,7 +308,7 @@ describe("ArchiveExporter", () => {
     });
 
     it("does not include missing files and removes metadata if all missing", async () => {
-      const exporter = new ArchiveExporter();
+      const exporter = new ArchiveExporter(EXPORT_QUBE);
       const archiveFilename = "test-archive4.tar.gz";
       const metadata = { foo: "bar" };
       const missingFile = path.join(archiveDir, "doesnotexist.txt");

--- a/app/src/main/export.ts
+++ b/app/src/main/export.ts
@@ -20,6 +20,9 @@ import {
 const mkdtemp = promisify(mkdtempCb);
 const chmodAsync = promisify(chmod);
 
+export const PRINT_QUBE = "sd-printers";
+export const EXPORT_QUBE = "sd-devices";
+
 export class PrintExportError extends Error {
   status?: DeviceStatus;
   constructor(message: string, status?: DeviceStatus) {
@@ -204,6 +207,11 @@ export class ArchiveExporter {
   process: ChildProcess | null = null;
   processStderr: string = "";
   tmpdir: string | null = null;
+  backendQube: string;
+
+  constructor(backendQube: string) {
+    this.backendQube = backendQube;
+  }
 
   /**
    * Create an archive to be sent to the Export VM.
@@ -312,7 +320,7 @@ export class ArchiveExporter {
       const qrexec = "/usr/bin/qrexec-client-vm";
       const args = [
         "--",
-        "sd-devices",
+        this.backendQube,
         "qubes.OpenInVM",
         "/usr/lib/qubes/qopen-in-vm",
         "--view-only",
@@ -378,7 +386,7 @@ export class ArchiveExporter {
       const last = lines.length > 0 ? lines[lines.length - 1] : "";
       if (!last) {
         throw new PrintExportError(
-          "No final line in sd-devices status response",
+          `No final line in ${this.backendQube} status response`,
         );
       }
 
@@ -427,7 +435,7 @@ export class Printer extends ArchiveExporter {
   private fsm: PrintStateMachine;
 
   constructor() {
-    super();
+    super(PRINT_QUBE);
     this.fsm = new PrintStateMachine();
   }
 
@@ -546,7 +554,7 @@ export class Exporter extends ArchiveExporter {
   private fsm: ExportStateMachine;
 
   constructor() {
-    super();
+    super(EXPORT_QUBE);
     this.fsm = new ExportStateMachine();
   }
 

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -260,8 +260,8 @@ export type ExportPayload = PayloadTranscript | PayloadSource | PayloadFile;
 // for now only transcripts or single files may be printed
 export type PrintPayload = PayloadTranscript | PayloadFile;
 
-// All possible strings returned by the qrexec calls to sd-devices. These values come from
-// `print/status.py` and `disk/status.py` in `securedrop-export`
+// All possible strings returned by the qrexec calls to sd-devices or sd-printers.
+// These values come from `print/status.py` and `disk/status.py` in `securedrop-export`
 // and must only be changed in coordination with changes released in that component.
 export type DeviceStatus =
   | ExportStatus


### PR DESCRIPTION
The qube 'sd-printers' was added to be separate printers from other USB devices. This partly addresses the risks of document rendering compromising documents from other sources.

This was part of the security fixes from the audit, but wasn't backported to 0.17.4 because it was Inbox-only and then got missed since we backported the actual release only and not the full set of fixes

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] Same as what was reviewed in https://github.com/freedomofpress/securedrop-client-security/pull/71/
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
