### PR TITLE
Deleting source mid-download/decryption aborts gracefully

### DIFF
--- a/app/.semgrep/custom-rules.yml
+++ b/app/.semgrep/custom-rules.yml
@@ -124,7 +124,7 @@ rules:
 
   # Rule: Ban ALL dynamic content in prepare() statements
   # Only allow template literals with safe constants (FetchStatus, EventStatus,
-  # MESSAGE_PREVIEW_LENGTH).
+  # PendingEventType, MESSAGE_PREVIEW_LENGTH).
   # Exception: selectWhereIn method uses TypeScript string literal types for safety.
   - id: better-sqlite3-ban-dynamic-content
     patterns:
@@ -132,6 +132,7 @@ rules:
       # Exclude safe constants
       - pattern-not: $DB.prepare(`...${FetchStatus.$FIELD}...`)
       - pattern-not: $DB.prepare(`...${EventStatus.$FIELD}...`)
+      - pattern-not: $DB.prepare(`...${PendingEventType.$FIELD}...`)
       - pattern-not: $DB.prepare(`...${MESSAGE_PREVIEW_LENGTH}...`)
       # Exclude selectWhereIn which is validated by using string literal types
       - pattern-not-inside: |
@@ -147,7 +148,7 @@ rules:
         - CORRECT: db.prepare('SELECT * FROM users WHERE name = @name').get({ name })
         - WRONG: db.prepare(`SELECT * FROM users WHERE id = ${userId}`)
 
-      Exception: FetchStatus and EventStatus enum values are allowed as they are compile-time constants.
+      Exception: FetchStatus, EventStatus, and PendingEventType enum values are allowed as they are compile-time constants.
 
       Note: selectWhereIn uses TypeScript string literal types for compile-time safety.
     languages:

--- a/app/src/main/crypto.ts
+++ b/app/src/main/crypto.ts
@@ -192,12 +192,21 @@ export class Crypto {
    * @param encryptedContent - The encrypted message content
    * @returns Promise<string> - The decrypted plaintext
    */
-  async decryptMessage(encryptedContent: Buffer): Promise<string> {
+  async decryptMessage(
+    encryptedContent: Buffer,
+    signal?: AbortSignal,
+  ): Promise<string> {
     const cmd = this.getGpgCommand();
     cmd.push("--decrypt");
 
     return new Promise((resolve, reject) => {
       const gpgProcess = spawn(cmd[0], cmd.slice(1), this.getSpawnOptions());
+
+      // Kill the process if the abort signal fires
+      const abortListener = () => {
+        gpgProcess.kill();
+      };
+      signal?.addEventListener("abort", abortListener, { once: true });
 
       let stdout = Buffer.alloc(0);
       let stderr = Buffer.alloc(0);
@@ -216,10 +225,18 @@ export class Crypto {
         stderr = Buffer.concat([stderr, chunk]);
       });
 
-      gpgProcess.on("close", async (code, signal) => {
+      gpgProcess.on("close", async (code, exitSignal) => {
+        signal?.removeEventListener("abort", abortListener);
         const errorMessage = stderr.toString("utf8");
-        if (signal) {
-          reject(new Error(`Process terminated with signal ${signal}`));
+        if (signal?.aborted) {
+          const err = new Error("Decryption was cancelled");
+          err.name = "AbortError";
+          reject(err);
+          return;
+        }
+        if (exitSignal) {
+          reject(new Error(`Process terminated with signal ${exitSignal}`));
+          return;
         } else if (code !== 0) {
           reject(
             new CryptoError(
@@ -243,6 +260,7 @@ export class Crypto {
       });
 
       gpgProcess.on("error", (error) => {
+        signal?.removeEventListener("abort", abortListener);
         reject(
           new CryptoError(
             `Failed to start GPG process: ${error.message}`,
@@ -263,6 +281,7 @@ export class Crypto {
     storage: Storage,
     itemDirectory: PathBuilder,
     filepath: string,
+    signal?: AbortSignal,
   ): Promise<string> {
     const cmd = this.getGpgCommand();
     cmd.push("--decrypt", filepath);
@@ -276,6 +295,12 @@ export class Crypto {
       let stderr = Buffer.alloc(0);
 
       const gpgProcess = spawn(cmd[0], cmd.slice(1), this.getSpawnOptions());
+
+      // Kill the process if the abort signal fires
+      const abortListener = () => {
+        gpgProcess.kill();
+      };
+      signal?.addEventListener("abort", abortListener, { once: true });
 
       // Stream GPG output directly to temporary file (no memory accumulation)
       gpgProcess.stdout.pipe(gpgOutputFile);
@@ -297,13 +322,21 @@ export class Crypto {
         fs.rmSync(tempDir.path, { recursive: true, force: true });
       };
 
-      gpgProcess.on("close", async (code, signal) => {
+      gpgProcess.on("close", async (code, exitSignal) => {
+        signal?.removeEventListener("abort", abortListener);
         gpgOutputFile.end();
         const errorMessage = stderr.toString("utf8");
 
-        if (signal) {
+        if (signal?.aborted) {
           await destroyAndCleanup();
-          reject(new Error(`Process terminated with signal ${signal}`));
+          const err = new Error("Decryption was cancelled");
+          err.name = "AbortError";
+          reject(err);
+          return;
+        }
+        if (exitSignal) {
+          await destroyAndCleanup();
+          reject(new Error(`Process terminated with signal ${exitSignal}`));
           return;
         } else if (code !== 0) {
           await destroyAndCleanup();
@@ -355,6 +388,7 @@ export class Crypto {
       });
 
       gpgProcess.on("error", async (error) => {
+        signal?.removeEventListener("abort", abortListener);
         await destroyAndCleanup();
         reject(
           new CryptoError(

--- a/app/src/main/crypto.ts
+++ b/app/src/main/crypto.ts
@@ -208,6 +208,15 @@ export class Crypto {
       };
       signal?.addEventListener("abort", abortListener, { once: true });
 
+      // Handle the case where the signal was already aborted before we registered the listener
+      if (signal?.aborted) {
+        gpgProcess.kill();
+        const err = new Error("Decryption was cancelled");
+        err.name = "AbortError";
+        reject(err);
+        return;
+      }
+
       let stdout = Buffer.alloc(0);
       let stderr = Buffer.alloc(0);
 
@@ -300,15 +309,6 @@ export class Crypto {
       const abortListener = () => {
         gpgProcess.kill();
       };
-      signal?.addEventListener("abort", abortListener, { once: true });
-
-      // Stream GPG output directly to temporary file (no memory accumulation)
-      gpgProcess.stdout.pipe(gpgOutputFile);
-
-      // Collect stderr (error messages)
-      gpgProcess.stderr.on("data", (chunk) => {
-        stderr = Buffer.concat([stderr, chunk]);
-      });
 
       // Destroy the write stream and wait for it to fully close before deleting
       // the temp directory, to avoid a race between a pending fs.open and rmSync.
@@ -321,6 +321,25 @@ export class Crypto {
         }
         fs.rmSync(tempDir.path, { recursive: true, force: true });
       };
+
+      signal?.addEventListener("abort", abortListener, { once: true });
+
+      // Handle the case where the signal was already aborted before we registered the listener
+      if (signal?.aborted) {
+        gpgProcess.kill();
+        const err = new Error("Decryption was cancelled");
+        err.name = "AbortError";
+        reject(err);
+        return;
+      }
+
+      // Stream GPG output directly to temporary file (no memory accumulation)
+      gpgProcess.stdout.pipe(gpgOutputFile);
+
+      // Collect stderr (error messages)
+      gpgProcess.stderr.on("data", (chunk) => {
+        stderr = Buffer.concat([stderr, chunk]);
+      });
 
       gpgProcess.on("close", async (code, exitSignal) => {
         signal?.removeEventListener("abort", abortListener);

--- a/app/src/main/crypto.ts
+++ b/app/src/main/crypto.ts
@@ -305,6 +305,8 @@ export class Crypto {
 
       const gpgProcess = spawn(cmd[0], cmd.slice(1), this.getSpawnOptions());
 
+      let isSettled = false;
+
       // Kill the process if the abort signal fires
       const abortListener = () => {
         gpgProcess.kill();
@@ -326,10 +328,14 @@ export class Crypto {
 
       // Handle the case where the signal was already aborted before we registered the listener
       if (signal?.aborted) {
+        signal?.removeEventListener("abort", abortListener);
+        isSettled = true;
         gpgProcess.kill();
-        const err = new Error("Decryption was cancelled");
-        err.name = "AbortError";
-        reject(err);
+        void destroyAndCleanup().finally(() => {
+          const err = new Error("Decryption was cancelled");
+          err.name = "AbortError";
+          reject(err);
+        });
         return;
       }
 
@@ -342,6 +348,10 @@ export class Crypto {
       });
 
       gpgProcess.on("close", async (code, exitSignal) => {
+        if (isSettled) {
+          return;
+        }
+
         signal?.removeEventListener("abort", abortListener);
         gpgOutputFile.end();
         const errorMessage = stderr.toString("utf8");
@@ -350,15 +360,18 @@ export class Crypto {
           await destroyAndCleanup();
           const err = new Error("Decryption was cancelled");
           err.name = "AbortError";
+          isSettled = true;
           reject(err);
           return;
         }
         if (exitSignal) {
           await destroyAndCleanup();
+          isSettled = true;
           reject(new Error(`Process terminated with signal ${exitSignal}`));
           return;
         } else if (code !== 0) {
           await destroyAndCleanup();
+          isSettled = true;
           reject(
             new CryptoError(
               `GPG file decryption failed (exit code ${code}): ${errorMessage}`,
@@ -367,6 +380,7 @@ export class Crypto {
           return;
         } else if (errorMessage.trim() && !isExpectedGpgStderr(errorMessage)) {
           await destroyAndCleanup();
+          isSettled = true;
           reject(
             // n.b. use JSON.stringify() to sanitize the error since it's not what we expect
             // and could be the result of some sort of injection attack
@@ -393,10 +407,12 @@ export class Crypto {
           // Clean up temporary GPG output file
           fs.unlink(tempGpgOutput, () => {});
 
+          isSettled = true;
           resolve(finalAbsolutePath);
         } catch (error) {
           // Clean up temp directory on error
           fs.rmSync(tempDir.path, { recursive: true, force: true });
+          isSettled = true;
           reject(
             new CryptoError(
               "Failed to decompress decrypted file",

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -391,7 +391,7 @@ export class DB {
       DELETE FROM pending_events WHERE item_uuid = @item_uuid`);
     this.selectSourcesScheduledForDeletion = this.db.prepare(`
       SELECT DISTINCT source_uuid FROM pending_events
-      WHERE type IN ('${PendingEventType.SourceDeleted}', '${PendingEventType.SourceConversationDeleted}')
+      WHERE type IN ('${PendingEventType.SourceDeleted}', '${PendingEventType.SourceConversationTruncated}')
     `);
     this.selectItemsScheduledForDeletion = this.db.prepare(`
       SELECT uuid FROM items WHERE fetch_status = ${FetchStatus.ScheduledDeletion}
@@ -1059,7 +1059,7 @@ export class DB {
 
       if (
         type === PendingEventType.SourceDeleted ||
-        type === PendingEventType.SourceConversationDeleted
+        type === PendingEventType.SourceConversationTruncated
       ) {
         this.purgePendingEventsForSource(sourceUuid);
         this.markSourceItemsScheduledDeletion(sourceUuid);

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -126,6 +126,11 @@ export class DB {
     source_uuid: string;
     fetch_status: number;
   }>;
+  private updateItemsFetchStatusBySourceUpTo: Statement<{
+    source_uuid: string;
+    upper_bound: number;
+    fetch_status: number;
+  }>;
   private selectItem: Statement<{ uuid: string }, ItemRow>;
 
   private selectAllJournalistVersion: Statement<
@@ -283,6 +288,9 @@ export class DB {
     );
     this.updateItemsFetchStatusBySource = this.db.prepare(
       "UPDATE items SET fetch_status = @fetch_status WHERE source_uuid = @source_uuid",
+    );
+    this.updateItemsFetchStatusBySourceUpTo = this.db.prepare(
+      "UPDATE items SET fetch_status = @fetch_status WHERE source_uuid = @source_uuid AND interaction_count <= @upper_bound",
     );
     this.upsertItem = this.db.prepare(
       "INSERT INTO items (uuid, data, version) VALUES (@uuid, @data, @version) ON CONFLICT(uuid) DO UPDATE SET data=@data, version=@version",
@@ -1041,6 +1049,17 @@ export class DB {
     });
   }
 
+  private markSourceItemsScheduledDeletionUpTo(
+    sourceUuid: string,
+    upperBound: number,
+  ) {
+    this.updateItemsFetchStatusBySourceUpTo.run({
+      source_uuid: sourceUuid,
+      upper_bound: upperBound,
+      fetch_status: FetchStatus.ScheduledDeletion,
+    });
+  }
+
   private purgePendingEventsForSource(sourceUuid: string) {
     this.deletePendingEventsBySourceScope.run({
       source_uuid: sourceUuid,
@@ -1057,12 +1076,17 @@ export class DB {
         .generate({ timestamp: Date.now() })
         .toString();
 
-      if (
-        type === PendingEventType.SourceDeleted ||
-        type === PendingEventType.SourceConversationTruncated
-      ) {
+      if (type === PendingEventType.SourceDeleted) {
         this.purgePendingEventsForSource(sourceUuid);
         this.markSourceItemsScheduledDeletion(sourceUuid);
+      } else if (type === PendingEventType.SourceConversationTruncated) {
+        this.purgePendingEventsForSource(sourceUuid);
+        if (data?.upper_bound !== undefined) {
+          this.markSourceItemsScheduledDeletionUpTo(
+            sourceUuid,
+            data.upper_bound,
+          );
+        }
       }
 
       this.insertSourcePendingEvent.run({

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -170,6 +170,10 @@ export class DB {
   private deletePendingEvent: Statement<{ snowflake_id: string }, void>;
   private selectPendingEvents: Statement<[{ limit: number }], PendingEventRow>;
   private deletePendingEventsBySource: Statement<{ source_uuid: string }, void>;
+  private deletePendingEventsBySourceScope: Statement<
+    { source_uuid: string },
+    void
+  >;
   private deletePendingEventsByItem: Statement<{ item_uuid: string }, void>;
 
   protected constructor(crypto: Crypto, dbDir?: string) {
@@ -361,6 +365,12 @@ export class DB {
     `);
     this.deletePendingEventsBySource = this.db.prepare(`
       DELETE FROM pending_events WHERE source_uuid = @source_uuid`);
+    this.deletePendingEventsBySourceScope = this.db.prepare(`
+      DELETE FROM pending_events
+      WHERE source_uuid = @source_uuid
+         OR item_uuid IN (
+           SELECT uuid FROM items WHERE source_uuid = @source_uuid
+         )`);
     this.deletePendingEventsByItem = this.db.prepare(`
       DELETE FROM pending_events WHERE item_uuid = @item_uuid`);
   }
@@ -981,6 +991,12 @@ export class DB {
     });
   }
 
+  private purgePendingEventsForSource(sourceUuid: string) {
+    this.deletePendingEventsBySourceScope.run({
+      source_uuid: sourceUuid,
+    });
+  }
+
   addPendingSourceEvent(
     sourceUuid: string,
     type: PendingEventType,
@@ -995,6 +1011,7 @@ export class DB {
         type === PendingEventType.SourceDeleted ||
         type === PendingEventType.SourceConversationDeleted
       ) {
+        this.purgePendingEventsForSource(sourceUuid);
         this.markSourceItemsScheduledDeletion(sourceUuid);
       }
 

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -97,7 +97,14 @@ export class DB {
     { uuid: string },
     { version: string }
   >;
-  private selectItemsProcessable: Statement<[], { uuid: string }>;
+  private selectMessageItemsProcessable: Statement<
+    { limit: number },
+    { uuid: string }
+  >;
+  private selectFileItemsProcessable: Statement<
+    { limit: number },
+    { uuid: string }
+  >;
   private selectUnprojectedItemsBySource: Statement<
     { source_uuid: string },
     { uuid: string }
@@ -246,12 +253,19 @@ export class DB {
     this.selectUnprojectedItemVersion = this.db.prepare(
       "SELECT version FROM items WHERE uuid = @uuid",
     );
-    this.selectItemsProcessable = this.db.prepare(
+    this.selectMessageItemsProcessable = this.db.prepare(
       `SELECT uuid FROM items
-      WHERE
-        (kind = 'file' AND fetch_status in (${FetchStatus.DownloadInProgress}, ${FetchStatus.DecryptionInProgress}, ${FetchStatus.FailedDownloadRetryable}, ${FetchStatus.FailedDecryptionRetryable}))
-        OR
-        (kind <> 'file' AND fetch_status in (${FetchStatus.Initial}, ${FetchStatus.DownloadInProgress}, ${FetchStatus.DecryptionInProgress}, ${FetchStatus.FailedDownloadRetryable}, ${FetchStatus.FailedDecryptionRetryable}))`,
+      WHERE kind <> 'file'
+        AND fetch_status in (${FetchStatus.Initial}, ${FetchStatus.DownloadInProgress}, ${FetchStatus.DecryptionInProgress}, ${FetchStatus.FailedDownloadRetryable}, ${FetchStatus.FailedDecryptionRetryable})
+      ORDER BY interaction_count ASC, uuid ASC
+      LIMIT @limit`,
+    );
+    this.selectFileItemsProcessable = this.db.prepare(
+      `SELECT uuid FROM items
+      WHERE kind = 'file'
+        AND fetch_status in (${FetchStatus.DownloadInProgress}, ${FetchStatus.DecryptionInProgress}, ${FetchStatus.FailedDownloadRetryable}, ${FetchStatus.FailedDownloadRetryable})
+      ORDER BY interaction_count ASC, uuid ASC
+      LIMIT @limit`,
     );
     this.selectUnprojectedItemsBySource = this.db.prepare(
       "SELECT uuid FROM items WHERE source_uuid = @source_uuid",
@@ -873,12 +887,20 @@ export class DB {
   // Selects items that are ready to be downloaded + decrypted. This
   // is all messages, and files that have been initiated from the client
   // by being put into FetchStatus.DownloadInProgress
-  getItemsToProcess(): string[] {
+  getItemsToProcess(limits: {
+    messageLimit: number;
+    fileLimit: number;
+  }): string[] {
     type Row = {
       uuid: string;
     };
-    const rows = this.selectItemsProcessable.all() as Array<Row>;
-    return rows.map((r) => r.uuid);
+    const messageRows = this.selectMessageItemsProcessable.all({
+      limit: limits.messageLimit,
+    }) as Array<Row>;
+    const fileRows = this.selectFileItemsProcessable.all({
+      limit: limits.fileLimit,
+    }) as Array<Row>;
+    return [...messageRows, ...fileRows].map((r) => r.uuid);
   }
 
   getItem(itemUuid: string): Item | null {

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -268,15 +268,12 @@ export class DB {
     this.selectFileItemsProcessable = this.db.prepare(
       `SELECT uuid FROM items
       WHERE kind = 'file'
-        AND fetch_status in (${FetchStatus.Initial}, ${FetchStatus.DownloadInProgress}, ${FetchStatus.DecryptionInProgress}, ${FetchStatus.FailedDownloadRetryable}, ${FetchStatus.FailedDecryptionRetryable})
+        AND fetch_status in (${FetchStatus.DownloadInProgress}, ${FetchStatus.DecryptionInProgress}, ${FetchStatus.FailedDownloadRetryable}, ${FetchStatus.FailedDecryptionRetryable})
       ORDER BY interaction_count ASC, uuid ASC
       LIMIT @limit`,
     );
     this.selectUnprojectedItemsBySource = this.db.prepare(
       "SELECT uuid FROM items WHERE source_uuid = @source_uuid",
-    );
-    this.upsertItem = this.db.prepare(
-      "INSERT INTO items (uuid, data, version) VALUES (@id, @data, @version) ON CONFLICT(uuid) DO UPDATE SET data=@data, version=@version",
     );
     this.updateItemFetchStatus = this.db.prepare(
       "UPDATE items SET fetch_status = @fetch_status WHERE uuid = @uuid",

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -182,6 +182,11 @@ export class DB {
     void
   >;
   private deletePendingEventsByItem: Statement<{ item_uuid: string }, void>;
+  private selectSourcesScheduledForDeletion: Statement<
+    [],
+    { source_uuid: string }
+  >;
+  private selectItemsScheduledForDeletion: Statement<[], { uuid: string }>;
 
   protected constructor(crypto: Crypto, dbDir?: string) {
     this.crypto = crypto;
@@ -387,6 +392,13 @@ export class DB {
          )`);
     this.deletePendingEventsByItem = this.db.prepare(`
       DELETE FROM pending_events WHERE item_uuid = @item_uuid`);
+    this.selectSourcesScheduledForDeletion = this.db.prepare(`
+      SELECT DISTINCT source_uuid FROM pending_events
+      WHERE type IN ('${PendingEventType.SourceDeleted}', '${PendingEventType.SourceConversationDeleted}')
+    `);
+    this.selectItemsScheduledForDeletion = this.db.prepare(`
+      SELECT uuid FROM items WHERE fetch_status = ${FetchStatus.ScheduledDeletion}
+    `);
   }
 
   // Detect runtime environment
@@ -603,24 +615,37 @@ export class DB {
     deleted_sources: string[];
   } {
     return this.db!.transaction((batch: BatchResponse) => {
+      const pendingDeletionSources = this.getSourcesScheduledForDeletion();
       this.updatePendingEvents(batch.events);
-      const deleted_items = this.updateItems(batch.items);
-      const deleted_sources = this.updateSources(batch.sources);
+      const deleted_items = this.updateItems(
+        batch.items,
+        pendingDeletionSources,
+      );
+      const deleted_sources = this.updateSources(
+        batch.sources,
+        pendingDeletionSources,
+      );
       this.updateJournalists(batch.journalists);
       this.updateVersion();
       return { deleted_items, deleted_sources };
     })(batchResponse);
   }
 
-  protected updateSources(sources: {
-    [uuid: string]: SourceMetadata | null;
-  }): string[] {
+  protected updateSources(
+    sources: {
+      [uuid: string]: SourceMetadata | null;
+    },
+    pendingDeletionSources?: Set<string>,
+  ): string[] {
     const deletedSourceUuids: string[] = [];
     this.db!.transaction(
       (sources: { [uuid: string]: SourceMetadata | null }) => {
         Object.keys(sources).forEach((sourceid: string) => {
           const metadata = sources[sourceid];
           if (metadata) {
+            if (pendingDeletionSources?.has(sourceid)) {
+              return;
+            }
             const info = JSON.stringify(metadata, sortKeys);
             const version = computeVersion(info);
             this.upsertSource.run({ uuid: sourceid, data: info, version });
@@ -635,14 +660,20 @@ export class DB {
     return deletedSourceUuids;
   }
 
-  protected updateItems(items: {
-    [uuid: string]: ItemMetadata | null;
-  }): Item[] {
+  protected updateItems(
+    items: {
+      [uuid: string]: ItemMetadata | null;
+    },
+    pendingDeletionSources?: Set<string>,
+  ): Item[] {
     const deletedItems: Item[] = [];
     this.db!.transaction((items: { [uuid: string]: ItemMetadata | null }) => {
       Object.keys(items).forEach((itemid: string) => {
         const metadata = items[itemid];
         if (metadata) {
+          if (pendingDeletionSources?.has(metadata.source)) {
+            return;
+          }
           const blob = JSON.stringify(metadata, sortKeys);
           const version = computeVersion(blob);
           this.upsertItem.run({ uuid: itemid, data: blob, version });
@@ -1185,6 +1216,16 @@ export class DB {
     });
 
     return pendingEvents;
+  }
+
+  getSourcesScheduledForDeletion(): Set<string> {
+    const rows = this.selectSourcesScheduledForDeletion.all();
+    return new Set(rows.map((r) => r.source_uuid));
+  }
+
+  getItemsScheduledForDeletion(): Set<string> {
+    const rows = this.selectItemsScheduledForDeletion.all();
+    return new Set(rows.map((r) => r.uuid));
   }
 
   // Takes pending events and their statuses from the server and applies

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -115,6 +115,10 @@ export class DB {
     uuid: string;
     fetch_status: number;
   }>;
+  private updateItemsFetchStatusBySource: Statement<{
+    source_uuid: string;
+    fetch_status: number;
+  }>;
   private selectItem: Statement<{ uuid: string }, ItemRow>;
 
   private selectAllJournalistVersion: Statement<
@@ -256,6 +260,9 @@ export class DB {
     );
     this.updateItemFetchStatusWithReset = this.db.prepare(
       "UPDATE items SET fetch_status = @fetch_status, fetch_progress = 0 WHERE uuid = @uuid",
+    );
+    this.updateItemsFetchStatusBySource = this.db.prepare(
+      "UPDATE items SET fetch_status = @fetch_status WHERE source_uuid = @source_uuid",
     );
     this.upsertItem = this.db.prepare(
       "INSERT INTO items (uuid, data, version) VALUES (@uuid, @data, @version) ON CONFLICT(uuid) DO UPDATE SET data=@data, version=@version",
@@ -967,21 +974,38 @@ export class DB {
     stmt.run({ uuid: itemUuid });
   }
 
+  private markSourceItemsScheduledDeletion(sourceUuid: string) {
+    this.updateItemsFetchStatusBySource.run({
+      source_uuid: sourceUuid,
+      fetch_status: FetchStatus.ScheduledDeletion,
+    });
+  }
+
   addPendingSourceEvent(
     sourceUuid: string,
     type: PendingEventType,
     data?: PendingEventData,
   ): string {
-    const snowflakeID = this.snowflake
-      .generate({ timestamp: Date.now() })
-      .toString();
-    this.insertSourcePendingEvent.run({
-      snowflake_id: snowflakeID,
-      source_uuid: sourceUuid,
-      type: type,
-      data: data ? JSON.stringify(data) : null,
-    });
-    return snowflakeID;
+    return this.db!.transaction(() => {
+      const snowflakeID = this.snowflake
+        .generate({ timestamp: Date.now() })
+        .toString();
+
+      if (
+        type === PendingEventType.SourceDeleted ||
+        type === PendingEventType.SourceConversationDeleted
+      ) {
+        this.markSourceItemsScheduledDeletion(sourceUuid);
+      }
+
+      this.insertSourcePendingEvent.run({
+        snowflake_id: snowflakeID,
+        source_uuid: sourceUuid,
+        type: type,
+        data: data ? JSON.stringify(data) : null,
+      });
+      return snowflakeID;
+    })();
   }
 
   async addPendingReplySentEvent(

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -263,7 +263,7 @@ export class DB {
     this.selectFileItemsProcessable = this.db.prepare(
       `SELECT uuid FROM items
       WHERE kind = 'file'
-        AND fetch_status in (${FetchStatus.DownloadInProgress}, ${FetchStatus.DecryptionInProgress}, ${FetchStatus.FailedDownloadRetryable}, ${FetchStatus.FailedDownloadRetryable})
+        AND fetch_status in (${FetchStatus.Initial}, ${FetchStatus.DownloadInProgress}, ${FetchStatus.DecryptionInProgress}, ${FetchStatus.FailedDownloadRetryable}, ${FetchStatus.FailedDecryptionRetryable})
       ORDER BY interaction_count ASC, uuid ASC
       LIMIT @limit`,
     );

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -1315,6 +1315,57 @@ describe("Datastore Method Tests", () => {
     );
   });
 
+  it("getItemsToProcess should return a bounded set of processable messages and files", () => {
+    db.updateSources({
+      source1: mockSourceMetadata("source1"),
+    });
+
+    db.updateItems({
+      message1: mockItemMetadata("message1", "source1", "message", 1),
+      message2: mockItemMetadata("message2", "source1", "message", 2),
+      message3: mockItemMetadata("message3", "source1", "message", 3),
+      file1: mockItemMetadata("file1", "source1", "file", 4),
+      file2: mockItemMetadata("file2", "source1", "file", 5),
+      file3: mockItemMetadata("file3", "source1", "file", 6),
+    });
+
+    db.setDownloadInProgress("file1", 10);
+    db.setDownloadInProgress("file2", 20);
+    db.setDownloadInProgress("file3", 30);
+
+    const itemsToProcess = db.getItemsToProcess({
+      messageLimit: 2,
+      fileLimit: 1,
+    });
+
+    expect(itemsToProcess).toEqual(["message1", "message2", "file1"]);
+  });
+
+  it("getItemsToProcess should exclude ScheduledDeletion items", () => {
+    db.updateSources({
+      source1: mockSourceMetadata("source1"),
+    });
+
+    db.updateItems({
+      message1: mockItemMetadata("message1", "source1", "message", 1),
+      message2: mockItemMetadata("message2", "source1", "message", 2),
+      file1: mockItemMetadata("file1", "source1", "file", 3),
+      file2: mockItemMetadata("file2", "source1", "file", 4),
+    });
+
+    db.setDownloadInProgress("file1", 10);
+    db.setDownloadInProgress("file2", 20);
+    db.updateFetchStatus("message2", FetchStatus.ScheduledDeletion);
+    db.updateFetchStatus("file2", FetchStatus.ScheduledDeletion);
+
+    const itemsToProcess = db.getItemsToProcess({
+      messageLimit: 5,
+      fileLimit: 5,
+    });
+
+    expect(itemsToProcess).toEqual(["message1", "file1"]);
+  });
+
   it("deleting a source should cascade to its pending events", () => {
     // Create a source and add a pending event for it
     db.updateSources({

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -376,7 +376,7 @@ describe("Datastore Method Tests", () => {
     expect(source1Item2).not.toBeNull();
   });
 
-  it("pending SourceConversationDeleted should mark only that source items as ScheduledDeletion", () => {
+  it("pending SourceConversationTruncated should mark only that source items as ScheduledDeletion", () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),
       source2: mockSourceMetadata("source2"),
@@ -393,7 +393,7 @@ describe("Datastore Method Tests", () => {
 
     db.addPendingSourceEvent(
       "source1",
-      PendingEventType.SourceConversationDeleted,
+      PendingEventType.SourceConversationTruncated,
     );
 
     const source1Item1 = db.getItem("source1Item1");
@@ -974,7 +974,7 @@ describe("Datastore Method Tests", () => {
     expect(unrelatedEvent!.target).toHaveProperty("source_uuid", "source2");
   });
 
-  it("pending SourceConversationDeleted should purge all pending events for that source scope", async () => {
+  it("pending SourceConversationTruncated should purge all pending events for that source scope", async () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),
       source2: mockSourceMetadata("source2"),
@@ -1000,7 +1000,7 @@ describe("Datastore Method Tests", () => {
 
     const deleteEventId = db.addPendingSourceEvent(
       "source1",
-      PendingEventType.SourceConversationDeleted,
+      PendingEventType.SourceConversationTruncated,
     );
 
     const events = db.getPendingEvents();
@@ -1008,7 +1008,9 @@ describe("Datastore Method Tests", () => {
 
     const deleteEvent = events.find((e) => e.id === deleteEventId);
     expect(deleteEvent).toBeDefined();
-    expect(deleteEvent!.type).toBe(PendingEventType.SourceConversationDeleted);
+    expect(deleteEvent!.type).toBe(
+      PendingEventType.SourceConversationTruncated,
+    );
     expect(deleteEvent!.target).toHaveProperty("source_uuid", "source1");
 
     const remainingSourceEvent = events.find(
@@ -1752,13 +1754,13 @@ describe("Datastore Method Tests", () => {
       // Delete conversation (not the whole source)
       db.addPendingSourceEvent(
         "source1",
-        PendingEventType.SourceConversationDeleted,
+        PendingEventType.SourceConversationTruncated,
       );
 
       // Events purged except the delete event itself
       const events = db.getPendingEvents();
       expect(events.length).toBe(1);
-      expect(events[0].type).toBe(PendingEventType.SourceConversationDeleted);
+      expect(events[0].type).toBe(PendingEventType.SourceConversationTruncated);
 
       // All items marked ScheduledDeletion
       for (let i = 1; i <= 30; i++) {

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -1361,6 +1361,23 @@ describe("Datastore Method Tests", () => {
       expect(item?.fetch_progress).toBe(75000);
     });
 
+    it("should NOT reset fetch_progress when updating to ScheduledDeletion", () => {
+      db.updateSources({
+        source1: mockSourceMetadata("source1"),
+      });
+      db.updateItems({
+        item1: mockItemMetadata("item1", "source1", "file"),
+      });
+
+      db.setDownloadInProgress("item1", 42000);
+
+      db.updateFetchStatus("item1", FetchStatus.ScheduledDeletion);
+
+      const item = db.getItem("item1");
+      expect(item?.fetch_status).toBe(FetchStatus.ScheduledDeletion);
+      expect(item?.fetch_progress).toBe(42000);
+    });
+
     it("should allow retry after terminal failure when status is reset", () => {
       db.updateSources({
         source1: mockSourceMetadata("source1"),

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -383,26 +383,34 @@ describe("Datastore Method Tests", () => {
     });
 
     db.updateItems({
-      source1Item1: mockItemMetadata("source1Item1", "source1", "file"),
-      source1Item2: mockItemMetadata("source1Item2", "source1"),
+      source1Item1: mockItemMetadata("source1Item1", "source1", "file", 1),
+      source1Item2: mockItemMetadata("source1Item2", "source1", "message", 1),
+      source1Item3: mockItemMetadata("source1Item3", "source1", "message", 2),
       source2Item1: mockItemMetadata("source2Item1", "source2", "file"),
     });
 
     db.setDownloadInProgress("source1Item1", 9000);
     db.setDownloadInProgress("source2Item1", 12000);
 
+    // Truncate only items up to interaction_count 1
     db.addPendingSourceEvent(
       "source1",
       PendingEventType.SourceConversationTruncated,
+      { upper_bound: 1 },
     );
 
     const source1Item1 = db.getItem("source1Item1");
     const source1Item2 = db.getItem("source1Item2");
+    const source1Item3 = db.getItem("source1Item3");
     const source2Item1 = db.getItem("source2Item1");
 
+    // Items within upper_bound are marked ScheduledDeletion
     expect(source1Item1?.fetch_status).toBe(FetchStatus.ScheduledDeletion);
     expect(source1Item1?.fetch_progress).toBe(9000);
     expect(source1Item2?.fetch_status).toBe(FetchStatus.ScheduledDeletion);
+    // Item above upper_bound is unaffected
+    expect(source1Item3?.fetch_status).toBe(FetchStatus.Initial);
+    // Unrelated source is unaffected
     expect(source2Item1?.fetch_status).toBe(FetchStatus.DownloadInProgress);
     expect(source2Item1?.fetch_progress).toBe(12000);
     expect(source1Item1).not.toBeNull();
@@ -1751,10 +1759,11 @@ describe("Datastore Method Tests", () => {
         db.addPendingItemEvent(`msg${i}`, PendingEventType.ItemDeleted);
       }
 
-      // Delete conversation (not the whole source)
+      // Delete conversation (not the whole source), covering all 30 items
       db.addPendingSourceEvent(
         "source1",
         PendingEventType.SourceConversationTruncated,
+        { upper_bound: 30 },
       );
 
       // Events purged except the delete event itself

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -934,6 +934,99 @@ describe("Datastore Method Tests", () => {
     expect(replyEvent!.data).toHaveProperty("plaintext", "reply text");
   });
 
+  it("pending SourceDeleted should purge all pending events for that source and its items", async () => {
+    db.updateSources({
+      source1: mockSourceMetadata("source1"),
+      source2: mockSourceMetadata("source2"),
+    });
+    db.updateItems({
+      item1: mockItemMetadata("item1", "source1", "message", 1),
+      item2: mockItemMetadata("item2", "source1", "message", 2),
+      item3: mockItemMetadata("item3", "source2", "message", 1),
+    });
+
+    db.addPendingSourceEvent("source1", PendingEventType.Starred);
+    db.addPendingSourceConversationSeen("source1", 2);
+    db.addPendingItemEvent("item1", PendingEventType.ItemDeleted);
+    db.addPendingItemEvent("item2", PendingEventType.ItemDeleted);
+    await db.addPendingReplySentEvent("reply text", "source1", 3);
+    const unrelated = db.addPendingSourceEvent(
+      "source2",
+      PendingEventType.Starred,
+    );
+
+    const deleteEventId = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.SourceDeleted,
+    );
+
+    const events = db.getPendingEvents();
+    expect(events.length).toBe(2);
+
+    const deleteEvent = events.find((e) => e.id === deleteEventId);
+    expect(deleteEvent).toBeDefined();
+    expect(deleteEvent!.type).toBe(PendingEventType.SourceDeleted);
+    expect(deleteEvent!.target).toHaveProperty("source_uuid", "source1");
+
+    const unrelatedEvent = events.find((e) => e.id === unrelated);
+    expect(unrelatedEvent).toBeDefined();
+    expect(unrelatedEvent!.type).toBe(PendingEventType.Starred);
+    expect(unrelatedEvent!.target).toHaveProperty("source_uuid", "source2");
+  });
+
+  it("pending SourceConversationDeleted should purge all pending events for that source scope", async () => {
+    db.updateSources({
+      source1: mockSourceMetadata("source1"),
+      source2: mockSourceMetadata("source2"),
+    });
+    db.updateItems({
+      item1: mockItemMetadata("item1", "source1", "message", 1),
+      item2: mockItemMetadata("item2", "source1", "message", 2),
+      item3: mockItemMetadata("item3", "source2", "message", 1),
+    });
+
+    db.addPendingSourceEvent("source1", PendingEventType.Unstarred);
+    db.addPendingSourceConversationSeen("source1", 2);
+    db.addPendingItemEvent("item1", PendingEventType.ItemDeleted);
+    await db.addPendingReplySentEvent("reply text", "source1", 3);
+    const unrelatedSourceEvent = db.addPendingSourceEvent(
+      "source2",
+      PendingEventType.Starred,
+    );
+    const unrelatedItemEvent = db.addPendingItemEvent(
+      "item3",
+      PendingEventType.ItemDeleted,
+    );
+
+    const deleteEventId = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.SourceConversationDeleted,
+    );
+
+    const events = db.getPendingEvents();
+    expect(events.length).toBe(3);
+
+    const deleteEvent = events.find((e) => e.id === deleteEventId);
+    expect(deleteEvent).toBeDefined();
+    expect(deleteEvent!.type).toBe(PendingEventType.SourceConversationDeleted);
+    expect(deleteEvent!.target).toHaveProperty("source_uuid", "source1");
+
+    const remainingSourceEvent = events.find(
+      (e) => e.id === unrelatedSourceEvent,
+    );
+    expect(remainingSourceEvent).toBeDefined();
+    expect(remainingSourceEvent!.type).toBe(PendingEventType.Starred);
+    expect(remainingSourceEvent!.target).toHaveProperty(
+      "source_uuid",
+      "source2",
+    );
+
+    const remainingItemEvent = events.find((e) => e.id === unrelatedItemEvent);
+    expect(remainingItemEvent).toBeDefined();
+    expect(remainingItemEvent!.type).toBe(PendingEventType.ItemDeleted);
+    expect(remainingItemEvent!.target).toHaveProperty("item_uuid", "item3");
+  });
+
   it("updatePendingEvents should remove successful events from pending_events", () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -349,6 +349,66 @@ describe("Datastore Method Tests", () => {
     expect(sourceWithItems.items.length).toEqual(3);
   });
 
+  it("pending SourceDeleted should mark source items as ScheduledDeletion without deleting rows", () => {
+    db.updateSources({
+      source1: mockSourceMetadata("source1"),
+      source2: mockSourceMetadata("source2"),
+    });
+
+    db.updateItems({
+      source1Item1: mockItemMetadata("source1Item1", "source1", "file"),
+      source1Item2: mockItemMetadata("source1Item2", "source1"),
+      source2Item1: mockItemMetadata("source2Item1", "source2"),
+    });
+
+    db.completePlaintextItem("source1Item2", "plaintext");
+
+    db.addPendingSourceEvent("source1", PendingEventType.SourceDeleted);
+
+    const source1Item1 = db.getItem("source1Item1");
+    const source1Item2 = db.getItem("source1Item2");
+    const source2Item1 = db.getItem("source2Item1");
+
+    expect(source1Item1?.fetch_status).toBe(FetchStatus.ScheduledDeletion);
+    expect(source1Item2?.fetch_status).toBe(FetchStatus.ScheduledDeletion);
+    expect(source2Item1?.fetch_status).toBe(FetchStatus.Initial);
+    expect(source1Item1).not.toBeNull();
+    expect(source1Item2).not.toBeNull();
+  });
+
+  it("pending SourceConversationDeleted should mark only that source items as ScheduledDeletion", () => {
+    db.updateSources({
+      source1: mockSourceMetadata("source1"),
+      source2: mockSourceMetadata("source2"),
+    });
+
+    db.updateItems({
+      source1Item1: mockItemMetadata("source1Item1", "source1", "file"),
+      source1Item2: mockItemMetadata("source1Item2", "source1"),
+      source2Item1: mockItemMetadata("source2Item1", "source2", "file"),
+    });
+
+    db.setDownloadInProgress("source1Item1", 9000);
+    db.setDownloadInProgress("source2Item1", 12000);
+
+    db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.SourceConversationDeleted,
+    );
+
+    const source1Item1 = db.getItem("source1Item1");
+    const source1Item2 = db.getItem("source1Item2");
+    const source2Item1 = db.getItem("source2Item1");
+
+    expect(source1Item1?.fetch_status).toBe(FetchStatus.ScheduledDeletion);
+    expect(source1Item1?.fetch_progress).toBe(9000);
+    expect(source1Item2?.fetch_status).toBe(FetchStatus.ScheduledDeletion);
+    expect(source2Item1?.fetch_status).toBe(FetchStatus.DownloadInProgress);
+    expect(source2Item1?.fetch_progress).toBe(12000);
+    expect(source1Item1).not.toBeNull();
+    expect(source1Item2).not.toBeNull();
+  });
+
   it("pending Starred event should star sources", () => {
     // Insert three sources
     db.updateSources({

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -1612,4 +1612,166 @@ describe("Datastore Method Tests", () => {
       expect(item?.fetch_progress).toBe(0);
     });
   });
+
+  describe("Large Backlog Regression", () => {
+    it("bounded queueing should drain a large backlog across multiple refills", () => {
+      db.updateSources({
+        source1: mockSourceMetadata("source1"),
+      });
+
+      // Simulate 100 messages and 10 files from a prolific source
+      const items: Record<string, ItemMetadata> = {};
+      for (let i = 1; i <= 100; i++) {
+        items[`msg${i}`] = mockItemMetadata(`msg${i}`, "source1", "message", i);
+      }
+      for (let i = 1; i <= 10; i++) {
+        items[`file${i}`] = mockItemMetadata(
+          `file${i}`,
+          "source1",
+          "file",
+          100 + i,
+        );
+      }
+      db.updateItems(items);
+
+      // Files need download progress set to be processable
+      for (let i = 1; i <= 10; i++) {
+        db.setDownloadInProgress(`file${i}`, i * 100);
+      }
+
+      // First batch: bounded to 25 messages and 2 files
+      const batch1 = db.getItemsToProcess({ messageLimit: 25, fileLimit: 2 });
+      expect(batch1.length).toBe(27);
+      expect(batch1.filter((id) => id.startsWith("msg")).length).toBe(25);
+      expect(batch1.filter((id) => id.startsWith("file")).length).toBe(2);
+
+      // Mark the first batch as complete so they leave the processable pool
+      for (const id of batch1) {
+        if (id.startsWith("msg")) {
+          db.completePlaintextItem(id, "decrypted");
+        } else {
+          db.completeFileItem(id, `/tmp/${id}.txt`, 1024);
+        }
+      }
+
+      // Second batch: next 25 messages and 2 files
+      const batch2 = db.getItemsToProcess({ messageLimit: 25, fileLimit: 2 });
+      expect(batch2.length).toBe(27);
+      expect(batch2.filter((id) => id.startsWith("msg")).length).toBe(25);
+      expect(batch2.filter((id) => id.startsWith("file")).length).toBe(2);
+
+      // No overlap with batch 1
+      expect(batch2.filter((id) => batch1.includes(id)).length).toBe(0);
+    });
+
+    it("deleting a source should mark all backlog items as ScheduledDeletion and purge events", async () => {
+      db.updateSources({
+        source1: mockSourceMetadata("source1"),
+        source2: mockSourceMetadata("source2"),
+      });
+
+      // Create a large backlog for source1 with various fetch statuses
+      const items: Record<string, ItemMetadata> = {};
+      for (let i = 1; i <= 50; i++) {
+        items[`msg${i}`] = mockItemMetadata(`msg${i}`, "source1", "message", i);
+      }
+      items["unrelated1"] = mockItemMetadata(
+        "unrelated1",
+        "source2",
+        "message",
+        1,
+      );
+      db.updateItems(items);
+
+      // Set some items to various in-progress states
+      db.setDownloadInProgress("msg1", 100);
+      db.updateFetchStatus("msg2", FetchStatus.DecryptionInProgress);
+      db.completePlaintextItem("msg3", "already decrypted");
+
+      // Create many pending events for source1
+      db.addPendingSourceEvent("source1", PendingEventType.Starred);
+      db.addPendingSourceConversationSeen("source1", 50);
+      for (let i = 4; i <= 10; i++) {
+        db.addPendingItemEvent(`msg${i}`, PendingEventType.ItemDeleted);
+      }
+      await db.addPendingReplySentEvent("reply text", "source1", 51);
+
+      // Add an unrelated event for source2
+      db.addPendingSourceEvent("source2", PendingEventType.Starred);
+
+      // Delete source1 — triggers purge and ScheduledDeletion marking
+      db.addPendingSourceEvent("source1", PendingEventType.SourceDeleted);
+
+      // All pending events for source1 should be purged, only delete + source2 remain
+      const events = db.getPendingEvents();
+      const source1Events = events.filter(
+        (e) => "source_uuid" in e.target && e.target.source_uuid === "source1",
+      );
+      const source2Events = events.filter(
+        (e) => "source_uuid" in e.target && e.target.source_uuid === "source2",
+      );
+      expect(source1Events.length).toBe(1);
+      expect(source1Events[0].type).toBe(PendingEventType.SourceDeleted);
+      expect(source2Events.length).toBe(1);
+
+      // All source1 items should be ScheduledDeletion (regardless of prior status)
+      for (let i = 1; i <= 50; i++) {
+        const item = db.getItem(`msg${i}`);
+        expect(item?.fetch_status).toBe(FetchStatus.ScheduledDeletion);
+      }
+
+      // Unrelated source2 item is unaffected
+      const unrelated = db.getItem("unrelated1");
+      expect(unrelated?.fetch_status).toBe(FetchStatus.Initial);
+
+      // No ScheduledDeletion items should appear in processable results
+      const processable = db.getItemsToProcess({
+        messageLimit: 100,
+        fileLimit: 100,
+      });
+      expect(processable).toEqual(["unrelated1"]);
+    });
+
+    it("conversation deletion should also exclude items from future queue intake", async () => {
+      db.updateSources({
+        source1: mockSourceMetadata("source1"),
+      });
+
+      const items: Record<string, ItemMetadata> = {};
+      for (let i = 1; i <= 30; i++) {
+        items[`msg${i}`] = mockItemMetadata(`msg${i}`, "source1", "message", i);
+      }
+      db.updateItems(items);
+
+      // Create events that will be purged
+      db.addPendingSourceEvent("source1", PendingEventType.Starred);
+      for (let i = 1; i <= 5; i++) {
+        db.addPendingItemEvent(`msg${i}`, PendingEventType.ItemDeleted);
+      }
+
+      // Delete conversation (not the whole source)
+      db.addPendingSourceEvent(
+        "source1",
+        PendingEventType.SourceConversationDeleted,
+      );
+
+      // Events purged except the delete event itself
+      const events = db.getPendingEvents();
+      expect(events.length).toBe(1);
+      expect(events[0].type).toBe(PendingEventType.SourceConversationDeleted);
+
+      // All items marked ScheduledDeletion
+      for (let i = 1; i <= 30; i++) {
+        const item = db.getItem(`msg${i}`);
+        expect(item?.fetch_status).toBe(FetchStatus.ScheduledDeletion);
+      }
+
+      // Nothing processable from this source
+      const processable = db.getItemsToProcess({
+        messageLimit: 100,
+        fileLimit: 100,
+      });
+      expect(processable.length).toBe(0);
+    });
+  });
 });

--- a/app/src/main/datastore.ts
+++ b/app/src/main/datastore.ts
@@ -40,18 +40,27 @@ export class Datastore extends DB {
     super.deleteJournalists(journalists);
   }
 
-  override updateItems(items: { [uuid: string]: ItemMetadata | null }): Item[] {
-    const deletedItems = super.updateItems(items);
+  override updateItems(
+    items: { [uuid: string]: ItemMetadata | null },
+    pendingDeletionSources?: Set<string>,
+  ): Item[] {
+    const deletedItems = super.updateItems(items, pendingDeletionSources);
     for (const item of deletedItems) {
       this.storage.deleteItemFs(item);
     }
     return deletedItems;
   }
 
-  override updateSources(sources: {
-    [uuid: string]: SourceMetadata | null;
-  }): string[] {
-    const deletedSourceUuids = super.updateSources(sources);
+  override updateSources(
+    sources: {
+      [uuid: string]: SourceMetadata | null;
+    },
+    pendingDeletionSources?: Set<string>,
+  ): string[] {
+    const deletedSourceUuids = super.updateSources(
+      sources,
+      pendingDeletionSources,
+    );
     for (const uuid of deletedSourceUuids) {
       this.storage.deleteSourceFs(uuid);
     }

--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -1263,7 +1263,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
       await new Promise((r) => setTimeout(r, 10));
 
       // Abort downloads for source1
-      queue.abortDownloadsForSource("source1");
+      queue.abortSourceFetch("source1");
 
       // Simulate the proxy rejecting due to abort
       rejectProxy!(new Error("AbortError: The operation was aborted"));
@@ -1299,7 +1299,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
       const queue = new TaskQueue(db);
 
       // Abort for a different source
-      queue.abortDownloadsForSource("source2");
+      queue.abortSourceFetch("source2");
 
       // Process should still complete normally
       await queue.process({ id: "msg1" }, db);
@@ -1372,7 +1372,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
       await queue.process({ id: "msg1" }, db);
 
       // Aborting now should be a no-op (entry already cleaned up)
-      queue.abortDownloadsForSource("source1");
+      queue.abortSourceFetch("source1");
       // No error thrown = success
     });
   });
@@ -2073,7 +2073,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
       await new Promise((r) => setTimeout(r, 10));
 
       // Abort all downloads for source1
-      queue.abortDownloadsForSource("source1");
+      queue.abortSourceFetch("source1");
 
       // Reject the hanging promises to simulate abort
       for (const reject of rejects) {

--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -1179,6 +1179,146 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
     });
   });
 
+  describe("Abort Downloads for Deleted Sources", () => {
+    it("should abort active downloads for a given source", async () => {
+      const db = createMockDB();
+      const metadata = {
+        kind: "file",
+        source: "source1",
+        size: 1000,
+        uuid: "file1",
+      } as ItemMetadata;
+
+      db.getItem = vi.fn(() => mockItem(metadata, FetchStatus.Initial, 0));
+
+      // Make proxyStreamRequest hang until aborted
+      let rejectProxy: (reason: unknown) => void;
+      mockProxyStreamRequest.mockReturnValue(
+        new Promise((_resolve, reject) => {
+          rejectProxy = reject;
+        }),
+      );
+
+      const queue = new TaskQueue(db);
+      const processPromise = queue.process({ id: "file1" }, db);
+
+      // Wait a tick so download registers the AbortController
+      await new Promise((r) => setTimeout(r, 10));
+
+      // Abort downloads for source1
+      queue.abortDownloadsForSource("source1");
+
+      // Simulate the proxy rejecting due to abort
+      rejectProxy!(new Error("AbortError: The operation was aborted"));
+
+      await expect(processPromise).rejects.toThrow("aborted");
+    });
+
+    it("should not abort downloads for unrelated sources", async () => {
+      const db = createMockDB();
+      const metadata = {
+        kind: "message",
+        source: "source1",
+        size: 100,
+        uuid: "msg1",
+      } as ItemMetadata;
+
+      db.getItem = vi.fn(() => mockItem(metadata, FetchStatus.Initial, 0));
+
+      mockProxyStreamRequest.mockResolvedValue({
+        complete: true,
+        bytesWritten: 100,
+        sha256sum: "abc",
+      });
+
+      const encryptedBuffer = Buffer.from("encrypted");
+      vi.spyOn(BufferedWriter.prototype, "getBuffer").mockReturnValue(
+        encryptedBuffer,
+      );
+      mockCrypto.decryptMessage.mockResolvedValue("decrypted");
+
+      const queue = new TaskQueue(db);
+
+      // Abort for a different source
+      queue.abortDownloadsForSource("source2");
+
+      // Process should still complete normally
+      await queue.process({ id: "msg1" }, db);
+      expect(db.completePlaintextItem).toHaveBeenCalledWith(
+        "msg1",
+        "decrypted",
+      );
+    });
+
+    it("should pass abort signal to proxyStreamRequest", async () => {
+      const db = createMockDB();
+      const metadata = {
+        kind: "message",
+        source: "source1",
+        size: 100,
+        uuid: "msg1",
+      } as ItemMetadata;
+
+      db.getItem = vi.fn(() => mockItem(metadata, FetchStatus.Initial, 0));
+
+      mockProxyStreamRequest.mockResolvedValue({
+        complete: true,
+        bytesWritten: 100,
+        sha256sum: "abc",
+      });
+
+      const encryptedBuffer = Buffer.from("encrypted");
+      vi.spyOn(BufferedWriter.prototype, "getBuffer").mockReturnValue(
+        encryptedBuffer,
+      );
+      mockCrypto.decryptMessage.mockResolvedValue("decrypted");
+
+      const queue = new TaskQueue(db);
+      await queue.process({ id: "msg1" }, db);
+
+      // Verify abortSignal was passed (not undefined anymore)
+      expect(mockProxyStreamRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        0,
+        expect.any(AbortSignal),
+        expect.any(Number),
+        expect.any(Function),
+      );
+    });
+
+    it("should clean up activeDownloads entry after download completes", async () => {
+      const db = createMockDB();
+      const metadata = {
+        kind: "message",
+        source: "source1",
+        size: 100,
+        uuid: "msg1",
+      } as ItemMetadata;
+
+      db.getItem = vi.fn(() => mockItem(metadata, FetchStatus.Initial, 0));
+
+      mockProxyStreamRequest.mockResolvedValue({
+        complete: true,
+        bytesWritten: 100,
+        sha256sum: "abc",
+      });
+
+      const encryptedBuffer = Buffer.from("encrypted");
+      vi.spyOn(BufferedWriter.prototype, "getBuffer").mockReturnValue(
+        encryptedBuffer,
+      );
+      mockCrypto.decryptMessage.mockResolvedValue("decrypted");
+
+      const queue = new TaskQueue(db);
+      await queue.process({ id: "msg1" }, db);
+
+      // Aborting now should be a no-op (entry already cleaned up)
+      queue.abortDownloadsForSource("source1");
+      // No error thrown = success
+    });
+  });
+
   describe("Download Retry and Cancel Scenarios", () => {
     it("should successfully retry a failed download when status is reset to DownloadInProgress with progress=0", async () => {
       const db = createMockDB();

--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -171,9 +171,18 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
       } as ItemMetadata;
 
       // First attempt: Initial status
+      // Calls: getItem(initial), getItem(post-download re-check), decrypt fails (no post-decrypt re-check)
+      // Second attempt: getItem(retry), getItem(post-download re-check), getItem(post-decrypt re-check)
       db.getItem = vi
         .fn()
         .mockReturnValueOnce(mockItem(metadata, FetchStatus.Initial, 0))
+        .mockReturnValueOnce(mockItem(metadata, FetchStatus.Initial, 0))
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.FailedDecryptionRetryable, 0),
+        )
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.FailedDecryptionRetryable, 0),
+        )
         .mockReturnValueOnce(
           mockItem(metadata, FetchStatus.FailedDecryptionRetryable, 0),
         );
@@ -245,10 +254,17 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         size: 1000,
       } as ItemMetadata;
 
-      // First attempt: Initial status, Second attempt: FailedDownloadRetryable
+      // First attempt: Initial status, download fails (throws, no re-checks)
+      // Second attempt: getItem(retry), getItem(post-download re-check), getItem(post-decrypt re-check)
       db.getItem = vi
         .fn()
         .mockReturnValueOnce(mockItem(metadata, FetchStatus.Initial, 0))
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.FailedDownloadRetryable, 50),
+        )
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.FailedDownloadRetryable, 50),
+        )
         .mockReturnValueOnce(
           mockItem(metadata, FetchStatus.FailedDownloadRetryable, 50),
         );
@@ -347,9 +363,19 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         size: 1000,
       } as ItemMetadata;
 
+      // First attempt: download succeeds, decrypt fails (no post-decrypt re-check on throw)
+      // Calls: getItem(initial), getItem(post-download re-check), decrypt fails
+      // Second attempt: getItem(retry), getItem(post-download re-check), getItem(post-decrypt re-check)
       db.getItem = vi
         .fn()
         .mockReturnValueOnce(mockItem(metadata, FetchStatus.Initial, 0))
+        .mockReturnValueOnce(mockItem(metadata, FetchStatus.Initial, 0))
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.FailedDecryptionRetryable, 0),
+        )
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.FailedDecryptionRetryable, 0),
+        )
         .mockReturnValueOnce(
           mockItem(metadata, FetchStatus.FailedDecryptionRetryable, 0),
         );
@@ -406,9 +432,17 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         size: 1000,
       } as ItemMetadata;
 
+      // First attempt: download fails (throws, no re-checks)
+      // Second attempt: getItem(retry), getItem(post-download re-check), getItem(post-decrypt re-check)
       db.getItem = vi
         .fn()
         .mockReturnValueOnce(mockItem(metadata, FetchStatus.Initial, 0))
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.FailedDownloadRetryable, 30),
+        )
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.FailedDownloadRetryable, 30),
+        )
         .mockReturnValueOnce(
           mockItem(metadata, FetchStatus.FailedDownloadRetryable, 30),
         );
@@ -578,11 +612,22 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         size: 1000000,
       } as ItemMetadata;
 
-      // First attempt: DownloadInProgress status, Second attempt: FailedDecryptionRetryable
+      // First attempt: download succeeds, decrypt fails (no post-decrypt re-check on throw)
+      // Calls: getItem(initial), getItem(post-download re-check), decrypt fails
+      // Second attempt: getItem(retry), getItem(post-download re-check), getItem(post-decrypt re-check)
       db.getItem = vi
         .fn()
         .mockReturnValueOnce(
           mockItem(metadata, FetchStatus.DownloadInProgress, 0),
+        )
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.DownloadInProgress, 0),
+        )
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.FailedDecryptionRetryable, 0),
+        )
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.FailedDecryptionRetryable, 0),
         )
         .mockReturnValueOnce(
           mockItem(metadata, FetchStatus.FailedDecryptionRetryable, 0),
@@ -647,10 +692,18 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         size: 1000000,
       } as ItemMetadata;
 
+      // First attempt: download fails (throws, no re-checks)
+      // Second attempt: getItem(retry), getItem(post-download re-check), getItem(post-decrypt re-check)
       db.getItem = vi
         .fn()
         .mockReturnValueOnce(
           mockItem(metadata, FetchStatus.DownloadInProgress, 0),
+        )
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.FailedDownloadRetryable, 30),
+        )
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.FailedDownloadRetryable, 30),
         )
         .mockReturnValueOnce(
           mockItem(metadata, FetchStatus.FailedDownloadRetryable, 30),
@@ -1316,6 +1369,181 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
       // Aborting now should be a no-op (entry already cleaned up)
       queue.abortDownloadsForSource("source1");
       // No error thrown = success
+    });
+  });
+
+  describe("Mid-flight Deletion Races", () => {
+    it("should skip decryption if item is deleted after download", async () => {
+      const db = createMockDB();
+      const metadata = {
+        kind: "message",
+        source: "source1",
+        size: 100,
+        uuid: "msg1",
+      } as ItemMetadata;
+
+      // First getItem returns processable item, second (re-check) returns ScheduledDeletion
+      db.getItem = vi
+        .fn()
+        .mockReturnValueOnce(mockItem(metadata, FetchStatus.Initial, 0))
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.ScheduledDeletion, 0),
+        );
+
+      mockProxyStreamRequest.mockResolvedValue({
+        complete: true,
+        bytesWritten: 100,
+        sha256sum: "abc",
+      });
+
+      vi.spyOn(BufferedWriter.prototype, "getBuffer").mockReturnValue(
+        Buffer.from("encrypted"),
+      );
+
+      const queue = new TaskQueue(db);
+      await queue.process({ id: "msg1" }, db);
+
+      // Decryption should never have been attempted
+      expect(mockCrypto.decryptMessage).not.toHaveBeenCalled();
+      expect(db.completePlaintextItem).not.toHaveBeenCalled();
+    });
+
+    it("should drop decryption result if item is deleted during message decryption", async () => {
+      const db = createMockDB();
+      const metadata = {
+        kind: "message",
+        source: "source1",
+        size: 100,
+        uuid: "msg1",
+      } as ItemMetadata;
+
+      // First call: processable, second (post-download re-check): still processable,
+      // third (post-decryption re-check): deleted
+      db.getItem = vi
+        .fn()
+        .mockReturnValueOnce(mockItem(metadata, FetchStatus.Initial, 0))
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.DecryptionInProgress, 0),
+        )
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.ScheduledDeletion, 0),
+        );
+
+      mockProxyStreamRequest.mockResolvedValue({
+        complete: true,
+        bytesWritten: 100,
+        sha256sum: "abc",
+      });
+
+      vi.spyOn(BufferedWriter.prototype, "getBuffer").mockReturnValue(
+        Buffer.from("encrypted"),
+      );
+      mockCrypto.decryptMessage.mockResolvedValue("decrypted plaintext");
+
+      const queue = new TaskQueue(db);
+      await queue.process({ id: "msg1" }, db);
+
+      // Decryption ran but the result was not persisted
+      expect(mockCrypto.decryptMessage).toHaveBeenCalled();
+      expect(db.completePlaintextItem).not.toHaveBeenCalled();
+    });
+
+    it("should drop decryption result if item is deleted during file decryption", async () => {
+      const db = createMockDB();
+      const metadata = {
+        kind: "file",
+        source: "source1",
+        size: 1000,
+        uuid: "file1",
+      } as ItemMetadata;
+
+      // First call: processable, second (post-download re-check): still processable,
+      // third (post-decryption re-check): deleted
+      db.getItem = vi
+        .fn()
+        .mockReturnValueOnce(mockItem(metadata, FetchStatus.Initial, 0))
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.DecryptionInProgress, 0),
+        )
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.ScheduledDeletion, 0),
+        );
+
+      mockProxyStreamRequest.mockResolvedValue({
+        complete: true,
+        bytesWritten: 1000,
+        sha256sum: "abc",
+      });
+
+      mockCrypto.decryptFile.mockResolvedValue("/tmp/decrypted/file.txt");
+
+      const queue = new TaskQueue(db);
+      await queue.process({ id: "file1" }, db);
+
+      // Decryption ran but completion was not written to DB
+      expect(mockCrypto.decryptFile).toHaveBeenCalled();
+      expect(db.completeFileItem).not.toHaveBeenCalled();
+    });
+
+    it("should drop retry decryption result if item is deleted during retry", async () => {
+      const db = createMockDB();
+      const metadata = {
+        kind: "message",
+        source: "source1",
+        size: 100,
+        uuid: "msg1",
+      } as ItemMetadata;
+
+      // Status is FailedDecryptionRetryable (retry path, no download phase)
+      // First call: processable retry state,
+      // second (post-download re-check): still processable,
+      // third (post-decryption re-check): deleted
+      db.getItem = vi
+        .fn()
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.FailedDecryptionRetryable, 0),
+        )
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.FailedDecryptionRetryable, 0),
+        )
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.ScheduledDeletion, 0),
+        );
+
+      mockCrypto.decryptMessage.mockResolvedValue("decrypted plaintext");
+      fs.promises.readFile = vi
+        .fn()
+        .mockResolvedValue(Buffer.from("encrypted"));
+
+      const queue = new TaskQueue(db);
+      await queue.process({ id: "msg1" }, db);
+
+      // Decryption ran but the result was not persisted
+      expect(mockCrypto.decryptMessage).toHaveBeenCalled();
+      expect(db.completePlaintextItem).not.toHaveBeenCalled();
+    });
+
+    it("should not re-check if item was not downloadable", async () => {
+      const db = createMockDB();
+      const metadata = {
+        kind: "message",
+        source: "source1",
+        size: 100,
+        uuid: "msg1",
+      } as ItemMetadata;
+
+      // Item is already complete — skipped immediately
+      db.getItem = vi.fn(() =>
+        mockItem(metadata, FetchStatus.ScheduledDeletion, 0),
+      );
+
+      const queue = new TaskQueue(db);
+      await queue.process({ id: "msg1" }, db);
+
+      // Should have been skipped at the initial check
+      expect(mockProxyStreamRequest).not.toHaveBeenCalled();
+      expect(mockCrypto.decryptMessage).not.toHaveBeenCalled();
+      expect(db.completePlaintextItem).not.toHaveBeenCalled();
     });
   });
 

--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -155,7 +155,10 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
 
       // Verify decryption phase
       expect(db.setDecryptionInProgress).toHaveBeenCalledWith("msg1");
-      expect(mockCrypto.decryptMessage).toHaveBeenCalledWith(encryptedBuffer);
+      expect(mockCrypto.decryptMessage).toHaveBeenCalledWith(
+        encryptedBuffer,
+        expect.any(AbortSignal),
+      );
       expect(db.completePlaintextItem).toHaveBeenCalledWith(
         "msg1",
         decryptedContent,
@@ -538,6 +541,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         expect.any(Object), // storage
         expect.any(Object), // itemDirectory
         downloadPath,
+        expect.any(AbortSignal),
       );
       expect(db.completeFileItem).toHaveBeenCalledWith(
         "msg1",

--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -1938,4 +1938,143 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
       expect(db.setDecryptionInProgress).not.toHaveBeenCalled();
     });
   });
+
+  describe("Large Backlog Regression", () => {
+    it("refill should drain a large backlog by re-querying after each task completes", () => {
+      const db = createMockDB();
+
+      // Simulate a large backlog: first call returns a batch, second returns more, third returns empty
+      db.getItemsToProcess = vi
+        .fn()
+        .mockReturnValueOnce(["msg1", "msg2", "msg3"])
+        .mockReturnValueOnce(["msg4", "msg5"])
+        .mockReturnValueOnce([]);
+
+      db.getItem = vi.fn((uuid: string) =>
+        mockItem(
+          {
+            kind: "message",
+            source: "source1",
+            size: 100,
+            uuid,
+          } as ItemMetadata,
+          FetchStatus.Initial,
+          0,
+        ),
+      );
+
+      const queue = new TaskQueue(db);
+      queue.authToken = "test-token";
+
+      // First call: initial queueFetches loads batch 1
+      queue.queueFetches({ authToken: "test-token" });
+      expect(db.getItemsToProcess).toHaveBeenCalledTimes(1);
+
+      // Simulate task completion triggers refill → loads batch 2
+      queue.messageQueue.emit("task_finish", "msg1", {});
+      expect(db.getItemsToProcess).toHaveBeenCalledTimes(2);
+
+      // Another completion → loads batch 3 (empty, backlog drained)
+      queue.messageQueue.emit("task_finish", "msg4", {});
+      expect(db.getItemsToProcess).toHaveBeenCalledTimes(3);
+    });
+
+    it("deletion during large backlog should prevent new items from being queued", () => {
+      const db = createMockDB();
+
+      // First call returns items, second call (after deletion) returns nothing
+      db.getItemsToProcess = vi
+        .fn()
+        .mockReturnValueOnce(["msg1", "msg2"])
+        .mockReturnValueOnce([]);
+
+      const msg1Meta = {
+        kind: "message",
+        source: "source1",
+        size: 100,
+        uuid: "msg1",
+      } as ItemMetadata;
+
+      db.getItem = vi.fn((uuid: string) => {
+        if (uuid === "msg1") {
+          // After deletion, item is ScheduledDeletion
+          return mockItem(msg1Meta, FetchStatus.ScheduledDeletion, 0);
+        }
+        return mockItem(
+          {
+            kind: "message",
+            source: "source1",
+            size: 100,
+            uuid,
+          } as ItemMetadata,
+          FetchStatus.Initial,
+          0,
+        );
+      });
+
+      const queue = new TaskQueue(db);
+      queue.authToken = "test-token";
+
+      // Initial queueing
+      queue.queueFetches({ authToken: "test-token" });
+
+      // Source gets deleted — items marked ScheduledDeletion in DB.
+      // On next refill, getItemsToProcess returns empty because all items
+      // are ScheduledDeletion and excluded by the bounded query.
+      queue.messageQueue.emit("task_finish", "msg1", {});
+
+      // Second call to getItemsToProcess returned [] — nothing new queued
+      expect(db.getItemsToProcess).toHaveBeenCalledTimes(2);
+    });
+
+    it("abort should cancel all active downloads for a deleted source across a backlog", async () => {
+      const db = createMockDB();
+
+      // Two files from the same source actively downloading
+      const fileMeta = (uuid: string) =>
+        ({
+          kind: "file",
+          source: "source1",
+          size: 10000,
+          uuid,
+        }) as ItemMetadata;
+
+      db.getItem = vi
+        .fn()
+        .mockReturnValueOnce(
+          mockItem(fileMeta("file1"), FetchStatus.Initial, 0),
+        )
+        .mockReturnValueOnce(
+          mockItem(fileMeta("file2"), FetchStatus.Initial, 0),
+        );
+
+      // Make downloads hang until aborted
+      const rejects: Array<(reason: unknown) => void> = [];
+      mockProxyStreamRequest.mockImplementation(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejects.push(reject);
+          }),
+      );
+
+      const queue = new TaskQueue(db);
+
+      const p1 = queue.process({ id: "file1" }, db);
+      const p2 = queue.process({ id: "file2" }, db);
+
+      // Wait for downloads to register
+      await new Promise((r) => setTimeout(r, 10));
+
+      // Abort all downloads for source1
+      queue.abortDownloadsForSource("source1");
+
+      // Reject the hanging promises to simulate abort
+      for (const reject of rejects) {
+        reject(new Error("AbortError: The operation was aborted"));
+      }
+
+      await expect(p1).rejects.toThrow("aborted");
+      await expect(p2).rejects.toThrow("aborted");
+    });
+  });
 });

--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -886,7 +886,10 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
 
       queue.queueFetches({ authToken: "test-token" });
 
-      expect(db.getItemsToProcess).toHaveBeenCalled();
+      expect(db.getItemsToProcess).toHaveBeenCalledWith({
+        messageLimit: 25,
+        fileLimit: 2,
+      });
       // 2 messages/replies should go to messageQueue
       expect(queue.messageQueue.push).toHaveBeenCalledTimes(2);
       // 1 file should go to fileQueue
@@ -982,6 +985,42 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
       expect(() => errorCallback(new Error("Task failed"))).not.toThrow();
       expect(mockPort.postMessage).toHaveBeenCalled();
       expect(db.failDownload).toHaveBeenCalledWith("item1");
+    });
+
+    it("should queue only the bounded set returned by getItemsToProcess", () => {
+      const db = createMockDB();
+      db.getItemsToProcess = vi.fn(() => ["message1", "message2", "file1"]);
+      db.getItem = vi.fn((id) => {
+        if (id === "file1") {
+          return mockItem(
+            {
+              kind: "file",
+              source: "source1",
+              uuid: "file1",
+              size: 1000,
+            } as ItemMetadata,
+            FetchStatus.DownloadInProgress,
+          );
+        }
+
+        return mockItem(
+          {
+            kind: "message",
+            source: "source1",
+            uuid: id,
+          } as ItemMetadata,
+          FetchStatus.Initial,
+        );
+      });
+
+      const queue = new TaskQueue(db);
+      vi.spyOn(queue.messageQueue, "push");
+      vi.spyOn(queue.fileQueue, "push");
+
+      queue.queueFetches({ authToken: "test-token" });
+
+      expect(queue.messageQueue.push).toHaveBeenCalledTimes(2);
+      expect(queue.fileQueue.push).toHaveBeenCalledTimes(1);
     });
 
     it("should not throw if terminallyFailItem throws in task_failed handler", () => {

--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -1064,6 +1064,121 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
     });
   });
 
+  describe("Queue Refill", () => {
+    it("should refill queues after a message task finishes", () => {
+      const db = createMockDB();
+      db.getItemsToProcess = vi.fn(() => []);
+      db.getItem = vi.fn(() => null);
+
+      const queue = new TaskQueue(db);
+      queue.authToken = "test-token";
+
+      // Emit task_finish on the message queue
+      queue.messageQueue.emit("task_finish", "item1", {});
+
+      // refillQueues should have called queueFetches → getItemsToProcess
+      expect(db.getItemsToProcess).toHaveBeenCalledWith({
+        messageLimit: 25,
+        fileLimit: 2,
+      });
+    });
+
+    it("should refill queues after a file task finishes", () => {
+      const db = createMockDB();
+      db.getItemsToProcess = vi.fn(() => []);
+      db.getItem = vi.fn(() => null);
+
+      const queue = new TaskQueue(db);
+      queue.authToken = "test-token";
+
+      queue.fileQueue.emit("task_finish", "file1", {});
+
+      expect(db.getItemsToProcess).toHaveBeenCalledWith({
+        messageLimit: 25,
+        fileLimit: 2,
+      });
+    });
+
+    it("should refill queues after a task terminally fails", () => {
+      const db = createMockDB();
+      db.getItemsToProcess = vi.fn(() => []);
+      db.getItem = vi.fn(() => null);
+
+      const queue = new TaskQueue(db);
+      queue.authToken = "test-token";
+
+      queue.messageQueue.emit("task_failed", "item1", new Error("boom"));
+
+      // Refill triggered after terminal failure
+      expect(db.getItemsToProcess).toHaveBeenCalledWith({
+        messageLimit: 25,
+        fileLimit: 2,
+      });
+    });
+
+    it("should not refill if no auth token is set", () => {
+      const db = createMockDB();
+      db.getItemsToProcess = vi.fn(() => []);
+
+      const queue = new TaskQueue(db);
+      // authToken is undefined
+
+      queue.messageQueue.emit("task_finish", "item1", {});
+
+      expect(db.getItemsToProcess).not.toHaveBeenCalled();
+    });
+
+    it("should enqueue new items returned by refill", () => {
+      const db = createMockDB();
+      // First call returns nothing (initial state), second returns new items
+      db.getItemsToProcess = vi
+        .fn()
+        .mockReturnValueOnce(["msg2", "msg3"])
+        .mockReturnValueOnce([]);
+      db.getItem = vi.fn((id) =>
+        mockItem(
+          { kind: "message", source: "source1", uuid: id } as ItemMetadata,
+          FetchStatus.Initial,
+        ),
+      );
+
+      const queue = new TaskQueue(db);
+      queue.authToken = "test-token";
+      vi.spyOn(queue.messageQueue, "push");
+
+      // Simulate a task finishing, which triggers refill
+      queue.messageQueue.emit("task_finish", "msg1", {});
+
+      // Refill should have pushed the newly returned items
+      expect(queue.messageQueue.push).toHaveBeenCalledTimes(2);
+      expect(queue.messageQueue.push).toHaveBeenCalledWith(
+        { id: "msg2" },
+        expect.any(Function),
+      );
+      expect(queue.messageQueue.push).toHaveBeenCalledWith(
+        { id: "msg3" },
+        expect.any(Function),
+      );
+    });
+
+    it("should stop refilling when database returns no more items", () => {
+      const db = createMockDB();
+      db.getItemsToProcess = vi.fn(() => []);
+      db.getItem = vi.fn(() => null);
+
+      const queue = new TaskQueue(db);
+      queue.authToken = "test-token";
+      vi.spyOn(queue.messageQueue, "push");
+      vi.spyOn(queue.fileQueue, "push");
+
+      queue.fileQueue.emit("task_finish", "file1", {});
+
+      // DB returned empty, so no items should be pushed
+      expect(queue.messageQueue.push).not.toHaveBeenCalled();
+      expect(queue.fileQueue.push).not.toHaveBeenCalled();
+    });
+  });
+
   describe("Download Retry and Cancel Scenarios", () => {
     it("should successfully retry a failed download when status is reset to DownloadInProgress with progress=0", async () => {
       const db = createMockDB();

--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -1539,7 +1539,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         uuid: "msg1",
       } as ItemMetadata;
 
-      // Item is already complete — skipped immediately
+      // Item is already scheduled for deletion — skipped immediately
       db.getItem = vi.fn(() =>
         mockItem(metadata, FetchStatus.ScheduledDeletion, 0),
       );

--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -1264,7 +1264,8 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
       // Simulate the proxy rejecting due to abort
       rejectProxy!(new Error("AbortError: The operation was aborted"));
 
-      await expect(processPromise).rejects.toThrow("aborted");
+      // Abort is treated as a graceful cancellation, not an error
+      await expect(processPromise).resolves.toBeUndefined();
     });
 
     it("should not abort downloads for unrelated sources", async () => {
@@ -1322,7 +1323,6 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         sha256sum: etagFor(encryptedBuffer),
       });
 
-      const encryptedBuffer = Buffer.from("encrypted");
       vi.spyOn(BufferedWriter.prototype, "getBuffer").mockReturnValue(
         encryptedBuffer,
       );
@@ -2076,8 +2076,9 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         reject(new Error("AbortError: The operation was aborted"));
       }
 
-      await expect(p1).rejects.toThrow("aborted");
-      await expect(p2).rejects.toThrow("aborted");
+      // Abort is treated as a graceful cancellation, not an error
+      await expect(p1).resolves.toBeUndefined();
+      await expect(p2).resolves.toBeUndefined();
     });
   });
 });

--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -1278,10 +1278,11 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
 
       db.getItem = vi.fn(() => mockItem(metadata, FetchStatus.Initial, 0));
 
+      const encryptedContent = Buffer.from("encrypted");
       mockProxyStreamRequest.mockResolvedValue({
         complete: true,
         bytesWritten: 100,
-        sha256sum: "abc",
+        sha256sum: etagFor(encryptedContent),
       });
 
       const encryptedBuffer = Buffer.from("encrypted");
@@ -1314,10 +1315,11 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
 
       db.getItem = vi.fn(() => mockItem(metadata, FetchStatus.Initial, 0));
 
+      const encryptedBuffer = Buffer.from("encrypted");
       mockProxyStreamRequest.mockResolvedValue({
         complete: true,
         bytesWritten: 100,
-        sha256sum: "abc",
+        sha256sum: etagFor(encryptedBuffer),
       });
 
       const encryptedBuffer = Buffer.from("encrypted");
@@ -1351,13 +1353,12 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
 
       db.getItem = vi.fn(() => mockItem(metadata, FetchStatus.Initial, 0));
 
+      const encryptedBuffer = Buffer.from("encrypted");
       mockProxyStreamRequest.mockResolvedValue({
         complete: true,
         bytesWritten: 100,
-        sha256sum: "abc",
+        sha256sum: etagFor(encryptedBuffer),
       });
-
-      const encryptedBuffer = Buffer.from("encrypted");
       vi.spyOn(BufferedWriter.prototype, "getBuffer").mockReturnValue(
         encryptedBuffer,
       );
@@ -1390,14 +1391,15 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
           mockItem(metadata, FetchStatus.ScheduledDeletion, 0),
         );
 
+      const encryptedBuffer = Buffer.from("encrypted");
       mockProxyStreamRequest.mockResolvedValue({
         complete: true,
         bytesWritten: 100,
-        sha256sum: "abc",
+        sha256sum: etagFor(encryptedBuffer),
       });
 
       vi.spyOn(BufferedWriter.prototype, "getBuffer").mockReturnValue(
-        Buffer.from("encrypted"),
+        encryptedBuffer,
       );
 
       const queue = new TaskQueue(db);
@@ -1429,14 +1431,15 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
           mockItem(metadata, FetchStatus.ScheduledDeletion, 0),
         );
 
+      const encryptedBuffer = Buffer.from("encrypted");
       mockProxyStreamRequest.mockResolvedValue({
         complete: true,
         bytesWritten: 100,
-        sha256sum: "abc",
+        sha256sum: etagFor(encryptedBuffer),
       });
 
       vi.spyOn(BufferedWriter.prototype, "getBuffer").mockReturnValue(
-        Buffer.from("encrypted"),
+        encryptedBuffer,
       );
       mockCrypto.decryptMessage.mockResolvedValue("decrypted plaintext");
 
@@ -1472,7 +1475,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
       mockProxyStreamRequest.mockResolvedValue({
         complete: true,
         bytesWritten: 1000,
-        sha256sum: "abc",
+        sha256sum: FILE_ETAG,
       });
 
       mockCrypto.decryptFile.mockResolvedValue("/tmp/decrypted/file.txt");

--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -719,6 +719,60 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
       expect(db.setDecryptionInProgress).not.toHaveBeenCalled();
     });
 
+    it("should skip items that are terminally failed", async () => {
+      const db = createMockDB();
+      const metadata = {
+        kind: "message",
+        source: "source1",
+        size: 1000,
+      } as ItemMetadata;
+
+      db.getItem = vi.fn(() =>
+        mockItem(metadata, FetchStatus.FailedTerminal, 0),
+      );
+
+      const queue = new TaskQueue(db);
+      await queue.process({ id: "msg1" }, db);
+
+      expect(mockProxyStreamRequest).not.toHaveBeenCalled();
+    });
+
+    it("should skip items that are paused", async () => {
+      const db = createMockDB();
+      const metadata = {
+        kind: "message",
+        source: "source1",
+        size: 1000,
+      } as ItemMetadata;
+
+      db.getItem = vi.fn(() => mockItem(metadata, FetchStatus.Paused, 0));
+
+      const queue = new TaskQueue(db);
+      await queue.process({ id: "msg1" }, db);
+
+      expect(mockProxyStreamRequest).not.toHaveBeenCalled();
+    });
+
+    it("should skip items that are scheduled for deletion", async () => {
+      const db = createMockDB();
+      const metadata = {
+        kind: "message",
+        source: "source1",
+        size: 1000,
+      } as ItemMetadata;
+
+      db.getItem = vi.fn(() =>
+        mockItem(metadata, FetchStatus.ScheduledDeletion, 0),
+      );
+
+      const queue = new TaskQueue(db);
+      await queue.process({ id: "msg1" }, db);
+
+      expect(mockProxyStreamRequest).not.toHaveBeenCalled();
+      expect(db.setDownloadInProgress).not.toHaveBeenCalled();
+      expect(db.setDecryptionInProgress).not.toHaveBeenCalled();
+    });
+
     it("should handle server error responses during download", async () => {
       const db = createMockDB();
       const metadata = {

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -13,7 +13,6 @@ import {
   FetchStatus,
   ItemMetadata,
   ProxyRequest,
-  ProxyResponse,
   ProxyStreamResponse,
   bytes,
   ms,
@@ -120,15 +119,6 @@ export class TaskQueue {
       return;
     }
     this.queueFetches({ authToken: this.authToken });
-  }
-
-  abortDownloadsForSource(sourceUuid: string) {
-    for (const [itemId, entry] of this.activeDownloads) {
-      if (entry.sourceUuid === sourceUuid) {
-        entry.controller.abort();
-        this.activeDownloads.delete(itemId);
-      }
-    }
   }
 
   private isScheduledForDeletion(itemId: string, db: DB): boolean {

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -226,7 +226,7 @@ export class TaskQueue {
         status == FetchStatus.Cancelled ||
         status == FetchStatus.ScheduledDeletion
       ) {
-        console.debug("Item task is not in an processable state, skipping...");
+        console.debug("Item task is not in a processable state, skipping...");
         return;
       }
 

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -79,6 +79,15 @@ export class TaskQueue {
     );
     this.port = port;
     this.storage = new Storage();
+
+    // After each completed or terminally-failed task, try to top up the
+    // queue from the database so large backlogs drain without waiting for
+    // the next sync tick.
+    const refill = () => this.refillQueues();
+    this.messageQueue.on("task_finish", refill);
+    this.messageQueue.on("task_failed", refill);
+    this.fileQueue.on("task_finish", refill);
+    this.fileQueue.on("task_failed", refill);
   }
 
   getAuthToken(): string {
@@ -91,6 +100,13 @@ export class TaskQueue {
     if (controller) {
       controller.abort();
     }
+  }
+
+  private refillQueues() {
+    if (!this.authToken) {
+      return;
+    }
+    this.queueFetches({ authToken: this.authToken });
   }
 
   // Queries the database for all items that need to be downloaded and queues

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -168,12 +168,14 @@ export class TaskQueue {
         fetch_progress: progress,
       } = dbItem;
 
-      // Skip items that are complete, terminally failed, paused, or cancelled
+      // Skip items that are complete, terminally failed, paused, cancelled,
+      // scheduled for deletion, or otherwise not in a processable state.
       if (
         status == FetchStatus.Complete ||
         status == FetchStatus.FailedTerminal ||
         status == FetchStatus.Paused ||
-        status == FetchStatus.Cancelled
+        status == FetchStatus.Cancelled ||
+        status == FetchStatus.ScheduledDeletion
       ) {
         console.debug("Item task is not in an processable state, skipping...");
         return;

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -13,6 +13,7 @@ import {
   FetchStatus,
   ItemMetadata,
   ProxyRequest,
+  ProxyResponse,
   ProxyStreamResponse,
   bytes,
   ms,
@@ -49,7 +50,10 @@ export class TaskQueue {
   authToken?: string;
   port?: MessagePort;
   storage: Storage;
-  activeDownloads: Map<string, AbortController> = new Map();
+  activeDownloads = new Map<
+    string,
+    { sourceUuid: string; controller: AbortController }
+  >();
 
   constructor(
     db: DB,
@@ -96,9 +100,18 @@ export class TaskQueue {
 
   // Aborts any in-progress download for the given item.
   cancelDownload(itemId: string) {
-    const controller = this.activeDownloads.get(itemId);
-    if (controller) {
-      controller.abort();
+    const entry = this.activeDownloads.get(itemId);
+    if (entry) {
+      entry.controller.abort();
+    }
+  }
+
+  abortDownloadsForSource(sourceUuid: string) {
+    for (const [itemId, entry] of this.activeDownloads) {
+      if (entry.sourceUuid === sourceUuid) {
+        entry.controller.abort();
+        this.activeDownloads.delete(itemId);
+      }
     }
   }
 
@@ -107,6 +120,15 @@ export class TaskQueue {
       return;
     }
     this.queueFetches({ authToken: this.authToken });
+  }
+
+  abortDownloadsForSource(sourceUuid: string) {
+    for (const [itemId, entry] of this.activeDownloads) {
+      if (entry.sourceUuid === sourceUuid) {
+        entry.controller.abort();
+        this.activeDownloads.delete(itemId);
+      }
+    }
   }
 
   // Queries the database for all items that need to be downloaded and queues
@@ -307,7 +329,10 @@ export class TaskQueue {
   ): Promise<DownloadResult> {
     console.debug(`Starting download for ${metadata.kind} ${item.id}`);
     const abortController = new AbortController();
-    this.activeDownloads.set(item.id, abortController);
+    this.activeDownloads.set(item.id, {
+      sourceUuid: metadata.source,
+      controller: abortController,
+    });
     try {
       db.setDownloadInProgress(item.id);
       return await this.innerDownload(

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -408,14 +408,22 @@ export class TaskQueue {
       }
     };
 
-    let downloadResponse = await proxyStreamRequest(
-      downloadRequest,
-      downloadWriter,
-      progress,
-      abortController.signal,
-      timeout,
-      onProgress,
-    );
+    let downloadResponse;
+    try {
+      downloadResponse = await proxyStreamRequest(
+        downloadRequest,
+        downloadWriter,
+        progress,
+        abortController.signal,
+        timeout,
+        onProgress,
+      );
+    } catch (e) {
+      if (abortController.signal.aborted) {
+        throw new DownloadCancelledError();
+      }
+      throw e;
+    }
 
     // If we received JSON response, indicates an error from the server
     if ("data" in downloadResponse && downloadResponse.error) {
@@ -628,6 +636,13 @@ export class TaskQueue {
 
       // Re-check: if the item was deleted during decryption, drop the result
       if (this.isScheduledForDeletion(item.id, db)) {
+        try {
+          await fs.promises.unlink(finalAbsolutePath);
+        } catch (error) {
+          console.warn(
+            `Failed to clean up decrypted file after deletion: ${error}`,
+          );
+        }
         return;
       }
 

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -109,7 +109,7 @@ export class TaskQueue {
     }
   }
 
-  abortDownloadsForSource(sourceUuid: string) {
+  abortSourceFetch(sourceUuid: string) {
     for (const [itemId, entry] of this.activeDownloads) {
       if (entry.sourceUuid === sourceUuid) {
         entry.controller.abort();

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -39,6 +39,9 @@ class DownloadCancelledError extends Error {
   }
 }
 
+const MESSAGE_QUEUE_BATCH_LIMIT = 25;
+const FILE_QUEUE_BATCH_LIMIT = 2;
+
 export class TaskQueue {
   db: DB;
   messageQueue: Queue;
@@ -100,7 +103,10 @@ export class TaskQueue {
   queueFetches(message: AuthedRequest) {
     this.authToken = message.authToken;
     try {
-      const itemsToProcess = this.db.getItemsToProcess();
+      const itemsToProcess = this.db.getItemsToProcess({
+        messageLimit: MESSAGE_QUEUE_BATCH_LIMIT,
+        fileLimit: FILE_QUEUE_BATCH_LIMIT,
+      });
       if (itemsToProcess.length > 0) {
         console.debug("Items to process: ", itemsToProcess);
       }

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -131,6 +131,11 @@ export class TaskQueue {
     }
   }
 
+  private isScheduledForDeletion(itemId: string, db: DB): boolean {
+    const item = db.getItem(itemId);
+    return !item || item.fetch_status === FetchStatus.ScheduledDeletion;
+  }
+
   // Queries the database for all items that need to be downloaded and queues
   // up download tasks to be processed.
   // Routes items to the appropriate queue:
@@ -248,6 +253,14 @@ export class TaskQueue {
           throw e;
         }
         nextStatus = FetchStatus.DecryptionInProgress;
+      }
+
+      // Re-check: if the item was marked for deletion during download, stop.
+      if (this.isScheduledForDeletion(item.id, db)) {
+        console.debug(
+          `Item ${item.id} scheduled for deletion after download, skipping decryption...`,
+        );
+        return;
       }
 
       // Phase 2: Decryption (or failed decryption retries)
@@ -544,6 +557,11 @@ export class TaskQueue {
     try {
       const decryptedContent = await crypto.decryptMessage(buffer);
 
+      // Re-check: if the item was deleted during decryption, drop the result
+      if (this.isScheduledForDeletion(item.id, db)) {
+        return;
+      }
+
       // Store the decrypted plaintext and mark item as complete
       db.completePlaintextItem(item.id, decryptedContent);
     } catch (error) {
@@ -582,6 +600,11 @@ export class TaskQueue {
       const buffer = await fs.promises.readFile(downloadPath);
       const decryptedContent = await crypto.decryptMessage(buffer);
 
+      // Re-check: if the item was deleted during decryption, drop the result
+      if (this.isScheduledForDeletion(item.id, db)) {
+        return;
+      }
+
       // Store the decrypted plaintext and mark item as complete
       db.completePlaintextItem(item.id, decryptedContent);
     } catch (error) {
@@ -612,6 +635,12 @@ export class TaskQueue {
         itemDirectory,
         downloadPath,
       );
+
+      // Re-check: if the item was deleted during decryption, drop the result
+      if (this.isScheduledForDeletion(item.id, db)) {
+        return;
+      }
+
       // Get the decrypted file size to display to the user
       const fileStats = await fs.promises.stat(finalAbsolutePath);
       const decryptedSize = fileStats.size;

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -53,6 +53,10 @@ export class TaskQueue {
     string,
     { sourceUuid: string; controller: AbortController }
   >();
+  activeDecryptions = new Map<
+    string,
+    { sourceUuid: string; controller: AbortController }
+  >();
 
   constructor(
     db: DB,
@@ -110,6 +114,12 @@ export class TaskQueue {
       if (entry.sourceUuid === sourceUuid) {
         entry.controller.abort();
         this.activeDownloads.delete(itemId);
+      }
+    }
+    for (const [itemId, entry] of this.activeDecryptions) {
+      if (entry.sourceUuid === sourceUuid) {
+        entry.controller.abort();
+        this.activeDecryptions.delete(itemId);
       }
     }
   }
@@ -258,7 +268,15 @@ export class TaskQueue {
         nextStatus === FetchStatus.DecryptionInProgress ||
         nextStatus === FetchStatus.FailedDecryptionRetryable
       ) {
-        await this.decrypt(item, db, metadata, downloadResult);
+        try {
+          await this.decrypt(item, db, metadata, downloadResult);
+        } catch (e) {
+          if (e instanceof DownloadCancelledError) {
+            // Decryption was intentionally aborted — not a failure
+            return;
+          }
+          throw e;
+        }
       } else {
         // Handle unexpected statuses
         console.debug(
@@ -518,11 +536,23 @@ export class TaskQueue {
       throw new Error("Crypto not initialized in fetch worker, cannot decrypt");
     }
 
+    const abortController = new AbortController();
+    this.activeDecryptions.set(item.id, {
+      sourceUuid: metadata.source,
+      controller: abortController,
+    });
+
     // Set status to decryption in progress
     db.setDecryptionInProgress(item.id);
     try {
       if (metadata.kind === "file") {
-        await this.decryptFile(item, db, crypto, metadata);
+        await this.decryptFile(
+          item,
+          db,
+          crypto,
+          metadata,
+          abortController.signal,
+        );
         return;
       }
       if (downloadResult) {
@@ -532,13 +562,25 @@ export class TaskQueue {
           crypto,
           metadata,
           downloadResult as Buffer,
+          abortController.signal,
         );
       } else {
-        await this.decryptRetry(item, db, crypto, metadata);
+        await this.decryptRetry(
+          item,
+          db,
+          crypto,
+          metadata,
+          abortController.signal,
+        );
       }
     } catch (error) {
+      if ((error as Error).name === "AbortError") {
+        throw new DownloadCancelledError();
+      }
       db.failDecryption(item.id);
       throw error;
+    } finally {
+      this.activeDecryptions.delete(item.id);
     }
   }
 
@@ -551,9 +593,10 @@ export class TaskQueue {
     crypto: Crypto,
     metadata: ItemMetadata,
     buffer: Buffer,
+    signal?: AbortSignal,
   ) {
     try {
-      const decryptedContent = await crypto.decryptMessage(buffer);
+      const decryptedContent = await crypto.decryptMessage(buffer, signal);
 
       // Re-check: if the item was deleted during decryption, drop the result
       if (this.isScheduledForDeletion(item.id, db)) {
@@ -563,22 +606,28 @@ export class TaskQueue {
       // Store the decrypted plaintext and mark item as complete
       db.completePlaintextItem(item.id, decryptedContent);
     } catch (error) {
-      if (error instanceof CryptoError) {
-        console.warn(
-          `Failed to decrypt ${metadata.kind} ${item.id}: ${error.message}`,
-        );
-      }
-      // Ensure data is persisted to disk for retries
-      try {
-        const downloadFilePath = this.storage.downloadFilePath(metadata, item);
-        const downloadDir = path.dirname(downloadFilePath);
-        await fs.promises.mkdir(downloadDir, { recursive: true });
-        await fs.promises.writeFile(downloadFilePath, buffer);
-        console.debug(
-          `Saved encrypted buffer data to disk for retry: ${downloadFilePath}`,
-        );
-      } catch (saveError) {
-        console.warn(`Failed to save encrypted data to disk: ${saveError}`);
+      // Don't save to disk if the decryption was intentionally aborted
+      if ((error as Error).name !== "AbortError") {
+        if (error instanceof CryptoError) {
+          console.warn(
+            `Failed to decrypt ${metadata.kind} ${item.id}: ${error.message}`,
+          );
+        }
+        // Ensure data is persisted to disk for retries
+        try {
+          const downloadFilePath = this.storage.downloadFilePath(
+            metadata,
+            item,
+          );
+          const downloadDir = path.dirname(downloadFilePath);
+          await fs.promises.mkdir(downloadDir, { recursive: true });
+          await fs.promises.writeFile(downloadFilePath, buffer);
+          console.debug(
+            `Saved encrypted buffer data to disk for retry: ${downloadFilePath}`,
+          );
+        } catch (saveError) {
+          console.warn(`Failed to save encrypted data to disk: ${saveError}`);
+        }
       }
       throw error;
     }
@@ -592,11 +641,12 @@ export class TaskQueue {
     db: DB,
     crypto: Crypto,
     metadata: ItemMetadata,
+    signal?: AbortSignal,
   ) {
     const downloadPath = this.storage.downloadFilePath(metadata, item);
     try {
       const buffer = await fs.promises.readFile(downloadPath);
-      const decryptedContent = await crypto.decryptMessage(buffer);
+      const decryptedContent = await crypto.decryptMessage(buffer, signal);
 
       // Re-check: if the item was deleted during decryption, drop the result
       if (this.isScheduledForDeletion(item.id, db)) {
@@ -606,6 +656,9 @@ export class TaskQueue {
       // Store the decrypted plaintext and mark item as complete
       db.completePlaintextItem(item.id, decryptedContent);
     } catch (error) {
+      if ((error as Error).name === "AbortError") {
+        throw error;
+      }
       throw new Error(`Failed to load encrypted data from disk: ${error}`);
     }
 
@@ -624,6 +677,7 @@ export class TaskQueue {
     db: DB,
     crypto: Crypto,
     metadata: ItemMetadata,
+    signal?: AbortSignal,
   ) {
     const downloadPath = this.storage.downloadFilePath(metadata, item);
     const itemDirectory = this.storage.itemDirectory(metadata);
@@ -632,6 +686,7 @@ export class TaskQueue {
         this.storage,
         itemDirectory,
         downloadPath,
+        signal,
       );
 
       // Re-check: if the item was deleted during decryption, drop the result

--- a/app/src/main/fetch/worker.ts
+++ b/app/src/main/fetch/worker.ts
@@ -1,7 +1,7 @@
 import { parentPort, workerData } from "worker_threads";
 
 import { TaskQueue } from "./queue";
-import { AuthedRequest } from "../../types";
+import { AuthedRequest, FetchWorkerMessage } from "../../types";
 import { Crypto } from "../crypto";
 import { Datastore } from "../datastore";
 import { Storage } from "../storage";
@@ -25,14 +25,11 @@ const crypto = Crypto.initialize(workerData.cryptoConfig);
 const db = new Datastore(crypto, new Storage());
 const q = new TaskQueue(db, port);
 
-type CancelMessage = {
-  type: "cancel";
-  itemId: string;
-};
-
-port.on("message", (message: AuthedRequest | CancelMessage) => {
+port.on("message", (message: FetchWorkerMessage) => {
   if ("type" in message && message.type === "cancel") {
     q.cancelDownload(message.itemId);
+  } else if ("type" in message && message.type === "abortSourceDownloads") {
+    q.abortDownloadsForSource(message.sourceUuid);
   } else {
     q.queueFetches(message as AuthedRequest);
   }

--- a/app/src/main/fetch/worker.ts
+++ b/app/src/main/fetch/worker.ts
@@ -28,8 +28,8 @@ const q = new TaskQueue(db, port);
 port.on("message", (message: FetchWorkerMessage) => {
   if ("type" in message && message.type === "cancel") {
     q.cancelDownload(message.itemId);
-  } else if ("type" in message && message.type === "abortSourceDownloads") {
-    q.abortDownloadsForSource(message.sourceUuid);
+  } else if ("type" in message && message.type === "abortSourceFetch") {
+    q.abortSourceFetch(message.sourceUuid);
   } else {
     q.queueFetches(message as AuthedRequest);
   }

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -459,7 +459,7 @@ if (!gotTheLock) {
             // Abort any in-flight downloads for this source in the fetch worker
             if (fetchWorker) {
               fetchWorker.postMessage({
-                type: "abortSourceDownloads",
+                type: "abortSourceFetch",
                 sourceUuid,
               });
             }
@@ -469,7 +469,7 @@ if (!gotTheLock) {
             // Abort any in-flight downloads for this source in the fetch worker
             if (fetchWorker) {
               fetchWorker.postMessage({
-                type: "abortSourceDownloads",
+                type: "abortSourceFetch",
                 sourceUuid,
               });
             }

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -464,8 +464,15 @@ if (!gotTheLock) {
               });
             }
           }
-          // For truncation, delete all truncated item files from the fs
+          // For truncation, abort in-flight downloads and delete truncated item files from the fs
           if (type === PendingEventType.SourceConversationTruncated) {
+            // Abort any in-flight downloads for this source in the fetch worker
+            if (fetchWorker) {
+              fetchWorker.postMessage({
+                type: "abortSourceDownloads",
+                sourceUuid,
+              });
+            }
             if (data?.upper_bound) {
               const items = db.getSourceWithItems(sourceUuid, {
                 beforeInteractionCount: data?.upper_bound + 1,

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -456,6 +456,13 @@ if (!gotTheLock) {
           // Immediately delete any source files from the fs on pending deletion
           if (type === PendingEventType.SourceDeleted) {
             db.deleteSourceFs(sourceUuid);
+            // Abort any in-flight downloads for this source in the fetch worker
+            if (fetchWorker) {
+              fetchWorker.postMessage({
+                type: "abortSourceDownloads",
+                sourceUuid,
+              });
+            }
           }
           // For truncation, delete all truncated item files from the fs
           if (type === PendingEventType.SourceConversationTruncated) {

--- a/app/src/main/sync/index.test.ts
+++ b/app/src/main/sync/index.test.ts
@@ -80,6 +80,8 @@ function mockDB({
     })),
     getItemFileData: vi.fn(() => itemFileData),
     getPendingEvents: vi.fn(() => pendingEvents),
+    getSourcesScheduledForDeletion: vi.fn(() => new Set<string>()),
+    getItemsScheduledForDeletion: vi.fn(() => new Set<string>()),
   } as unknown as Datastore;
   return db;
 }
@@ -545,6 +547,97 @@ describe("syncMetadata", () => {
 
     expect(proxyMock).toHaveBeenCalledTimes(2);
     expect(db.updateBatch).toHaveBeenCalledWith(metadata);
+  });
+
+  it("excludes pending-deleted sources from reconcile request", async () => {
+    // Server index has two sources with updated versions
+    const serverIndex: Index = {
+      sources: {
+        [SOURCE_UUID_1]: "v2",
+        [SOURCE_UUID_2]: "v2",
+      },
+      items: {},
+      journalists: {},
+    };
+
+    // Client index has both sources at older versions
+    const clientIndex: Index = {
+      sources: {
+        [SOURCE_UUID_1]: "v1",
+        [SOURCE_UUID_2]: "v1",
+      },
+      items: {},
+      journalists: {},
+    };
+
+    db = mockDB({ index: clientIndex });
+    // SOURCE_UUID_2 is pending deletion locally
+    db.getSourcesScheduledForDeletion = vi.fn(() => new Set([SOURCE_UUID_2]));
+
+    const result = syncModule.reconcileIndex(db, serverIndex, clientIndex);
+
+    // Should request only SOURCE_UUID_1, not the pending-deleted SOURCE_UUID_2
+    expect(result.sources).toEqual([SOURCE_UUID_1]);
+  });
+
+  it("excludes pending-deleted items from reconcile request", async () => {
+    // Server index has two items with updated versions
+    const serverIndex: Index = {
+      sources: {},
+      items: {
+        [ITEM_UUID_1]: "v2",
+        [ITEM_UUID_2]: "v2",
+      },
+      journalists: {},
+    };
+
+    // Client index has both items at older versions
+    const clientIndex: Index = {
+      sources: {},
+      items: {
+        [ITEM_UUID_1]: "v1",
+        [ITEM_UUID_2]: "v1",
+      },
+      journalists: {},
+    };
+
+    db = mockDB({ index: clientIndex });
+    // ITEM_UUID_2 is scheduled for deletion
+    db.getItemsScheduledForDeletion = vi.fn(() => new Set([ITEM_UUID_2]));
+
+    const result = syncModule.reconcileIndex(db, serverIndex, clientIndex);
+
+    // Should request only ITEM_UUID_1, not the pending-deleted ITEM_UUID_2
+    expect(result.items).toEqual([ITEM_UUID_1]);
+  });
+
+  it("still allows server-side deletions for pending-deleted sources", async () => {
+    // Client index has SOURCE_UUID_2 which is absent from server (deleted server-side)
+    const serverIndex: Index = {
+      sources: {
+        [SOURCE_UUID_1]: "v1",
+      },
+      items: {},
+      journalists: {},
+    };
+
+    const clientIndex: Index = {
+      sources: {
+        [SOURCE_UUID_1]: "v1",
+        [SOURCE_UUID_2]: "v1",
+      },
+      items: {},
+      journalists: {},
+    };
+
+    db = mockDB({ index: clientIndex });
+    // SOURCE_UUID_2 is also pending deletion locally
+    db.getSourcesScheduledForDeletion = vi.fn(() => new Set([SOURCE_UUID_2]));
+
+    syncModule.reconcileIndex(db, serverIndex, clientIndex);
+
+    // The source should still be deleted locally (final cleanup)
+    expect(db.deleteSources).toHaveBeenCalledWith([SOURCE_UUID_2]);
   });
 
   it("deletes sources on sync + updates source delta", async () => {

--- a/app/src/main/sync/index.ts
+++ b/app/src/main/sync/index.ts
@@ -121,8 +121,13 @@ export function reconcileIndex(
   serverIndex: Index,
   clientIndex: Index,
 ): BatchRequest {
+  const pendingDeletionSources = db.getSourcesScheduledForDeletion();
+
   const sourcesToUpdate: string[] = [];
   Object.keys(serverIndex.sources).forEach((sourceID) => {
+    if (pendingDeletionSources.has(sourceID)) {
+      return;
+    }
     if (
       !clientIndex.sources[sourceID] ||
       serverIndex.sources[sourceID] != clientIndex.sources[sourceID]
@@ -140,7 +145,11 @@ export function reconcileIndex(
   }
 
   const itemsToUpdate: string[] = [];
+  const pendingDeletionItems = db.getItemsScheduledForDeletion();
   Object.keys(serverIndex.items).forEach((itemID) => {
+    if (pendingDeletionItems.has(itemID)) {
+      return;
+    }
     if (
       !clientIndex.items[itemID] ||
       serverIndex.items[itemID] != clientIndex.items[itemID]

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.test.tsx
@@ -57,6 +57,18 @@ describe("File Component Memoization", () => {
       },
       4,
     ],
+    [
+      {
+        item: {
+          ...mockItem,
+          uuid: "item-2",
+          fetch_status: FetchStatus.ScheduledDeletion,
+        },
+        designation: "Different Source",
+        onUpdate: mockOnUpdate,
+      },
+      5,
+    ],
   ];
 
   it("should handle memoization correctly", testMemoization(File, cases));

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
@@ -205,6 +205,7 @@ const File = memo(function File({ item, designation, onUpdate }: FileProps) {
     case FetchStatus.FailedDownloadRetryable:
     case FetchStatus.FailedDecryptionRetryable:
     case FetchStatus.Paused:
+    case FetchStatus.ScheduledDeletion:
       FileInner = InProgressFile;
       break;
     case FetchStatus.Complete:

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -61,9 +61,9 @@ export type AuthedRequest = {
   hintedVersion?: string;
 };
 
-// Message sent to the fetch worker to abort all active downloads for a source
-export type AbortSourceDownloads = {
-  type: "abortSourceDownloads";
+// Message sent to the fetch worker to abort all active downloads and decryptions for a source
+export type AbortSourceFetch = {
+  type: "abortSourceFetch";
   sourceUuid: string;
 };
 
@@ -76,7 +76,7 @@ export type CancelDownload = {
 // Union of all message types the fetch worker can receive
 export type FetchWorkerMessage =
   | AuthedRequest
-  | AbortSourceDownloads
+  | AbortSourceFetch
   | CancelDownload;
 
 // Re-export some types that are derived from zod schemas

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -61,6 +61,24 @@ export type AuthedRequest = {
   hintedVersion?: string;
 };
 
+// Message sent to the fetch worker to abort all active downloads for a source
+export type AbortSourceDownloads = {
+  type: "abortSourceDownloads";
+  sourceUuid: string;
+};
+
+// Message sent to the fetch worker to cancel a single item download
+export type CancelDownload = {
+  type: "cancel";
+  itemId: string;
+};
+
+// Union of all message types the fetch worker can receive
+export type FetchWorkerMessage =
+  | AuthedRequest
+  | AbortSourceDownloads
+  | CancelDownload;
+
 // Re-export some types that are derived from zod schemas
 import type {
   TokenResponse,

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -208,6 +208,8 @@ export enum FetchStatus {
   FailedTerminal = 7,
   // User explicitly cancelled the download
   Cancelled = 8,
+  // Item is pending deletion and must not be fetched again
+  ScheduledDeletion = 9,
 }
 
 // EventStatus codes returned from the server


### PR DESCRIPTION
Fixes #3132

- I added a new `FetchStatus.ScheduledDeletion` state
- When a source or source conversation is deleted, all items belonging to the source are set to `ScheduledDeletion`, and it purges all prior pending events for the source
- The queue intake is now bounded, so it only fills up a small amount at a time, and then refills when it's done processing
- Active downloads and decryptions are aborted
- Sync reconciliation filters out pending-deleted sources and pending-deleted items
- There are regression tests

## Test plan

### Load the dev server with a test source with 5000 messages

Start the server:

```sh
make dev
```

In another tab, load a dev source with 5000 messages:

```sh
NUM_SOURCES=1 make dev-load-data SD_LOADDATA_ARGS="--messages-per-source 5000 --files-per-source 0 --replies-per-source 0"
```

### Reproduce on `main`

Clear the local data and start the Inbox.

```sh
rm -rf ~/.config/SecureDrop/
pnpm run dev -- --no-qubes --login
```

This should login and start downloading all of the messages. You'll see download log messages madly scroll across the terminal.

In the Inbox, delete the new source. The download log messages continue, despite deleting the source.

### Try in this branch

Switch to the PR branch and try again. When you delete the source, it should immediately abort.


## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
