### PR TITLE
fix(`download`): bail if the file we're about to download has been explicitly halted

### DIFF
--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -31,11 +31,13 @@ export type ItemFetchTask = {
 
 type DownloadResult = Buffer | string;
 
-// Thrown when a download is intentionally aborted (paused or cancelled by the user).
-// This is not an error condition and should not cause the item to be marked as failed.
+// Thrown when a download is intentionally aborted (cancelled or paused by the user).
+// This is not an error condition and should not cause the item to be marked as failed,
+// but download of the item should not be attempted again until explicitly
+// resumed by the user.
 class DownloadCancelledError extends Error {
   constructor() {
-    super("Download was cancelled");
+    super("Download is cancelled or paused");
   }
 }
 
@@ -348,6 +350,16 @@ export class TaskQueue {
     metadata: ItemMetadata,
     progress: number,
   ): Promise<DownloadResult> {
+    const currentItem = db.getItem(item.id);
+    if (
+      // Bail if the download has been explicitly halted.  We need it to be
+      // explicitly resumed either by the back end via `resumeItem()` or by the
+      // front end via `updateFetchStatus()` before we continue downloading it.
+      currentItem?.fetch_status === FetchStatus.Paused ||
+      currentItem?.fetch_status === FetchStatus.Cancelled
+    ) {
+      throw new DownloadCancelledError();
+    }
     console.debug(`Starting download for ${metadata.kind} ${item.id}`);
     const abortController = new AbortController();
     this.activeDownloads.set(item.id, {


### PR DESCRIPTION
- [ ] Tests TK

Fixes #3206 by fixing the race between (a) manually pausing or cancelling download of a file and (b) automatic retry when download of the same file has failed.[^1]

[^1]: https://github.com/freedomofpress/securedrop-client/issues/3206#issuecomment-4284927861

## Test plan

https://github.com/freedomofpress/securedrop-client/issues/3206#issuecomment-4283793203


## Checklist

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- any needed updates to the [AppArmor profile] for files beyond the application code
- any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
