### PR TITLE
[inbox] do not resurrect cancelled downloads

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -18,6 +18,7 @@ import {
   Journalist,
   JournalistRow,
   FetchStatus,
+  NONPROCESSABLE_FETCH_STATUSES,
   Item,
   PendingEventType,
   ReplySentData,
@@ -1005,22 +1006,25 @@ export class DB {
     stmt.run({ uuid: itemUuid });
   }
 
-  setDownloadInProgress(itemUuid: string, progress?: number) {
-    if (progress !== undefined) {
-      const stmt: Statement<{ uuid: string; progress: number }, void> =
-        this.db!.prepare(
-          `UPDATE items SET fetch_progress = @progress, fetch_status = ${FetchStatus.DownloadInProgress}, fetch_last_updated_at = CURRENT_TIMESTAMP WHERE uuid = @uuid`,
-        );
-      stmt.run({
-        uuid: itemUuid,
-        progress: progress,
-      });
-    } else {
-      const stmt: Statement<{ uuid: string }, void> = this.db!.prepare(
-        `UPDATE items SET fetch_status = ${FetchStatus.DownloadInProgress}, fetch_last_updated_at = CURRENT_TIMESTAMP WHERE uuid = @uuid`,
+  startDownloadInProgress(itemUuid: string) {
+    const stmt: Statement<{ uuid: string }, void> = this.db!.prepare(
+      `UPDATE items SET fetch_status = ${FetchStatus.DownloadInProgress}, fetch_last_updated_at = CURRENT_TIMESTAMP WHERE uuid = @uuid`,
+    );
+    stmt.run({ uuid: itemUuid });
+  }
+
+  // Updates a download in progress if it is still in a processable state. Returns true
+  // if the update was successful, and false if no rows were updated.
+  updateDownloadInProgress(itemUuid: string, progress: number): boolean {
+    const stmt: Statement<{ uuid: string; progress: number }, void> =
+      this.db!.prepare(
+        `UPDATE items SET fetch_progress = @progress, fetch_status = ${FetchStatus.DownloadInProgress}, fetch_last_updated_at = CURRENT_TIMESTAMP WHERE uuid = @uuid AND fetch_status NOT IN (${[...NONPROCESSABLE_FETCH_STATUSES].join(", ")})`,
       );
-      stmt.run({ uuid: itemUuid });
-    }
+    const result = stmt.run({
+      uuid: itemUuid,
+      progress: progress,
+    });
+    return result.changes !== 0;
   }
 
   setDecryptionInProgress(itemUuid: string) {

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -389,8 +389,8 @@ describe("Datastore Method Tests", () => {
       source2Item1: mockItemMetadata("source2Item1", "source2", "file"),
     });
 
-    db.setDownloadInProgress("source1Item1", 9000);
-    db.setDownloadInProgress("source2Item1", 12000);
+    db.updateDownloadInProgress("source1Item1", 9000);
+    db.updateDownloadInProgress("source2Item1", 12000);
 
     // Truncate only items up to interaction_count 1
     db.addPendingSourceEvent(
@@ -1339,9 +1339,9 @@ describe("Datastore Method Tests", () => {
       file3: mockItemMetadata("file3", "source1", "file", 6),
     });
 
-    db.setDownloadInProgress("file1", 10);
-    db.setDownloadInProgress("file2", 20);
-    db.setDownloadInProgress("file3", 30);
+    db.updateDownloadInProgress("file1", 10);
+    db.updateDownloadInProgress("file2", 20);
+    db.updateDownloadInProgress("file3", 30);
 
     const itemsToProcess = db.getItemsToProcess({
       messageLimit: 2,
@@ -1363,8 +1363,8 @@ describe("Datastore Method Tests", () => {
       file2: mockItemMetadata("file2", "source1", "file", 4),
     });
 
-    db.setDownloadInProgress("file1", 10);
-    db.setDownloadInProgress("file2", 20);
+    db.updateDownloadInProgress("file1", 10);
+    db.updateDownloadInProgress("file2", 20);
     db.updateFetchStatus("message2", FetchStatus.ScheduledDeletion);
     db.updateFetchStatus("file2", FetchStatus.ScheduledDeletion);
 
@@ -1514,7 +1514,7 @@ describe("Datastore Method Tests", () => {
       });
 
       // Simulate a partial download by setting progress
-      db.setDownloadInProgress("item1", 50000);
+      db.updateDownloadInProgress("item1", 50000);
 
       // Verify progress was set
       let item = db.getItem("item1");
@@ -1538,7 +1538,7 @@ describe("Datastore Method Tests", () => {
       });
 
       // Simulate a paused download with progress
-      db.setDownloadInProgress("item1", 100000);
+      db.updateDownloadInProgress("item1", 100000);
       db.pauseItem("item1");
 
       // Verify progress was preserved during pause
@@ -1564,7 +1564,7 @@ describe("Datastore Method Tests", () => {
       });
 
       // Set some progress
-      db.setDownloadInProgress("item1", 75000);
+      db.updateDownloadInProgress("item1", 75000);
 
       // Update to Paused status
       db.updateFetchStatus("item1", FetchStatus.Paused);
@@ -1583,13 +1583,38 @@ describe("Datastore Method Tests", () => {
         item1: mockItemMetadata("item1", "source1", "file"),
       });
 
-      db.setDownloadInProgress("item1", 42000);
+      db.updateDownloadInProgress("item1", 42000);
 
       db.updateFetchStatus("item1", FetchStatus.ScheduledDeletion);
 
       const item = db.getItem("item1");
       expect(item?.fetch_status).toBe(FetchStatus.ScheduledDeletion);
       expect(item?.fetch_progress).toBe(42000);
+    });
+
+    it("should NOT resurrect cancelled download when updating progress", () => {
+      db.updateSources({
+        source1: mockSourceMetadata("source1"),
+      });
+      db.updateItems({
+        item1: mockItemMetadata("item1", "source1", "file"),
+      });
+
+      db.startDownloadInProgress("item1");
+      db.updateDownloadInProgress("item1", 42000);
+      let item = db.getItem("item1");
+      expect(item?.fetch_status).toBe(FetchStatus.DownloadInProgress);
+      expect(item?.fetch_progress).toBe(42000);
+
+      db.updateFetchStatus("item1", FetchStatus.Cancelled);
+
+      const result = db.updateDownloadInProgress("item1", 48000);
+
+      expect(result).toBe(false);
+
+      item = db.getItem("item1");
+      expect(item?.fetch_status).toBe(FetchStatus.Cancelled);
+      expect(item?.fetch_progress).toBe(0);
     });
 
     it("should allow retry after terminal failure when status is reset", () => {
@@ -1601,7 +1626,7 @@ describe("Datastore Method Tests", () => {
       });
 
       // Simulate a terminal failure with progress
-      db.setDownloadInProgress("item1", 50000);
+      db.updateDownloadInProgress("item1", 50000);
       db.terminallyFailItem("item1");
 
       let item = db.getItem("item1");
@@ -1646,7 +1671,7 @@ describe("Datastore Method Tests", () => {
 
       // Files need download progress set to be processable
       for (let i = 1; i <= 10; i++) {
-        db.setDownloadInProgress(`file${i}`, i * 100);
+        db.updateDownloadInProgress(`file${i}`, i * 100);
       }
 
       // First batch: bounded to 25 messages and 2 files
@@ -1694,7 +1719,7 @@ describe("Datastore Method Tests", () => {
       db.updateItems(items);
 
       // Set some items to various in-progress states
-      db.setDownloadInProgress("msg1", 100);
+      db.updateDownloadInProgress("msg1", 100);
       db.updateFetchStatus("msg2", FetchStatus.DecryptionInProgress);
       db.completePlaintextItem("msg3", "already decrypted");
 

--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -81,7 +81,8 @@ function createMockDB() {
     getSource: vi.fn(),
     completePlaintextItem: vi.fn(),
     completeFileItem: vi.fn(),
-    setDownloadInProgress: vi.fn(),
+    startDownloadInProgress: vi.fn(),
+    updateDownloadInProgress: vi.fn(() => true),
     setDecryptionInProgress: vi.fn(),
     setSourceMessagePreview: vi.fn(),
     failDownload: vi.fn(),
@@ -141,7 +142,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
       await queue.process({ id: "msg1" }, db);
 
       // Verify download phase
-      expect(db.setDownloadInProgress).toHaveBeenCalledWith("msg1");
+      expect(db.startDownloadInProgress).toHaveBeenCalledWith("msg1");
       expect(mockProxyStreamRequest).toHaveBeenCalledWith(
         expect.objectContaining({
           path_query: "/api/v1/sources/source1/submissions/msg1/download",
@@ -214,7 +215,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         `Decryption failed`,
       );
 
-      expect(db.setDownloadInProgress).toHaveBeenCalledWith("msg1");
+      expect(db.startDownloadInProgress).toHaveBeenCalledWith("msg1");
       expect(db.setDecryptionInProgress).toHaveBeenCalledWith("msg1");
       expect(db.failDecryption).toHaveBeenCalledWith("msg1");
 
@@ -285,8 +286,8 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         "Unable to complete stream download",
       );
 
-      expect(db.setDownloadInProgress).toHaveBeenCalledWith("msg1");
-      expect(db.setDownloadInProgress).toHaveBeenCalledWith("msg1", 50); // Progress update
+      expect(db.startDownloadInProgress).toHaveBeenCalledWith("msg1");
+      expect(db.updateDownloadInProgress).toHaveBeenCalledWith("msg1", 50); // Progress update
       expect(db.failDownload).toHaveBeenCalledWith("msg1");
 
       // Second attempt - download and decrypt successfully
@@ -516,7 +517,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
       await queue.process({ id: "msg1" }, db);
 
       // Verify download phase
-      expect(db.setDownloadInProgress).toHaveBeenCalledWith("msg1");
+      expect(db.startDownloadInProgress).toHaveBeenCalledWith("msg1");
       expect(mockProxyStreamRequest).toHaveBeenCalledWith(
         expect.objectContaining({
           path_query: "/api/v1/sources/source1/submissions/msg1/download",
@@ -595,9 +596,8 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
 
       await queue.process({ id: "file-uuid-progress" }, db);
 
-      // First call is the initial setDownloadInProgress, subsequent calls are from onProgress
-      const setDownloadMock = db.setDownloadInProgress as unknown as Mock;
-      const progressCalls = setDownloadMock.mock.calls.slice(1);
+      const updateDownloadMock = db.updateDownloadInProgress as unknown as Mock;
+      const progressCalls = updateDownloadMock.mock.calls;
       expect(progressCalls.map((call) => call[1])).toEqual([10, 20, 30]);
 
       // One throttled progress post plus source update and final item update
@@ -663,7 +663,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         expect.any(Object),
       );
 
-      expect(db.setDownloadInProgress).toHaveBeenCalledWith("msg1");
+      expect(db.startDownloadInProgress).toHaveBeenCalledWith("msg1");
       expect(db.setDecryptionInProgress).toHaveBeenCalledWith("msg1");
       expect(db.failDecryption).toHaveBeenCalledWith("msg1");
 
@@ -726,8 +726,8 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
         "Unable to complete stream download",
       );
 
-      expect(db.setDownloadInProgress).toHaveBeenCalledWith("msg1");
-      expect(db.setDownloadInProgress).toHaveBeenCalledWith("msg1", 50); // Progress update
+      expect(db.startDownloadInProgress).toHaveBeenCalledWith("msg1");
+      expect(db.updateDownloadInProgress).toHaveBeenCalledWith("msg1", 50); // Progress update
       expect(db.failDownload).toHaveBeenCalledWith("msg1");
 
       // Second attempt - download and decrypt successfully
@@ -772,7 +772,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
       await queue.process({ id: "msg1" }, db);
 
       expect(mockProxyStreamRequest).not.toHaveBeenCalled();
-      expect(db.setDownloadInProgress).not.toHaveBeenCalled();
+      expect(db.startDownloadInProgress).not.toHaveBeenCalled();
       expect(db.setDecryptionInProgress).not.toHaveBeenCalled();
     });
 
@@ -826,7 +826,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
       await queue.process({ id: "msg1" }, db);
 
       expect(mockProxyStreamRequest).not.toHaveBeenCalled();
-      expect(db.setDownloadInProgress).not.toHaveBeenCalled();
+      expect(db.startDownloadInProgress).not.toHaveBeenCalled();
       expect(db.setDecryptionInProgress).not.toHaveBeenCalled();
     });
 

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -12,6 +12,7 @@ import {
   AuthedRequest,
   FetchStatus,
   ItemMetadata,
+  NONPROCESSABLE_FETCH_STATUSES,
   ProxyRequest,
   ProxyStreamResponse,
   bytes,
@@ -131,9 +132,15 @@ export class TaskQueue {
     this.queueFetches({ authToken: this.authToken });
   }
 
-  private isScheduledForDeletion(itemId: string, db: DB): boolean {
+  // Check that item is still in processable state: not cancelled, paused
+  // complete, or scheduled for deletion
+  private isProcessable(itemId: string, db: DB): boolean {
     const item = db.getItem(itemId);
-    return !item || item.fetch_status === FetchStatus.ScheduledDeletion;
+    return (
+      item !== null &&
+      item?.fetch_status !== undefined &&
+      !NONPROCESSABLE_FETCH_STATUSES.has(item.fetch_status)
+    );
   }
 
   // Queries the database for all items that need to be downloaded and queues
@@ -205,9 +212,15 @@ export class TaskQueue {
     try {
       console.log("Processing item: ", item);
 
+      // Skip items that are complete, terminally failed, paused, cancelled,
+      // scheduled for deletion, or otherwise not in a processable state.
       const dbItem = db.getItem(item.id);
-      if (!dbItem) {
-        console.debug("Item not found");
+      if (
+        !dbItem ||
+        dbItem.fetch_status === undefined ||
+        NONPROCESSABLE_FETCH_STATUSES.has(dbItem.fetch_status)
+      ) {
+        console.debug("Item task is not in a processable state, skipping...");
         return;
       }
 
@@ -216,19 +229,6 @@ export class TaskQueue {
         fetch_status: status,
         fetch_progress: progress,
       } = dbItem;
-
-      // Skip items that are complete, terminally failed, paused, cancelled,
-      // scheduled for deletion, or otherwise not in a processable state.
-      if (
-        status == FetchStatus.Complete ||
-        status == FetchStatus.FailedTerminal ||
-        status == FetchStatus.Paused ||
-        status == FetchStatus.Cancelled ||
-        status == FetchStatus.ScheduledDeletion
-      ) {
-        console.debug("Item task is not in a processable state, skipping...");
-        return;
-      }
 
       // Phase 1: Download
       let downloadResult: DownloadResult | undefined;
@@ -256,9 +256,9 @@ export class TaskQueue {
       }
 
       // Re-check: if the item was marked for deletion during download, stop.
-      if (this.isScheduledForDeletion(item.id, db)) {
+      if (!this.isProcessable(item.id, db)) {
         console.debug(
-          `Item ${item.id} scheduled for deletion after download, skipping decryption...`,
+          `Item ${item.id} in non-processable state after download, skipping decryption...`,
         );
         return;
       }
@@ -355,7 +355,7 @@ export class TaskQueue {
       controller: abortController,
     });
     try {
-      db.setDownloadInProgress(item.id);
+      db.startDownloadInProgress(item.id);
       return await this.innerDownload(
         item,
         db,
@@ -413,7 +413,9 @@ export class TaskQueue {
 
       // Don't override the DB status if the download has been cancelled
       if (!abortController.signal.aborted) {
-        db.setDownloadInProgress(item.id, totalBytesWritten);
+        if (!db.updateDownloadInProgress(item.id, totalBytesWritten)) {
+          return;
+        }
       }
 
       // Throttle UI updates to avoid overwhelming the renderer
@@ -461,7 +463,7 @@ export class TaskQueue {
       }
 
       const bytesWritten = progress + downloadResponse.bytesWritten;
-      db.setDownloadInProgress(item.id, bytesWritten);
+      db.updateDownloadInProgress(item.id, bytesWritten);
       db.failDownload(item.id);
       throw new Error(
         `Unable to complete stream download, wrote ${downloadResponse.bytesWritten} bytes: ${downloadResponse.error?.message}`,
@@ -599,7 +601,7 @@ export class TaskQueue {
       const decryptedContent = await crypto.decryptMessage(buffer, signal);
 
       // Re-check: if the item was deleted during decryption, drop the result
-      if (this.isScheduledForDeletion(item.id, db)) {
+      if (!this.isProcessable(item.id, db)) {
         return;
       }
 
@@ -649,7 +651,7 @@ export class TaskQueue {
       const decryptedContent = await crypto.decryptMessage(buffer, signal);
 
       // Re-check: if the item was deleted during decryption, drop the result
-      if (this.isScheduledForDeletion(item.id, db)) {
+      if (!this.isProcessable(item.id, db)) {
         return;
       }
 
@@ -690,7 +692,7 @@ export class TaskQueue {
       );
 
       // Re-check: if the item was deleted during decryption, drop the result
-      if (this.isScheduledForDeletion(item.id, db)) {
+      if (!this.isProcessable(item.id, db)) {
         try {
           await fs.promises.unlink(finalAbsolutePath);
         } catch (error) {

--- a/app/src/renderer/features/conversation/conversationSlice.test.ts
+++ b/app/src/renderer/features/conversation/conversationSlice.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { configureStore } from "@reduxjs/toolkit";
-import type { SourceWithItems } from "../../../types";
+import { FetchStatus, type SourceWithItems } from "../../../types";
 import conversationSlice, {
   fetchConversation,
   clearError,
   clearConversation,
+  updateItem,
   selectConversation,
   selectConversationLoading,
   type ConversationState,
@@ -363,6 +364,105 @@ describe("conversationSlice", () => {
       // Only the last conversation should be stored
       expect(state.conversation).toEqual(mockSourceWithItems2);
       expect(state.loading).toBe(false);
+    });
+  });
+
+  describe("updateItem reducer — worker updates", () => {
+    const fileItem = {
+      uuid: "file-1",
+      data: {
+        kind: "file" as const,
+        uuid: "file-1",
+        source: "source-1",
+        size: 1024,
+        is_read: false,
+        seen_by: [],
+        interaction_count: 1,
+      },
+      fetch_progress: 0,
+      fetch_status: FetchStatus.DownloadInProgress,
+    };
+
+    const sourceWithFile: SourceWithItems = {
+      ...mockSourceWithItems,
+      items: [fileItem],
+    };
+
+    const stateWithFile: ConversationState = {
+      conversation: sourceWithFile,
+      loading: false,
+      error: null,
+      lastFetchTime: null,
+      hasMoreHistoricalItems: false,
+      olderItemsLoading: false,
+    };
+
+    it("does not resurrect a Cancelled item", () => {
+      const canceledState: ConversationState = {
+        ...stateWithFile,
+        conversation: {
+          ...sourceWithFile,
+          items: [{ ...fileItem, fetch_status: FetchStatus.Cancelled }],
+        },
+      };
+      const staleUpdate = {
+        ...fileItem,
+        fetch_status: FetchStatus.DownloadInProgress,
+      };
+      const newState = conversationSlice(
+        canceledState,
+        updateItem(staleUpdate),
+      );
+      expect(newState.conversation?.items[0].fetch_status).toBe(
+        FetchStatus.Cancelled,
+      );
+    });
+
+    it("applies legitimate terminal transitions from the worker", () => {
+      const inProgressState: ConversationState = {
+        ...stateWithFile,
+        conversation: {
+          ...sourceWithFile,
+          items: [
+            { ...fileItem, fetch_status: FetchStatus.DownloadInProgress },
+          ],
+        },
+      };
+      // Worker marks download as terminally failed
+      const failedUpdate = {
+        ...fileItem,
+        fetch_status: FetchStatus.FailedTerminal,
+      };
+      const newState = conversationSlice(
+        inProgressState,
+        updateItem(failedUpdate),
+      );
+      expect(newState.conversation?.items[0].fetch_status).toBe(
+        FetchStatus.FailedTerminal,
+      );
+    });
+
+    it("applies Complete status update from the worker", () => {
+      const inProgressState: ConversationState = {
+        ...stateWithFile,
+        conversation: {
+          ...sourceWithFile,
+          items: [
+            { ...fileItem, fetch_status: FetchStatus.DecryptionInProgress },
+          ],
+        },
+      };
+      const completedUpdate = {
+        ...fileItem,
+        fetch_status: FetchStatus.Complete,
+      };
+      const newState = conversationSlice(
+        inProgressState,
+        updateItem(completedUpdate),
+      );
+      expect(newState.conversation?.items[0].fetch_status).toBe(
+        FetchStatus.Complete,
+      );
     });
   });
 });

--- a/app/src/renderer/features/conversation/conversationSlice.ts
+++ b/app/src/renderer/features/conversation/conversationSlice.ts
@@ -1,5 +1,9 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
-import { Item, type SourceWithItems } from "../../../types";
+import {
+  Item,
+  NONPROCESSABLE_FETCH_STATUSES,
+  type SourceWithItems,
+} from "../../../types";
 import type { RootState } from "../../store";
 import { fetchSources } from "../sources/sourcesSlice";
 
@@ -124,11 +128,22 @@ const conversationSlice = createSlice({
     updateItem: (state, action) => {
       const updatedItem: Item = action.payload;
       if (state.conversation) {
-        state.conversation.items = state.conversation.items.map((item, _) => {
-          if (item.uuid === updatedItem.uuid) {
-            return updatedItem;
+        state.conversation.items = state.conversation.items.map((item) => {
+          if (item.uuid !== updatedItem.uuid) {
+            return item;
           }
-          return item;
+
+          // Check that the update does not transition from a terminal state, indicating
+          // a stale update. If so, ignore.
+
+          if (
+            item.fetch_status &&
+            NONPROCESSABLE_FETCH_STATUSES.has(item.fetch_status)
+          ) {
+            return item;
+          }
+
+          return updatedItem;
         });
       }
     },

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -230,6 +230,14 @@ export enum FetchStatus {
   ScheduledDeletion = 9,
 }
 
+export const NONPROCESSABLE_FETCH_STATUSES = new Set<FetchStatus>([
+  FetchStatus.Complete,
+  FetchStatus.Paused,
+  FetchStatus.FailedTerminal,
+  FetchStatus.Cancelled,
+  FetchStatus.ScheduledDeletion,
+]);
+
 // EventStatus codes returned from the server
 export enum EventStatus {
   Processing = 102,


### PR DESCRIPTION
Fixes #3206

Adds checks in the DB to avoid resurrecting cancelled/paused downloads when updating progress, and also adds a guard in the Redux store to ignore potential stale dispatches from the worker.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
