### PR TITLE
Pipe securedrop-app output to syslog

### DIFF
--- a/app/src/main/export.ts
+++ b/app/src/main/export.ts
@@ -376,7 +376,7 @@ export class ArchiveExporter {
       );
     }
 
-    console.debug(`Parsing response from process: ${outputUntrusted}`);
+    console.log(`Parsing response from process: ${outputUntrusted}`);
     try {
       // final line is the status string
       const lines = outputUntrusted

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -203,7 +203,7 @@ export class TaskQueue {
   // decrypting data to plaintext stored in the DB or to a file on disk.
   process = async (item: ItemFetchTask, db: DB) => {
     try {
-      console.debug("Processing item: ", item);
+      console.log("Processing item: ", item);
 
       const dbItem = db.getItem(item.id);
       if (!dbItem) {
@@ -398,7 +398,7 @@ export class TaskQueue {
       timeout = getRealisticTimeout(metadata.size as bytes);
     }
 
-    console.debug(
+    console.log(
       `Downloading ${metadata.kind} ${item.id} (size: ${metadata.size} bytes) with timeout: ${timeout}ms`,
     );
 
@@ -705,7 +705,7 @@ export class TaskQueue {
       const fileStats = await fs.promises.stat(finalAbsolutePath);
       const decryptedSize = fileStats.size;
       db.completeFileItem(item.id, finalAbsolutePath, decryptedSize);
-      console.debug(`Successfully decrypted ${metadata.kind} ${item.id}`);
+      console.log(`Successfully decrypted ${metadata.kind} ${item.id}`);
     } catch (error) {
       if (error instanceof CryptoError) {
         console.warn(

--- a/app/src/main/fetch/worker.ts
+++ b/app/src/main/fetch/worker.ts
@@ -5,6 +5,9 @@ import { AuthedRequest, FetchWorkerMessage } from "../../types";
 import { Crypto } from "../crypto";
 import { Datastore } from "../datastore";
 import { Storage } from "../storage";
+import { initLogging } from "../log";
+
+initLogging();
 
 console.log("Starting fetch worker...");
 

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -421,7 +421,7 @@ if (!gotTheLock) {
         "syncMetadata",
         async (_event, request: AuthedRequest): Promise<SyncStatus> => {
           if (shouldSkipSync(db, request.hintedVersion)) {
-            console.debug(`Already at ${request.hintedVersion}; skipping sync`);
+            console.log(`Already at ${request.hintedVersion}; skipping sync`);
             wakeFetchWorkerIfNeeded(request.authToken);
             return SyncStatus.NOT_MODIFIED;
           }

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -43,10 +43,13 @@ import { setUmask } from "./umask";
 import { Exporter, Printer } from "./export";
 import { Storage } from "./storage";
 import { writeTranscript } from "./transcriber";
+import { initLogging } from "./log";
 
 // Set umask so any files written are owner-only read/write (600).
 // This must be done before we create any files or spawn any worker threads.
 setUmask();
+
+initLogging();
 
 // Handle --version flag early, before any other initialization
 if (process.argv.includes("--version")) {

--- a/app/src/main/log.ts
+++ b/app/src/main/log.ts
@@ -1,0 +1,10 @@
+// In production, unless LOGLEVEL=debug is set, turn console.log into a no-op.
+// This must be repeated for any additional workers.
+export function initLogging() {
+  if (
+    import.meta.env.MODE === "production" &&
+    process.env.LOGLEVEL !== "debug"
+  ) {
+    console.debug = () => {};
+  }
+}

--- a/debian/rules
+++ b/debian/rules
@@ -30,6 +30,7 @@ override_dh_install:
 	rm -rf debian/securedrop-app/usr/lib/securedrop-app/resources/app.asar.unpacked/node_modules/better-sqlite3/deps/
 	rm -rf debian/securedrop-app/usr/lib/securedrop-app/resources/app.asar.unpacked/node_modules/better-sqlite3/src/
 	rm -rf debian/securedrop-app/usr/lib/securedrop-app/resources/app.asar.unpacked/node_modules/@dbmate/
+	install -Dm755 debian/securedrop-app-wrapper debian/securedrop-app/usr/bin/securedrop-app
 
 override_dh_strip_nondeterminism:
 	find ./debian/ -type f -name '*.pyc' -delete

--- a/debian/securedrop-app-wrapper
+++ b/debian/securedrop-app-wrapper
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Wrap the real securedrop-app binary, forwarding its stdout/stderr to syslog
+exec /usr/bin/securedrop-app.real "$@" \
+    > >(logger -t securedrop-inbox -p user.info) \
+    2> >(logger -t securedrop-inbox -p user.err)

--- a/debian/securedrop-app.links
+++ b/debian/securedrop-app.links
@@ -1,1 +1,1 @@
-/usr/lib/securedrop-app/securedrop-app /usr/bin/securedrop-app
+/usr/lib/securedrop-app/securedrop-app /usr/bin/securedrop-app.real


### PR DESCRIPTION
And disable debug messages in production unless LOGLEVEL=debug is set via the environment.

Fixes #3254.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] Install this on SDW with try-client-pr
* [x] Launch the Inbox, observe that logs flow into sd-log. Trigger a sync failure by disabling network access, see that stacktrace gets logged too.
* [x] Close the Inbox. In a sd-app terminal, run `LOGLEVEL=debug securedrop-app`, observe you get the full firehose of debug log messages

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
