### PR TITLE
Fix "Select all" and filters

### DIFF
--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
@@ -1398,4 +1398,173 @@ describe("Sources Component", () => {
       consoleErrorSpy.mockRestore();
     });
   });
+
+  describe("Selection behavior with filters and search", () => {
+    // Use 3 sources where only source-2 (bob builder) is starred
+    const singleStarredSources = mockSources.slice(0, 3).map((s, i) => ({
+      ...s,
+      data: { ...s.data, is_starred: i === 1 },
+    }));
+
+    beforeEach(() => {
+      window.electronAPI.addPendingSourceEvent = vi
+        .fn()
+        .mockResolvedValue(BigInt(123));
+      window.electronAPI.getSourceWithItems = vi.fn().mockResolvedValue(null);
+    });
+
+    it("select all then filter to starred: only the starred source is submitted for deletion", async () => {
+      vi.mocked(window.electronAPI.getSources).mockResolvedValue(
+        singleStarredSources,
+      );
+      renderSourceList(singleStarredSources);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+        expect(screen.getByTestId("source-source-2")).toBeInTheDocument();
+        expect(screen.getByTestId("source-source-3")).toBeInTheDocument();
+      });
+
+      // Select all (source-1, source-2, source-3)
+      await userEvent.click(screen.getByTestId("select-all-checkbox"));
+      expect(screen.getByTestId("source-checkbox-source-1")).toBeChecked();
+      expect(screen.getByTestId("source-checkbox-source-2")).toBeChecked();
+      expect(screen.getByTestId("source-checkbox-source-3")).toBeChecked();
+
+      // Filter to starred sources (only source-2 is visible)
+      await userEvent.click(screen.getByTestId("filter-dropdown"));
+      await userEvent.click(screen.getByText("Starred"));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("source-source-1")).not.toBeInTheDocument();
+        expect(screen.getByTestId("source-checkbox-source-2")).toBeChecked();
+        expect(screen.queryByTestId("source-source-3")).not.toBeInTheDocument();
+      });
+
+      // Delete source accounts
+      await userEvent.click(screen.getByTestId("bulk-delete-button"));
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("delete-modal-delete-account-button"),
+        ).toBeInTheDocument();
+      });
+
+      await userEvent.click(
+        screen.getByTestId("delete-modal-delete-account-button"),
+      );
+
+      // Only the one starred source should have been submitted for deletion
+      await waitFor(() => {
+        expect(window.electronAPI.addPendingSourceEvent).toHaveBeenCalledTimes(
+          1,
+        );
+        expect(window.electronAPI.addPendingSourceEvent).toHaveBeenCalledWith(
+          "source-2",
+          PendingEventType.SourceDeleted,
+          undefined,
+        );
+      });
+    });
+
+    it("filter to starred then select all then remove filter: only the starred source stays selected", async () => {
+      vi.mocked(window.electronAPI.getSources).mockResolvedValue(
+        singleStarredSources,
+      );
+      renderSourceList(singleStarredSources);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+        expect(screen.getByTestId("source-source-2")).toBeInTheDocument();
+        expect(screen.getByTestId("source-source-3")).toBeInTheDocument();
+      });
+
+      // Filter to starred sources first (only source-2 is visible)
+      await userEvent.click(screen.getByTestId("filter-dropdown"));
+      await userEvent.click(screen.getByText("Starred"));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("source-source-1")).not.toBeInTheDocument();
+        expect(screen.getByTestId("source-source-2")).toBeInTheDocument();
+        expect(screen.queryByTestId("source-source-3")).not.toBeInTheDocument();
+      });
+
+      // Select all (only source-2 is visible, so only source-2 gets selected)
+      await userEvent.click(screen.getByTestId("select-all-checkbox"));
+      expect(screen.getByTestId("source-checkbox-source-2")).toBeChecked();
+
+      // Remove the filter to show all sources
+      await userEvent.click(screen.getByTestId("filter-dropdown"));
+      await userEvent.click(screen.getByText("All"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+        expect(screen.getByTestId("source-source-2")).toBeInTheDocument();
+        expect(screen.getByTestId("source-source-3")).toBeInTheDocument();
+      });
+
+      // Only source-2 should remain selected
+      expect(screen.getByTestId("source-checkbox-source-1")).not.toBeChecked();
+      expect(screen.getByTestId("source-checkbox-source-2")).toBeChecked();
+      expect(screen.getByTestId("source-checkbox-source-3")).not.toBeChecked();
+    });
+
+    it("select all then search for one source then clear search: only that source stays selected", async () => {
+      renderSourceList();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+        expect(screen.getByTestId("source-source-2")).toBeInTheDocument();
+        expect(screen.getByTestId("source-source-3")).toBeInTheDocument();
+        expect(screen.getByTestId("source-source-4")).toBeInTheDocument();
+      });
+
+      // Select all four sources
+      await userEvent.click(screen.getByTestId("select-all-checkbox"));
+      expect(screen.getByTestId("source-checkbox-source-1")).toBeChecked();
+      expect(screen.getByTestId("source-checkbox-source-2")).toBeChecked();
+      expect(screen.getByTestId("source-checkbox-source-3")).toBeChecked();
+      expect(screen.getByTestId("source-checkbox-source-4")).toBeChecked();
+
+      // Search for "alice" — only source-1 (alice wonderland) is visible
+      const searchInput = screen.getByTestId("source-search-input");
+      await userEvent.type(searchInput, "alice");
+
+      await waitFor(
+        () => {
+          expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+          expect(
+            screen.queryByTestId("source-source-2"),
+          ).not.toBeInTheDocument();
+          expect(
+            screen.queryByTestId("source-source-3"),
+          ).not.toBeInTheDocument();
+          expect(
+            screen.queryByTestId("source-source-4"),
+          ).not.toBeInTheDocument();
+        },
+        { timeout: 1000 },
+      );
+
+      // Clear the search
+      await userEvent.clear(searchInput);
+
+      // All sources are visible again
+      await waitFor(
+        () => {
+          expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+          expect(screen.getByTestId("source-source-2")).toBeInTheDocument();
+          expect(screen.getByTestId("source-source-3")).toBeInTheDocument();
+          expect(screen.getByTestId("source-source-4")).toBeInTheDocument();
+        },
+        { timeout: 1000 },
+      );
+
+      // Only source-1 should remain selected
+      expect(screen.getByTestId("source-checkbox-source-1")).toBeChecked();
+      expect(screen.getByTestId("source-checkbox-source-2")).not.toBeChecked();
+      expect(screen.getByTestId("source-checkbox-source-3")).not.toBeChecked();
+      expect(screen.getByTestId("source-checkbox-source-4")).not.toBeChecked();
+    });
+  });
 });

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
@@ -1507,6 +1507,13 @@ describe("Sources Component", () => {
       expect(screen.getByTestId("source-checkbox-source-1")).not.toBeChecked();
       expect(screen.getByTestId("source-checkbox-source-2")).toBeChecked();
       expect(screen.getByTestId("source-checkbox-source-3")).not.toBeChecked();
+
+      // Select-all should be indeterminate: one of three visible sources is selected
+      const selectAllCheckbox = screen.getByTestId(
+        "select-all-checkbox",
+      ) as HTMLInputElement;
+      expect(selectAllCheckbox).not.toBeChecked();
+      expect(selectAllCheckbox.indeterminate).toBe(true);
     });
 
     it("select all then search for one source then clear search: only that source stays selected", async () => {
@@ -1565,6 +1572,13 @@ describe("Sources Component", () => {
       expect(screen.getByTestId("source-checkbox-source-2")).not.toBeChecked();
       expect(screen.getByTestId("source-checkbox-source-3")).not.toBeChecked();
       expect(screen.getByTestId("source-checkbox-source-4")).not.toBeChecked();
+
+      // Select-all should be indeterminate: one of four visible sources is selected
+      const selectAllCheckbox = screen.getByTestId(
+        "select-all-checkbox",
+      ) as HTMLInputElement;
+      expect(selectAllCheckbox).not.toBeChecked();
+      expect(selectAllCheckbox.indeterminate).toBe(true);
     });
   });
 });

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -67,7 +67,6 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
   const [selectedSources, setSelectedSources] = useState<Set<string>>(
     new Set(),
   );
-  const [allSelected, setAllSelected] = useState(false);
   const [sortedAsc, setSortedAsc] = useState(false);
   const [filter, setFilter] = useState<filterOption>("all");
   const [searchTerm, setSearchTerm] = useState("");
@@ -134,11 +133,10 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
         } else {
           newSelection.delete(sourceId);
         }
-        setAllSelected(newSelection.size === sources.length);
         return newSelection;
       });
     },
-    [sources.length],
+    [],
   );
 
   // Handle starring/unstarring a source
@@ -266,9 +264,6 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
           for (const uuid of pendingDeleteSources) {
             next.delete(uuid);
           }
-          if (next.size === 0) {
-            setAllSelected(false);
-          }
           return next;
         });
         setPendingDeleteSources(new Set());
@@ -358,6 +353,13 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
       });
   }, [sources, searchResults, filter, sortedAsc]);
 
+  const allSelected = useMemo(
+    () =>
+      filteredSources.length > 0 &&
+      filteredSources.every((s) => selectedSources.has(s.uuid)),
+    [filteredSources, selectedSources],
+  );
+
   // Handle select all checkbox
   const handleSelectAll = useCallback(
     (checked: boolean) => {
@@ -365,10 +367,8 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
         setSelectedSources(
           new Set(filteredSources.map((source) => source.uuid)),
         );
-        setAllSelected(filteredSources.length > 0);
       } else {
         setSelectedSources(new Set());
-        setAllSelected(false);
       }
     },
     [filteredSources],
@@ -381,7 +381,6 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
     setSelectedSources((prev) => {
       const next = new Set([...prev].filter((uuid) => visibleUuids.has(uuid)));
       if (next.size !== prev.size) {
-        setAllSelected(next.size > 0 && next.size === filteredSources.length);
         return next;
       }
       return prev;

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -124,20 +124,6 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
     };
   }, [debouncedSearchTerm, sources]);
 
-  // Handle select all checkbox
-  const handleSelectAll = useCallback(
-    (checked: boolean) => {
-      if (checked) {
-        setSelectedSources(new Set(sources.map((source) => source.uuid)));
-        setAllSelected(true);
-      } else {
-        setSelectedSources(new Set());
-        setAllSelected(false);
-      }
-    },
-    [sources],
-  );
-
   // Handle individual source selection
   const handleSourceSelect = useCallback(
     (sourceId: string, checked: boolean) => {
@@ -371,6 +357,34 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
         }
       });
   }, [sources, searchResults, filter, sortedAsc]);
+
+  // Handle select all checkbox
+  const handleSelectAll = useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        setSelectedSources(new Set(filteredSources.map((source) => source.uuid)));
+        setAllSelected(true);
+      } else {
+        setSelectedSources(new Set());
+        setAllSelected(false);
+      }
+    },
+    [filteredSources],
+  );
+
+  // When the visible sources change (due to filter or search), trim the selection
+  // to only sources that are still visible.
+  useEffect(() => {
+    const visibleUuids = new Set(filteredSources.map((s) => s.uuid));
+    setSelectedSources((prev) => {
+      const next = new Set([...prev].filter((uuid) => visibleUuids.has(uuid)));
+      if (next.size !== prev.size) {
+        setAllSelected(next.size > 0 && next.size === filteredSources.length);
+        return next;
+      }
+      return prev;
+    });
+  }, [filteredSources]);
 
   // Helper to get all source option elements in the list
   const getSourceOptions = useCallback((): HTMLElement[] => {

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -362,7 +362,9 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
   const handleSelectAll = useCallback(
     (checked: boolean) => {
       if (checked) {
-        setSelectedSources(new Set(filteredSources.map((source) => source.uuid)));
+        setSelectedSources(
+          new Set(filteredSources.map((source) => source.uuid)),
+        );
         setAllSelected(true);
       } else {
         setSelectedSources(new Set());

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -446,7 +446,7 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
         <Toolbar
           allSelected={allSelected}
           selectedCount={selectedSources.size}
-          totalCount={sources.length}
+          totalCount={filteredSources.length}
           onSelectAll={handleSelectAll}
           onBulkDelete={handleBulkDelete}
           searchTerm={searchTerm}

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -365,7 +365,7 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
         setSelectedSources(
           new Set(filteredSources.map((source) => source.uuid)),
         );
-        setAllSelected(true);
+        setAllSelected(filteredSources.length > 0);
       } else {
         setSelectedSources(new Set());
         setAllSelected(false);


### PR DESCRIPTION
Fixes #3290

Now, clicking "Select all" only selects sources that are filtered. And when you change the filter (either through the dropdown or search), it removes non-filtered sources from the selection.

## Test plan

There are unit tests for the following, but you can also test manually to confirm it's working like it should.

Test 1:

- Select all.
- Star a source.
- Filter to starred sources.
- Delete source accounts.
- Only the single starred source should be selected for deletion.

Test 2:

- Star a source.
- Filter to starred sources.
- Select all.
- Filter to all.
- Only the starred source should be selected.

Test 3:

- Select all.
- Search the name of just one of the sources.
- Remove the search filter.
- Only that one source should be selected.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
