### PR TITLE
Encode json_each() pattern into the type level

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -34,6 +34,7 @@ import {
 } from "../../types";
 import { Crypto } from "../crypto";
 import { Search } from "./search";
+import { JsonArray, jsonArray } from "./utils";
 
 // Truncate message previews to 200 Unicode code points
 // at the database layer; CSS will handle the rest
@@ -115,7 +116,7 @@ export class DB {
     void
   >;
   private deleteItem: Statement<{ uuid: string }, void>;
-  private deleteItemMany: Statement<{ uuids_json: string }, void>;
+  private deleteItemMany: Statement<{ uuids_json: JsonArray<string> }, void>;
   private updateItemFetchStatus: Statement<{
     uuid: string;
     fetch_status: number;
@@ -134,7 +135,7 @@ export class DB {
     fetch_status: number;
   }>;
   private selectItem: Statement<{ uuid: string }, ItemRow>;
-  private selectItemMany: Statement<{ uuids_json: string }, ItemRow>;
+  private selectItemMany: Statement<{ uuids_json: JsonArray<string> }, ItemRow>;
 
   private selectAllJournalistVersion: Statement<
     [],
@@ -565,7 +566,7 @@ export class DB {
       const deletedItems: Item[] = [];
       for (let i = 0; i < items.length; i += DELETE_BATCH_SIZE) {
         const batch = items.slice(i, i + DELETE_BATCH_SIZE);
-        const uuids_json = JSON.stringify(batch);
+        const uuids_json = jsonArray(batch);
         // Batch fetch before delete so callers can act on deleted items
         const rows = this.selectItemMany.all({ uuids_json }) as ItemRow[];
         rows.forEach((row) => {

--- a/app/src/main/database/search.ts
+++ b/app/src/main/database/search.ts
@@ -1,5 +1,6 @@
 import Database, { Statement } from "better-sqlite3";
 import { SearchResult } from "../../types";
+import { JsonArray } from "./utils";
 
 type SearchRow = {
   source_uuid: string;
@@ -79,7 +80,10 @@ export class Search {
 
   private searchStmt: Statement<[string, number, number], SearchRow>;
   private deleteByItemStmt: Statement<[string], void>;
-  private deleteItemManyStmt: Statement<{ uuids_json: string }, void>;
+  private deleteItemManyStmt: Statement<
+    { uuids_json: JsonArray<string> },
+    void
+  >;
   private deleteBySourceStmt: Statement<[string], void>;
   private upsertItemStmt: Statement<
     {
@@ -221,10 +225,8 @@ export class Search {
     this.deleteByItemStmt.run(itemUuid);
   }
 
-  removeItemMany(uuidsJSON: string): void {
-    this.deleteItemManyStmt.run({
-      uuids_json: uuidsJSON,
-    });
+  removeItemMany(uuids: JsonArray<string>): void {
+    this.deleteItemManyStmt.run({ uuids_json: uuids });
   }
 
   close(): void {

--- a/app/src/main/database/utils.ts
+++ b/app/src/main/database/utils.ts
@@ -1,0 +1,7 @@
+// Branded string that carries the element type at compile time.
+// At runtime this is a plain string, so better-sqlite3 sees no difference.
+export type JsonArray<T> = string & { readonly __jsonArray: T[] };
+
+export function jsonArray<T>(values: T[]): JsonArray<T> {
+  return JSON.stringify(values) as JsonArray<T>;
+}


### PR DESCRIPTION
To pass in lists of parameters into queries, we serialize them as JSON and then have SQLite unpack those lists. Because this takes a string, there was no type safety in that what we were passing was valid JSON, an array, etc.

This introduces a JsonArray type and a jsonArray() creation function which allows enforcing that we're passing in an encoded array, it is JSON, and what the inner type is (currently just strings).

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] CI passes, which esp. verifies `pnpm typecheck` is happy
* [ ] API is usable and understandable
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
