### PR TITLE
inbox: remove Ctrl+Shift+I signin shortcut from offline mode

### DIFF
--- a/app/src/renderer/views/Inbox/Sidebar/Account/MainMenu.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/Account/MainMenu.tsx
@@ -153,7 +153,6 @@ function MainMenu() {
           key: "signIn",
           label: t("account.signIn"),
           icon: <LogIn strokeWidth={1.5} />,
-          extra: "Ctrl+Shift+I",
         },
 
     {


### PR DESCRIPTION
Fixes #3258 

Removes the Ctrl+Shift+I shortcut from being displayed in the main menu in offline mode, since that shortcut is unimplemented.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
