### PR TITLE
[inbox] use SourceConversationTruncated event

### DIFF
--- a/app/server_tests/delete-conversation.test.ts
+++ b/app/server_tests/delete-conversation.test.ts
@@ -58,7 +58,7 @@ describe.sequential("deleting source conversation", () => {
 
     // Verify pending event was created
     const pendingEvents = await helpers.getPendingEventsByType(
-      PendingEventType.SourceConversationDeleted,
+      PendingEventType.SourceConversationTruncated,
     );
     expect(pendingEvents).toHaveLength(1);
     expect(pendingEvents[0].sourceUuid).toBe(TARGET_SOURCE.uuid);
@@ -74,7 +74,7 @@ describe.sequential("deleting source conversation", () => {
 
     // Verify pending events are cleared
     const pendingEvents = await helpers.getPendingEventsByType(
-      PendingEventType.SourceConversationDeleted,
+      PendingEventType.SourceConversationTruncated,
     );
     expect(pendingEvents).toHaveLength(0);
 

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -29,6 +29,7 @@ import {
   EventStatus,
   SearchResult,
   FirstRunStatus,
+  PendingEventData,
 } from "../../types";
 import { Crypto } from "../crypto";
 import { Search } from "./search";
@@ -287,7 +288,8 @@ export class DB {
         s.has_attachment,
         i.kind AS last_message_kind,
         substr(i.plaintext, 1, ${MESSAGE_PREVIEW_LENGTH}) AS last_message_plaintext,
-        i.filename AS last_message_filename
+        i.filename AS last_message_filename,
+        i.interaction_count AS last_interaction_count
       FROM sources_projected s
       LEFT JOIN sorted_items i
         ON s.uuid = i.source_uuid
@@ -301,7 +303,8 @@ export class DB {
         s.has_attachment,
         i.kind AS last_message_kind,
         substr(i.plaintext, 1, ${MESSAGE_PREVIEW_LENGTH}) AS last_message_plaintext,
-        i.filename AS last_message_filename
+        i.filename AS last_message_filename,
+        i.interaction_count AS last_interaction_count
       FROM sources_projected s
       LEFT JOIN sorted_items i
         ON s.uuid = i.source_uuid AND i.rn = 1
@@ -696,6 +699,7 @@ export class DB {
                 : row.last_message_plaintext) ?? null,
           }
         : null,
+      lastInteractionCount: row.last_interaction_count ?? null,
     };
   }
 
@@ -963,7 +967,11 @@ export class DB {
     stmt.run({ uuid: itemUuid });
   }
 
-  addPendingSourceEvent(sourceUuid: string, type: PendingEventType): string {
+  addPendingSourceEvent(
+    sourceUuid: string,
+    type: PendingEventType,
+    data?: PendingEventData,
+  ): string {
     const snowflakeID = this.snowflake
       .generate({ timestamp: Date.now() })
       .toString();
@@ -971,7 +979,7 @@ export class DB {
       snowflake_id: snowflakeID,
       source_uuid: sourceUuid,
       type: type,
-      data: null,
+      data: data ? JSON.stringify(data) : null,
     });
     return snowflakeID;
   }

--- a/app/src/main/database/migrations/20260416000000_source_conversation_truncated.sql
+++ b/app/src/main/database/migrations/20260416000000_source_conversation_truncated.sql
@@ -1,79 +1,12 @@
-CREATE TABLE IF NOT EXISTS "schema_migrations" (version varchar(128) primary key);
-CREATE TABLE sources (
-    uuid TEXT PRIMARY KEY,
-    data JSON,
-    version TEXT,
-    is_seen INTEGER GENERATED ALWAYS AS (json_extract(data, '$.is_seen')) STORED,
-    has_attachment INTEGER GENERATED ALWAYS AS (json_extract(data, '$.has_attachment')) STORED
-);
-CREATE TABLE items (
-    uuid TEXT PRIMARY KEY,
-    data JSON,
-    plaintext TEXT,
-    filename TEXT,
-    version TEXT,
-    source_uuid TEXT GENERATED ALWAYS AS (json_extract(data, '$.source')) STORED,
-    kind TEXT GENERATED ALWAYS AS (json_extract(data, '$.kind')) STORED,
-    is_read INTEGER GENERATED ALWAYS AS (json_extract(data, '$.is_read')) STORED,
-    last_updated INTEGER GENERATED ALWAYS AS (json_extract(data, '$.last_updated')) STORED,
-    fetch_progress INTEGER,
-    fetch_status INTEGER NOT NULL DEFAULT 0,
-    fetch_last_updated_at TIMESTAMP,
-    fetch_retry_attempts INTEGER NOT NULL DEFAULT 0,
-    interaction_count INTEGER GENERATED ALWAYS AS (json_extract(data, '$.interaction_count')),
-    decrypted_size INTEGER
-);
-CREATE TABLE journalists (
-    uuid TEXT PRIMARY KEY,
-    data JSON,
-    version TEXT
-);
-CREATE TABLE state_history (
-    version TEXT,
-    updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    id INTEGER PRIMARY KEY AUTOINCREMENT
-);
-CREATE TABLE pending_events (
-    snowflake_id TEXT PRIMARY KEY,
-    source_uuid TEXT REFERENCES sources(uuid) ON DELETE CASCADE,
-    item_uuid TEXT REFERENCES items(uuid) ON DELETE CASCADE,
-    type TEXT NOT NULL,
-    data JSON,
-    CHECK (NOT (source_uuid IS NOT NULL AND item_uuid IS NOT NULL))
-);
-CREATE VIEW state AS
-SELECT *
-FROM state_history
-ORDER BY id DESC
-LIMIT 1
-/* state(version,updated,id) */;
-CREATE INDEX idx_items_kind ON items(kind);
-CREATE INDEX idx_items_is_read ON items(is_read);
-CREATE INDEX idx_items_last_updated ON items(last_updated);
-CREATE INDEX idx_sources_uuid ON sources(uuid);
-CREATE INDEX idx_items_source_uuid ON items(source_uuid);
-CREATE INDEX idx_items_fetch_status ON items(fetch_status);
-CREATE VIRTUAL TABLE search_index USING fts5 (
-    source_uuid UNINDEXED,
-    item_uuid UNINDEXED,
-    type UNINDEXED,
-    content,
-    tokenize = 'unicode61'
-)
-/* search_index(source_uuid,item_uuid,type,content) */;
-CREATE TABLE IF NOT EXISTS 'search_index_data'(id INTEGER PRIMARY KEY, block BLOB);
-CREATE TABLE IF NOT EXISTS 'search_index_idx'(segid, term, pgno, PRIMARY KEY(segid, term)) WITHOUT ROWID;
-CREATE TABLE IF NOT EXISTS 'search_index_content'(id INTEGER PRIMARY KEY, c0, c1, c2, c3);
-CREATE TABLE IF NOT EXISTS 'search_index_docsize'(id INTEGER PRIMARY KEY, sz BLOB);
-CREATE TABLE IF NOT EXISTS 'search_index_config'(k PRIMARY KEY, v) WITHOUT ROWID;
-CREATE TRIGGER items_kind_immutable
-BEFORE UPDATE OF data ON items
-FOR EACH ROW
-WHEN json_extract(OLD.data, '$.kind') IS NOT NULL
-    AND json_extract(NEW.data, '$.kind') IS NOT json_extract(OLD.data, '$.kind')
-BEGIN
-    SELECT RAISE(ABORT, 'items.kind is immutable');
-END;
+-- migrate:up
+DROP VIEW IF EXISTS sorted_items;
+
+DROP VIEW IF EXISTS sources_projected;
+
+DROP VIEW IF EXISTS items_projected;
+
+-- Recreate items_projected to replace source_conversation_deleted with
+-- source_conversation_truncated
 CREATE VIEW items_projected AS
 SELECT
     items.uuid,
@@ -165,8 +98,8 @@ WHERE pending_events.type = 'reply_sent'
             )
         )
         AND later.snowflake_id > pending_events.snowflake_id
-    )
-/* items_projected(uuid,data,version,plaintext,filename,kind,is_read,last_updated,source_uuid,fetch_progress,fetch_status,fetch_last_updated_at,fetch_retry_attempts,interaction_count,decrypted_size) */;
+    );
+
 CREATE VIEW sources_projected AS
 WITH latest_starred AS (
     SELECT
@@ -216,8 +149,8 @@ WHERE NOT EXISTS (
     FROM pending_events
     WHERE pending_events.source_uuid = sources.uuid
         AND pending_events.type = 'source_deleted'
-)
-/* sources_projected(uuid,data,version,has_attachment,is_seen) */;
+);
+
 CREATE VIEW sorted_items AS
 SELECT
     *,
@@ -225,13 +158,151 @@ SELECT
         PARTITION BY source_uuid
         ORDER BY interaction_count DESC
     ) AS rn
-FROM items_projected
-/* sorted_items(uuid,data,version,plaintext,filename,kind,is_read,last_updated,source_uuid,fetch_progress,fetch_status,fetch_last_updated_at,fetch_retry_attempts,interaction_count,decrypted_size,rn) */;
--- Dbmate schema migrations
-INSERT INTO "schema_migrations" (version) VALUES
-  ('20260203225412'),
-  ('20260213000000'),
-  ('20260217000000'),
-  ('20260326182530'),
-  ('20260331000000'),
-  ('20260416000000');
+FROM items_projected;
+
+-- migrate:down
+DROP VIEW IF EXISTS sorted_items;
+
+DROP VIEW IF EXISTS sources_projected;
+
+DROP VIEW IF EXISTS items_projected;
+
+CREATE VIEW items_projected AS
+SELECT
+    items.uuid,
+    items.data,
+    items.version,
+    items.plaintext,
+    items.filename,
+    items.kind,
+    CASE
+        WHEN items.is_read THEN 1
+        WHEN EXISTS (
+            SELECT 1 FROM pending_events
+            WHERE pending_events.item_uuid = items.uuid
+                AND pending_events.type = 'item_seen'
+        ) THEN 1
+        WHEN EXISTS (
+            SELECT 1 FROM pending_events
+            WHERE pending_events.source_uuid = items.source_uuid
+                AND pending_events.type = 'source_conversation_seen'
+                AND CAST(json_extract(pending_events.data, '$.upper_bound') AS INTEGER) >= items.interaction_count
+        ) THEN 1
+        ELSE 0
+    END AS is_read,
+    items.last_updated,
+    items.source_uuid,
+    items.fetch_progress,
+    items.fetch_status,
+    items.fetch_last_updated_at,
+    items.fetch_retry_attempts,
+    items.interaction_count,
+    items.decrypted_size
+FROM items
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM pending_events
+    WHERE pending_events.item_uuid = items.uuid
+        AND pending_events.type = 'item_deleted'
+)
+    AND NOT EXISTS (
+        SELECT 1
+        FROM pending_events
+        WHERE pending_events.source_uuid = items.source_uuid
+            AND pending_events.type IN ('source_deleted', 'source_conversation_deleted')
+    )
+UNION ALL
+SELECT
+    json_extract(pending_events.data, '$.metadata.uuid') AS uuid,
+    json_extract(pending_events.data, '$.metadata') AS data,
+    NULL AS version,
+    json_extract(pending_events.data, '$.plaintext') AS plaintext,
+    NULL AS filename,
+    'reply' AS kind,
+    1 AS is_read,
+    NULL AS last_updated,
+    json_extract(pending_events.data, '$.metadata.source') AS source_uuid,
+    NULL AS fetch_progress,
+    NULL AS fetch_status,
+    NULL AS fetch_last_updated_at,
+    NULL AS fetch_retry_attempts,
+    json_extract(pending_events.data, '$.metadata.interaction_count') AS interaction_count,
+    NULL AS decrypted_size
+FROM pending_events
+WHERE pending_events.type = 'reply_sent'
+    AND NOT EXISTS (
+        SELECT 1
+        FROM pending_events later
+        WHERE (
+            (
+                later.source_uuid = json_extract(pending_events.data, '$.metadata.source')
+                AND later.type IN ('source_deleted', 'source_conversation_deleted')
+            )
+            OR
+            (
+                later.item_uuid = json_extract(pending_events.data, '$.metadata.uuid')
+                AND later.type = 'item_deleted'
+            )
+        )
+        AND later.snowflake_id > pending_events.snowflake_id
+    );
+
+CREATE VIEW sources_projected AS
+WITH latest_starred AS (
+    SELECT
+        source_uuid,
+        CASE
+            WHEN type = 'source_starred' THEN true
+            WHEN type = 'source_unstarred' THEN false
+        END AS starred_value
+    FROM (
+        SELECT
+            source_uuid,
+            type,
+            ROW_NUMBER() OVER (
+                PARTITION BY source_uuid
+                ORDER BY snowflake_id DESC
+            ) AS rn
+        FROM pending_events
+        WHERE type IN ('source_starred', 'source_unstarred')
+            AND source_uuid IS NOT NULL
+    ) latest
+    WHERE rn = 1
+)
+SELECT
+    sources.uuid,
+    CASE
+        WHEN latest_starred.starred_value IS NOT NULL THEN json_set(sources.data, '$.is_starred', starred_value)
+        ELSE sources.data
+    END AS data,
+    sources.version,
+    sources.has_attachment,
+    CASE
+        WHEN sources.is_seen THEN 1
+        WHEN EXISTS (
+            SELECT 1 FROM items_projected ip
+            WHERE ip.source_uuid = sources.uuid AND ip.is_read = 0
+        ) THEN 0
+        WHEN NOT EXISTS (
+            SELECT 1 FROM items_projected ip
+            WHERE ip.source_uuid = sources.uuid
+        ) THEN 0
+        ELSE 1
+    END AS is_seen
+FROM sources
+LEFT JOIN latest_starred ON latest_starred.source_uuid = sources.uuid
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM pending_events
+    WHERE pending_events.source_uuid = sources.uuid
+        AND pending_events.type = 'source_deleted'
+);
+
+CREATE VIEW sorted_items AS
+SELECT
+    *,
+    ROW_NUMBER() OVER (
+        PARTITION BY source_uuid
+        ORDER BY interaction_count DESC
+    ) AS rn
+FROM items_projected;

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -290,15 +290,15 @@ describe("Datastore Method Tests", () => {
     expect(sources.map((s) => s.uuid)).toEqual(["source1", "source2"]);
   });
 
-  it("pending SourceConversationDeleted should remove all items", () => {
+  it("pending SourceConversationTruncated should remove items up to and including upper_bound", () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),
     });
 
     db.updateItems({
-      item1: mockItemMetadata("item1", "source1"),
-      item2: mockItemMetadata("item2", "source1"),
-      item3: mockItemMetadata("item3", "source1"),
+      item1: mockItemMetadata("item1", "source1", "message", 1),
+      item2: mockItemMetadata("item2", "source1", "message", 2),
+      item3: mockItemMetadata("item3", "source1", "message", 3),
     });
 
     let sourceWithItems = db.getSourceWithItems("source1");
@@ -306,25 +306,22 @@ describe("Datastore Method Tests", () => {
 
     db.addPendingSourceEvent(
       "source1",
-      PendingEventType.SourceConversationDeleted,
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 2 },
     );
     sourceWithItems = db.getSourceWithItems("source1");
-    expect(sourceWithItems.items.length).toEqual(0);
-
-    db.updateSources({
-      source2: mockSourceMetadata("source2"),
-    });
+    expect(sourceWithItems.items.length).toEqual(1);
   });
 
-  it("pending SourceConversationDeleted event should only affect given source", () => {
+  it("pending SourceConversationTruncated event should only affect given source", () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),
     });
 
     db.updateItems({
-      item1: mockItemMetadata("item1", "source1"),
-      item2: mockItemMetadata("item2", "source1"),
-      item3: mockItemMetadata("item3", "source1"),
+      item1: mockItemMetadata("item1", "source1", "message", 1),
+      item2: mockItemMetadata("item2", "source1", "message", 2),
+      item3: mockItemMetadata("item3", "source1", "message", 3),
     });
 
     let sourceWithItems = db.getSourceWithItems("source1");
@@ -332,7 +329,8 @@ describe("Datastore Method Tests", () => {
 
     db.addPendingSourceEvent(
       "source1",
-      PendingEventType.SourceConversationDeleted,
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 3 },
     );
     sourceWithItems = db.getSourceWithItems("source1");
     expect(sourceWithItems.items.length).toEqual(0);
@@ -343,9 +341,9 @@ describe("Datastore Method Tests", () => {
     });
 
     db.updateItems({
-      item1: mockItemMetadata("item1", "source2"),
-      item2: mockItemMetadata("item2", "source2"),
-      item3: mockItemMetadata("item3", "source2"),
+      item1: mockItemMetadata("item1", "source2", "message", 1),
+      item2: mockItemMetadata("item2", "source2", "message", 2),
+      item3: mockItemMetadata("item3", "source2", "message", 3),
     });
     sourceWithItems = db.getSourceWithItems("source2");
     expect(sourceWithItems.items.length).toEqual(3);
@@ -553,14 +551,14 @@ describe("Datastore Method Tests", () => {
     expect(sourceWithItems.items.length).toEqual(2);
   });
 
-  it("pending ReplySent and pending SourceConversationDeleted should delete all items in conversation", async () => {
+  it("pending ReplySent and pending SourceConversationTruncated should delete all items in conversation", async () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),
     });
 
     db.updateItems({
-      item1: mockItemMetadata("item1", "source1"),
-      item2: mockItemMetadata("item2", "source1"),
+      item1: mockItemMetadata("item1", "source1", "message", 1),
+      item2: mockItemMetadata("item2", "source1", "message", 2),
     });
 
     await db.addPendingReplySentEvent("reply text", "source1", 3);
@@ -569,25 +567,27 @@ describe("Datastore Method Tests", () => {
 
     db.addPendingSourceEvent(
       "source1",
-      PendingEventType.SourceConversationDeleted,
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 3 },
     );
     sourceWithItems = db.getSourceWithItems("source1");
     expect(sourceWithItems.items.length).toEqual(0);
   });
 
-  it("pending SourceConversationDeleted and ReplySent should show reply", async () => {
+  it("pending SourceConversationTruncated and ReplySent should show reply", async () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),
     });
 
     db.updateItems({
-      item1: mockItemMetadata("item1", "source1"),
-      item2: mockItemMetadata("item2", "source1"),
+      item1: mockItemMetadata("item1", "source1", "message", 1),
+      item2: mockItemMetadata("item2", "source1", "message", 2),
     });
 
     const snowflake1 = db.addPendingSourceEvent(
       "source1",
-      PendingEventType.SourceConversationDeleted,
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 2 },
     );
     let sourceWithItems = db.getSourceWithItems("source1");
     expect(sourceWithItems.items.length).toEqual(0);
@@ -595,7 +595,7 @@ describe("Datastore Method Tests", () => {
     const snowflake2 = await db.addPendingReplySentEvent(
       "reply text",
       "source1",
-      1,
+      3,
     );
     expect(snowflake2 > snowflake1);
     sourceWithItems = db.getSourceWithItems("source1");
@@ -1040,7 +1040,7 @@ describe("Datastore Method Tests", () => {
     }
   });
 
-  it("getSources should return sources with correct last_message_kind, last_message_plaintext, and last_message_filename", () => {
+  it("getSources should return sources with correct last_message_kind, last_message_plaintext, last_message_filename, and last_interaction_count", () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),
       source2: mockSourceMetadata("source2"),
@@ -1057,7 +1057,7 @@ describe("Datastore Method Tests", () => {
       item4: mockItemMetadata("item4", "source2", "file", 2),
       // source3 items
       item5: mockItemMetadata("item5", "source3", "message", 1),
-      item6: mockItemMetadata("item6", "source3", "message", 2),
+      item6: mockItemMetadata("item6", "source3", "message", 5),
     });
 
     db.completePlaintextItem("item1", "reply message 1");
@@ -1076,6 +1076,7 @@ describe("Datastore Method Tests", () => {
       expect(s1.messagePreview).not.toBeNull();
       expect(s1.messagePreview?.kind).toBe("message");
       expect(s1.messagePreview?.plaintext).toBe("message 2");
+      expect(s1.lastInteractionCount).toBe(2);
     }
 
     expect(s2).not.toBeNull();
@@ -1083,6 +1084,7 @@ describe("Datastore Method Tests", () => {
       expect(s2.messagePreview).not.toBeNull();
       expect(s2.messagePreview?.kind).toBe("file");
       expect(s2.messagePreview?.plaintext).toBe("filename.txt");
+      expect(s2.lastInteractionCount).toBe(2);
     }
 
     expect(s3).not.toBeNull();
@@ -1090,6 +1092,7 @@ describe("Datastore Method Tests", () => {
       expect(s3.messagePreview).not.toBeNull();
       expect(s3.messagePreview?.kind).toBe("message");
       expect(s3.messagePreview?.plaintext).toBeNull();
+      expect(s3.lastInteractionCount).toBe(5);
     }
 
     expect(s4).not.toBeNull();

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -33,6 +33,7 @@ import {
   FetchStatus,
   PendingEventType,
   SyncStatus,
+  PendingEventData,
 } from "../types";
 import { syncMetadata, shouldSkipSync } from "./sync";
 import workerPath from "./fetch/worker?modulePath";
@@ -450,15 +451,24 @@ if (!gotTheLock) {
           _event,
           sourceUuid: string,
           type: PendingEventType,
+          data?: PendingEventData,
         ): Promise<string> => {
-          const snowflakeID = db.addPendingSourceEvent(sourceUuid, type);
           // Immediately delete any source files from the fs on pending deletion
-          if (
-            type === PendingEventType.SourceDeleted ||
-            type === PendingEventType.SourceConversationDeleted
-          ) {
+          if (type === PendingEventType.SourceDeleted) {
             db.deleteSourceFs(sourceUuid);
           }
+          // For truncation, delete all truncated item files from the fs
+          if (type === PendingEventType.SourceConversationTruncated) {
+            if (data?.upper_bound) {
+              const items = db.getSourceWithItems(sourceUuid, {
+                beforeInteractionCount: data?.upper_bound + 1,
+              }).items;
+              for (const item of items) {
+                db.deleteItemFs(item);
+              }
+            }
+          }
+          const snowflakeID = db.addPendingSourceEvent(sourceUuid, type, data);
           return snowflakeID;
         },
       );

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -15,6 +15,7 @@ import {
   PendingEventType,
   SyncStatus,
   DeviceStatus,
+  PendingEventData,
 } from "../types";
 
 // Log the performance of IPC calls
@@ -88,8 +89,8 @@ const electronAPI = {
   ),
   addPendingSourceEvent: logIpcCall<bigint>(
     "addPendingSourceEvent",
-    (sourceUuid: string, type: PendingEventType) =>
-      ipcRenderer.invoke("addPendingSourceEvent", sourceUuid, type),
+    (sourceUuid: string, type: PendingEventType, data?: PendingEventData) =>
+      ipcRenderer.invoke("addPendingSourceEvent", sourceUuid, type, data),
   ),
   addPendingReplySentEvent: logIpcCall<bigint>(
     "addPendingReplySentEvent",

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
@@ -112,6 +112,7 @@ describe("Sources Component", () => {
       isRead: false,
       hasAttachment: false,
       messagePreview: null,
+      lastInteractionCount: 6,
     },
     {
       uuid: "source-2",
@@ -131,6 +132,7 @@ describe("Sources Component", () => {
         kind: "message",
         plaintext: "Hello from Bob,",
       },
+      lastInteractionCount: 5,
     },
     {
       uuid: "source-3",
@@ -147,6 +149,7 @@ describe("Sources Component", () => {
       isRead: false,
       hasAttachment: false,
       messagePreview: null,
+      lastInteractionCount: 6,
     },
     {
       uuid: "source-4",
@@ -163,6 +166,7 @@ describe("Sources Component", () => {
       isRead: true,
       hasAttachment: false,
       messagePreview: null,
+      lastInteractionCount: 7,
     },
   ];
 
@@ -856,11 +860,12 @@ describe("Sources Component", () => {
         expect(window.electronAPI.addPendingSourceEvent).toHaveBeenCalledWith(
           "source-1",
           PendingEventType.SourceDeleted,
+          undefined,
         );
       });
     });
 
-    it("calls addPendingSourceEvent with SourceConversationDeleted when Delete Conversation is clicked", async () => {
+    it("calls addPendingSourceEvent with SourceConversationTruncated when Delete Conversation is clicked", async () => {
       renderSourceList();
 
       await waitFor(() => {
@@ -889,7 +894,8 @@ describe("Sources Component", () => {
       await waitFor(() => {
         expect(window.electronAPI.addPendingSourceEvent).toHaveBeenCalledWith(
           "source-1",
-          PendingEventType.SourceConversationDeleted,
+          PendingEventType.SourceConversationTruncated,
+          { upper_bound: 6 },
         );
       });
     });
@@ -928,14 +934,17 @@ describe("Sources Component", () => {
         expect(addPendingSourceEvent).toHaveBeenCalledWith(
           "source-1",
           PendingEventType.SourceDeleted,
+          undefined,
         );
         expect(addPendingSourceEvent).toHaveBeenCalledWith(
           "source-2",
           PendingEventType.SourceDeleted,
+          undefined,
         );
         expect(addPendingSourceEvent).toHaveBeenCalledWith(
           "source-3",
           PendingEventType.SourceDeleted,
+          undefined,
         );
       });
     });
@@ -1377,6 +1386,7 @@ describe("Sources Component", () => {
         expect(window.electronAPI.addPendingSourceEvent).toHaveBeenCalledWith(
           "source-1",
           PendingEventType.SourceDeleted,
+          undefined,
         );
         expect(consoleErrorSpy).toHaveBeenCalledWith(
           "Failed to delete source(s):",

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -246,7 +246,16 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
     async (eventType: PendingEventType) => {
       try {
         for (const sourceUuid of pendingDeleteSources) {
-          await window.electronAPI.addPendingSourceEvent(sourceUuid, eventType);
+          const sourceToDelete = sources.find((x) => x.uuid === sourceUuid);
+          await window.electronAPI.addPendingSourceEvent(
+            sourceUuid,
+            eventType,
+            eventType === PendingEventType.SourceConversationTruncated
+              ? {
+                  upper_bound: sourceToDelete?.lastInteractionCount ?? 0,
+                }
+              : undefined,
+          );
         }
         // If we deleted an account and it was the currently active source, navigate away
         if (
@@ -258,7 +267,7 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
         }
         // If we deleted a conversation and there's an active source, refresh the conversation
         if (
-          eventType === PendingEventType.SourceConversationDeleted &&
+          eventType === PendingEventType.SourceConversationTruncated &&
           activeSourceUuid
         ) {
           dispatch(fetchConversation(activeSourceUuid));
@@ -282,7 +291,7 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
         console.error("Failed to delete source(s):", error);
       }
     },
-    [pendingDeleteSources, dispatch, activeSourceUuid, navigate],
+    [pendingDeleteSources, dispatch, activeSourceUuid, navigate, sources],
   );
 
   const handleToggleSort = useCallback(() => {
@@ -484,7 +493,7 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
             data-testid="delete-modal-delete-conversation-button"
             type="primary"
             onClick={() =>
-              handleDeleteAction(PendingEventType.SourceConversationDeleted)
+              handleDeleteAction(PendingEventType.SourceConversationTruncated)
             }
           >
             {pendingDeleteSources.size === 1

--- a/app/src/schemas.ts
+++ b/app/src/schemas.ts
@@ -138,7 +138,7 @@ export enum PendingEventType {
   ReplySent = "reply_sent",
   ItemDeleted = "item_deleted",
   SourceDeleted = "source_deleted",
-  SourceConversationDeleted = "source_conversation_deleted",
+  SourceConversationTruncated = "source_conversation_truncated",
   Starred = "source_starred",
   Unstarred = "source_unstarred",
   SourceConversationSeen = "source_conversation_seen",
@@ -151,6 +151,15 @@ const BasePendingEvent = {
 
 const SourceConversationSeenDataSchema = z.object({ upper_bound: z.number() });
 
+const SourceConversationTruncatedDataSchema = z.object({
+  upper_bound: z.number(),
+});
+
+export const PendingEventDataSchema = z.union([
+  SourceConversationSeenDataSchema,
+  SourceConversationTruncatedDataSchema,
+]);
+
 export const PendingEventSchema = z.discriminatedUnion("type", [
   z.object({
     ...BasePendingEvent,
@@ -162,12 +171,18 @@ export const PendingEventSchema = z.discriminatedUnion("type", [
     type: z.literal(PendingEventType.SourceConversationSeen),
     data: SourceConversationSeenDataSchema,
   }),
+  z.object({
+    ...BasePendingEvent,
+    type: z.literal(PendingEventType.SourceConversationTruncated),
+    data: SourceConversationTruncatedDataSchema,
+  }),
   // All other event types
   ...Object.values(PendingEventType)
     .filter(
       (v) =>
         v !== PendingEventType.ReplySent &&
-        v !== PendingEventType.SourceConversationSeen,
+        v !== PendingEventType.SourceConversationSeen &&
+        v !== PendingEventType.SourceConversationTruncated,
     )
     .map((v) => {
       return z.object({
@@ -198,3 +213,4 @@ export type BatchRequest = z.infer<typeof BatchRequestSchema>;
 export type SourceTarget = z.infer<typeof SourceTargetSchema>;
 export type ItemTarget = z.infer<typeof ItemTargetSchema>;
 export type PendingEvent = z.infer<typeof PendingEventSchema>;
+export type PendingEventData = z.infer<typeof PendingEventDataSchema>;

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -75,6 +75,7 @@ import type {
   SourceTarget,
   ItemTarget,
   PendingEvent,
+  PendingEventData,
 } from "./schemas";
 import { PendingEventType } from "./schemas";
 
@@ -91,6 +92,7 @@ export type {
   SourceTarget,
   ItemTarget,
   PendingEvent,
+  PendingEventData,
 };
 
 export { PendingEventType };
@@ -109,6 +111,7 @@ export type Source = {
   isRead: boolean;
   hasAttachment: boolean;
   messagePreview: MessagePreview | null;
+  lastInteractionCount?: number | null;
 };
 
 export type MessagePreview = {
@@ -151,6 +154,7 @@ export type SourceRow = {
   last_message_kind?: "message" | "reply" | "file";
   last_message_plaintext?: string;
   last_message_filename?: string;
+  last_interaction_count?: number;
 };
 
 export type Item = {
@@ -215,8 +219,6 @@ export enum EventStatus {
   NotFound = 404,
   NotImplemented = 501,
 }
-
-export type PendingEventData = ReplySentData;
 
 export type ReplySentData = {
   uuid: string;


### PR DESCRIPTION
Fixes #3153 

Deprecates the `source_conversation_deleted` event and uses `source_conversation_truncated` instead which takes an `upper_bound` interaction count so that the request is idempotent. Adds a `last_interaction_count` field to the internal Source struct, and also updates the `_projected` views to use the truncated event type.

## Test plan

- Start SecureDrop Inbox and dev server 
- Select a source conversation and `Delete Conversation`
- Verify that all messages in the source conversation are deleted 
- Send new messages from the source or journalist replies 
- Verify that those messages are part of the new conversation 

To test that the `upper_bound` is respected:

- Send a new message from a source, then immediately `Delete Conversation` for that source. 
- Manually trigger a server sync 
- All previous messages should be deleted except the just-sent message

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
