### PR TITLE
Don't inherit source timestamps when building packages

### DIFF
--- a/scripts/build-debs-main.sh
+++ b/scripts/build-debs-main.sh
@@ -13,7 +13,7 @@ apt-get update && apt-get upgrade --yes
 # Make a copy of the source tree since we do destructive operations on it
 rsync --exclude=build --exclude=.git --exclude=__pycache__ --exclude=node_modules --exclude=target \
     --exclude=htmlcov --exclude=app/coverage --exclude=app/dist --exclude=app/out \
-    -av /src/ /srv/securedrop-client
+    -av --no-times /src/ /srv/securedrop-client
 cd /srv/securedrop-client
 
 apt-get build-dep . --yes


### PR DESCRIPTION
Because SOURCE_DATE_EPOCH only clamps times, if someone has an old checkout, it will contain files that haven't been modified in a while, and those timestamps will make it into the build, which will highly likely conflict with someone else's build.

By having the timestamps of the files be set to the build time, SOURCE_DATE_EPOCH will clamp them to the time in in debian/changelog, which will be (at least) a few minutes in the past.

Fixes #3219.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] Against main, run `find . -exec touch -d "1 year ago" {} +`
* [ ] Run `FAST=1 make build-debs`
* [ ] Run `dpkg -c build/securedrop-app_0.18.0~rc1+bookworm_amd64.deb | grep 2025` and see:
```
-rw-r--r-- root/root        99 2025-04-27 10:12 ./usr/share/applications/press.freedom.SecureDropApp.desktop
-rw-r--r-- root/root       272 2025-04-27 10:12 ./usr/share/doc/securedrop-app/copyright
-rw-r--r-- root/root      1614 2025-04-27 10:12 ./usr/share/lintian/overrides/securedrop-app
```
* [ ] Now, check out this PR and run `find . -exec touch -d "1 year ago" {} +` again
* [ ] Run `FAST=1 make build-debs`
* [ ] Run `dpkg -c build/securedrop-app_0.18.0~rc1+bookworm_amd64.deb | grep 2025` and see no hits

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
