### PR TITLE
[1.0.0] Backport "Fetch messages/replies ordered by source.last_updated"

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -264,17 +264,19 @@ export class DB {
       "SELECT version FROM items WHERE uuid = @uuid",
     );
     this.selectMessageItemsProcessable = this.db.prepare(
-      `SELECT uuid FROM items
+      `SELECT items.uuid FROM items
+      JOIN sources ON items.source_uuid = sources.uuid
       WHERE kind <> 'file'
         AND fetch_status in (${FetchStatus.Initial}, ${FetchStatus.DownloadInProgress}, ${FetchStatus.DecryptionInProgress}, ${FetchStatus.FailedDownloadRetryable}, ${FetchStatus.FailedDecryptionRetryable})
-      ORDER BY interaction_count ASC, uuid ASC
+      ORDER BY json_extract(sources.data, '$.last_updated') DESC, interaction_count DESC, items.uuid ASC
       LIMIT @limit`,
     );
     this.selectFileItemsProcessable = this.db.prepare(
-      `SELECT uuid FROM items
+      `SELECT items.uuid FROM items
+      JOIN sources ON items.source_uuid = sources.uuid
       WHERE kind = 'file'
         AND fetch_status in (${FetchStatus.DownloadInProgress}, ${FetchStatus.DecryptionInProgress}, ${FetchStatus.FailedDownloadRetryable}, ${FetchStatus.FailedDecryptionRetryable})
-      ORDER BY interaction_count ASC, uuid ASC
+      ORDER BY json_extract(sources.data, '$.last_updated') DESC, interaction_count DESC, items.uuid ASC
       LIMIT @limit`,
     );
     this.selectUnprojectedItemsBySource = this.db.prepare(

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -1348,7 +1348,7 @@ describe("Datastore Method Tests", () => {
       fileLimit: 1,
     });
 
-    expect(itemsToProcess).toEqual(["message1", "message2", "file1"]);
+    expect(itemsToProcess).toEqual(["message3", "message2", "file3"]);
   });
 
   it("getItemsToProcess should exclude ScheduledDeletion items", () => {


### PR DESCRIPTION
Backport of #3253.

## Testing

* [ ] base is `release/1.0.0`
* [ ] Only contains changes from #3253.
