### PR TITLE
Count items to be deleted in one SQL query

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -31,6 +31,7 @@ import {
   SearchResult,
   FirstRunStatus,
   PendingEventData,
+  SourceItemCounts,
 } from "../../types";
 import { Crypto } from "../crypto";
 import { Search } from "./search";
@@ -154,6 +155,10 @@ export class DB {
   private selectItemsBySourceIdBefore: Statement<
     [string, number, number],
     ItemRow
+  >;
+  private selectItemCountsBySourceUuids: Statement<
+    { uuids_json: string },
+    { messages: number; files: number; replies: number }
   >;
   private selectAllJournalists: Statement<[], JournalistRow>;
   private insertSourcePendingEvent: Statement<
@@ -363,6 +368,14 @@ export class DB {
       WHERE source_uuid = ? AND interaction_count < ?
       ORDER BY interaction_count DESC
       LIMIT ?
+    `);
+    this.selectItemCountsBySourceUuids = this.db.prepare(`
+      SELECT
+        COALESCE(SUM(CASE WHEN kind = 'message' THEN 1 ELSE 0 END), 0) AS messages,
+        COALESCE(SUM(CASE WHEN kind = 'file' THEN 1 ELSE 0 END), 0) AS files,
+        COALESCE(SUM(CASE WHEN kind = 'reply' THEN 1 ELSE 0 END), 0) AS replies
+      FROM items_projected
+      WHERE source_uuid IN (SELECT value FROM json_each(@uuids_json))
     `);
     this.selectAllJournalists = this.db.prepare(`
       SELECT uuid, data FROM journalists
@@ -866,6 +879,24 @@ export class DB {
       items,
       hasMoreHistoricalItems,
       lastSeenInteractionCount,
+    };
+  }
+
+  getSourceItemCounts(sourceUuids: string[]): SourceItemCounts {
+    if (!this.db) {
+      throw new Error("Database is not open");
+    }
+
+    const uuids_json = JSON.stringify(sourceUuids);
+    const row = this.selectItemCountsBySourceUuids.get({ uuids_json }) as {
+      messages: number | null;
+      files: number | null;
+      replies: number | null;
+    };
+    return {
+      messages: row.messages ?? 0,
+      files: row.files ?? 0,
+      replies: row.replies ?? 0,
     };
   }
 

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -1826,4 +1826,65 @@ describe("Datastore Method Tests", () => {
       expect(processable.length).toBe(0);
     });
   });
+
+  describe("getSourceItemCounts", () => {
+    it("returns zeros when no sources are selected", () => {
+      const counts = db.getSourceItemCounts([]);
+      expect(counts).toEqual({ messages: 0, files: 0, replies: 0 });
+    });
+
+    it("returns zeros when selected sources have no items", () => {
+      db.updateSources({
+        ["source1"]: mockSourceMetadata("source1"),
+      });
+      const counts = db.getSourceItemCounts(["source1"]);
+      expect(counts).toEqual({ messages: 0, files: 0, replies: 0 });
+    });
+
+    it("counts items by kind for a single source", () => {
+      db.updateSources({
+        ["source1"]: mockSourceMetadata("source1"),
+      });
+      db.updateItems({
+        ["msg1"]: mockItemMetadata("msg1", "source1", "message"),
+        ["msg2"]: mockItemMetadata("msg2", "source1", "message"),
+        ["file1"]: mockItemMetadata("file1", "source1", "file"),
+        ["reply1"]: mockItemMetadata("reply1", "source1", "reply"),
+      });
+
+      const counts = db.getSourceItemCounts(["source1"]);
+      expect(counts).toEqual({ messages: 2, files: 1, replies: 1 });
+    });
+
+    it("aggregates counts across multiple sources", () => {
+      db.updateSources({
+        ["source1"]: mockSourceMetadata("source1"),
+        ["source2"]: mockSourceMetadata("source2"),
+      });
+      db.updateItems({
+        ["msg1"]: mockItemMetadata("msg1", "source1", "message"),
+        ["file1"]: mockItemMetadata("file1", "source1", "file"),
+        ["msg2"]: mockItemMetadata("msg2", "source2", "message"),
+        ["reply1"]: mockItemMetadata("reply1", "source2", "reply"),
+      });
+
+      const counts = db.getSourceItemCounts(["source1", "source2"]);
+      expect(counts).toEqual({ messages: 2, files: 1, replies: 1 });
+    });
+
+    it("only counts items belonging to the selected sources", () => {
+      db.updateSources({
+        ["source1"]: mockSourceMetadata("source1"),
+        ["source2"]: mockSourceMetadata("source2"),
+      });
+      db.updateItems({
+        ["msg1"]: mockItemMetadata("msg1", "source1", "message"),
+        ["msg2"]: mockItemMetadata("msg2", "source2", "message"),
+        ["msg3"]: mockItemMetadata("msg3", "source2", "message"),
+      });
+
+      const counts = db.getSourceItemCounts(["source1"]);
+      expect(counts).toEqual({ messages: 1, files: 0, replies: 0 });
+    });
+  });
 });

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -24,6 +24,7 @@ import {
   type ProxyResponse,
   type Source,
   type SourceWithItems,
+  type SourceItemCounts,
   type Journalist,
   type AuthedRequest,
   type Item,
@@ -376,6 +377,13 @@ if (!gotTheLock) {
         ): Promise<SourceWithItems> => {
           const sourceWithItems = db.getSourceWithItems(sourceUuid, options);
           return sourceWithItems;
+        },
+      );
+
+      ipcMain.handle(
+        "getSourceItemCounts",
+        async (_event, sourceUuids: string[]): Promise<SourceItemCounts> => {
+          return db.getSourceItemCounts(sourceUuids);
         },
       );
 

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -7,6 +7,7 @@ import {
   type ProxyResponse,
   type Source,
   type SourceWithItems,
+  type SourceItemCounts,
   type Journalist,
   type AuthedRequest,
   type SearchResult,
@@ -74,6 +75,11 @@ const electronAPI = {
         journalistUuid?: string;
       },
     ) => ipcRenderer.invoke("getSourceWithItems", sourceUuid, options),
+  ),
+  getSourceItemCounts: logIpcCall<SourceItemCounts>(
+    "getSourceItemCounts",
+    (sourceUuids: string[]) =>
+      ipcRenderer.invoke("getSourceItemCounts", sourceUuids),
   ),
   getItem: logIpcCall<Item | null>("getItem", (itemUuid: string) =>
     ipcRenderer.invoke("getItem", itemUuid),

--- a/app/src/renderer/test-component-setup.tsx
+++ b/app/src/renderer/test-component-setup.tsx
@@ -188,6 +188,9 @@ beforeEach(() => {
         },
       ],
     }),
+    getSourceItemCounts: vi
+      .fn()
+      .mockResolvedValue({ messages: 0, files: 0, replies: 0 }),
     getJournalists: vi.fn().mockResolvedValue([
       {
         uuid: "journalist-1",

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -169,35 +169,12 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
     setDeleteModalLoading(true);
 
     try {
-      // Fetch all source items to count messages, files, and replies
-      let totalMessages = 0;
-      let totalFiles = 0;
-      let totalReplies = 0;
-
-      for (const sourceUuid of sources) {
-        const sourceWithItems =
-          await window.electronAPI.getSourceWithItems(sourceUuid);
-        if (sourceWithItems) {
-          // Count messages, files, and replies
-          for (const item of sourceWithItems.items) {
-            if (item.data.kind === "message") {
-              totalMessages++;
-            } else if (item.data.kind === "file") {
-              totalFiles++;
-            } else if (item.data.kind === "reply") {
-              totalReplies++;
-            }
-          }
-        }
-      }
-
-      setDeleteCounts({
-        messages: totalMessages,
-        files: totalFiles,
-        replies: totalReplies,
-      });
+      const counts = await window.electronAPI.getSourceItemCounts(
+        Array.from(sources),
+      );
+      setDeleteCounts(counts);
     } catch (error) {
-      console.error("Error fetching source items:", error);
+      console.error("Error fetching source item counts:", error);
       setDeleteCounts({ messages: 0, files: 0, replies: 0 });
     } finally {
       setDeleteModalLoading(false);

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -145,6 +145,12 @@ export type SourceWithItems = {
   lastSeenInteractionCount?: number | null;
 };
 
+export type SourceItemCounts = {
+  messages: number;
+  files: number;
+  replies: number;
+};
+
 export type Journalist = {
   uuid: string;
   data: JournalistMetadata;


### PR DESCRIPTION
Instead of one-by-one, per source, which is inefficient for a large number of sources.

Fixes #3299.

Mostly done by Claude.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] open Inbox w/ 1000 sources, select all and open deletion dialog, counts should load in less than 1 second; in debug console you should only see 1 IPC call being invoked
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
