### PR TITLE
Correctly set Inbox's icon to the SecureDrop logo

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -177,7 +177,7 @@ if (!gotTheLock) {
       minWidth: 1200,
       minHeight: 900,
       title: "SecureDrop Inbox",
-      icon: join(__dirname, "../renderer/resources/icon.png"),
+      icon: join(__dirname, "../../resources/images/logo.png"),
       show: false,
       autoHideMenuBar: true,
       webPreferences: {


### PR DESCRIPTION
The previously referenced file didn't exist.

Fixes #3262.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] Use try-client-pr to deploy this SDW and then open the Inbox, see it has an icon in the menubar
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
