### PR TITLE
inbox: increase search page limit

### DIFF
--- a/app/src/main/database/search.test.ts
+++ b/app/src/main/database/search.test.ts
@@ -207,19 +207,31 @@ describe("Search", () => {
       expect(results[0].type).toBe("reply");
     });
 
-    it("returns multiple results across sources and items", () => {
+    it("returns one result per source when multiple items match", () => {
       db.updateSources({
         ["source1"]: mockSource("source1", "colorful caterpillar"),
-        ["source2"]: mockSource("source2", "dramatic dolphin"),
       });
       db.updateItems({ ["item1"]: mockItem("item1", "source1", "message") });
       db.completePlaintextItem("item1", "colorful flowers in the garden");
 
+      // Both the source name and the message match, but we expect only one
+      // result for source1 (the highest-ranked row).
+      const results = db.search("colorful");
+      expect(results).toHaveLength(1);
+      expect(results[0].sourceUuid).toBe("source1");
+    });
+
+    it("returns one result per matching source", () => {
+      db.updateSources({
+        ["source1"]: mockSource("source1", "colorful caterpillar"),
+        ["source2"]: mockSource("source2", "colorful dolphin"),
+      });
+
       const results = db.search("colorful");
       expect(results).toHaveLength(2);
-      const types = results.map((r) => r.type);
-      expect(types).toContain("source");
-      expect(types).toContain("message");
+      const sourceUuids = results.map((r) => r.sourceUuid);
+      expect(sourceUuids).toContain("source1");
+      expect(sourceUuids).toContain("source2");
     });
 
     it("supports prefix matching", () => {

--- a/app/src/main/database/search.ts
+++ b/app/src/main/database/search.ts
@@ -1,6 +1,9 @@
 import Database, { Statement } from "better-sqlite3";
 import { SearchResult } from "../../types";
 
+// Set a large page size since we currently don't paginate from the SourceList
+const SEARCH_PAGE_SIZE = 1000;
+
 type SearchRow = {
   source_uuid: string;
   item_uuid: string | null;
@@ -77,7 +80,7 @@ export function buildQuery(input: string): string | null {
 export class Search {
   private db: Database.Database;
 
-  private searchStmt: Statement<[string, number, number], SearchRow>;
+  private searchBySourceStmt: Statement<[string, number], SearchRow>;
   private deleteByItemStmt: Statement<[string], void>;
   private deleteItemManyStmt: Statement<{ uuids_json: string }, void>;
   private deleteBySourceStmt: Statement<[string], void>;
@@ -103,18 +106,23 @@ export class Search {
   constructor(db: Database.Database) {
     this.db = db;
 
-    this.searchStmt = this.db.prepare(`
-      SELECT
-        si.source_uuid,
-        si.item_uuid,
-        si.type,
-        content AS snippet
-      FROM search_index si
-      INNER JOIN sources_projected sp ON sp.uuid = si.source_uuid
-      LEFT JOIN items_projected ip ON ip.uuid = si.item_uuid
-      WHERE search_index MATCH ?
+    this.searchBySourceStmt = this.db.prepare(`
+      SELECT 
+        source_uuid, 
+        item_uuid, 
+        type, 
+        content AS snippet                                                                                                                               
+      FROM (                                                                                                                                                                                
+        SELECT si.source_uuid, si.item_uuid, si.type, content, rank,                                                                                                                        
+              ROW_NUMBER() OVER (PARTITION BY si.source_uuid ORDER BY rank) AS rn
+        FROM search_index si
+        INNER JOIN sources_projected sp ON sp.uuid = si.source_uuid
+        LEFT JOIN items_projected ip ON ip.uuid = si.item_uuid
+        WHERE search_index MATCH ?
+      )
+      WHERE rn = 1
       ORDER BY rank
-      LIMIT ? OFFSET ?
+      LIMIT ?
     `);
 
     this.deleteByItemStmt = this.db.prepare(
@@ -159,17 +167,15 @@ export class Search {
     `);
   }
 
-  search(
-    query: string,
-    limit: number = 20,
-    offset: number = 0,
-  ): SearchResult[] {
+  // Searches by the query string over the search index, returning the top
+  // result per-source.
+  search(query: string): SearchResult[] {
     const ftsQuery = buildQuery(query);
     if (!ftsQuery) {
       return [];
     }
 
-    const rows = this.searchStmt.all(ftsQuery, limit, offset);
+    const rows = this.searchBySourceStmt.all(ftsQuery, SEARCH_PAGE_SIZE);
     return rows.map((row) => ({
       sourceUuid: row.source_uuid,
       itemUuid: row.item_uuid,

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
@@ -168,6 +168,23 @@ describe("Sources Component", () => {
       messagePreview: null,
       lastInteractionCount: 7,
     },
+    {
+      uuid: "source-5",
+      data: {
+        fingerprint: "fingerprint-5",
+        is_starred: false,
+        is_seen: true,
+        has_attachment: false,
+        journalist_designation: "bob ross",
+        last_updated: "2024-01-18T11:20:00Z",
+        public_key: "key-5",
+        uuid: "source-5",
+      },
+      isRead: true,
+      hasAttachment: false,
+      messagePreview: null,
+      lastInteractionCount: 7,
+    },
   ];
 
   const mockSearchResults: SearchResult[] = [
@@ -193,6 +210,12 @@ describe("Sources Component", () => {
       sourceUuid: "source-4",
       type: "source",
       snippet: "diana ross",
+      itemUuid: null,
+    },
+    {
+      sourceUuid: "source-5",
+      type: "source",
+      snippet: "bob ross",
       itemUuid: null,
     },
   ];
@@ -266,7 +289,7 @@ describe("Sources Component", () => {
       // Verify virtual list is being used
       const virtualList = screen.getByTestId("virtualized-list");
       expect(virtualList).toBeInTheDocument();
-      expect(virtualList.getAttribute("data-item-count")).toBe("4");
+      expect(virtualList.getAttribute("data-item-count")).toBe("5");
     });
 
     it("dispatches fetchSources action on mount", async () => {
@@ -450,7 +473,7 @@ describe("Sources Component", () => {
       const searchInput = screen.getByTestId("source-search-input");
       await userEvent.type(searchInput, "BOB");
 
-      // Wait for debounce and Bob Builder should be visible (case-insensitive search)
+      // Wait for debounce and Bob Builder and Bob Ross should be visible (case-insensitive search)
       await waitFor(
         () => {
           expect(
@@ -463,6 +486,7 @@ describe("Sources Component", () => {
           expect(
             screen.queryByTestId("source-source-4"),
           ).not.toBeInTheDocument();
+          expect(screen.queryByTestId("source-source-5")).toBeInTheDocument();
         },
         { timeout: 1000 },
       );
@@ -645,7 +669,8 @@ describe("Sources Component", () => {
 
       // Should be ordered by last_updated descending: source-4, source-2, source-1, source-3
       expect(sourceOrder).toEqual([
-        "source-source-4", // 2024-01-17 (newest)
+        "source-source-5", // 2024-01-18 (newest)
+        "source-source-4", // 2024-01-17
         "source-source-2", // 2024-01-16
         "source-source-1", // 2024-01-15
         "source-source-3", // 2024-01-14 (oldest)
@@ -671,7 +696,8 @@ describe("Sources Component", () => {
         "source-source-3", // 2024-01-14 (oldest)
         "source-source-1", // 2024-01-15
         "source-source-2", // 2024-01-16
-        "source-source-4", // 2024-01-17 (newest)
+        "source-source-4", // 2024-01-17
+        "source-source-5", // 2024-01-18 (newest)
       ]);
     });
 
@@ -696,7 +722,7 @@ describe("Sources Component", () => {
 
       sources = screen.getAllByTestId(/^source-source-/);
       sourceOrder = sources.map((el) => el.getAttribute("data-testid"));
-      expect(sourceOrder[0]).toBe("source-source-4"); // newest first
+      expect(sourceOrder[0]).toBe("source-source-5"); // newest first
     });
   });
 
@@ -708,18 +734,18 @@ describe("Sources Component", () => {
         expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
       });
 
-      // Search for "b" (should match bob builder and charlie chaplin)
+      // Search for "bob" (should match bob builder and bob ross)
       const searchInput = screen.getByTestId("source-search-input");
-      await userEvent.type(searchInput, "b");
+      await userEvent.type(searchInput, "bob");
 
-      // Filter to starred (should only show bob builder since charlie isn't starred)
+      // Filter to starred (should only show bob builder since bob ross isn't starred)
       const filterButton = screen.getByTestId("filter-dropdown");
       await userEvent.click(filterButton);
       await userEvent.click(screen.getByText("Starred"));
 
       await waitFor(
         () => {
-          // Only Bob Builder should be visible (matches search "b" and is starred)
+          // Only Bob Builder should be visible (matches search "bob" and is starred)
           expect(
             screen.queryByTestId("source-source-1"),
           ).not.toBeInTheDocument();
@@ -729,6 +755,9 @@ describe("Sources Component", () => {
           ).not.toBeInTheDocument();
           expect(
             screen.queryByTestId("source-source-4"),
+          ).not.toBeInTheDocument();
+          expect(
+            screen.queryByTestId("source-source-5"),
           ).not.toBeInTheDocument();
         },
         { timeout: 1000 },
@@ -1524,14 +1553,16 @@ describe("Sources Component", () => {
         expect(screen.getByTestId("source-source-2")).toBeInTheDocument();
         expect(screen.getByTestId("source-source-3")).toBeInTheDocument();
         expect(screen.getByTestId("source-source-4")).toBeInTheDocument();
+        expect(screen.getByTestId("source-source-5")).toBeInTheDocument();
       });
 
-      // Select all four sources
+      // Select all five sources
       await userEvent.click(screen.getByTestId("select-all-checkbox"));
       expect(screen.getByTestId("source-checkbox-source-1")).toBeChecked();
       expect(screen.getByTestId("source-checkbox-source-2")).toBeChecked();
       expect(screen.getByTestId("source-checkbox-source-3")).toBeChecked();
       expect(screen.getByTestId("source-checkbox-source-4")).toBeChecked();
+      expect(screen.getByTestId("source-checkbox-source-5")).toBeChecked();
 
       // Search for "alice" — only source-1 (alice wonderland) is visible
       const searchInput = screen.getByTestId("source-search-input");
@@ -1549,6 +1580,9 @@ describe("Sources Component", () => {
           expect(
             screen.queryByTestId("source-source-4"),
           ).not.toBeInTheDocument();
+          expect(
+            screen.queryByTestId("source-source-5"),
+          ).not.toBeInTheDocument();
         },
         { timeout: 1000 },
       );
@@ -1563,6 +1597,7 @@ describe("Sources Component", () => {
           expect(screen.getByTestId("source-source-2")).toBeInTheDocument();
           expect(screen.getByTestId("source-source-3")).toBeInTheDocument();
           expect(screen.getByTestId("source-source-4")).toBeInTheDocument();
+          expect(screen.getByTestId("source-source-5")).toBeInTheDocument();
         },
         { timeout: 1000 },
       );
@@ -1572,8 +1607,9 @@ describe("Sources Component", () => {
       expect(screen.getByTestId("source-checkbox-source-2")).not.toBeChecked();
       expect(screen.getByTestId("source-checkbox-source-3")).not.toBeChecked();
       expect(screen.getByTestId("source-checkbox-source-4")).not.toBeChecked();
+      expect(screen.getByTestId("source-checkbox-source-5")).not.toBeChecked();
 
-      // Select-all should be indeterminate: one of four visible sources is selected
+      // Select-all should be indeterminate: one of five visible sources is selected
       const selectAllCheckbox = screen.getByTestId(
         "select-all-checkbox",
       ) as HTMLInputElement;

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -97,7 +97,8 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
   useEffect(() => {
     let cancelled = false;
 
-    if (!debouncedSearchTerm.trim()) {
+    // Do not search until we have at least 3 characters
+    if (debouncedSearchTerm.trim().length < 3) {
       setSearchResults(null);
       return;
     }


### PR DESCRIPTION
Fixes #3326
Fixes #3327 

Removes the low search limit of 20 and replaces with a large upper bound of 1000. Eventually we should have some form of pagination for the SourceList + search to guard against an extremely pathological case, but 1000 should cover almost all SecureDrop use cases.

Also moves the result aggregation by source into the SQL query so that the page size limit also corresponds to the number of results returned, and also improves efficiency. 

Updates search UI to only begin querying after 3 characters.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

- Type one or two characters into search box: no filtering should occur
- After 3+ characters, results should begin to filter 
- Searching for a string with >20 results should show 20+ results (ex: string `this` if using `loaddata.py` with ~50+ sources)

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
