### PR TITLE
inbox: handle GONE code from server apiv2

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -1315,7 +1315,10 @@ export class DB {
       if (result === EventStatus.OK) {
         appliedEventIDs.push(snowflake_id);
       }
-      if (result === EventStatus.AlreadyReported) {
+      if (
+        result === EventStatus.AlreadyReported ||
+        result === EventStatus.Gone
+      ) {
         eventIDsToRemove.push(snowflake_id);
       }
     });

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -245,6 +245,7 @@ export enum EventStatus {
   AlreadyReported = 208,
   BadRequest = 400,
   NotFound = 404,
+  Gone = 410,
   NotImplemented = 501,
 }
 


### PR DESCRIPTION
When the SecureDrop server receives a duplicate deletion request, it responds with the code `410` GONE. This handles that on the Inbox, removing the pending event.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
