### PR TITLE
fix: typo in username placeholder

### DIFF
--- a/app/src/renderer/views/SignIn.test.tsx
+++ b/app/src/renderer/views/SignIn.test.tsx
@@ -134,7 +134,7 @@ describe("SignInView Component", () => {
     const signInButton = screen.getByTestId("sign-in-button");
 
     // Fill in valid inputs
-    await userEvent.type(usernameInput, "neliebly");
+    await userEvent.type(usernameInput, "nelliebly");
     await userEvent.type(passphraseInput, "validPassphrase12345");
     await userEvent.type(oneTimeCodeInput, "123456");
 
@@ -175,7 +175,7 @@ describe("SignInView Component", () => {
     const signInButton = screen.getByTestId("sign-in-button");
 
     // Fill in valid inputs
-    await userEvent.type(usernameInput, "neliebly");
+    await userEvent.type(usernameInput, "nelliebly");
     await userEvent.type(passphraseInput, "validPassphrase12345");
     await userEvent.type(oneTimeCodeInput, "123456");
 
@@ -237,7 +237,7 @@ describe("SignInView Component", () => {
     const signInButton = screen.getByTestId("sign-in-button");
 
     // Fill in valid inputs
-    await userEvent.type(usernameInput, "neliebly");
+    await userEvent.type(usernameInput, "nelliebly");
     await userEvent.type(passphraseInput, "validPassphrase12345");
     await userEvent.type(oneTimeCodeInput, "123456");
 

--- a/app/src/renderer/views/SignIn.tsx
+++ b/app/src/renderer/views/SignIn.tsx
@@ -279,7 +279,7 @@ function SignInView() {
             >
               <Input
                 data-testid="username-input"
-                placeholder="neliebly"
+                placeholder="nelliebly"
                 autoFocus
               />
             </Form.Item>


### PR DESCRIPTION
The login form for the Inbox was showing a greyed out username with a conspicuous typo.

## Test plan
I would expect visual review to be sufficient here.

## Checklist

I haven't done any legwork to confirm this change doesn't break something: all I did was grep for the string "neliebly" after noticing it in the GUI, and replace all occurrences. 