### PR TITLE
[inbox] remove empty string translation

### DIFF
--- a/app/src/renderer/components/QuitModal.tsx
+++ b/app/src/renderer/components/QuitModal.tsx
@@ -15,9 +15,7 @@ function QuitModal() {
       autoFocusButton: "ok",
       title: t("title"),
       icon: null,
-      content: t(
-        Object.keys(drafts.drafts).length > 0 ? "withDrafts" : "noDrafts",
-      ),
+      content: Object.keys(drafts.drafts).length > 0 ? t("withDrafts") : "",
       cancelText: t("goBack"),
       okText: t(
         Object.keys(drafts.drafts).length > 0 ? "discardAndQuit" : "Quit",

--- a/app/src/renderer/locales/de.json
+++ b/app/src/renderer/locales/de.json
@@ -241,7 +241,6 @@
     "withDrafts": "Entwürfe von Antworten werden gelöscht.",
     "Quit": "Beenden",
     "discardAndQuit": "Verwerfen und beenden",
-    "noDrafts": "",
     "goBack": "Gehe zurück",
     "title": "SecureDrop-Posteingang verlassen?"
   },

--- a/app/src/renderer/locales/en-XA.json
+++ b/app/src/renderer/locales/en-XA.json
@@ -216,8 +216,7 @@
     "Quit": "[Quit]",
     "discardAndQuit": "[!Discard and Quit!]",
     "goBack": "[Go Back]",
-    "title": "[!!Quit SecureDrop Inbox?!!]",
-    "noDrafts": ""
+    "title": "[!!Quit SecureDrop Inbox?!!]"
   },
   "MainContent": {
     "menu": {

--- a/app/src/renderer/locales/en.json
+++ b/app/src/renderer/locales/en.json
@@ -255,7 +255,6 @@
   "QuitModal": {
     "title": "Quit SecureDrop Inbox?",
     "withDrafts": "Draft replies will be discarded.",
-    "noDrafts": "",
     "goBack": "Go Back",
     "Quit": "Quit",
     "discardAndQuit": "Discard and Quit"

--- a/app/src/renderer/locales/es.json
+++ b/app/src/renderer/locales/es.json
@@ -244,7 +244,6 @@
     "withDrafts": "",
     "Quit": "",
     "discardAndQuit": "",
-    "noDrafts": "",
     "goBack": "",
     "title": ""
   },

--- a/app/src/renderer/locales/fr.json
+++ b/app/src/renderer/locales/fr.json
@@ -248,7 +248,6 @@
   "QuitModal": {
     "title": "Fermer la boîte de réception SecureDrop ?",
     "withDrafts": "Les brouillons de réponse seront supprimés.",
-    "noDrafts": "",
     "cancel": "Annuler",
     "ok": "Oui, quitter",
     "goBack": "Retour",

--- a/app/src/renderer/locales/nb-NO.json
+++ b/app/src/renderer/locales/nb-NO.json
@@ -215,7 +215,6 @@
     "withDrafts": "",
     "Quit": "",
     "discardAndQuit": "",
-    "noDrafts": "",
     "goBack": "",
     "title": ""
   },


### PR DESCRIPTION
Fixes #3246

## Test plan
Quit modal when there are no drafts doesn't display any additional message

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
