### PR TITLE
inbox: fix Reply tooltip + Send button

### DIFF
--- a/app/src/renderer/views/Inbox/MainContent/Conversation.css
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation.css
@@ -1,7 +1,3 @@
-.conversation-textarea {
-  padding-right: 40px;
-}
-
 .conversation-textarea textarea {
   field-sizing: content;
   min-height: calc(1lh + 24px); /* 2 lines + padding */
@@ -9,6 +5,7 @@
   overflow-y: auto !important;
   resize: none !important;
   padding: 10px;
+  padding-right: 55px;
 }
 
 .conversation-send-btn {

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Reply.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Reply.tsx
@@ -116,16 +116,20 @@ function Reply({ item }: ReplyProps) {
         <div className="flex items-center justify-start mb-1 gap-1">
           <span className="author reply-author">{getAuthorDisplay()}</span>
         </div>
-        <Tooltip title={statusIcon.tooltip} placement="bottomRight">
-          <div className="reply-box whitespace-pre-wrap overflow-hidden relative with-status-icon">
-            {isEncrypted ? (
-              <span className="italic text-gray-500">{t("itemEncrypted")}</span>
-            ) : (
-              <TruncatedText text={messageContent} />
-            )}
+        <div className="reply-box whitespace-pre-wrap overflow-hidden relative with-status-icon">
+          {isEncrypted ? (
+            <span className="italic text-gray-500">{t("itemEncrypted")}</span>
+          ) : (
+            <TruncatedText text={messageContent} />
+          )}
+          <Tooltip
+            title={statusIcon.tooltip}
+            placement="topRight"
+            styles={{ root: { position: "fixed" } }}
+          >
             {statusIcon.icon}
-          </div>
-        </Tooltip>
+          </Tooltip>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Fixes issue reported in https://github.com/freedomofpress/securedrop-client/issues/3076#issuecomment-4260355350
Fixes #3100 

The "Reply sent successfully" tooltip at the bottom of the reply box can cause strange scrolling behavior when moused over while scrolling through the conversation view. This PR addresses that bug by wrapping only the icon in the tooltip, and fixing its position so it doesn't trigger scroll changes when it is scrolled out of view.

Also fixes a small bug where the `Send` reply button overlaps with text.

## Test plan
Reproduce original issue:

- [x] Send a long message (with emojis or without)
- [x] With the mouse in hover position over the status tooltip, scroll up. This should (briefly) create two scrollbars in the window and shift the conversation items

On this PR:

- [x] Render the same conversation
- [ ] Replicate the scroll action with mouse in hover position. Scroll should operate as expected, no double scroll bars or unexpected repositioning

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
