### PR TITLE
[inbox] only export allowed languages

### DIFF
--- a/app/src/renderer/locales/index.ts
+++ b/app/src/renderer/locales/index.ts
@@ -1,13 +1,9 @@
-import de from "./de.json";
 import en from "./en.json";
 import en_XA from "./en-XA.json";
-import es from "./es.json";
 import fr from "./fr.json";
 
 export const resources = {
-  de,
   en,
   en_XA,
-  es,
   fr,
 } as const;


### PR DESCRIPTION
Only enables `en`, `en_XA`, and `fr` for the SecureDrop Inbox since those are fully translated + approved (or the `en_XA` special case for testing). 

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
