### PR TITLE
[inbox] include pending-deleted items during sync reconciliation

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -188,11 +188,6 @@ export class DB {
     { source_uuid: string },
     void
   >;
-  private selectSourcesScheduledForDeletion: Statement<
-    [],
-    { source_uuid: string }
-  >;
-  private selectItemsScheduledForDeletion: Statement<[], { uuid: string }>;
 
   protected constructor(crypto: Crypto, dbDir?: string) {
     this.crypto = crypto;
@@ -405,13 +400,6 @@ export class DB {
          OR item_uuid IN (
            SELECT uuid FROM items WHERE source_uuid = @source_uuid
          )`);
-    this.selectSourcesScheduledForDeletion = this.db.prepare(`
-      SELECT DISTINCT source_uuid FROM pending_events
-      WHERE type IN ('${PendingEventType.SourceDeleted}', '${PendingEventType.SourceConversationTruncated}')
-    `);
-    this.selectItemsScheduledForDeletion = this.db.prepare(`
-      SELECT uuid FROM items WHERE fetch_status = ${FetchStatus.ScheduledDeletion}
-    `);
   }
 
   // Detect runtime environment
@@ -636,37 +624,24 @@ export class DB {
     deleted_sources: string[];
   } {
     return this.db!.transaction((batch: BatchResponse) => {
-      const pendingDeletionSources = this.getSourcesScheduledForDeletion();
       this.updatePendingEvents(batch.events);
-      const deleted_items = this.updateItems(
-        batch.items,
-        pendingDeletionSources,
-      );
-      const deleted_sources = this.updateSources(
-        batch.sources,
-        pendingDeletionSources,
-      );
+      const deleted_items = this.updateItems(batch.items);
+      const deleted_sources = this.updateSources(batch.sources);
       this.updateJournalists(batch.journalists);
       this.updateVersion();
       return { deleted_items, deleted_sources };
     })(batchResponse);
   }
 
-  protected updateSources(
-    sources: {
-      [uuid: string]: SourceMetadata | null;
-    },
-    pendingDeletionSources?: Set<string>,
-  ): string[] {
+  protected updateSources(sources: {
+    [uuid: string]: SourceMetadata | null;
+  }): string[] {
     const deletedSourceUuids: string[] = [];
     this.db!.transaction(
       (sources: { [uuid: string]: SourceMetadata | null }) => {
         Object.keys(sources).forEach((sourceid: string) => {
           const metadata = sources[sourceid];
           if (metadata) {
-            if (pendingDeletionSources?.has(sourceid)) {
-              return;
-            }
             const info = JSON.stringify(metadata, sortKeys);
             const version = computeVersion(info);
             this.upsertSource.run({ uuid: sourceid, data: info, version });
@@ -681,20 +656,14 @@ export class DB {
     return deletedSourceUuids;
   }
 
-  protected updateItems(
-    items: {
-      [uuid: string]: ItemMetadata | null;
-    },
-    pendingDeletionSources?: Set<string>,
-  ): Item[] {
+  protected updateItems(items: {
+    [uuid: string]: ItemMetadata | null;
+  }): Item[] {
     const deletedItems: Item[] = [];
     this.db!.transaction((items: { [uuid: string]: ItemMetadata | null }) => {
       Object.keys(items).forEach((itemid: string) => {
         const metadata = items[itemid];
         if (metadata) {
-          if (pendingDeletionSources?.has(metadata.source)) {
-            return;
-          }
           const blob = JSON.stringify(metadata, sortKeys);
           const version = computeVersion(blob);
           this.upsertItem.run({ uuid: itemid, data: blob, version });
@@ -1288,16 +1257,6 @@ export class DB {
     });
 
     return pendingEvents;
-  }
-
-  getSourcesScheduledForDeletion(): Set<string> {
-    const rows = this.selectSourcesScheduledForDeletion.all();
-    return new Set(rows.map((r) => r.source_uuid));
-  }
-
-  getItemsScheduledForDeletion(): Set<string> {
-    const rows = this.selectItemsScheduledForDeletion.all();
-    return new Set(rows.map((r) => r.uuid));
   }
 
   // Takes pending events and their statuses from the server and applies

--- a/app/src/main/datastore.ts
+++ b/app/src/main/datastore.ts
@@ -47,27 +47,18 @@ export class Datastore extends DB {
     super.deleteJournalists(journalists);
   }
 
-  override updateItems(
-    items: { [uuid: string]: ItemMetadata | null },
-    pendingDeletionSources?: Set<string>,
-  ): Item[] {
-    const deletedItems = super.updateItems(items, pendingDeletionSources);
+  override updateItems(items: { [uuid: string]: ItemMetadata | null }): Item[] {
+    const deletedItems = super.updateItems(items);
     for (const item of deletedItems) {
       void this.storage.deleteItemFs(item);
     }
     return deletedItems;
   }
 
-  override updateSources(
-    sources: {
-      [uuid: string]: SourceMetadata | null;
-    },
-    pendingDeletionSources?: Set<string>,
-  ): string[] {
-    const deletedSourceUuids = super.updateSources(
-      sources,
-      pendingDeletionSources,
-    );
+  override updateSources(sources: {
+    [uuid: string]: SourceMetadata | null;
+  }): string[] {
+    const deletedSourceUuids = super.updateSources(sources);
     for (const uuid of deletedSourceUuids) {
       void this.storage.deleteSourceFs(uuid);
     }

--- a/app/src/main/sync/index.test.ts
+++ b/app/src/main/sync/index.test.ts
@@ -82,8 +82,6 @@ function mockDB({
     })),
     getItemFileData: vi.fn(() => itemFileData),
     getPendingEvents: vi.fn(() => pendingEvents),
-    getSourcesScheduledForDeletion: vi.fn(() => new Set<string>()),
-    getItemsScheduledForDeletion: vi.fn(() => new Set<string>()),
   } as unknown as Datastore;
   return db;
 }
@@ -549,105 +547,6 @@ describe("syncMetadata", () => {
 
     expect(proxyMock).toHaveBeenCalledTimes(2);
     expect(db.updateBatch).toHaveBeenCalledWith(metadata);
-  });
-
-  it("excludes pending-deleted sources from reconcile request", async () => {
-    // Server index has two sources with updated versions
-    const serverIndex: Index = {
-      sources: {
-        [SOURCE_UUID_1]: "v2",
-        [SOURCE_UUID_2]: "v2",
-      },
-      items: {},
-      journalists: {},
-    };
-
-    // Client index has both sources at older versions
-    const clientIndex: Index = {
-      sources: {
-        [SOURCE_UUID_1]: "v1",
-        [SOURCE_UUID_2]: "v1",
-      },
-      items: {},
-      journalists: {},
-    };
-
-    db = mockDB({ index: clientIndex });
-    // SOURCE_UUID_2 is pending deletion locally
-    db.getSourcesScheduledForDeletion = vi.fn(() => new Set([SOURCE_UUID_2]));
-
-    const result = await syncModule.reconcileIndex(
-      db,
-      serverIndex,
-      clientIndex,
-    );
-
-    // Should request only SOURCE_UUID_1, not the pending-deleted SOURCE_UUID_2
-    expect(result.sources).toEqual([SOURCE_UUID_1]);
-  });
-
-  it("excludes pending-deleted items from reconcile request", async () => {
-    // Server index has two items with updated versions
-    const serverIndex: Index = {
-      sources: {},
-      items: {
-        [ITEM_UUID_1]: "v2",
-        [ITEM_UUID_2]: "v2",
-      },
-      journalists: {},
-    };
-
-    // Client index has both items at older versions
-    const clientIndex: Index = {
-      sources: {},
-      items: {
-        [ITEM_UUID_1]: "v1",
-        [ITEM_UUID_2]: "v1",
-      },
-      journalists: {},
-    };
-
-    db = mockDB({ index: clientIndex });
-    // ITEM_UUID_2 is scheduled for deletion
-    db.getItemsScheduledForDeletion = vi.fn(() => new Set([ITEM_UUID_2]));
-
-    const result = await syncModule.reconcileIndex(
-      db,
-      serverIndex,
-      clientIndex,
-    );
-
-    // Should request only ITEM_UUID_1, not the pending-deleted ITEM_UUID_2
-    expect(result.items).toEqual([ITEM_UUID_1]);
-  });
-
-  it("still allows server-side deletions for pending-deleted sources", async () => {
-    // Client index has SOURCE_UUID_2 which is absent from server (deleted server-side)
-    const serverIndex: Index = {
-      sources: {
-        [SOURCE_UUID_1]: "v1",
-      },
-      items: {},
-      journalists: {},
-    };
-
-    const clientIndex: Index = {
-      sources: {
-        [SOURCE_UUID_1]: "v1",
-        [SOURCE_UUID_2]: "v1",
-      },
-      items: {},
-      journalists: {},
-    };
-
-    db = mockDB({ index: clientIndex });
-    // SOURCE_UUID_2 is also pending deletion locally
-    db.getSourcesScheduledForDeletion = vi.fn(() => new Set([SOURCE_UUID_2]));
-
-    await syncModule.reconcileIndex(db, serverIndex, clientIndex);
-
-    // The source should still be deleted locally (final cleanup)
-    expect(db.deleteSourcesAsync).toHaveBeenCalledWith([SOURCE_UUID_2]);
   });
 
   it("deletes sources on sync + updates source delta", async () => {

--- a/app/src/main/sync/index.ts
+++ b/app/src/main/sync/index.ts
@@ -124,13 +124,8 @@ export async function reconcileIndex(
   serverIndex: Index,
   clientIndex: Index,
 ): Promise<BatchRequest> {
-  const pendingDeletionSources = db.getSourcesScheduledForDeletion();
-
   const sourcesToUpdate: string[] = [];
   Object.keys(serverIndex.sources).forEach((sourceID) => {
-    if (pendingDeletionSources.has(sourceID)) {
-      return;
-    }
     if (
       !clientIndex.sources[sourceID] ||
       serverIndex.sources[sourceID] != clientIndex.sources[sourceID]
@@ -149,11 +144,7 @@ export async function reconcileIndex(
   }
 
   const itemsToUpdate: string[] = [];
-  const pendingDeletionItems = db.getItemsScheduledForDeletion();
   Object.keys(serverIndex.items).forEach((itemID) => {
-    if (pendingDeletionItems.has(itemID)) {
-      return;
-    }
     if (
       !clientIndex.items[itemID] ||
       serverIndex.items[itemID] != clientIndex.items[itemID]

--- a/app/src/main/sync/index.ts
+++ b/app/src/main/sync/index.ts
@@ -261,9 +261,9 @@ export async function syncMetadata(
     return syncStatus;
   }
 
-  console.debug("Client batch request: ", request);
+  console.debug("Client batch request: ", JSON.stringify(request));
   const batchResponse = await submitBatch(authToken, request);
-  console.debug("Server batch response: ", batchResponse);
+  console.debug("Server batch response: ", JSON.stringify(batchResponse));
 
   // Check for 403 Forbidden
   if (batchResponse.status === 403) {


### PR DESCRIPTION
Reverts https://github.com/freedomofpress/securedrop-client/commit/07d37c695e8d7877dc8eead9f6e7c58cf1cc120d 

We need to include pending-deleted items + sources in sync reconciliation. If the version for a deletion event does not match the server version, then the server will reject that deletion. If we do not update pending-deleted items in sync reconciliation, then we will forever keep the stale version, essentially orphaning these pending deletion events so they can never be accepted.

This could happen if a source is read or starred in one client, and then scheduled for deletion in another, and the server accepts the read/starred event before processing the deletion event so there is a version mismatch.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

Steps to reproduce bug behavior on `main` - helpful to include the change to `JSON.stringify` the `batchResponse` to inspect the server response

1. Start Inbox and JI with a server with many sources 
2. Star a source in the JI
3. Delete that same source in the Inbox 
4. Perform a sync of the Inbox 
5. [x] Server should respond with `409,"outdated source: expected  ...`, and the deletion `pending_event` remains in the DB and is not cleared on subsequent syncs 
6. [x] JI still shows the source

Verify the fix: check out the branch

1. Start the Inbox 
2. [x] Sync should complete successfully with 200 event code 
3. [x] `pending_events` table is empty 
4. [x] Deletion request has been accepted by the server: can verify on the server and via JI

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
