### PR TITLE
inbox: add more debug logs on sync process

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -1204,7 +1204,7 @@ export class DB {
   }
 
   getPendingEvents(): PendingEvent[] {
-    const rows: PendingEventRow[] = this.selectPendingEvents.all({ limit: 50 });
+    const rows: PendingEventRow[] = this.selectPendingEvents.all({ limit: 10 });
     const pendingEvents = rows.map((r) => {
       let target: SourceTarget | ItemTarget;
       if (r.source_uuid) {

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -111,6 +111,10 @@ export class TaskQueue {
   }
 
   abortSourceFetch(sourceUuid: string) {
+    console.debug(
+      "Source has been deleted: aborting downloads + decryptions: ",
+      sourceUuid,
+    );
     for (const [itemId, entry] of this.activeDownloads) {
       if (entry.sourceUuid === sourceUuid) {
         entry.controller.abort();

--- a/app/src/main/sync/index.ts
+++ b/app/src/main/sync/index.ts
@@ -219,6 +219,7 @@ export async function syncMetadata(
     currentVersion,
     hintedRecords,
   );
+  console.debug("Server index: ", indexResponse);
 
   // Check for 403 Forbidden
   if (indexResponse.status === 403) {
@@ -237,6 +238,7 @@ export async function syncMetadata(
   if (indexResponse.status === 200) {
     // Reconcile with client's index to get metadata to update
     const clientIndex = db.getIndex();
+    console.debug("Client index: ", clientIndex);
     const { sources, items, journalists } = reconcileIndex(
       db,
       indexResponse.index,
@@ -252,10 +254,13 @@ export async function syncMetadata(
     indexResponse.status === 304 &&
     (!pendingEvents || pendingEvents.length == 0)
   ) {
+    console.debug("No pending events + no server updates: sync complete");
     return syncStatus;
   }
 
+  console.debug("Client batch request: ", request);
   const batchResponse = await submitBatch(authToken, request);
+  console.debug("Server batch response: ", batchResponse);
 
   // Check for 403 Forbidden
   if (batchResponse.status === 403) {
@@ -265,6 +270,5 @@ export async function syncMetadata(
   db.updateBatch(batchResponse.data);
 
   syncStatus = SyncStatus.UPDATED;
-
   return syncStatus;
 }


### PR DESCRIPTION
Fixes #

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
