### PR TITLE
Don't send `--version` output to syslog

### DIFF
--- a/debian/securedrop-app-wrapper
+++ b/debian/securedrop-app-wrapper
@@ -1,5 +1,8 @@
 #!/bin/bash
 # Wrap the real securedrop-app binary, forwarding its stdout/stderr to syslog
+if [[ "$*" == *"--version"* ]]; then
+    exec /usr/bin/securedrop-app.real "$@"
+fi
 exec /usr/bin/securedrop-app.real "$@" \
     > >(logger -t securedrop-inbox -p user.info) \
     2> >(logger -t securedrop-inbox -p user.err)


### PR DESCRIPTION
Fixes #3292.

Written by Claude.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
full plan:
* [ ] use try-client-pr to install this in SDW and then run `securedrop-app --version` and see it gets output as you'd expect

alternative light plan:
* [ ] check out this PR and run `bash debian/securedrop-app-wrapper`; it should silently exit with a non-zero status code
* [ ] then run `bash debian/securedrop-app-wrapper --version`; it should emit the underlying error message (securedrop-app.real not found), which shows that with --version the output doesn't go to syslog 
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
