### PR TITLE
Use unix-dgram to log to syslog

### DIFF
--- a/app/electron-builder.yml
+++ b/app/electron-builder.yml
@@ -10,6 +10,7 @@ files:
 asarUnpack:
   - resources/**
   - node_modules/better-sqlite3/**
+  - node_modules/unix-dgram/**
 extraResources:
   - from: src/main/database/migrations
     to: migrations

--- a/app/package.json
+++ b/app/package.json
@@ -33,7 +33,8 @@
     "dbmate:check": "pnpm run dbmate up && pnpm run dbmate dump && git diff --exit-code ./src/main/database/schema.sql",
     "translator-screenshots": "electron-vite build --mode test && rm -rf ./screenshots && mkdir -p ./screenshots && node ./scripts/translator-screenshots/main.js",
     "test-data-generate": "./scripts/test-data-generate.py",
-    "test-data-insert": "./scripts/test-data-insert.sh"
+    "test-data-insert": "./scripts/test-data-insert.sh",
+    "rebuild": "electron-rebuild -f -w unix-dgram"
   },
   "keywords": [],
   "license": "AGPL-3.0-or-later",
@@ -107,11 +108,13 @@
     "openpgp": "^6.3.0",
     "source-map-support": "^0.5.21",
     "tar": "^7.5.8",
+    "unix-dgram": "^2.0.7",
     "zod": "^4.3.5"
   },
   "pnpm": {
     "overrides": {
-      "prebuild-install": "file:empty-package"
+      "prebuild-install": "file:empty-package",
+      "unix-dgram>nan": "^2.26.2"
     }
   },
   "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748"

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   prebuild-install: file:empty-package
+  unix-dgram>nan: ^2.26.2
 
 importers:
 
@@ -41,6 +42,9 @@ importers:
       tar:
         specifier: ^7.5.8
         version: 7.5.8
+      unix-dgram:
+        specifier: ^2.0.7
+        version: 2.0.7
       zod:
         specifier: ^4.3.5
         version: 4.3.5
@@ -3712,6 +3716,9 @@ packages:
   nan@2.24.0:
     resolution: {integrity: sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg==}
 
+  nan@2.26.2:
+    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -4922,6 +4929,10 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  unix-dgram@2.0.7:
+    resolution: {integrity: sha512-pWaQorcdxEUBFIKjCqqIlQaOoNVmchyoaNAJ/1LwyyfK2XSxcBhgJNiSE8ZRhR0xkNGyk4xInt1G03QPoKXY5A==}
+    engines: {node: '>=0.10.48'}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -9212,6 +9223,8 @@ snapshots:
   nan@2.24.0:
     optional: true
 
+  nan@2.26.2: {}
+
   nanoid@3.3.11: {}
 
   napi-postinstall@0.3.0: {}
@@ -10638,6 +10651,11 @@ snapshots:
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
+
+  unix-dgram@2.0.7:
+    dependencies:
+      bindings: 1.5.0
+      nan: 2.26.2
 
   unrs-resolver@1.11.1:
     dependencies:

--- a/app/src/main/config.ts
+++ b/app/src/main/config.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "child_process";
+import { log } from "./log";
 
 /**
  * Config loads configuration at runtime from QubesDB (if available),
@@ -13,7 +14,7 @@ export class Config {
 
   public static load(noQubes: boolean): Config {
     const isQubes = noQubes ? !noQubes : detectQubes();
-    console.log("Loading with isQubes: ", isQubes);
+    log.info(`Loading with isQubes: ${isQubes}`);
     return {
       qubes_gpg_domain: read(isQubes, "QUBES_GPG_DOMAIN", ""),
       sd_submission_key_fpr: read(isQubes, "SD_SUBMISSION_KEY_FPR"),

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -3,6 +3,7 @@ import os from "os";
 import path from "path";
 import { execSync } from "child_process";
 import Database, { Statement } from "better-sqlite3";
+import { log } from "../log";
 import blake from "blakejs";
 import { Snowflake } from "@sapphire/snowflake";
 
@@ -430,7 +431,7 @@ export class DB {
       `Release-${runtime}`,
       "better_sqlite3.node",
     );
-    console.log(
+    log.info(
       `Loading better-sqlite3 from ${binaryPath} (packaged: ${isPackaged})`,
     );
     return binaryPath;
@@ -485,11 +486,11 @@ export class DB {
         "up",
       ].join(" ");
 
-      console.log("Running migrations:", command);
+      log.info(`Running migrations: ${command}`);
       execSync(command, { stdio: "inherit" });
-      console.log("Migrations completed successfully");
+      log.info("Migrations completed successfully");
     } catch (error) {
-      console.error("Migration failed:", error);
+      log.error(`Migration failed: ${error}`);
       throw new Error(`Migration failed: ${error}`);
     }
   }

--- a/app/src/main/export.ts
+++ b/app/src/main/export.ts
@@ -10,6 +10,7 @@ import * as path from "path";
 import { spawn, ChildProcess } from "child_process";
 import { promisify } from "util";
 import * as tar from "tar";
+import { log } from "./log";
 import {
   DeviceErrorStatus,
   DeviceStatus,
@@ -258,7 +259,7 @@ export class ArchiveExporter {
         filesToAdd.set(filepath, arcname);
       } catch {
         missingCount += 1;
-        console.debug(
+        log.debug(
           `'${filepath}' does not exist, and will not be included in archive`,
         );
       }
@@ -337,7 +338,7 @@ export class ArchiveExporter {
           });
 
           if (!this.process) {
-            console.log("Failed to spawn qrexec-client-vm");
+            log.error("Failed to spawn qrexec-client-vm");
             reject(new Error("Failed to spawn qrexec-client-vm"));
             return;
           }
@@ -347,7 +348,7 @@ export class ArchiveExporter {
           });
 
           this.process.on("error", (err) => {
-            console.log("qrexec spawn error", err);
+            log.error(`qrexec spawn error: ${err}`);
             reject(err);
           });
 
@@ -360,7 +361,7 @@ export class ArchiveExporter {
           });
         })
         .catch((e) => {
-          console.log("Archive path not accessible", e);
+          log.error(`Archive path not accessible: ${e}`);
           reject(e);
         });
     });
@@ -376,7 +377,7 @@ export class ArchiveExporter {
       );
     }
 
-    console.debug(`Parsing response from process: ${outputUntrusted}`);
+    log.debug(`Parsing response from process: ${outputUntrusted}`);
     try {
       // final line is the status string
       const lines = outputUntrusted
@@ -414,7 +415,7 @@ export class ArchiveExporter {
       try {
         rmSync(this.tmpdir, { recursive: true, force: true });
       } catch (e) {
-        console.log("Failed to cleanup tmpdir", e);
+        log.warn(`Failed to cleanup tmpdir: ${e}`);
       } finally {
         this.tmpdir = null;
       }
@@ -441,7 +442,7 @@ export class Printer extends ArchiveExporter {
 
   // Initiate print and run preflight checks to make sure that Export VM is started
   public async initiatePrint(): Promise<DeviceStatus> {
-    console.log("Initiating print, beginning printer preflight checks");
+    log.info("Initiating print, beginning printer preflight checks");
     this.fsm.transition({ action: "initiatePrint" });
 
     try {
@@ -459,14 +460,14 @@ export class Printer extends ArchiveExporter {
       await this.runQrexecExport(archivePath);
       return this._onComplete();
     } catch (err) {
-      console.log("Error creating archive for printer preflight", err);
+      log.error(`Error creating archive for printer preflight: ${err}`);
       this._onError();
       return DeviceErrorStatus.UNEXPECTED_RETURN_STATUS;
     }
   }
 
   public async print(filepaths: string[]): Promise<DeviceStatus> {
-    console.log("Beginning print");
+    log.info("Beginning print");
     this.fsm.transition({ action: "print" });
 
     try {
@@ -485,7 +486,7 @@ export class Printer extends ArchiveExporter {
       await this.runQrexecExport(archivePath);
       return this._onComplete();
     } catch (err) {
-      console.log("Print failed", err);
+      log.error(`Print failed: ${err}`);
       this._onError();
       return DeviceErrorStatus.UNEXPECTED_RETURN_STATUS;
     }
@@ -532,7 +533,7 @@ export class Printer extends ArchiveExporter {
   }
 
   public cancelPrint(): void {
-    console.log("Cancelling print operation");
+    log.info("Cancelling print operation");
     if (this.process) {
       this.process.kill();
       this.process = null;
@@ -559,7 +560,7 @@ export class Exporter extends ArchiveExporter {
   }
 
   public async initiateExport(): Promise<DeviceStatus> {
-    console.log("Beginning export preflight check");
+    log.info("Beginning export preflight check");
     this.fsm.transition({ action: "initiateExport" });
 
     let status: DeviceStatus = DeviceErrorStatus.UNEXPECTED_RETURN_STATUS;
@@ -577,7 +578,7 @@ export class Exporter extends ArchiveExporter {
       await this.runQrexecExport(archivePath);
       status = this._onComplete(true);
     } catch (err) {
-      console.log("Export preflight check failed", err);
+      log.error(`Export preflight check failed: ${err}`);
       this._onError();
     }
     return status;
@@ -590,7 +591,7 @@ export class Exporter extends ArchiveExporter {
   ): Promise<DeviceStatus> {
     let status: DeviceStatus;
     try {
-      console.log(`Begin exporting ${filepaths.length} item(s)`);
+      log.info(`Begin exporting ${filepaths.length} item(s)`);
       this.fsm.transition({ action: "export" });
 
       const metadata = { ...Exporter.DISK_METADATA } as Record<string, unknown>;
@@ -612,7 +613,7 @@ export class Exporter extends ArchiveExporter {
       await this.runQrexecExport(archivePath);
       status = this._onComplete(false);
     } catch (err) {
-      console.log("Export failed", err);
+      log.error(`Export failed: ${err}`);
       this._onError();
       throw err;
     }
@@ -650,7 +651,7 @@ export class Exporter extends ArchiveExporter {
           `Export status returned unexpected value ${err}`,
         ),
       });
-      console.log("Export returned unexpected value", err);
+      log.warn(`Export returned unexpected value: ${err}`);
       return DeviceErrorStatus.UNEXPECTED_RETURN_STATUS;
     } finally {
       this.process = null;
@@ -671,7 +672,7 @@ export class Exporter extends ArchiveExporter {
   }
 
   public cancelExport(): void {
-    console.log("Cancelling export operation");
+    log.info("Cancelling export operation");
     if (this.process) {
       this.process.kill();
       this.process = null;

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 import fs from "fs";
 import path from "path";
 import { Writable } from "stream";
+import { log } from "../log";
 
 import { BufferedWriter } from "./bufferedWriter";
 import { DB } from "../database";
@@ -151,7 +152,7 @@ export class TaskQueue {
         fileLimit: FILE_QUEUE_BATCH_LIMIT,
       });
       if (itemsToProcess.length > 0) {
-        console.debug("Items to process: ", itemsToProcess);
+        log.debug(`Items to process: ${JSON.stringify(itemsToProcess)}`);
       }
       for (const itemUUID of itemsToProcess) {
         const task: ItemFetchTask = {
@@ -168,26 +169,22 @@ export class TaskQueue {
 
         queue.push(task, (err, _result) => {
           if (err) {
-            console.error(
-              `Error executing fetch download task in queue: `,
-              task,
-              err,
+            log.error(
+              `Error executing fetch download task in queue: ${JSON.stringify(task)} ${err}`,
             );
             try {
               this.db.failDownload(task.id);
             } catch (failError) {
-              console.error(
-                `Error failing download in queue callback for item ${task.id}:`,
-                failError,
+              log.error(
+                `Error failing download in queue callback for item ${task.id}: ${failError}`,
               );
             }
             if (this.port) {
               try {
                 this.port.postMessage(this.db.getItem(task.id));
               } catch (postError) {
-                console.error(
-                  `Error posting queue callback update for item ${task.id}:`,
-                  postError,
+                log.error(
+                  `Error posting queue callback update for item ${task.id}: ${postError}`,
                 );
               }
             }
@@ -195,7 +192,7 @@ export class TaskQueue {
         });
       }
     } catch (e) {
-      console.error("Error queueing fetches: ", e);
+      log.error(`Error queueing fetches: ${e}`);
     }
   }
 
@@ -203,11 +200,11 @@ export class TaskQueue {
   // decrypting data to plaintext stored in the DB or to a file on disk.
   process = async (item: ItemFetchTask, db: DB) => {
     try {
-      console.debug("Processing item: ", item);
+      log.debug(`Processing item: ${JSON.stringify(item)}`);
 
       const dbItem = db.getItem(item.id);
       if (!dbItem) {
-        console.debug("Item not found");
+        log.debug("Item not found");
         return;
       }
 
@@ -226,7 +223,7 @@ export class TaskQueue {
         status == FetchStatus.Cancelled ||
         status == FetchStatus.ScheduledDeletion
       ) {
-        console.debug("Item task is not in a processable state, skipping...");
+        log.debug("Item task is not in a processable state, skipping...");
         return;
       }
 
@@ -257,7 +254,7 @@ export class TaskQueue {
 
       // Re-check: if the item was marked for deletion during download, stop.
       if (this.isScheduledForDeletion(item.id, db)) {
-        console.debug(
+        log.debug(
           `Item ${item.id} scheduled for deletion after download, skipping decryption...`,
         );
         return;
@@ -279,7 +276,7 @@ export class TaskQueue {
         }
       } else {
         // Handle unexpected statuses
-        console.debug(
+        log.debug(
           `Unexpected status ${nextStatus} for item ${item.id}, skipping...`,
         );
       }
@@ -348,7 +345,7 @@ export class TaskQueue {
     metadata: ItemMetadata,
     progress: number,
   ): Promise<DownloadResult> {
-    console.debug(`Starting download for ${metadata.kind} ${item.id}`);
+    log.debug(`Starting download for ${metadata.kind} ${item.id}`);
     const abortController = new AbortController();
     this.activeDownloads.set(item.id, {
       sourceUuid: metadata.source,
@@ -398,7 +395,7 @@ export class TaskQueue {
       timeout = getRealisticTimeout(metadata.size as bytes);
     }
 
-    console.debug(
+    log.debug(
       `Downloading ${metadata.kind} ${item.id} (size: ${metadata.size} bytes) with timeout: ${timeout}ms`,
     );
 
@@ -609,7 +606,7 @@ export class TaskQueue {
       // Don't save to disk if the decryption was intentionally aborted
       if ((error as Error).name !== "AbortError") {
         if (error instanceof CryptoError) {
-          console.warn(
+          log.warn(
             `Failed to decrypt ${metadata.kind} ${item.id}: ${error.message}`,
           );
         }
@@ -622,11 +619,11 @@ export class TaskQueue {
           const downloadDir = path.dirname(downloadFilePath);
           await fs.promises.mkdir(downloadDir, { recursive: true });
           await fs.promises.writeFile(downloadFilePath, buffer);
-          console.debug(
+          log.debug(
             `Saved encrypted buffer data to disk for retry: ${downloadFilePath}`,
           );
         } catch (saveError) {
-          console.warn(`Failed to save encrypted data to disk: ${saveError}`);
+          log.warn(`Failed to save encrypted data to disk: ${saveError}`);
         }
       }
       throw error;
@@ -666,7 +663,7 @@ export class TaskQueue {
     try {
       await fs.promises.unlink(downloadPath);
     } catch (error) {
-      console.warn(`Failed to clean up encrypted file: ${error}`);
+      log.warn(`Failed to clean up encrypted file: ${error}`);
     }
   }
 
@@ -694,7 +691,7 @@ export class TaskQueue {
         try {
           await fs.promises.unlink(finalAbsolutePath);
         } catch (error) {
-          console.warn(
+          log.warn(
             `Failed to clean up decrypted file after deletion: ${error}`,
           );
         }
@@ -705,10 +702,10 @@ export class TaskQueue {
       const fileStats = await fs.promises.stat(finalAbsolutePath);
       const decryptedSize = fileStats.size;
       db.completeFileItem(item.id, finalAbsolutePath, decryptedSize);
-      console.debug(`Successfully decrypted ${metadata.kind} ${item.id}`);
+      log.debug(`Successfully decrypted ${metadata.kind} ${item.id}`);
     } catch (error) {
       if (error instanceof CryptoError) {
-        console.warn(
+        log.warn(
           `Failed to decrypt ${metadata.kind} ${item.id}: ${error.message}`,
         );
       }
@@ -719,7 +716,7 @@ export class TaskQueue {
     try {
       await fs.promises.unlink(downloadPath);
     } catch (error) {
-      console.warn(`Failed to clean up encrypted file: ${error}`);
+      log.warn(`Failed to clean up encrypted file: ${error}`);
     }
   }
 }
@@ -757,30 +754,26 @@ function createQueue(
   );
 
   q.on("error", (error) => {
-    console.error(`Error from ${name}: `, error);
+    log.error(`Error from ${name}: ${error}`);
   });
 
   q.on("task_failed", (taskId, errorMessage) => {
-    console.error(
-      `Task failed and exceeded retry attempts in ${name}, removing from queue: `,
-      taskId,
-      errorMessage,
+    log.error(
+      `Task failed and exceeded retry attempts in ${name}, removing from queue: ${taskId} ${errorMessage}`,
     );
     try {
       db.terminallyFailItem(taskId);
     } catch (failError) {
-      console.error(
-        `Error terminally failing item ${taskId} in ${name}:`,
-        failError,
+      log.error(
+        `Error terminally failing item ${taskId} in ${name}: ${failError}`,
       );
     }
     if (port) {
       try {
         port.postMessage(db.getItem(taskId));
       } catch (postError) {
-        console.error(
-          `Error posting task_failed update for item ${taskId} in ${name}:`,
-          postError,
+        log.error(
+          `Error posting task_failed update for item ${taskId} in ${name}: ${postError}`,
         );
       }
     }

--- a/app/src/main/fetch/worker.ts
+++ b/app/src/main/fetch/worker.ts
@@ -5,8 +5,9 @@ import { AuthedRequest, FetchWorkerMessage } from "../../types";
 import { Crypto } from "../crypto";
 import { Datastore } from "../datastore";
 import { Storage } from "../storage";
+import { log } from "../log";
 
-console.log("Starting fetch worker...");
+log.info("Starting fetch worker...");
 
 if (!parentPort) {
   throw new Error("Must run as a worker thread");
@@ -19,7 +20,7 @@ if (!workerData.cryptoConfig) {
   throw new Error("Worker missing crypto config");
 }
 
-console.log("Initializing crypto with config:", workerData.cryptoConfig);
+log.info("Initializing crypto for fetch worker");
 const crypto = Crypto.initialize(workerData.cryptoConfig);
 
 const db = new Datastore(crypto, new Storage());

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -43,6 +43,7 @@ import { setUmask } from "./umask";
 import { Exporter, Printer } from "./export";
 import { Storage } from "./storage";
 import { writeTranscript } from "./transcriber";
+import { log } from "./log";
 
 // Set umask so any files written are owner-only read/write (600).
 // This must be done before we create any files or spawn any worker threads.
@@ -74,9 +75,8 @@ if (!gotTheLock) {
         });
     })
     .catch((error) => {
-      console.error(
-        "Failed to show 'already running' dialog during app startup:",
-        error,
+      log.error(
+        `Failed to show 'already running' dialog during app startup: ${error}`,
       );
       process.exit(1);
     });
@@ -115,7 +115,7 @@ if (!gotTheLock) {
     }
 
     process.env.GNUPGHOME = gpgHome;
-    console.log(`Mac demo mode: GPG keyring initialized at ${gpgHome}`);
+    log.info(`Mac demo mode: GPG keyring initialized at ${gpgHome}`);
   }
 
   // Parse command line arguments
@@ -148,7 +148,7 @@ if (!gotTheLock) {
         cryptoConfig: configForCrypto,
       };
     } catch (error) {
-      console.error("Failed to initialize SecureDrop Inbox:", error);
+      log.error(`Failed to initialize SecureDrop Inbox: ${error}`);
       process.exit(1);
     }
   }
@@ -222,7 +222,7 @@ if (!gotTheLock) {
     });
 
     worker.on("message", (result) => {
-      console.debug("Message from worker: ", result);
+      log.debug(`Message from worker: ${JSON.stringify(result)}`);
       if (!result) {
         return;
       }
@@ -235,15 +235,15 @@ if (!gotTheLock) {
     });
 
     worker.on("error", (err) => {
-      console.log("Error from worker: ", err);
+      log.error(`Error from worker: ${err}`);
     });
 
     worker.on("exit", (err) => {
-      console.log("Worker exited with code ", err);
+      log.warn(`Worker exited with code ${err}`);
     });
 
     worker.on("messageerror", (err) => {
-      console.log("Message error from worker: ", err);
+      log.error(`Message error from worker: ${err}`);
     });
 
     return worker;
@@ -312,10 +312,10 @@ if (!gotTheLock) {
             installExtension([REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS]),
           )
           .then(([react, redux]) =>
-            console.log(`Added extensions: ${react.name}, ${redux.name}`),
+            log.debug(`Added extensions: ${react.name}, ${redux.name}`),
           )
           .catch((err) =>
-            console.log("An error occurred during extension setup: ", err),
+            log.warn(`An error occurred during extension setup: ${err}`),
           );
       }
 
@@ -418,7 +418,7 @@ if (!gotTheLock) {
         "syncMetadata",
         async (_event, request: AuthedRequest): Promise<SyncStatus> => {
           if (shouldSkipSync(db, request.hintedVersion)) {
-            console.debug(`Already at ${request.hintedVersion}; skipping sync`);
+            log.debug(`Already at ${request.hintedVersion}; skipping sync`);
             wakeFetchWorkerIfNeeded(request.authToken);
             return SyncStatus.NOT_MODIFIED;
           }
@@ -569,7 +569,7 @@ if (!gotTheLock) {
           const process = spawn(command, args);
           // Log errors but don't wait for the process to finish
           process.on("error", (error) => {
-            console.error(`Failed to launch qvm-open-in-vm: ${error.message}`);
+            log.error(`Failed to launch qvm-open-in-vm: ${error.message}`);
           });
 
           // Return immediately without waiting for the process to finish
@@ -601,9 +601,8 @@ if (!gotTheLock) {
             const sourceName = sourceWithItems.data.journalist_designation;
             return await exporter.export([filePath], passphrase, sourceName);
           } catch (error) {
-            console.error(
-              `Failed to export transcript for source: ${sourceUuid}:`,
-              error,
+            log.error(
+              `Failed to export transcript for source: ${sourceUuid}: ${error}`,
             );
             throw error;
           }
@@ -673,7 +672,7 @@ if (!gotTheLock) {
             const sourceName = sourceWithItems.data.journalist_designation;
             return await exporter.export(filenames, passphrase, sourceName);
           } catch (error) {
-            console.error(`Failed to export source: ${sourceUuid}:`, error);
+            log.error(`Failed to export source: ${sourceUuid}: ${error}`);
             throw error;
           }
         },
@@ -694,9 +693,8 @@ if (!gotTheLock) {
             }
             return printer.print([filePath]);
           } catch (error) {
-            console.error(
-              `Failed to print transcript for source: ${sourceUuid}:`,
-              error,
+            log.error(
+              `Failed to print transcript for source: ${sourceUuid}: ${error}`,
             );
             throw error;
           }
@@ -744,7 +742,7 @@ if (!gotTheLock) {
       fetchWorker = spawnFetchWorker(mainWindow);
     })
     .catch((error) => {
-      console.error("Unhandled error during app startup:", error);
+      log.error(`Unhandled error during app startup: ${error}`);
       app.exit(1);
     });
 

--- a/app/src/main/log.ts
+++ b/app/src/main/log.ts
@@ -1,0 +1,40 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const unixDgram = require("unix-dgram") as typeof import("unix-dgram");
+
+const SYSLOG_PATH = "/dev/log";
+const TAG = "securedrop-inbox";
+const PID = process.pid;
+const LOG_USER = 1;
+
+const SEVERITY = { debug: 7, info: 6, warn: 4, error: 3 } as const;
+
+type Level = keyof typeof SEVERITY;
+
+let socket: ReturnType<(typeof unixDgram)["createSocket"]> | null = null;
+
+function getSocket() {
+  if (!socket) {
+    socket = unixDgram.createSocket("unix_dgram");
+    socket.on("error", () => {
+      socket = null;
+    });
+  }
+  return socket;
+}
+
+function write(level: Level, message: string): void {
+  const pri = LOG_USER * 8 + SEVERITY[level];
+  const buf = Buffer.from(`<${pri}>${TAG}[${PID}]: ${message}`);
+  try {
+    getSocket().send(buf, 0, buf.length, SYSLOG_PATH, () => {});
+  } catch {
+    socket = null;
+  }
+}
+
+export const log = {
+  debug: (message: string) => write("debug", message),
+  info: (message: string) => write("info", message),
+  warn: (message: string) => write("warn", message),
+  error: (message: string) => write("error", message),
+};

--- a/app/src/main/proxy.ts
+++ b/app/src/main/proxy.ts
@@ -2,6 +2,7 @@ import child_process from "node:child_process";
 import path from "node:path";
 import { Writable } from "node:stream";
 import { finished } from "node:stream/promises";
+import { log } from "./log";
 
 import type {
   ProxyRequest,
@@ -35,7 +36,7 @@ function parseJSONResponse(response: string): ProxyJSONResponse {
         body = JSON.parse(body);
       }
     } catch (e) {
-      console.log(
+      log.warn(
         `Failed to parse response body as JSON: ${result["status"]}: ${result["body"]}: ${e}`,
       );
     }

--- a/app/src/main/storage.ts
+++ b/app/src/main/storage.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import os from "os";
 import { Item, ItemMetadata } from "../types";
 import { ItemFetchTask } from "./fetch/queue";
+import { log } from "./log";
 
 /// Newtype for when we know a path component is potentially unsafe,
 /// which prevents it from being used in anything except PathBuilder
@@ -140,10 +141,9 @@ export class Storage {
         fs.rmSync(sourceDirectory, { recursive: true, force: true });
       }
     } catch (err) {
-      console.error("Failed to delete source from filesystem: ", {
-        sourceID,
-        error: err,
-      });
+      log.error(
+        `Failed to delete source from filesystem: sourceID=${sourceID} error=${err}`,
+      );
     }
   }
 
@@ -154,10 +154,9 @@ export class Storage {
         fs.rmSync(itemDirectory.path, { recursive: true, force: true });
       }
     } catch (err) {
-      console.error("Failed to delete item from filesystem", {
-        item: item.uuid,
-        error: err,
-      });
+      log.error(
+        `Failed to delete item from filesystem: item=${item.uuid} error=${err}`,
+      );
     }
   }
 }

--- a/app/src/main/timeouts.ts
+++ b/app/src/main/timeouts.ts
@@ -1,5 +1,6 @@
 import { bytes, ms } from "../types";
 import type { SizedSchema } from "../schemas";
+import { log } from "./log";
 import { DEFAULT_PROXY_CMD_TIMEOUT_MS } from "./proxy";
 
 // Calculate a realistic timeout in milliseconds based on the size of the total
@@ -44,7 +45,7 @@ export function estimateTimeout(schema: SizedSchema, records?: number): ms {
   const size = estimateSize(schema, records);
   const timeout = getRealisticTimeout(size, DEFAULT_PROXY_CMD_TIMEOUT_MS);
 
-  console.debug(
+  log.debug(
     `Expecting ${schema.description} of ~${records} records to be ~${size} bytes within ~${timeout} ms`,
   );
   return timeout;

--- a/app/src/main/transcriber.ts
+++ b/app/src/main/transcriber.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import { DB } from "./database";
 import { Storage } from "./storage";
 import { type SourceWithItems, Journalist } from "../types";
+import { log } from "./log";
 
 import { Liquid } from "liquidjs";
 
@@ -18,7 +19,7 @@ export async function renderTranscript(data: SourceWithItems, db: DB) {
       const journalist: Journalist = db.getJournalistByID(uuid);
       return journalist.data.username || "Unknown journalist";
     } catch (error) {
-      console.error("Error looking up journalist ", error);
+      log.error(`Error looking up journalist: ${error}`);
       return "Unknown journalist";
     }
   });
@@ -35,7 +36,7 @@ export async function renderTranscript(data: SourceWithItems, db: DB) {
     );
     return output;
   } catch (error) {
-    console.error("Error generating transcript: ", error);
+    log.error(`Error generating transcript: ${error}`);
     throw error;
   }
 }
@@ -57,10 +58,7 @@ export async function writeTranscript(
     fs.writeFileSync(filePath, fileContent, "utf-8");
     return filePath;
   } catch (error) {
-    console.error(
-      `Failed to write transcript for source: ${sourceUuid}:`,
-      error,
-    );
+    log.error(`Failed to write transcript for source: ${sourceUuid}: ${error}`);
     throw error;
   }
 }

--- a/app/src/unix-dgram.d.ts
+++ b/app/src/unix-dgram.d.ts
@@ -1,0 +1,23 @@
+declare module "unix-dgram" {
+  import { EventEmitter } from "events";
+
+  class Socket extends EventEmitter {
+    connected: boolean;
+    send(
+      buf: Buffer,
+      offset: number,
+      length: number,
+      path: string,
+      callback?: (err?: Error) => void,
+    ): void;
+    send(buf: Buffer, callback?: (err?: Error) => void): void;
+    connect(path: string): void;
+    bind(path: string): void;
+    close(): void;
+  }
+
+  function createSocket(
+    type: "unix_dgram",
+    listener?: (msg: Buffer) => void,
+  ): Socket;
+}

--- a/debian/build-app.sh
+++ b/debian/build-app.sh
@@ -8,4 +8,5 @@ npm install -g pnpm@10
 cd app
 
 pnpm install --frozen-lockfile
+pnpm run rebuild
 pnpm run build:unpack

--- a/debian/rules
+++ b/debian/rules
@@ -29,6 +29,7 @@ override_dh_install:
 	rmdir debian/securedrop-app/usr/lib/securedrop-app/linux-unpacked
 	rm -rf debian/securedrop-app/usr/lib/securedrop-app/resources/app.asar.unpacked/node_modules/better-sqlite3/deps/
 	rm -rf debian/securedrop-app/usr/lib/securedrop-app/resources/app.asar.unpacked/node_modules/better-sqlite3/src/
+	rm -rf debian/securedrop-app/usr/lib/securedrop-app/resources/app.asar.unpacked/node_modules/unix-dgram/src/
 	rm -rf debian/securedrop-app/usr/lib/securedrop-app/resources/app.asar.unpacked/node_modules/@dbmate/
 
 override_dh_strip_nondeterminism:


### PR DESCRIPTION
This is an untested PR to implement native logging from electron to syslog, i.e. option 1 in #3254.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
