### PR TITLE
[inbox] exclude unneeded files from asar

### DIFF
--- a/app/electron-builder.yml
+++ b/app/electron-builder.yml
@@ -4,10 +4,16 @@ directories:
   buildResources: build
 files:
   - "!**/.vscode/*"
+  - "!screenshots/*"
   - "!src/*"
+  - "!integration_tests/*"
+  - "!server_tests/*"
+  - "!scripts/*"
   - "!electron.vite.config.{js,ts,mjs,cjs}"
-  - "!{.eslintcache,eslint.config.mjs,.prettierignore,.prettierrc.yaml,dev-app-update.yml,CHANGELOG.md,README.md}"
-  - "!{.env,.env.*,.npmrc,pnpm-lock.yaml}"
+  - "!{vitest.config.ts,tailwind.config.ts}"
+  - "!{.eslintcache,eslint.config.ts,.prettierignore,.prettierrc.yaml,dev-app-update.yml}"
+  - "!{CHANGELOG.md,README.md,architecture.md}"
+  - "!{.env,.env.*,.npmrc,pnpm-lock.yaml,pnpm-workspace.yaml}"
   - "!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}"
 asarUnpack:
   - resources/**

--- a/app/electron-builder.yml
+++ b/app/electron-builder.yml
@@ -3,18 +3,10 @@ productName: securedrop-app
 directories:
   buildResources: build
 files:
-  - "!**/.vscode/*"
-  - "!screenshots/*"
-  - "!src/*"
-  - "!integration_tests/*"
-  - "!server_tests/*"
-  - "!scripts/*"
-  - "!electron.vite.config.{js,ts,mjs,cjs}"
-  - "!{vitest.config.ts,tailwind.config.ts}"
-  - "!{.eslintcache,eslint.config.ts,.prettierignore,.prettierrc.yaml,dev-app-update.yml}"
-  - "!{CHANGELOG.md,README.md,architecture.md}"
-  - "!{.env,.env.*,.npmrc,pnpm-lock.yaml,pnpm-workspace.yaml}"
-  - "!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}"
+  - out/**
+  - resources/**
+  - package.json
+  - node_modules/**
 asarUnpack:
   - resources/**
   - node_modules/better-sqlite3/**


### PR DESCRIPTION
Excludes unneeded files from asar:

- `screenshots/` directory
- `integration_tests` and `server_tests`
- missed vitest/tailwind config
- other markdown docs

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
