### PR TITLE
inbox: improve UI lag and sync for large bulk deletes

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -106,10 +106,6 @@ export class DB {
     { limit: number },
     { uuid: string }
   >;
-  private selectUnprojectedItemsBySource: Statement<
-    { source_uuid: string },
-    { uuid: string }
-  >;
   private deleteUnprojectedItemsBySource: Statement<
     { source_uuid: string },
     void
@@ -188,14 +184,8 @@ export class DB {
   >;
   private deletePendingEvent: Statement<{ snowflake_id: string }, void>;
   private selectPendingEvents: Statement<[{ limit: number }], PendingEventRow>;
-  private deletePendingEventsBySource: Statement<{ source_uuid: string }, void>;
   private deletePendingEventsBySourceScope: Statement<
     { source_uuid: string },
-    void
-  >;
-  private deletePendingEventsByItem: Statement<{ item_uuid: string }, void>;
-  private deletePendingEventsByItemMany: Statement<
-    { item_uuids_json: string },
     void
   >;
   private selectSourcesScheduledForDeletion: Statement<
@@ -289,9 +279,6 @@ export class DB {
         AND fetch_status in (${FetchStatus.DownloadInProgress}, ${FetchStatus.DecryptionInProgress}, ${FetchStatus.FailedDownloadRetryable}, ${FetchStatus.FailedDecryptionRetryable})
       ORDER BY json_extract(sources.data, '$.last_updated') DESC, interaction_count DESC, items.uuid ASC
       LIMIT @limit`,
-    );
-    this.selectUnprojectedItemsBySource = this.db.prepare(
-      "SELECT uuid FROM items WHERE source_uuid = @source_uuid",
     );
     this.deleteUnprojectedItemsBySource = this.db.prepare(
       "DELETE FROM items WHERE source_uuid = @source_uuid",
@@ -409,19 +396,12 @@ export class DB {
     this.selectPendingEvents = this.db.prepare(`
       SELECT snowflake_id, source_uuid, item_uuid, type, data FROM pending_events ORDER BY snowflake_id ASC LIMIT @limit
     `);
-    this.deletePendingEventsBySource = this.db.prepare(`
-      DELETE FROM pending_events WHERE source_uuid = @source_uuid`);
     this.deletePendingEventsBySourceScope = this.db.prepare(`
       DELETE FROM pending_events
       WHERE source_uuid = @source_uuid
          OR item_uuid IN (
            SELECT uuid FROM items WHERE source_uuid = @source_uuid
          )`);
-    this.deletePendingEventsByItem = this.db.prepare(`
-      DELETE FROM pending_events WHERE item_uuid = @item_uuid`);
-    this.deletePendingEventsByItemMany = this.db.prepare(
-      "DELETE FROM pending_events WHERE item_uuid IN (SELECT value FROM json_each(@item_uuids_json))",
-    );
     this.selectSourcesScheduledForDeletion = this.db.prepare(`
       SELECT DISTINCT source_uuid FROM pending_events
       WHERE type IN ('${PendingEventType.SourceDeleted}', '${PendingEventType.SourceConversationTruncated}')
@@ -613,9 +593,7 @@ export class DB {
         for (const id of batch) {
           this.searchIndex.removeItem(id);
         }
-        this.deletePendingEventsByItemMany.run({
-          item_uuids_json: uuids_json,
-        });
+        // Delete the items. This cascades to delete pending_events as well.
         this.deleteItemMany.run({ uuids_json });
       }
       this.updateVersion();
@@ -628,11 +606,9 @@ export class DB {
     return this.db!.transaction((sourceUuid: string) => {
       // First, remove all search index entries for this source
       this.searchIndex.removeSource(sourceUuid);
-      // Delete any pending events for this source
-      this.deletePendingEventsBySource.run({ source_uuid: sourceUuid });
       // Delete all source items
       this.deleteUnprojectedItemsBySource.run({ source_uuid: sourceUuid });
-      // Then, delete the source
+      // Then, delete the source. This cascades to delete pending_events as well.
       this.deleteSource.run({ uuid: sourceUuid });
     })(sourceUuid);
   }

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -221,6 +221,9 @@ export class DB {
     // WAL mode must be set after auto_vacuum
     db.pragma("journal_mode = WAL");
 
+    // enable foreign key
+    db.pragma("foreign_keys = ON");
+
     // Determine first-run status before migrations run
     if (isNewDatabase) {
       const legacyPath = path.join(os.homedir(), ".securedrop_client");
@@ -588,11 +591,8 @@ export class DB {
             decrypted_size: row.decrypted_size,
           });
         });
-        // Delete from search index per-item
-        // TODO: batch this call as well
-        for (const id of batch) {
-          this.searchIndex.removeItem(id);
-        }
+        // Delete from search index
+        this.searchIndex.removeItemMany(uuids_json);
         // Delete the items. This cascades to delete pending_events as well.
         this.deleteItemMany.run({ uuids_json });
       }

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -1089,7 +1089,7 @@ export class DB {
     sourceUuid: string,
     type: PendingEventType,
     data?: PendingEventData,
-  ): string {
+  ): string | null {
     return this.db!.transaction(() => {
       const snowflakeID = this.snowflake
         .generate({ timestamp: Date.now() })
@@ -1108,12 +1108,23 @@ export class DB {
         }
       }
 
-      this.insertSourcePendingEvent.run({
-        snowflake_id: snowflakeID,
-        source_uuid: sourceUuid,
-        type: type,
-        data: data ? JSON.stringify(data) : null,
-      });
+      try {
+        this.insertSourcePendingEvent.run({
+          snowflake_id: snowflakeID,
+          source_uuid: sourceUuid,
+          type: type,
+          data: data ? JSON.stringify(data) : null,
+        });
+      } catch (err) {
+        if (err instanceof Error && "code" in err) {
+          if (err.code === "SQLITE_CONSTRAINT_FOREIGNKEY") {
+            return null;
+          } else {
+            throw err;
+          }
+        }
+      }
+
       return snowflakeID;
     })();
   }
@@ -1163,16 +1174,26 @@ export class DB {
     return snowflakeID;
   }
 
-  addPendingItemEvent(itemUuid: string, type: PendingEventType): string {
+  addPendingItemEvent(itemUuid: string, type: PendingEventType): string | null {
     const snowflakeID = this.snowflake
       .generate({ timestamp: Date.now() })
       .toString();
-    this.insertItemPendingEvent.run({
-      snowflake_id: snowflakeID,
-      item_uuid: itemUuid,
-      type: type,
-      data: null,
-    });
+    try {
+      this.insertItemPendingEvent.run({
+        snowflake_id: snowflakeID,
+        item_uuid: itemUuid,
+        type: type,
+        data: null,
+      });
+    } catch (err) {
+      if (err instanceof Error && "code" in err) {
+        if (err.code === "SQLITE_CONSTRAINT_FOREIGNKEY") {
+          return null;
+        } else {
+          throw err;
+        }
+      }
+    }
     return snowflakeID;
   }
 
@@ -1206,12 +1227,23 @@ export class DB {
       const snowflakeId = this.snowflake
         .generate({ timestamp: Date.now() })
         .toString();
-      this.insertSourcePendingEvent.run({
-        snowflake_id: snowflakeId,
-        source_uuid: sourceUuid,
-        type: PendingEventType.SourceConversationSeen,
-        data: JSON.stringify({ upper_bound: upperBound }),
-      });
+      try {
+        this.insertSourcePendingEvent.run({
+          snowflake_id: snowflakeId,
+          source_uuid: sourceUuid,
+          type: PendingEventType.SourceConversationSeen,
+          data: JSON.stringify({ upper_bound: upperBound }),
+        });
+      } catch (err) {
+        if (err instanceof Error && "code" in err) {
+          if (err.code === "SQLITE_CONSTRAINT_FOREIGNKEY") {
+            return null;
+          } else {
+            throw err;
+          }
+        }
+      }
+
       return snowflakeId;
     })();
   }

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -110,11 +110,16 @@ export class DB {
     { source_uuid: string },
     { uuid: string }
   >;
+  private deleteUnprojectedItemsBySource: Statement<
+    { source_uuid: string },
+    void
+  >;
   private upsertItem: Statement<
     { uuid: string; data: string; version: string },
     void
   >;
   private deleteItem: Statement<{ uuid: string }, void>;
+  private deleteItemMany: Statement<{ uuids_json: string }, void>;
   private updateItemFetchStatus: Statement<{
     uuid: string;
     fetch_status: number;
@@ -133,6 +138,7 @@ export class DB {
     fetch_status: number;
   }>;
   private selectItem: Statement<{ uuid: string }, ItemRow>;
+  private selectItemMany: Statement<{ uuids_json: string }, ItemRow>;
 
   private selectAllJournalistVersion: Statement<
     [],
@@ -188,6 +194,10 @@ export class DB {
     void
   >;
   private deletePendingEventsByItem: Statement<{ item_uuid: string }, void>;
+  private deletePendingEventsByItemMany: Statement<
+    { item_uuids_json: string },
+    void
+  >;
   private selectSourcesScheduledForDeletion: Statement<
     [],
     { source_uuid: string }
@@ -283,6 +293,9 @@ export class DB {
     this.selectUnprojectedItemsBySource = this.db.prepare(
       "SELECT uuid FROM items WHERE source_uuid = @source_uuid",
     );
+    this.deleteUnprojectedItemsBySource = this.db.prepare(
+      "DELETE FROM items WHERE source_uuid = @source_uuid",
+    );
     this.updateItemFetchStatus = this.db.prepare(
       "UPDATE items SET fetch_status = @fetch_status WHERE uuid = @uuid",
     );
@@ -299,8 +312,14 @@ export class DB {
       "INSERT INTO items (uuid, data, version) VALUES (@uuid, @data, @version) ON CONFLICT(uuid) DO UPDATE SET data=@data, version=@version",
     );
     this.deleteItem = this.db.prepare("DELETE FROM items WHERE uuid = @uuid");
+    this.deleteItemMany = this.db.prepare(
+      "DELETE FROM items WHERE uuid IN (SELECT value FROM json_each(@uuids_json))",
+    );
     this.selectItem = this.db.prepare(
       `SELECT uuid, data, plaintext, filename, fetch_status, fetch_progress, decrypted_size FROM items WHERE uuid = @uuid`,
+    );
+    this.selectItemMany = this.db.prepare(
+      `SELECT uuid, data, plaintext, filename, fetch_status, fetch_progress, decrypted_size FROM items WHERE uuid IN (SELECT value FROM json_each(@uuids_json))`,
     );
 
     this.selectAllJournalistVersion = this.db.prepare(
@@ -400,6 +419,9 @@ export class DB {
          )`);
     this.deletePendingEventsByItem = this.db.prepare(`
       DELETE FROM pending_events WHERE item_uuid = @item_uuid`);
+    this.deletePendingEventsByItemMany = this.db.prepare(
+      "DELETE FROM pending_events WHERE item_uuid IN (SELECT value FROM json_each(@item_uuids_json))",
+    );
     this.selectSourcesScheduledForDeletion = this.db.prepare(`
       SELECT DISTINCT source_uuid FROM pending_events
       WHERE type IN ('${PendingEventType.SourceDeleted}', '${PendingEventType.SourceConversationTruncated}')
@@ -564,16 +586,37 @@ export class DB {
   }
 
   protected deleteItems(items: string[]): Item[] {
+    if (items.length === 0) {
+      return [];
+    }
     return this.db!.transaction((items: string[]) => {
+      const DELETE_BATCH_SIZE = 500;
       const deletedItems: Item[] = [];
-      for (const itemID of items) {
-        const item = this.getItem(itemID);
-        if (item) {
-          deletedItems.push(item);
+      for (let i = 0; i < items.length; i += DELETE_BATCH_SIZE) {
+        const batch = items.slice(i, i + DELETE_BATCH_SIZE);
+        const uuids_json = JSON.stringify(batch);
+        // Batch fetch before delete so callers can act on deleted items
+        const rows = this.selectItemMany.all({ uuids_json }) as ItemRow[];
+        rows.forEach((row) => {
+          deletedItems.push({
+            uuid: row.uuid,
+            data: JSON.parse(row.data) as ItemMetadata,
+            plaintext: row.plaintext,
+            filename: row.filename,
+            fetch_status: row.fetch_status as FetchStatus,
+            fetch_progress: row.fetch_progress,
+            decrypted_size: row.decrypted_size,
+          });
+        });
+        // Delete from search index per-item
+        // TODO: batch this call as well
+        for (const id of batch) {
+          this.searchIndex.removeItem(id);
         }
-        this.searchIndex.removeItem(itemID);
-        this.deletePendingEventsByItem.run({ item_uuid: itemID });
-        this.deleteItem.run({ uuid: itemID });
+        this.deletePendingEventsByItemMany.run({
+          item_uuids_json: uuids_json,
+        });
+        this.deleteItemMany.run({ uuids_json });
       }
       this.updateVersion();
       return deletedItems;
@@ -587,14 +630,8 @@ export class DB {
       this.searchIndex.removeSource(sourceUuid);
       // Delete any pending events for this source
       this.deletePendingEventsBySource.run({ source_uuid: sourceUuid });
-      // Delete all source items, querying from unprojected view to not
-      // orphan pending deleted items
-      const itemUuids = this.selectUnprojectedItemsBySource
-        .all({
-          source_uuid: sourceUuid,
-        })
-        .map((row) => row.uuid);
-      this.deleteItems(itemUuids);
+      // Delete all source items
+      this.deleteUnprojectedItemsBySource.run({ source_uuid: sourceUuid });
       // Then, delete the source
       this.deleteSource.run({ uuid: sourceUuid });
     })(sourceUuid);
@@ -1204,7 +1241,7 @@ export class DB {
   }
 
   getPendingEvents(): PendingEvent[] {
-    const rows: PendingEventRow[] = this.selectPendingEvents.all({ limit: 50 });
+    const rows: PendingEventRow[] = this.selectPendingEvents.all({ limit: 20 });
     const pendingEvents = rows.map((r) => {
       let target: SourceTarget | ItemTarget;
       if (r.source_uuid) {

--- a/app/src/main/database/search.test.ts
+++ b/app/src/main/database/search.test.ts
@@ -261,14 +261,14 @@ describe("Search", () => {
       expect(results).toHaveLength(0);
     });
 
-    it("does not return results for deleted items", () => {
+    it("does not return results for deleted items", async () => {
       db.updateSources({
         ["source1"]: mockSource("source1", "colorful caterpillar"),
       });
       db.updateItems({ ["item1"]: mockItem("item1", "source1", "message") });
       db.completePlaintextItem("item1", "secret document");
 
-      db.deleteItems(["item1"]);
+      await db.deleteItemsAsync(["item1"]);
 
       const results = db.search("secret");
       expect(results).toHaveLength(0);
@@ -399,26 +399,26 @@ describe("Search", () => {
   });
 
   describe("deleteSources", () => {
-    it("removes all entries for a source", () => {
+    it("removes all entries for a source", async () => {
       db.updateSources({
         ["source1"]: mockSource("source1", "dramatic dolphin"),
       });
       db.updateItems({ ["item1"]: mockItem("item1", "source1", "message") });
       db.completePlaintextItem("item1", "secret info");
 
-      db.deleteSources(["source1"]);
+      await db.deleteSourcesAsync(["source1"]);
 
       expect(db.search("dramatic")).toHaveLength(0);
       expect(db.search("secret")).toHaveLength(0);
     });
 
-    it("does not affect other sources", () => {
+    it("does not affect other sources", async () => {
       db.updateSources({
         ["source1"]: mockSource("source1", "dramatic dolphin"),
         ["source2"]: mockSource("source2", "elegant elephant"),
       });
 
-      db.deleteSources(["source1"]);
+      await db.deleteSourcesAsync(["source1"]);
 
       expect(db.search("dramatic")).toHaveLength(0);
       expect(db.search("elegant")).toHaveLength(1);
@@ -426,21 +426,21 @@ describe("Search", () => {
   });
 
   describe("deleteItems", () => {
-    it("removes a specific item entry", () => {
+    it("removes a specific item entry", async () => {
       db.updateSources({
         ["source1"]: mockSource("source1", "dramatic dolphin"),
       });
       db.updateItems({ ["item1"]: mockItem("item1", "source1", "message") });
       db.completePlaintextItem("item1", "secret info");
 
-      db.deleteItems(["item1"]);
+      await db.deleteItemsAsync(["item1"]);
 
       expect(db.search("secret")).toHaveLength(0);
       // Source entry should remain
       expect(db.search("dramatic")).toHaveLength(1);
     });
 
-    it("does not affect other items", () => {
+    it("does not affect other items", async () => {
       db.updateSources({
         ["source1"]: mockSource("source1", "dramatic dolphin"),
       });
@@ -451,7 +451,7 @@ describe("Search", () => {
       db.completePlaintextItem("item1", "first message");
       db.completePlaintextItem("item2", "second message");
 
-      db.deleteItems(["item1"]);
+      await db.deleteItemsAsync(["item1"]);
 
       expect(db.search("first")).toHaveLength(0);
       expect(db.search("second")).toHaveLength(1);

--- a/app/src/main/database/search.ts
+++ b/app/src/main/database/search.ts
@@ -79,6 +79,7 @@ export class Search {
 
   private searchStmt: Statement<[string, number, number], SearchRow>;
   private deleteByItemStmt: Statement<[string], void>;
+  private deleteItemManyStmt: Statement<{ uuids_json: string }, void>;
   private deleteBySourceStmt: Statement<[string], void>;
   private upsertItemStmt: Statement<
     {
@@ -118,6 +119,10 @@ export class Search {
 
     this.deleteByItemStmt = this.db.prepare(
       `DELETE FROM search_index WHERE item_uuid = ?`,
+    );
+
+    this.deleteItemManyStmt = this.db.prepare(
+      "DELETE FROM search_index WHERE item_uuid IN (SELECT value FROM json_each(@uuids_json))",
     );
 
     this.deleteBySourceStmt = this.db.prepare(
@@ -214,6 +219,12 @@ export class Search {
 
   removeItem(itemUuid: string): void {
     this.deleteByItemStmt.run(itemUuid);
+  }
+
+  removeItemMany(uuidsJSON: string): void {
+    this.deleteItemManyStmt.run({
+      uuids_json: uuidsJSON,
+    });
   }
 
   close(): void {

--- a/app/src/main/database/search.ts
+++ b/app/src/main/database/search.ts
@@ -207,6 +207,7 @@ export class Search {
     });
   }
 
+  // Removes source and all its items from the search index
   removeSource(sourceUuid: string): void {
     this.deleteBySourceStmt.run(sourceUuid);
   }

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -1376,7 +1376,7 @@ describe("Datastore Method Tests", () => {
     expect(itemsToProcess).toEqual(["message1", "file1"]);
   });
 
-  it("deleting a source should cascade to its pending events", () => {
+  it("deleting a source should cascade to its pending events", async () => {
     // Create a source and add a pending event for it
     db.updateSources({
       source1: mockSourceMetadata("source1"),
@@ -1393,14 +1393,14 @@ describe("Datastore Method Tests", () => {
     expect(events[0].id).toBe(snowflakeId);
 
     // Delete the source (should cascade to its pending events)
-    db.deleteSources(["source1"]);
+    await db.deleteSourcesAsync(["source1"]);
 
     // Pending events for the deleted source should be gone
     events = db.getPendingEvents();
     expect(events.length).toBe(0);
   });
 
-  it("deleting an item should cascade to its pending events", () => {
+  it("deleting an item should cascade to its pending events", async () => {
     // Create a source and item, then add a pending event for the item
     db.updateSources({
       source1: mockSourceMetadata("source1"),
@@ -1420,14 +1420,14 @@ describe("Datastore Method Tests", () => {
     expect(events[0].id).toBe(snowflakeId);
 
     // Delete the item (should cascade to its pending events)
-    db.deleteItems(["item1"]);
+    await db.deleteItemsAsync(["item1"]);
 
     // Pending events for the deleted item should be gone
     events = db.getPendingEvents();
     expect(events.length).toBe(0);
   });
 
-  it("cascading deletion should preserve unrelated pending events", () => {
+  it("cascading deletion should preserve unrelated pending events", async () => {
     // Create two sources with items
     db.updateSources({
       source1: mockSourceMetadata("source1"),
@@ -1461,7 +1461,7 @@ describe("Datastore Method Tests", () => {
     expect(events.length).toBe(4);
 
     // Delete source1 (should cascade to source1 and item1 events)
-    db.deleteSources(["source1"]);
+    await db.deleteSourcesAsync(["source1"]);
 
     // Only events for source2/item2 should remain
     events = db.getPendingEvents();
@@ -1474,7 +1474,7 @@ describe("Datastore Method Tests", () => {
     expect(remainingIds).not.toContain(snowflakeItem1);
   });
 
-  it("cascading deletion should handle multiple sources and events", () => {
+  it("cascading deletion should handle multiple sources and events", async () => {
     // Create sources and items
     db.updateSources({
       source1: mockSourceMetadata("source1"),
@@ -1497,7 +1497,7 @@ describe("Datastore Method Tests", () => {
     expect(events.length).toBe(5);
 
     // Delete both sources (should cascade to all related events)
-    db.deleteSources(["source1", "source2"]);
+    await db.deleteSourcesAsync(["source1", "source2"]);
 
     // All events should be deleted via cascade
     events = db.getPendingEvents();

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -619,6 +619,22 @@ describe("Datastore Method Tests", () => {
     expect(sourceWithItems.items.length).toEqual(2);
   });
 
+  it("addPendingSourceEvent returns null when source does not exist", async () => {
+    const result = await db.addPendingSourceEvent(
+      "nonexistent-source",
+      PendingEventType.Starred,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("addPendingItemEvent returns null when item does not exist", async () => {
+    const result = await db.addPendingItemEvent(
+      "nonexistent-item",
+      PendingEventType.ItemDeleted,
+    );
+    expect(result).toBeNull();
+  });
+
   it("pending ReplySent and pending SourceConversationTruncated should delete all items in conversation", async () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),
@@ -656,7 +672,7 @@ describe("Datastore Method Tests", () => {
       "source1",
       PendingEventType.SourceConversationTruncated,
       { upper_bound: 2 },
-    );
+    )!;
     let sourceWithItems = db.getSourceWithItems("source1");
     expect(sourceWithItems.items.length).toEqual(0);
 
@@ -1055,11 +1071,11 @@ describe("Datastore Method Tests", () => {
     const snowflakeSource = db.addPendingSourceEvent(
       "source1",
       PendingEventType.Starred,
-    );
+    )!;
     const snowflakeItem = db.addPendingItemEvent(
       "item1",
       PendingEventType.ItemDeleted,
-    );
+    )!;
 
     // Before update, both events are present
     let events = db.getPendingEvents();
@@ -1087,11 +1103,11 @@ describe("Datastore Method Tests", () => {
     const snowflakeSource = db.addPendingSourceEvent(
       "source1",
       PendingEventType.Starred,
-    );
+    )!;
     const snowflakeItem = db.addPendingItemEvent(
       "item1",
       PendingEventType.ItemDeleted,
-    );
+    )!;
 
     // Simulate server response: only one event succeeded
     db.updatePendingEvents({

--- a/app/src/main/datastore.ts
+++ b/app/src/main/datastore.ts
@@ -15,26 +15,31 @@ import { Crypto } from "./crypto";
  */
 export class Datastore extends DB {
   private readonly storage: Storage;
+  DELETE_BATCH_SIZE = 8;
 
   constructor(crypto: Crypto, storage: Storage, dbDir?: string) {
     super(crypto, dbDir);
     this.storage = storage;
   }
 
-  override deleteItems(items: string[]): Item[] {
+  async deleteItemsAsync(items: string[]): Promise<Item[]> {
     const deletedItems = super.deleteItems(items);
     // TODO: Consider routing FS deletions to the fetch worker so that FS I/O
     // never runs on the main process event loop.
-    for (const item of deletedItems) {
-      void this.storage.deleteItemFs(item);
+    for (let i = 0; i < deletedItems.length; i += this.DELETE_BATCH_SIZE) {
+      const batch = deletedItems.slice(i, i + this.DELETE_BATCH_SIZE);
+      await Promise.all(batch.map((item) => this.storage.deleteItemFs(item)));
     }
     return deletedItems;
   }
 
-  override deleteSources(sources: string[]): void {
+  async deleteSourcesAsync(sources: string[]): Promise<void> {
     super.deleteSources(sources);
-    for (const uuid of sources) {
-      void this.storage.deleteSourceFs(uuid);
+    for (let i = 0; i < sources.length; i += this.DELETE_BATCH_SIZE) {
+      const batch = sources.slice(i, i + this.DELETE_BATCH_SIZE);
+      await Promise.all(
+        batch.map((source) => this.storage.deleteSourceFs(source)),
+      );
     }
   }
 

--- a/app/src/main/datastore.ts
+++ b/app/src/main/datastore.ts
@@ -23,8 +23,10 @@ export class Datastore extends DB {
 
   override deleteItems(items: string[]): Item[] {
     const deletedItems = super.deleteItems(items);
+    // TODO: Consider routing FS deletions to the fetch worker so that FS I/O
+    // never runs on the main process event loop.
     for (const item of deletedItems) {
-      this.storage.deleteItemFs(item);
+      void this.storage.deleteItemFs(item);
     }
     return deletedItems;
   }
@@ -32,7 +34,7 @@ export class Datastore extends DB {
   override deleteSources(sources: string[]): void {
     super.deleteSources(sources);
     for (const uuid of sources) {
-      this.storage.deleteSourceFs(uuid);
+      void this.storage.deleteSourceFs(uuid);
     }
   }
 
@@ -46,7 +48,7 @@ export class Datastore extends DB {
   ): Item[] {
     const deletedItems = super.updateItems(items, pendingDeletionSources);
     for (const item of deletedItems) {
-      this.storage.deleteItemFs(item);
+      void this.storage.deleteItemFs(item);
     }
     return deletedItems;
   }
@@ -62,7 +64,7 @@ export class Datastore extends DB {
       pendingDeletionSources,
     );
     for (const uuid of deletedSourceUuids) {
-      this.storage.deleteSourceFs(uuid);
+      void this.storage.deleteSourceFs(uuid);
     }
     return deletedSourceUuids;
   }
@@ -81,19 +83,19 @@ export class Datastore extends DB {
     const result = super.updateBatch(batchResponse);
     // Perform all filesystem cleanups as necessary
     for (const item of result.deleted_items) {
-      this.storage.deleteItemFs(item);
+      void this.storage.deleteItemFs(item);
     }
     for (const uuid of result.deleted_sources) {
-      this.storage.deleteSourceFs(uuid);
+      void this.storage.deleteSourceFs(uuid);
     }
     return result;
   }
 
-  deleteSourceFs(sourceID: string): void {
+  async deleteSourceFs(sourceID: string): Promise<void> {
     return this.storage.deleteSourceFs(sourceID);
   }
 
-  deleteItemFs(item: Item): void {
+  async deleteItemFs(item: Item): Promise<void> {
     return this.storage.deleteItemFs(item);
   }
 }

--- a/app/src/main/datastore.ts
+++ b/app/src/main/datastore.ts
@@ -15,7 +15,7 @@ import { Crypto } from "./crypto";
  */
 export class Datastore extends DB {
   private readonly storage: Storage;
-  DELETE_BATCH_SIZE = 8;
+  private readonly DELETE_BATCH_SIZE = 8;
 
   constructor(crypto: Crypto, storage: Storage, dbDir?: string) {
     super(crypto, dbDir);

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -111,6 +111,10 @@ export class TaskQueue {
   }
 
   abortSourceFetch(sourceUuid: string) {
+    console.debug(
+      "Source has been deleted: aborting downloads + decryptions: ",
+      sourceUuid,
+    );
     for (const [itemId, entry] of this.activeDownloads) {
       if (entry.sourceUuid === sourceUuid) {
         entry.controller.abort();

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -465,7 +465,7 @@ if (!gotTheLock) {
         ): Promise<string> => {
           // Immediately delete any source files from the fs on pending deletion
           if (type === PendingEventType.SourceDeleted) {
-            db.deleteSourceFs(sourceUuid);
+            await db.deleteSourceFs(sourceUuid);
             // Abort any in-flight downloads for this source in the fetch worker
             if (fetchWorker) {
               fetchWorker.postMessage({
@@ -487,9 +487,7 @@ if (!gotTheLock) {
               const items = db.getSourceWithItems(sourceUuid, {
                 beforeInteractionCount: data?.upper_bound + 1,
               }).items;
-              for (const item of items) {
-                db.deleteItemFs(item);
-              }
+              await Promise.all(items.map((item) => db.deleteItemFs(item)));
             }
           }
           const snowflakeID = db.addPendingSourceEvent(sourceUuid, type, data);

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -487,7 +487,11 @@ if (!gotTheLock) {
               const items = db.getSourceWithItems(sourceUuid, {
                 beforeInteractionCount: data?.upper_bound + 1,
               }).items;
-              await Promise.all(items.map((item) => db.deleteItemFs(item)));
+              const DELETE_BATCH_SIZE = 8;
+              for (let i = 0; i < items.length; i += DELETE_BATCH_SIZE) {
+                const batch = items.slice(i, i + DELETE_BATCH_SIZE);
+                await Promise.all(batch.map((item) => db.deleteItemFs(item)));
+              }
             }
           }
           const snowflakeID = db.addPendingSourceEvent(sourceUuid, type, data);

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -462,7 +462,7 @@ if (!gotTheLock) {
           sourceUuid: string,
           type: PendingEventType,
           data?: PendingEventData,
-        ): Promise<string> => {
+        ): Promise<string | null> => {
           // Immediately delete any source files from the fs on pending deletion
           if (type === PendingEventType.SourceDeleted) {
             await db.deleteSourceFs(sourceUuid);
@@ -494,8 +494,7 @@ if (!gotTheLock) {
               }
             }
           }
-          const snowflakeID = db.addPendingSourceEvent(sourceUuid, type, data);
-          return snowflakeID;
+          return db.addPendingSourceEvent(sourceUuid, type, data);
         },
       );
 
@@ -521,7 +520,7 @@ if (!gotTheLock) {
           _event,
           itemUuid: string,
           type: PendingEventType,
-        ): Promise<string> => {
+        ): Promise<string | null> => {
           if (type === PendingEventType.ItemDeleted) {
             const item = db.getItem(itemUuid);
             if (item) {

--- a/app/src/main/storage.ts
+++ b/app/src/main/storage.ts
@@ -133,12 +133,10 @@ export class Storage {
     return new PathBuilder(tempDir + "/");
   }
 
-  deleteSourceFs(sourceID: string): void {
+  async deleteSourceFs(sourceID: string): Promise<void> {
     try {
       const sourceDirectory = this.sourceDirectory(sourceID, false).path;
-      if (fs.existsSync(sourceDirectory)) {
-        fs.rmSync(sourceDirectory, { recursive: true, force: true });
-      }
+      await fs.promises.rm(sourceDirectory, { recursive: true, force: true });
     } catch (err) {
       console.error("Failed to delete source from filesystem: ", {
         sourceID,
@@ -147,12 +145,13 @@ export class Storage {
     }
   }
 
-  deleteItemFs(item: Item): void {
+  async deleteItemFs(item: Item): Promise<void> {
     try {
       const itemDirectory = this.itemDirectory(item.data, false);
-      if (fs.existsSync(itemDirectory.path)) {
-        fs.rmSync(itemDirectory.path, { recursive: true, force: true });
-      }
+      await fs.promises.rm(itemDirectory.path, {
+        recursive: true,
+        force: true,
+      });
     } catch (err) {
       console.error("Failed to delete item from filesystem", {
         item: item.uuid,

--- a/app/src/main/sync/index.test.ts
+++ b/app/src/main/sync/index.test.ts
@@ -20,7 +20,9 @@ import { IndexSized, BatchResponseSized } from "../../../src/schemas";
 import * as fs from "fs";
 
 vi.mock("fs", () => ({
-  rmSync: vi.fn(),
+  promises: {
+    rm: vi.fn(),
+  },
   existsSync: vi.fn(() => true),
   realpathSync: vi.fn((path) => path),
   mkdirSync: vi.fn(),
@@ -465,8 +467,8 @@ describe("syncMetadata", () => {
     expect(proxyMock).toHaveBeenCalledTimes(2);
     expect(db.deleteItems).toHaveBeenCalledWith([ITEM_UUID_2]);
     expect(db.updateBatch).toHaveBeenCalledWith(metadata);
-    expect(fs.rmSync).toHaveBeenCalledTimes(1);
-    expect(fs.rmSync).toHaveBeenCalledWith(
+    expect(fs.promises.rm).toHaveBeenCalledTimes(1);
+    expect(fs.promises.rm).toHaveBeenCalledWith(
       `/mock-home/.config/SecureDrop/files/${SOURCE_UUID_1}/${ITEM_UUID_2}/`,
       {
         recursive: true,
@@ -730,7 +732,7 @@ describe("syncMetadata", () => {
 
     await syncModule.syncMetadata(db, "");
 
-    expect(fs.rmSync).toHaveBeenCalledWith(
+    expect(fs.promises.rm).toHaveBeenCalledWith(
       `/mock-home/.config/SecureDrop/files/${SOURCE_UUID_2}/`,
       { recursive: true, force: true },
     );
@@ -916,19 +918,10 @@ describe("Storage.deleteSourceFs", () => {
 
     storage.deleteSourceFs(SOURCE_UUID_1);
 
-    expect(fs.rmSync).toHaveBeenCalledWith(
+    expect(fs.promises.rm).toHaveBeenCalledWith(
       `/mock-home/.config/SecureDrop/files/${SOURCE_UUID_1}/`,
       { recursive: true, force: true },
     );
-  });
-
-  it("does nothing when source directory does not exist", () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false);
-    const storage = new Storage();
-
-    storage.deleteSourceFs(SOURCE_UUID_1);
-
-    expect(fs.rmSync).not.toHaveBeenCalled();
   });
 });
 

--- a/app/src/main/sync/index.test.ts
+++ b/app/src/main/sync/index.test.ts
@@ -68,10 +68,10 @@ function mockDB({
         }
       }
     }),
-    deleteSourcesAsync: vi.fn((sourceIDs: string[]) => {
+    deleteSourcesAsync: vi.fn(async (sourceIDs: string[]) => {
       if (storage) {
         for (const sourceID of sourceIDs) {
-          storage.deleteSourceFs(sourceID);
+          await storage.deleteSourceFs(sourceID);
         }
       }
     }),
@@ -920,11 +920,11 @@ describe("Storage.deleteSourceFs", () => {
     vi.resetAllMocks();
   });
 
-  it("deletes source directory when it exists", () => {
+  it("deletes source directory when it exists", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     const storage = new Storage();
 
-    storage.deleteSourceFs(SOURCE_UUID_1);
+    await storage.deleteSourceFs(SOURCE_UUID_1);
 
     expect(fs.promises.rm).toHaveBeenCalledWith(
       `/mock-home/.config/SecureDrop/files/${SOURCE_UUID_1}/`,

--- a/app/src/main/sync/index.test.ts
+++ b/app/src/main/sync/index.test.ts
@@ -58,7 +58,7 @@ function mockDB({
     getIndex: vi.fn(() => index),
     getItem: vi.fn((_itemID) => null),
     getItemsToProcess: vi.fn(() => []),
-    deleteItems: vi.fn((itemIDs: string[]) => {
+    deleteItemsAsync: vi.fn((itemIDs: string[]) => {
       if (storage) {
         for (const itemID of itemIDs) {
           const item = db.getItem(itemID);
@@ -68,7 +68,7 @@ function mockDB({
         }
       }
     }),
-    deleteSources: vi.fn((sourceIDs: string[]) => {
+    deleteSourcesAsync: vi.fn((sourceIDs: string[]) => {
       if (storage) {
         for (const sourceID of sourceIDs) {
           storage.deleteSourceFs(sourceID);
@@ -376,7 +376,7 @@ describe("syncMetadata", () => {
     db = mockDB({
       index: clientIndex,
     });
-    const metadataToUpdate = syncModule.reconcileIndex(
+    const metadataToUpdate = await syncModule.reconcileIndex(
       db,
       serverIndex,
       clientIndex,
@@ -465,7 +465,7 @@ describe("syncMetadata", () => {
     await syncModule.syncMetadata(db, "");
 
     expect(proxyMock).toHaveBeenCalledTimes(2);
-    expect(db.deleteItems).toHaveBeenCalledWith([ITEM_UUID_2]);
+    expect(db.deleteItemsAsync).toHaveBeenCalledWith([ITEM_UUID_2]);
     expect(db.updateBatch).toHaveBeenCalledWith(metadata);
     expect(fs.promises.rm).toHaveBeenCalledTimes(1);
     expect(fs.promises.rm).toHaveBeenCalledWith(
@@ -509,7 +509,7 @@ describe("syncMetadata", () => {
       index: clientIndex,
     });
 
-    const metadataToUpdate = syncModule.reconcileIndex(
+    const metadataToUpdate = await syncModule.reconcileIndex(
       db,
       serverIndex,
       clientIndex,
@@ -576,7 +576,11 @@ describe("syncMetadata", () => {
     // SOURCE_UUID_2 is pending deletion locally
     db.getSourcesScheduledForDeletion = vi.fn(() => new Set([SOURCE_UUID_2]));
 
-    const result = syncModule.reconcileIndex(db, serverIndex, clientIndex);
+    const result = await syncModule.reconcileIndex(
+      db,
+      serverIndex,
+      clientIndex,
+    );
 
     // Should request only SOURCE_UUID_1, not the pending-deleted SOURCE_UUID_2
     expect(result.sources).toEqual([SOURCE_UUID_1]);
@@ -607,7 +611,11 @@ describe("syncMetadata", () => {
     // ITEM_UUID_2 is scheduled for deletion
     db.getItemsScheduledForDeletion = vi.fn(() => new Set([ITEM_UUID_2]));
 
-    const result = syncModule.reconcileIndex(db, serverIndex, clientIndex);
+    const result = await syncModule.reconcileIndex(
+      db,
+      serverIndex,
+      clientIndex,
+    );
 
     // Should request only ITEM_UUID_1, not the pending-deleted ITEM_UUID_2
     expect(result.items).toEqual([ITEM_UUID_1]);
@@ -636,10 +644,10 @@ describe("syncMetadata", () => {
     // SOURCE_UUID_2 is also pending deletion locally
     db.getSourcesScheduledForDeletion = vi.fn(() => new Set([SOURCE_UUID_2]));
 
-    syncModule.reconcileIndex(db, serverIndex, clientIndex);
+    await syncModule.reconcileIndex(db, serverIndex, clientIndex);
 
     // The source should still be deleted locally (final cleanup)
-    expect(db.deleteSources).toHaveBeenCalledWith([SOURCE_UUID_2]);
+    expect(db.deleteSourcesAsync).toHaveBeenCalledWith([SOURCE_UUID_2]);
   });
 
   it("deletes sources on sync + updates source delta", async () => {
@@ -684,7 +692,7 @@ describe("syncMetadata", () => {
     await syncModule.syncMetadata(db, "");
 
     expect(proxyMock).toHaveBeenCalledTimes(2);
-    expect(db.deleteSources).toHaveBeenCalledWith([SOURCE_UUID_2]);
+    expect(db.deleteSourcesAsync).toHaveBeenCalledWith([SOURCE_UUID_2]);
     expect(db.updateBatch).toHaveBeenCalledWith({
       items: {},
       sources: {},

--- a/app/src/main/sync/index.ts
+++ b/app/src/main/sync/index.ts
@@ -77,7 +77,7 @@ async function submitBatch(
   request: BatchRequest,
 ): Promise<BatchSubmitResponse> {
   // we include sources, items, and also events in the timeout since events may
-  // require serve compute time even if low payload size
+  // require server compute time even if low payload size
   const records =
     (request.sources?.length || 0) +
     (request.items?.length || 0) +
@@ -119,11 +119,11 @@ async function submitBatch(
 
 // Given the server index and the client's index, return the sources and items
 // that need to be synced. Also deletes items that are not in the server index.
-export function reconcileIndex(
+export async function reconcileIndex(
   db: Datastore,
   serverIndex: Index,
   clientIndex: Index,
-): BatchRequest {
+): Promise<BatchRequest> {
   const pendingDeletionSources = db.getSourcesScheduledForDeletion();
 
   const sourcesToUpdate: string[] = [];
@@ -145,7 +145,7 @@ export function reconcileIndex(
     (source) => !serverSourceSet.has(source),
   );
   if (sourcesToDelete.length > 0) {
-    db.deleteSources(sourcesToDelete);
+    await db.deleteSourcesAsync(sourcesToDelete);
   }
 
   const itemsToUpdate: string[] = [];
@@ -167,7 +167,7 @@ export function reconcileIndex(
     (item) => !serverItemSet.has(item),
   );
   if (itemsToDelete.length > 0) {
-    db.deleteItems(itemsToDelete);
+    await db.deleteItemsAsync(itemsToDelete);
   }
 
   const journalistsToUpdate: string[] = [];
@@ -243,7 +243,7 @@ export async function syncMetadata(
   if (indexResponse.status === 200) {
     // Reconcile with client's index to get metadata to update
     const clientIndex = db.getIndex();
-    const { sources, items, journalists } = reconcileIndex(
+    const { sources, items, journalists } = await reconcileIndex(
       db,
       indexResponse.index,
       clientIndex,

--- a/app/src/main/sync/index.ts
+++ b/app/src/main/sync/index.ts
@@ -76,9 +76,12 @@ async function submitBatch(
   authToken: string,
   request: BatchRequest,
 ): Promise<BatchSubmitResponse> {
-  // (sources + items) >> (journalists + events), so the former is good enough
-  // for estimation.
-  const records = (request.sources?.length || 0) + (request.items?.length || 0);
+  // we include sources, items, and also events in the timeout since events may
+  // require serve compute time even if low payload size
+  const records =
+    (request.sources?.length || 0) +
+    (request.items?.length || 0) +
+    (request.events?.length || 0);
   const timeout = estimateTimeout(BatchResponseSized, records);
 
   const resp = (await proxyJSONRequest(
@@ -137,8 +140,9 @@ export function reconcileIndex(
   });
   // Check for sources to delete, which are ones that the client has which
   // are no longer on the server.
+  const serverSourceSet = new Set(Object.keys(serverIndex.sources));
   const sourcesToDelete = Object.keys(clientIndex.sources).filter(
-    (source) => !Object.keys(serverIndex.sources).includes(source),
+    (source) => !serverSourceSet.has(source),
   );
   if (sourcesToDelete.length > 0) {
     db.deleteSources(sourcesToDelete);
@@ -158,8 +162,9 @@ export function reconcileIndex(
     }
   });
   // Also check for items to delete
+  const serverItemSet = new Set(Object.keys(serverIndex.items));
   const itemsToDelete = Object.keys(clientIndex.items).filter(
-    (item) => !Object.keys(serverIndex.items).includes(item),
+    (item) => !serverItemSet.has(item),
   );
   if (itemsToDelete.length > 0) {
     db.deleteItems(itemsToDelete);
@@ -176,8 +181,9 @@ export function reconcileIndex(
     }
   });
   // Also check for journalists to delete
+  const serverJournalistSet = new Set(Object.keys(serverIndex.journalists));
   const journalistsToDelete = Object.keys(clientIndex.journalists).filter(
-    (journalist) => !Object.keys(serverIndex.journalists).includes(journalist),
+    (journalist) => !serverJournalistSet.has(journalist),
   );
   if (journalistsToDelete.length > 0) {
     db.deleteJournalists(journalistsToDelete);
@@ -255,7 +261,9 @@ export async function syncMetadata(
     return syncStatus;
   }
 
+  console.debug("Client batch request: ", request);
   const batchResponse = await submitBatch(authToken, request);
+  console.debug("Server batch response: ", batchResponse);
 
   // Check for 403 Forbidden
   if (batchResponse.status === 403) {
@@ -265,6 +273,5 @@ export async function syncMetadata(
   db.updateBatch(batchResponse.data);
 
   syncStatus = SyncStatus.UPDATED;
-
   return syncStatus;
 }

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -87,7 +87,7 @@ const electronAPI = {
   getSystemLanguage: logIpcCall<string>("getSystemLanguage", () =>
     ipcRenderer.invoke("getSystemLanguage"),
   ),
-  addPendingSourceEvent: logIpcCall<bigint>(
+  addPendingSourceEvent: logIpcCall<string | null>(
     "addPendingSourceEvent",
     (sourceUuid: string, type: PendingEventType, data?: PendingEventData) =>
       ipcRenderer.invoke("addPendingSourceEvent", sourceUuid, type, data),
@@ -102,7 +102,7 @@ const electronAPI = {
         interactionCount,
       ),
   ),
-  addPendingItemEvent: logIpcCall<bigint>(
+  addPendingItemEvent: logIpcCall<string | null>(
     "addPendingItemEvent",
     (itemUuid: string, type: PendingEventType) =>
       ipcRenderer.invoke("addPendingItemEvent", itemUuid, type),


### PR DESCRIPTION
Fixes #3234

Contains a few changes:
- Improves sync index reconciliation by using Sets
- Batches item deletion in the db
- Performs fs rm operations asynchronously to not block the main thread
- Adds debug logging for sync batch request/response
- Scales batch request timeout to `events` size, since that involves some amount of server compute time
- Reduces size of `pending_events` batch sent in each sync as a way of throttling updates 

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

Verify that large deletion does not cause UI freeze
- [ ] Load a SecureDrop server with a large # of sources (2-500)
- [ ] Open SecureDrop Inbox and sync, waiting for many of the source items to complete download + decryption
- [ ] From the server, delete 50 sources 
- [ ] Sync the SecureDrop Inbox and verify that the deletion synced (sources should disappear from the source list) and interface is still usable 

Verify that Inbox-initiated bulk deletion goes through

- [ ] From the SecureDrop Inbox, initiate a deletion of 20 sources
- [ ] Sync the Inbox, verifying that the UI is still usable 
- [ ] Check logs and DB state, verifying that deletions are being accepted by the server. Eventually `pending_events` should reach 0

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
