### PR TITLE
[1.0.0] Backport "Don't inherit source timestamps when building packages"

### DIFF
--- a/scripts/build-debs-main.sh
+++ b/scripts/build-debs-main.sh
@@ -13,7 +13,7 @@ apt-get update && apt-get upgrade --yes
 # Make a copy of the source tree since we do destructive operations on it
 rsync --exclude=build --exclude=.git --exclude=__pycache__ --exclude=node_modules --exclude=target \
     --exclude=htmlcov --exclude=app/coverage --exclude=app/dist --exclude=app/out \
-    -av /src/ /srv/securedrop-client
+    -av --no-times /src/ /srv/securedrop-client
 cd /srv/securedrop-client
 
 apt-get build-dep . --yes


### PR DESCRIPTION
Backport of #3307.

## Testing

* [ ] base is `release/1.0.0`
* [ ] Only contains changes from #3307.
