### PR TITLE
Fetch messages/replies ordered by source.last_updated

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -264,17 +264,19 @@ export class DB {
       "SELECT version FROM items WHERE uuid = @uuid",
     );
     this.selectMessageItemsProcessable = this.db.prepare(
-      `SELECT uuid FROM items
+      `SELECT items.uuid FROM items
+      JOIN sources ON items.source_uuid = sources.uuid
       WHERE kind <> 'file'
         AND fetch_status in (${FetchStatus.Initial}, ${FetchStatus.DownloadInProgress}, ${FetchStatus.DecryptionInProgress}, ${FetchStatus.FailedDownloadRetryable}, ${FetchStatus.FailedDecryptionRetryable})
-      ORDER BY interaction_count ASC, uuid ASC
+      ORDER BY json_extract(sources.data, '$.last_updated') DESC, interaction_count DESC, items.uuid ASC
       LIMIT @limit`,
     );
     this.selectFileItemsProcessable = this.db.prepare(
-      `SELECT uuid FROM items
+      `SELECT items.uuid FROM items
+      JOIN sources ON items.source_uuid = sources.uuid
       WHERE kind = 'file'
         AND fetch_status in (${FetchStatus.DownloadInProgress}, ${FetchStatus.DecryptionInProgress}, ${FetchStatus.FailedDownloadRetryable}, ${FetchStatus.FailedDecryptionRetryable})
-      ORDER BY interaction_count ASC, uuid ASC
+      ORDER BY json_extract(sources.data, '$.last_updated') DESC, interaction_count DESC, items.uuid ASC
       LIMIT @limit`,
     );
     this.selectUnprojectedItemsBySource = this.db.prepare(

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -1348,7 +1348,7 @@ describe("Datastore Method Tests", () => {
       fileLimit: 1,
     });
 
-    expect(itemsToProcess).toEqual(["message1", "message2", "file1"]);
+    expect(itemsToProcess).toEqual(["message3", "message2", "file3"]);
   });
 
   it("getItemsToProcess should exclude ScheduledDeletion items", () => {


### PR DESCRIPTION
Currently we fetch based on (interaction_count ASC, uuid ASC), which
means we grab the first message in each conversation, then move to the
second message in each conversation, etc. And those conversations are
randomly picked since uuid is randomly assigned.

This ends up providing a bad UX because you can't even see the progress
via the sourcelist since the most recent message will still be
encrypted.

So let's instead fetch the most recent source's messages first and get
that conversation in reverse order, so it appears in the source list
immediately. This provides a good semblance of progress since you can
more quickly see the source list be populated with message previews.

On initial syncs this will allow users to immediately start processing
new messages while older messages are slowly backfilled.

Fixes #3184.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] reset the DB and launch the inbox, see messages are fetched in the newly described order

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
