### PR TITLE
[inbox] autoscroll or show new messages button

### DIFF
--- a/app/src/renderer/views/Inbox/MainContent/Conversation.css
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation.css
@@ -17,3 +17,15 @@
   height: auto;
   line-height: normal;
 }
+
+.new-messages-notification-btn {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  white-space: nowrap;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  border-color: rgba(206, 55, 92, 0.6) !important;
+  color: rgba(206, 55, 92, 1) !important;
+}

--- a/app/src/renderer/views/Inbox/MainContent/Conversation.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
@@ -762,5 +762,197 @@ describe("Conversation new message indicator", () => {
       delete (window as any).requestAnimationFrame;
     }
     offsetSpy.mockRestore();
+  });
+});
+
+describe("Conversation autoscroll and new messages button", () => {
+  const baseItems = [createMessageItem("item-1", 1)];
+  let rafCallbacks: FrameRequestCallback[];
+  let originalRAF: typeof window.requestAnimationFrame;
+
+  beforeEach(() => {
+    originalRAF = window.requestAnimationFrame;
+    rafCallbacks = [];
+    (window as any).requestAnimationFrame = vi.fn(
+      (cb: FrameRequestCallback) => {
+        rafCallbacks.push(cb);
+        return 0;
+      },
+    ) as typeof window.requestAnimationFrame;
+  });
+
+  afterEach(() => {
+    window.requestAnimationFrame = originalRAF;
+  });
+
+  const flushAllRAF = async () => {
+    let passes = 0;
+    while (rafCallbacks.length > 0 && passes < 20) {
+      const batch = [...rafCallbacks];
+      rafCallbacks.length = 0;
+      await act(async () => {
+        batch.forEach((cb) => cb(0));
+      });
+      passes++;
+    }
+  };
+
+  // Sets scroll properties on the container, completes the initial auto-scroll
+  // via RAF flush, then simulates the user scrolling up so new items trigger
+  // the button / auto-scroll logic instead of being silently ignored.
+  const setupScrolledUp = async (container: HTMLDivElement) => {
+    let scrollTopValue = 0;
+    Object.defineProperty(container, "scrollHeight", {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(container, "clientHeight", {
+      configurable: true,
+      value: 400,
+    });
+    Object.defineProperty(container, "scrollTop", {
+      configurable: true,
+      get: () => scrollTopValue,
+      set: (value: number) => {
+        scrollTopValue = value;
+      },
+    });
+
+    // Complete the initial auto-scroll so isAutoScrolling resets to false,
+    // which allows subsequent manual scroll events to be processed.
+    await flushAllRAF();
+
+    // Simulate user scrolling up (distanceToBottom = 1000 - 500 = 500 > threshold)
+    await act(async () => {
+      scrollTopValue = 100;
+      container.dispatchEvent(new Event("scroll"));
+    });
+  };
+
+  it("shows new messages button when a new message arrives while scrolled up", async () => {
+    const { rerender } = renderWithProviders(
+      <Conversation sourceWithItems={withItems(baseItems)} />,
+    );
+
+    const container = screen.getByTestId(
+      "conversation-items-container",
+    ) as HTMLDivElement;
+    await setupScrolledUp(container);
+
+    expect(screen.queryByTestId("new-messages-button")).not.toBeInTheDocument();
+
+    rerender(
+      <Conversation
+        sourceWithItems={withItems([
+          ...baseItems,
+          createMessageItem("item-2", 2),
+        ])}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("new-messages-button")).toBeInTheDocument();
+    });
+  });
+
+  it("auto-scrolls to bottom instead of showing button when a reply arrives while scrolled up", async () => {
+    const { rerender } = renderWithProviders(
+      <Conversation sourceWithItems={withItems(baseItems)} />,
+    );
+
+    const container = screen.getByTestId(
+      "conversation-items-container",
+    ) as HTMLDivElement;
+    await setupScrolledUp(container);
+
+    rerender(
+      <Conversation
+        sourceWithItems={withItems([
+          ...baseItems,
+          createReplyItem("reply-1", 2),
+        ])}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("new-messages-button"),
+      ).not.toBeInTheDocument();
+    });
+
+    // After RAFs fire, the container should have scrolled to the bottom
+    await flushAllRAF();
+    expect(container.scrollTop).toBe(container.scrollHeight);
+  });
+
+  it("hides new messages button and scrolls to bottom when clicked", async () => {
+    const { rerender } = renderWithProviders(
+      <Conversation sourceWithItems={withItems(baseItems)} />,
+    );
+
+    const container = screen.getByTestId(
+      "conversation-items-container",
+    ) as HTMLDivElement;
+    await setupScrolledUp(container);
+
+    rerender(
+      <Conversation
+        sourceWithItems={withItems([
+          ...baseItems,
+          createMessageItem("item-2", 2),
+        ])}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("new-messages-button")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByTestId("new-messages-button"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("new-messages-button"),
+      ).not.toBeInTheDocument();
+    });
+
+    // After RAFs fire, the container should have scrolled to the bottom
+    await flushAllRAF();
+    expect(container.scrollTop).toBe(container.scrollHeight);
+  });
+
+  it("hides new messages button when user scrolls to the bottom", async () => {
+    const { rerender } = renderWithProviders(
+      <Conversation sourceWithItems={withItems(baseItems)} />,
+    );
+
+    const container = screen.getByTestId(
+      "conversation-items-container",
+    ) as HTMLDivElement;
+    await setupScrolledUp(container);
+
+    rerender(
+      <Conversation
+        sourceWithItems={withItems([
+          ...baseItems,
+          createMessageItem("item-2", 2),
+        ])}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("new-messages-button")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      container.scrollTop = container.scrollHeight;
+      container.dispatchEvent(new Event("scroll"));
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("new-messages-button"),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/app/src/renderer/views/Inbox/MainContent/Conversation.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation.tsx
@@ -88,6 +88,8 @@ const Conversation = memo(function Conversation({
     newItems,
     oldItems,
     scrollElement,
+    showNewMessagesButton,
+    scrollToBottom,
   } = useConversationScroll(sourceWithItems);
 
   // Restore draft when switching sources (including initial mount)
@@ -278,6 +280,16 @@ const Conversation = memo(function Conversation({
           <div className="flex items-center justify-center h-full">
             <EmptyConversation />
           </div>
+        )}
+        {showNewMessagesButton && (
+          <Button
+            data-testid="new-messages-button"
+            size="small"
+            onClick={scrollToBottom}
+            className="new-messages-notification-btn"
+          >
+            {t("conversation.newMessagesDivider")} ↓
+          </Button>
         )}
       </div>
       <div className="flex-shrink-0 p-4 pt-0">

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/useConversationScroll.ts
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/useConversationScroll.ts
@@ -27,6 +27,8 @@ export interface ConversationScrollState {
   oldItems: Item[];
   newItems: Item[];
   acknowledgeNewMessages: () => void;
+  showNewMessagesButton: boolean;
+  scrollToBottom: () => void;
 }
 
 export function useConversationScroll(
@@ -41,6 +43,8 @@ export function useConversationScroll(
 
   const [_isAutoScrolling, setIsAutoScrollingState] = useState(false);
   const isAutoScrollingValueRef = useRef(false);
+  const isAtBottomRef = useRef(true);
+  const [showNewMessagesButton, setShowNewMessagesButton] = useState(false);
   const setIsAutoScrolling = useCallback(
     (nextValue: boolean) => {
       isAutoScrollingValueRef.current = nextValue;
@@ -175,6 +179,9 @@ export function useConversationScroll(
       pendingScrollTargetRef.current = dividerIndex
         ? { kind: "index", rowIndex: dividerIndex }
         : "bottom";
+      isAtBottomRef.current = true;
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setShowNewMessagesButton(false);
     } else if (itemCount > prevCount) {
       if (
         prevFirstItemUuid !== null &&
@@ -187,6 +194,17 @@ export function useConversationScroll(
           kind: "index",
           rowIndex: numPrepended,
         };
+      } else if (prevCount > 0) {
+        // New messages appended at the bottom while the user is scrolled up
+        const lastItem = sourceWithItems.items.at(-1);
+
+        if (lastItem?.data.kind === "reply") {
+          // Auto-scroll to bottom if it is a user-sent reply
+          pendingScrollTargetRef.current = "bottom";
+        } else if (!isAtBottomRef.current) {
+          // Otherwise, show the "new messages" button if we are not at the bottom
+          setShowNewMessagesButton(true);
+        }
       }
     }
 
@@ -275,9 +293,11 @@ export function useConversationScroll(
     scrollToRowWithRetry,
   ]);
 
+  // Track whether the user is at the bottom to show/hide new messages button
+  // and acknowledge newly seen messages
   useEffect(() => {
     const el = listAPI?.element;
-    if (!el || !dividerItemUuid) {
+    if (!el) {
       return;
     }
     const handleScroll = () => {
@@ -286,13 +306,26 @@ export function useConversationScroll(
       }
       const distanceToBottom =
         el.scrollHeight - (el.scrollTop + el.clientHeight);
-      if (distanceToBottom <= NEW_MESSAGE_SEEN_THRESHOLD) {
-        acknowledgeNewMessages();
+      isAtBottomRef.current = distanceToBottom <= NEW_MESSAGE_SEEN_THRESHOLD;
+      if (isAtBottomRef.current) {
+        if (dividerItemUuid) {
+          acknowledgeNewMessages();
+        }
+        setShowNewMessagesButton(false);
       }
     };
     el.addEventListener("scroll", handleScroll);
     return () => el.removeEventListener("scroll", handleScroll);
   }, [listAPI, acknowledgeNewMessages, dividerItemUuid]);
+
+  const scrollToBottom = useCallback(() => {
+    const totalRows =
+      oldItems.length + (dividerIndex !== null ? 1 : 0) + newItems.length;
+    if (totalRows > 0) {
+      scrollToRowWithRetry(totalRows - 1, "end", 3);
+    }
+    setShowNewMessagesButton(false);
+  }, [dividerIndex, newItems.length, oldItems.length, scrollToRowWithRetry]);
 
   return {
     listRef: listRef as (api: ListImperativeAPI | null) => void,
@@ -305,6 +338,8 @@ export function useConversationScroll(
     oldItems,
     newItems,
     acknowledgeNewMessages,
+    showNewMessagesButton,
+    scrollToBottom,
   };
 }
 


### PR DESCRIPTION
Fixes #3264 

Autoscrolls to the bottom of conversation on new replies, and shows a `new messages` button when new items are received that lets the user scroll to the bottom.

## Test plan

- [x] Load a long conversation (enough where you can scroll so the bottom messages are out of view)
- [x] Scroll to the top of the conversation view
- [x] Send a new reply
- [x] Verify that conversation auto-scrolls to the bottom
- [x] Scroll back up to the top of the conversation view
- [x] Send a new message from the source
- [x] Verify that the `new messages` button appears. Clicking this should scroll to the bottom of the conversation

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
