### PR TITLE
[inbox] fix sync lock bug

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -772,10 +772,12 @@ async function syncWithLock(
   let syncStatus: SyncStatus;
   try {
     syncStatus = await syncLock.run(async () => {
+      console.log("Acquired lock, syncing metadata");
       return await syncMetadata(db, request.authToken, request.hintedRecords);
     }, 1000);
   } catch (error) {
     // Check if this is a timeout error from the lock
+    console.log("Failed to acquire lock");
     if (error instanceof LockTimeoutError) {
       return SyncStatus.TIMEOUT;
     }

--- a/app/src/main/sync/lock.test.ts
+++ b/app/src/main/sync/lock.test.ts
@@ -162,4 +162,35 @@ describe("Lock", () => {
     }, 100);
     expect(executed).toBe(true);
   });
+
+  it("allows concurrent access when a timed-out waiter unblocks the next waiter", async () => {
+    const lock = new Lock();
+    let call1Active = false;
+    let concurrentAccess = false;
+
+    // Call 1 holds the lock for 200ms
+    const call1 = lock.run(async () => {
+      call1Active = true;
+      await new Promise((res) => setTimeout(res, 200));
+      call1Active = false;
+    });
+
+    // Call 2 times out after 50ms while call 1 still holds the lock.
+    // On timeout, the lock incorrectly calls release() on call 2's mutex,
+    // which unblocks call 3 even though call 1 hasn't finished.
+    const call2 = lock.run(async () => {}, 50).catch(() => {});
+
+    // Call 3 is queued behind call 2 and gets incorrectly unblocked at ~50ms.
+    const call3 = lock.run(async () => {
+      if (call1Active) {
+        concurrentAccess = true;
+      }
+    });
+
+    await Promise.all([call1, call2, call3]);
+
+    // Should be false, but the bug causes call 2's timeout to release its mutex
+    // and unblock call 3 before call 1 has finished
+    expect(concurrentAccess).toBe(false);
+  });
 });

--- a/app/src/main/sync/lock.test.ts
+++ b/app/src/main/sync/lock.test.ts
@@ -163,7 +163,7 @@ describe("Lock", () => {
     expect(executed).toBe(true);
   });
 
-  it("allows concurrent access when a timed-out waiter unblocks the next waiter", async () => {
+  it("does not allows concurrent access when a timed-out waiter unblocks the next waiter", async () => {
     const lock = new Lock();
     let call1Active = false;
     let concurrentAccess = false;

--- a/app/src/main/sync/lock.ts
+++ b/app/src/main/sync/lock.ts
@@ -37,9 +37,10 @@ export class Lock {
       try {
         await Promise.race([currentMutex, timeoutPromise]);
       } catch (error) {
-        // On timeout, release the mutex so subsequent acquires don't block forever
+        // On timeout, chain our mutex to the previous holder so downstream
+        // waiters still wait for the actual lock holder to finish
         // @ts-expect-error - release is always assigned before this point
-        release();
+        currentMutex.then(release);
         throw error;
       } finally {
         // Clean up the timer to prevent memory leaks


### PR DESCRIPTION
Fixes #3270

Applies the Claude-suggested fix that correctly chains the sync lock so that the lock only resolves when the underlying resource or original holder resolves. 

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

- [ ] Set up SecureDrop server to take >1s to respond to sync. I did this by adding a `time.sleep(5)` inside the call to `/index`, but can also do so by creating a large dataset where the index response will take >1s 
- [ ] Start the SecureDrop Inbox with debug logging enabled
- [ ] Fire many repeated sync requests (spam `Ctrl+S`) 
- [ ] Verify that the logs show a single `Acquired lock, syncing metadata` followed by many `Failed to acquire lock` logs

In the original bug behavior, there would be alternating `Acquired lock` and `Failed to acquire lock` that ultimately resulted in many concurrent syncs occurring with the false lock resolution.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
