### PR TITLE
[inbox] fix export wizard undownloaded files warning

### DIFF
--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.test.tsx
@@ -532,6 +532,100 @@ describe("ExportWizard Component", () => {
     });
   });
 
+  describe("Source Export", () => {
+    const mockSourcePayload: ExportPayload = {
+      type: "source",
+      payload: {
+        source_uuid: "source-uuid-1",
+        undownloaded_items: false,
+      },
+    };
+
+    it("shows CONFIRM_SOURCE state first when exporting a source", async () => {
+      renderWithProviders(
+        <ExportWizard
+          item={mockSourcePayload}
+          open={true}
+          onClose={mockOnClose}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Export Transcript and Files"),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(
+            "The transcript and all downloaded files will be exported.",
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("does not show the undownloaded warning when all files are downloaded", async () => {
+      renderWithProviders(
+        <ExportWizard
+          item={mockSourcePayload}
+          open={true}
+          onClose={mockOnClose}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText("Some files will not be exported"),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("shows undownloaded warning when source has undownloaded files", async () => {
+      const payloadWithUndownloaded: ExportPayload = {
+        type: "source",
+        payload: {
+          source_uuid: "source-uuid-1",
+          undownloaded_items: true,
+        },
+      };
+
+      renderWithProviders(
+        <ExportWizard
+          item={payloadWithUndownloaded}
+          open={true}
+          onClose={mockOnClose}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Some files have not been downloaded/),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("transitions to PREFLIGHT when Continue is clicked from CONFIRM_SOURCE", async () => {
+      renderWithProviders(
+        <ExportWizard
+          item={mockSourcePayload}
+          open={true}
+          onClose={mockOnClose}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Export Transcript and Files"),
+        ).toBeInTheDocument();
+      });
+
+      const continueButton = screen.getByRole("button", { name: /continue/i });
+      await userEvent.click(continueButton);
+
+      await waitFor(() => {
+        expect(screen.getByText("Preparing to export.")).toBeInTheDocument();
+      });
+    });
+  });
+
   describe("Export Errors", () => {
     const partialSuccessTests = [
       {

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.test.tsx
@@ -573,7 +573,7 @@ describe("ExportWizard Component", () => {
 
       await waitFor(() => {
         expect(
-          screen.queryByText("Some files will not be exported"),
+          screen.queryByText("Some files have not been downloaded"),
         ).not.toBeInTheDocument();
       });
     });

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.tsx
@@ -34,7 +34,8 @@ type ExportAction =
   | { type: "START_EXPORT" }
   | { type: "EXPORT_COMPLETE"; deviceStatus: DeviceStatus }
   | { type: "EXPORT_ERROR"; payload: string; deviceStatus?: DeviceStatus }
-  | { type: "CANCEL" };
+  | { type: "CANCEL" }
+  | { type: "UPDATE_UNDOWNLOADED_ITEMS"; value: boolean };
 
 interface ExportContext {
   state: ExportState;
@@ -144,6 +145,9 @@ function exportReducer(
       deviceStatus: action.deviceStatus,
       passphrase: "",
     };
+  }
+  if (action.type === "UPDATE_UNDOWNLOADED_ITEMS") {
+    return { ...context, undownloadedItems: action.value };
   }
   if (action.type === "CANCEL") {
     return {
@@ -632,6 +636,13 @@ export const ExportWizard = memo(function ExportWizard({
       exportInProgress.current = false;
     }
   }, [open]);
+
+  // Sync undownloaded_items to update when items have been downloaded
+  const undownloadedItems =
+    item.type === "source" ? item.payload.undownloaded_items : false;
+  useEffect(() => {
+    dispatch({ type: "UPDATE_UNDOWNLOADED_ITEMS", value: undownloadedItems });
+  }, [undownloadedItems]);
 
   // Initiate export preflight checks
   useEffect(() => {

--- a/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.test.tsx
@@ -6,7 +6,7 @@ import {
   testMemoization,
   renderWithProviders,
 } from "../../../../test-component-setup";
-import type { SourceWithItems } from "../../../../../types";
+import { FetchStatus, type SourceWithItems } from "../../../../../types";
 
 describe("SourceMenu Component", () => {
   beforeEach(() => {
@@ -196,6 +196,88 @@ describe("SourceMenu Component", () => {
         expect(screen.getByText("Preparing to export.")).toBeInTheDocument();
       });
     });
+    it("shows undownloaded warning when source has undownloaded file items", async () => {
+      const sourceWithUndownloadedFile: SourceWithItems = {
+        ...s,
+        items: [
+          ...s.items,
+          {
+            uuid: "file-1",
+            data: {
+              kind: "file",
+              uuid: "file-1",
+              source: "source-1",
+              size: 2048,
+              seen_by: [],
+              is_read: false,
+              interaction_count: 2,
+            },
+            fetch_status: FetchStatus.Initial,
+          },
+        ],
+      };
+
+      renderWithProviders(
+        <SourceMenu sourceWithItems={sourceWithUndownloadedFile} />,
+      );
+      const menuButton = screen.getByRole("button");
+      await userEvent.click(menuButton);
+
+      const exportSourceItem = screen.getByRole("menuitem", {
+        name: /export transcript and files/i,
+      });
+      await userEvent.click(exportSourceItem);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Some files have not been downloaded/),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("does not show undownloaded warning when only message items have non-complete fetch status", async () => {
+      const sourceWithUndownloadedMessage: SourceWithItems = {
+        ...s,
+        items: [
+          {
+            uuid: "msg-1",
+            data: {
+              kind: "message",
+              uuid: "msg-1",
+              source: "source-1",
+              size: 512,
+              seen_by: [],
+              is_read: false,
+              interaction_count: 1,
+            },
+            fetch_status: FetchStatus.Initial,
+          },
+        ],
+      };
+
+      renderWithProviders(
+        <SourceMenu sourceWithItems={sourceWithUndownloadedMessage} />,
+      );
+      const menuButton = screen.getByRole("button");
+      await userEvent.click(menuButton);
+
+      const exportSourceItem = screen.getByRole("menuitem", {
+        name: /export transcript and files/i,
+      });
+      await userEvent.click(exportSourceItem);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "The transcript and all downloaded files will be exported.",
+          ),
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByText("Some files will not be exported"),
+        ).not.toBeInTheDocument();
+      });
+    });
+
     it("opens the Print Wizard when Print Transcript is clicked ", async () => {
       renderWithProviders(<SourceMenu sourceWithItems={s} />);
       const menuButton = screen.getByRole("button");

--- a/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.test.tsx
@@ -273,7 +273,7 @@ describe("SourceMenu Component", () => {
           ),
         ).toBeInTheDocument();
         expect(
-          screen.queryByText("Some files will not be exported"),
+          screen.queryByText("Some files have not been downloaded"),
         ).not.toBeInTheDocument();
       });
     });

--- a/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.tsx
@@ -32,12 +32,10 @@ const SourceMenu = memo(function SourceMenu({
         type: "source",
         payload: {
           source_uuid: sourceWithItems.uuid,
-          undownloaded_items:
-            sourceWithItems.items.filter(
-              (i) =>
-                i.data.kind === "file" &&
-                i.fetch_status !== FetchStatus.Complete,
-            ).length > 0,
+          undownloaded_items: sourceWithItems.items.some(
+            (i) =>
+              i.data.kind === "file" && i.fetch_status !== FetchStatus.Complete,
+          ),
         },
       };
     }

--- a/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo, useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import {
   type SourceWithItems,
@@ -21,10 +21,31 @@ const SourceMenu = memo(function SourceMenu({
 }: SourceMenuProps) {
   const { t } = useTranslation("MainContent");
 
-  const [exportPayload, setExportPayload] = useState<ExportPayload>({
-    type: "transcript",
-    payload: { source_uuid: sourceWithItems.uuid },
-  });
+  const [exportType, setExportType] = useState<"transcript" | "source">(
+    "transcript",
+  );
+  const [exportWizardKey, setExportWizardKey] = useState(0);
+
+  const exportPayload = useMemo((): ExportPayload => {
+    if (exportType === "source") {
+      return {
+        type: "source",
+        payload: {
+          source_uuid: sourceWithItems.uuid,
+          undownloaded_items:
+            sourceWithItems.items.filter(
+              (i) =>
+                i.data.kind === "file" &&
+                i.fetch_status !== FetchStatus.Complete,
+            ).length > 0,
+        },
+      };
+    }
+    return {
+      type: "transcript",
+      payload: { source_uuid: sourceWithItems.uuid },
+    };
+  }, [exportType, sourceWithItems]);
 
   const printPayload: PrintPayload = {
     type: "transcript",
@@ -38,12 +59,8 @@ const SourceMenu = memo(function SourceMenu({
     switch (e.key) {
       case "exportTranscript":
         try {
-          setExportPayload({
-            type: "transcript",
-            payload: {
-              source_uuid: sourceWithItems.uuid,
-            },
-          });
+          setExportType("transcript");
+          setExportWizardKey((k) => k + 1);
           setExportWizardOpen(true);
         } catch (error) {
           console.error("Failed to export:", error);
@@ -51,16 +68,8 @@ const SourceMenu = memo(function SourceMenu({
         break;
       case "exportSource":
         try {
-          setExportPayload({
-            type: "source",
-            payload: {
-              source_uuid: sourceWithItems.uuid,
-              undownloaded_items:
-                sourceWithItems.items.filter(
-                  (i) => i.fetch_status !== FetchStatus.Complete,
-                ).length > 0,
-            },
-          });
+          setExportType("source");
+          setExportWizardKey((k) => k + 1);
           setExportWizardOpen(true);
         } catch (error) {
           console.error("Failed to export:", error);
@@ -127,7 +136,7 @@ const SourceMenu = memo(function SourceMenu({
         </Dropdown>
       </Tooltip>
       <ExportWizard
-        key={exportPayload.type}
+        key={exportWizardKey}
         item={exportPayload}
         open={exportWizardOpen}
         onClose={handleExportWizardClose}


### PR DESCRIPTION
Fixes #3261 

The export wizard has a bug where the `undownloadedFiles` state in the wizard was not being properly updated from the source conversation state. This change adds a handle in the wizard to update the `undownloadedFiles` state from the conversation state so that we properly render the warning when there are undownloaded files, and can also adjust the wizard as changes occur (if files are downloaded or new messages received while the conversation is open).

## Test plan

- [ ] Open a conversation with undownloaded files
- [ ] Select [...] -> "Export transcript and files" and verify that the warning shows in the first Export wizard dialog
- [ ] Download the files in the conversation
- [ ] Re-open "Export transcript and files" to show that the warning is no longer present in the Export wizard 
- [ ] Send another file to this source
- [ ] Opening "Export transcript and files" a third time should again show the undownloaded file warning

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
