### PR TITLE
Raise login timeout to 30 seconds

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -34,6 +34,7 @@ import {
   PendingEventType,
   SyncStatus,
   PendingEventData,
+  type ms,
 } from "../types";
 import { syncMetadata, shouldSkipSync } from "./sync";
 import workerPath from "./fetch/worker?modulePath";
@@ -343,10 +344,16 @@ if (!gotTheLock) {
         return app.getVersion();
       });
 
+      // TODO: Remove this generic IPC and instead replace it with a dedicated login one
+      // since that's the only thing that uses it
       ipcMain.handle(
         "request",
         async (_event, request: ProxyRequest): Promise<ProxyResponse> => {
-          const result = await proxyJSONRequest(request);
+          const result = await proxyJSONRequest(
+            request,
+            undefined,
+            30_000 as ms,
+          );
           return result;
         },
       );


### PR DESCRIPTION
Just so Tor and the API have a bit more time instead of failing quickly.

Refs #3282.

This does expect https://github.com/freedomofpress/securedrop-client/issues/3208 will happen soon.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

not sure exactly, maybe just visual review is sufficient.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
