### PR TITLE
[inbox] flush all pending_events on sync + move authToken to main proc

### DIFF
--- a/app/src/main/index.test.ts
+++ b/app/src/main/index.test.ts
@@ -164,6 +164,32 @@ function getSyncMetadataHandler() {
   return handler as (_event: unknown, request: unknown) => Promise<SyncStatus>;
 }
 
+async function loginWithToken(token: string) {
+  testState.proxyJSONRequest.mockResolvedValueOnce({
+    status: 200,
+    error: false,
+    data: {
+      token,
+      expiration: "2025-07-16T19:25:44.388054+00:00",
+      journalist_uuid: "7f19192d-c8e3-4518-9d4a-26cb39bc8662",
+      journalist_first_name: null,
+      journalist_last_name: null,
+      hints: { version: "abc123", sources: 0, items: 0 },
+    },
+    headers: {},
+  });
+  const loginHandler = testState.registeredHandlers.get("login");
+  expect(loginHandler).toBeDefined();
+  await loginHandler!(
+    {},
+    {
+      username: "user",
+      passphrase: "passphrase",
+      oneTimeCode: "123456",
+    },
+  );
+}
+
 describe("syncMetadata IPC handler", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -207,14 +233,10 @@ describe("syncMetadata IPC handler", () => {
 
   it("re-wakes the fetch worker when sync returns NOT_MODIFIED", async () => {
     await loadMainProcessModule();
+    await loginWithToken("resume-token");
 
     const handler = getSyncMetadataHandler();
-    const request = {
-      authToken: "resume-token",
-      hintedVersion: undefined,
-    };
-
-    const status = await handler({}, request);
+    const status = await handler({}, { hintedVersion: undefined });
 
     expect(status).toBe(SyncStatus.NOT_MODIFIED);
     expect(testState.syncModule.shouldSkipSync).toHaveBeenCalledTimes(1);
@@ -229,14 +251,10 @@ describe("syncMetadata IPC handler", () => {
     testState.syncModule.shouldSkipSync.mockReturnValue(true);
 
     await loadMainProcessModule();
+    await loginWithToken("skip-token");
 
     const handler = getSyncMetadataHandler();
-    const request = {
-      authToken: "skip-token",
-      hintedVersion: "v1",
-    };
-
-    const status = await handler({}, request);
+    const status = await handler({}, { hintedVersion: "v1" });
 
     expect(status).toBe(SyncStatus.NOT_MODIFIED);
     expect(testState.syncModule.shouldSkipSync).toHaveBeenCalledTimes(1);

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -20,12 +20,13 @@ import { Datastore } from "./datastore";
 import { Crypto, CryptoConfig } from "./crypto";
 import { proxyJSONRequest } from "./proxy";
 import {
-  type ProxyRequest,
-  type ProxyResponse,
   type Source,
   type SourceWithItems,
   type Journalist,
   type AuthedRequest,
+  type SyncRequest,
+  type LoginCredentials,
+  type LoginResult,
   type Item,
   type DeviceStatus,
   type SearchResult,
@@ -36,6 +37,7 @@ import {
   PendingEventData,
   type ms,
 } from "../types";
+import { TokenResponseSchema, API_MINOR_VERSION } from "../schemas";
 import { syncMetadata, shouldSkipSync } from "./sync";
 import workerPath from "./fetch/worker?modulePath";
 import { Lock, LockTimeoutError } from "./sync/lock";
@@ -254,9 +256,11 @@ if (!gotTheLock) {
   }
 
   let fetchWorker: Worker | null = null;
+  let authToken: string | null = null;
+  let syncLoopTimer: NodeJS.Timeout | null = null;
 
-  function wakeFetchWorkerIfNeeded(authToken: string): void {
-    if (!fetchWorker) {
+  function wakeFetchWorkerIfNeeded(): void {
+    if (!fetchWorker || !authToken) {
       return;
     }
 
@@ -344,17 +348,63 @@ if (!gotTheLock) {
         return app.getVersion();
       });
 
-      // TODO: Remove this generic IPC and instead replace it with a dedicated login one
-      // since that's the only thing that uses it
       ipcMain.handle(
-        "request",
-        async (_event, request: ProxyRequest): Promise<ProxyResponse> => {
-          const result = await proxyJSONRequest(
-            request,
-            undefined,
-            30_000 as ms,
-          );
-          return result;
+        "login",
+        async (_event, credentials: LoginCredentials): Promise<LoginResult> => {
+          // Clear authToken on new login attempt
+          authToken = null;
+          try {
+            const result = await proxyJSONRequest(
+              {
+                method: "POST",
+                path_query: "/api/v1/token",
+                stream: false,
+                body: JSON.stringify({
+                  username: credentials.username,
+                  passphrase: credentials.passphrase,
+                  one_time_code: credentials.oneTimeCode,
+                }),
+                headers: { Prefer: `securedrop=${API_MINOR_VERSION}` },
+              },
+              undefined,
+              30_000 as ms,
+            );
+            if (result.status === 403) {
+              return { success: false, errorType: "credentials" };
+            }
+            // TODO: use a dedicated error message here that exposes the code
+            if (result.status !== 200 || !result.data) {
+              console.error(
+                `Authentication failed with HTTP status ${result.status}`,
+                result.data,
+              );
+              return { success: false, errorType: "generic" };
+            }
+
+            const resp = TokenResponseSchema.safeParse(result.data);
+            if (!resp.success) {
+              return { success: false, errorType: "generic" };
+            }
+            authToken = resp.data.token;
+
+            // Initiate sync loop
+            if (import.meta.env.MODE != "test") {
+              void runSyncLoop({});
+            }
+
+            return {
+              success: true,
+              expiration: resp.data.expiration,
+              journalistUUID: resp.data.journalist_uuid,
+              journalistFirstName: resp.data.journalist_first_name,
+              journalistLastName: resp.data.journalist_last_name,
+              lastHintedVersion: resp.data.hints.version,
+              lastHintedSources: resp.data.hints.sources,
+              lastHintedItems: resp.data.hints.items,
+            };
+          } catch {
+            return { success: false, errorType: "network" };
+          }
         },
       );
 
@@ -403,12 +453,7 @@ if (!gotTheLock) {
 
       ipcMain.handle(
         "updateFetchStatus",
-        async (
-          _event,
-          itemUuid: string,
-          fetchStatus: number,
-          authToken: string,
-        ) => {
+        async (_event, itemUuid: string, fetchStatus: number) => {
           // If the user is pausing or cancelling, abort any in-progress download
           // before updating the DB so the worker doesn't overwrite the new status
           if (
@@ -418,35 +463,14 @@ if (!gotTheLock) {
             fetchWorker?.postMessage({ type: "cancel", itemId: itemUuid });
           }
           db.updateFetchStatus(itemUuid, fetchStatus);
-          fetchWorker?.postMessage({
-            authToken: authToken,
-          } as AuthedRequest);
+          wakeFetchWorkerIfNeeded();
         },
       );
 
       ipcMain.handle(
         "syncMetadata",
-        async (_event, request: AuthedRequest): Promise<SyncStatus> => {
-          if (shouldSkipSync(db, request.hintedVersion)) {
-            console.log(`Already at ${request.hintedVersion}; skipping sync`);
-            wakeFetchWorkerIfNeeded(request.authToken);
-            return SyncStatus.NOT_MODIFIED;
-          }
-
-          let syncStatus = await syncWithLock(syncLock, db, request);
-
-          if (syncStatus === SyncStatus.UPDATED) {
-            // Check to see if there are still pending events
-            // If so, attempt a second sync. This may happen
-            // when there are multiple events per source
-            if (db.getPendingEvents().length > 0) {
-              syncStatus = await syncWithLock(syncLock, db, request);
-            }
-          }
-
-          wakeFetchWorkerIfNeeded(request.authToken);
-
-          return syncStatus;
+        async (_event, request: SyncRequest): Promise<SyncStatus> => {
+          return runSyncLoop(request);
         },
       );
 
@@ -753,6 +777,65 @@ if (!gotTheLock) {
       const mainWindow = createWindow();
 
       fetchWorker = spawnFetchWorker(mainWindow);
+
+      function scheduleNextSync(): void {
+        if (syncLoopTimer) {
+          clearTimeout(syncLoopTimer);
+        }
+        // Short-circuit loops on test
+        if (import.meta.env.MODE === "test") {
+          return;
+        }
+
+        syncLoopTimer = setTimeout(() => {
+          if (authToken) {
+            void runSyncLoop({});
+          }
+        }, 1000 * 60);
+      }
+
+      // Checks if sync is necessary, and then continually sync with the
+      // server until all pending events are flushed. Schedules the next sync
+      // after sync interval on completion.
+      async function runSyncLoop(request: SyncRequest): Promise<SyncStatus> {
+        try {
+          if (!authToken) {
+            return SyncStatus.FORBIDDEN;
+          }
+          if (shouldSkipSync(db, request.hintedVersion)) {
+            console.log(`Already at ${request.hintedVersion}; skipping sync`);
+            wakeFetchWorkerIfNeeded();
+            return SyncStatus.NOT_MODIFIED;
+          }
+
+          // Clear timer to unschedule syncs until this loop is complete
+          if (syncLoopTimer) {
+            clearTimeout(syncLoopTimer);
+          }
+
+          // Keep syncing while there are still pending events to flush
+          const authedRequest: AuthedRequest = { authToken, ...request };
+          let syncStatus = SyncStatus.NOT_MODIFIED;
+          do {
+            syncStatus = await syncWithLock(syncLock, db, authedRequest);
+            // Update renderer on each sync cycle completion
+            if (!mainWindow.isDestroyed()) {
+              mainWindow.webContents.send("sync-complete", syncStatus);
+            }
+            wakeFetchWorkerIfNeeded();
+          } while (
+            syncStatus === SyncStatus.UPDATED &&
+            db.getPendingEvents().length > 0
+          );
+          // If we receive an auth error from sync, reset the auth token
+          if (syncStatus === SyncStatus.FORBIDDEN) {
+            authToken = null;
+          }
+          return syncStatus;
+        } finally {
+          scheduleNextSync();
+        }
+      }
     })
     .catch((error) => {
       console.error("Unhandled error during app startup:", error);

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -2,13 +2,13 @@
 // https://www.electronjs.org/docs/latest/tutorial/process-model#preload-scripts
 import { contextBridge, ipcRenderer } from "electron";
 import {
-  type ProxyJSONResponse,
-  type ProxyRequest,
   type ProxyResponse,
   type Source,
   type SourceWithItems,
   type Journalist,
-  type AuthedRequest,
+  type SyncRequest,
+  type LoginCredentials,
+  type LoginResult,
   type SearchResult,
   type FirstRunStatus,
   Item,
@@ -16,6 +16,7 @@ import {
   SyncStatus,
   DeviceStatus,
   PendingEventData,
+  ProxyRequest,
 } from "../types";
 
 // Log the performance of IPC calls
@@ -44,22 +45,21 @@ const electronAPI = {
     ipcRenderer.invoke("getAppVersion"),
   ),
   quitApp: logIpcCall<string>("quitApp", () => ipcRenderer.invoke("quitApp")),
-  request: logIpcCall<ProxyJSONResponse>("request", (request: ProxyRequest) =>
-    ipcRenderer.invoke("request", request),
+  login: logIpcCall<LoginResult>("login", (credentials: LoginCredentials) =>
+    ipcRenderer.invoke("login", credentials),
   ),
   requestStream: logIpcCall<ProxyResponse>(
     "requestStream",
     (request: ProxyRequest, downloadPath: string) =>
       ipcRenderer.invoke("requestStream", request, downloadPath),
   ),
-  syncMetadata: logIpcCall<SyncStatus>(
-    "syncMetadata",
-    (request: AuthedRequest) => ipcRenderer.invoke("syncMetadata", request),
+  syncMetadata: logIpcCall<SyncStatus>("syncMetadata", (request: SyncRequest) =>
+    ipcRenderer.invoke("syncMetadata", request),
   ),
   updateFetchStatus: logIpcCall(
     "updateFetchStatus",
-    (itemUuid: string, fetchStatus: number, authToken: string) =>
-      ipcRenderer.invoke("updateFetchStatus", itemUuid, fetchStatus, authToken),
+    (itemUuid: string, fetchStatus: number) =>
+      ipcRenderer.invoke("updateFetchStatus", itemUuid, fetchStatus),
   ),
   getSources: logIpcCall<Source[]>("getSources", () =>
     ipcRenderer.invoke("getSources"),
@@ -136,6 +136,12 @@ const electronAPI = {
       callback(source);
     ipcRenderer.on("source-update", listener);
     return () => ipcRenderer.removeListener("source-update", listener);
+  },
+  onSyncComplete: (callback: (status: SyncStatus) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, status: SyncStatus) =>
+      callback(status);
+    ipcRenderer.on("sync-complete", listener);
+    return () => ipcRenderer.removeListener("sync-complete", listener);
   },
   onQuitRequested: (callback: () => void) => {
     const listener = () => callback();

--- a/app/src/renderer/features/conversation/conversationSlice.ts
+++ b/app/src/renderer/features/conversation/conversationSlice.ts
@@ -95,18 +95,12 @@ export const updateItemFetchStatus = createAsyncThunk(
   async ({
     itemUuid,
     fetchStatus,
-    authToken,
   }: {
     sourceUuid: string;
     itemUuid: string;
     fetchStatus: number;
-    authToken: string | undefined;
   }) => {
-    await window.electronAPI.updateFetchStatus(
-      itemUuid,
-      fetchStatus,
-      authToken,
-    );
+    await window.electronAPI.updateFetchStatus(itemUuid, fetchStatus);
     const item = await window.electronAPI.getItem(itemUuid);
     return { item };
   },

--- a/app/src/renderer/features/session/sessionSlice.test.ts
+++ b/app/src/renderer/features/session/sessionSlice.test.ts
@@ -12,7 +12,6 @@ import sessionReducer, {
 describe("sessionSlice", () => {
   const mockAuthData: AuthData = {
     expiration: "2025-07-16T19:25:44.388054+00:00",
-    token: "test-token-123",
     journalistUUID: "journalist-uuid-456",
     journalistFirstName: "John",
     journalistLastName: "Doe",
@@ -60,7 +59,6 @@ describe("sessionSlice", () => {
     it("should replace existing session state", () => {
       const newAuthData: AuthData = {
         expiration: "2025-12-31T23:59:59.000000+00:00",
-        token: "new-token-789",
         journalistUUID: "new-uuid-123",
         journalistFirstName: "Jane",
         journalistLastName: "Smith",

--- a/app/src/renderer/features/session/sessionSlice.ts
+++ b/app/src/renderer/features/session/sessionSlice.ts
@@ -10,7 +10,6 @@ enum SessionStatus {
 
 interface AuthData {
   expiration: string;
-  token: string;
   journalistUUID: string;
   journalistFirstName: string | null;
   journalistLastName: string | null;

--- a/app/src/renderer/features/sync/syncSlice.test.ts
+++ b/app/src/renderer/features/sync/syncSlice.test.ts
@@ -6,10 +6,9 @@ import sourcesSlice from "../sources/sourcesSlice";
 import sessionSlice, { type AuthData } from "../session/sessionSlice";
 import conversationSlice from "../conversation/conversationSlice";
 
-function mockAuthData(token: string): AuthData {
+function mockAuthData(): AuthData {
   return {
     expiration: "",
-    token,
     journalistUUID: "550e8400-e29b-41d4-a716-446655440000",
     journalistFirstName: null,
     journalistLastName: null,
@@ -97,13 +96,11 @@ describe("syncSlice", () => {
   });
 
   describe("syncMetadata async thunk", () => {
-    it("handles successful sync with auth token", async () => {
-      const authToken = "test-auth-token";
-      const action = syncMetadata(mockAuthData(authToken));
+    it("handles successful sync", async () => {
+      const action = syncMetadata(mockAuthData());
       await (store.dispatch as any)(action);
 
       expect(mockSyncMetadata).toHaveBeenCalledWith({
-        authToken,
         hintedRecords: 0,
         hintedVersion: undefined,
       });
@@ -117,16 +114,13 @@ describe("syncSlice", () => {
       expect(syncState.lastSyncFinished).toBeGreaterThan(0);
     });
 
-    it("handles sync failure with invalid auth token", async () => {
+    it("handles sync failure", async () => {
       const errorMessage = "Authentication required";
       mockSyncMetadata.mockRejectedValue(new Error(errorMessage));
 
-      await (store.dispatch as any)(
-        syncMetadata(mockAuthData("invalid-token")),
-      );
+      await (store.dispatch as any)(syncMetadata(mockAuthData()));
 
       expect(mockSyncMetadata).toHaveBeenCalledWith({
-        authToken: "invalid-token",
         hintedRecords: 0,
         hintedVersion: undefined,
       });
@@ -142,7 +136,7 @@ describe("syncSlice", () => {
       const errorMessage = "Failed to sync metadata";
       mockSyncMetadata.mockRejectedValue(new Error(errorMessage));
 
-      const action = syncMetadata(mockAuthData("test-token"));
+      const action = syncMetadata(mockAuthData());
       await (store.dispatch as any)(action);
 
       expect(mockSyncMetadata).toHaveBeenCalledTimes(1);
@@ -158,7 +152,7 @@ describe("syncSlice", () => {
       const errorMessage = "Failed to get sources";
       mockGetSources.mockRejectedValue(new Error(errorMessage));
 
-      const action = syncMetadata(mockAuthData("test-token"));
+      const action = syncMetadata(mockAuthData());
       await (store.dispatch as any)(action);
 
       expect(mockSyncMetadata).toHaveBeenCalledTimes(1);
@@ -209,7 +203,7 @@ describe("syncSlice", () => {
         items: [],
       });
 
-      await (store.dispatch as any)(syncMetadata(mockAuthData("test-token")));
+      await (store.dispatch as any)(syncMetadata(mockAuthData()));
 
       // Should have called getSourceWithItems for the active source only
       expect(mockGetSourceWithItems).toHaveBeenCalledWith(activeSourceUuid, {
@@ -226,7 +220,7 @@ describe("syncSlice", () => {
       const mockGetSourceWithItems = vi.fn();
       (window as any).electronAPI.getSourceWithItems = mockGetSourceWithItems;
 
-      await (store.dispatch as any)(syncMetadata(mockAuthData("test-token")));
+      await (store.dispatch as any)(syncMetadata(mockAuthData()));
 
       // Should NOT have called getSourceWithItems since no active source
       expect(mockGetSourceWithItems).not.toHaveBeenCalled();
@@ -239,7 +233,7 @@ describe("syncSlice", () => {
     it("handles network timeout error during sync", async () => {
       mockSyncMetadata.mockRejectedValue(new Error("Network timeout"));
 
-      await (store.dispatch as any)(syncMetadata(mockAuthData("valid-token")));
+      await (store.dispatch as any)(syncMetadata(mockAuthData()));
 
       const syncState = (store.getState() as any).sync;
       const sourcesState = (store.getState() as any).sources;
@@ -254,7 +248,7 @@ describe("syncSlice", () => {
     it("sets ERROR status when sync thunk rejects", async () => {
       mockSyncMetadata.mockRejectedValue(new Error("items.kind is immutable"));
 
-      await (store.dispatch as any)(syncMetadata(mockAuthData("test-token")));
+      await (store.dispatch as any)(syncMetadata(mockAuthData()));
 
       const syncState = (store.getState() as any).sync;
       expect(syncState.status).toBe(SyncStatus.ERROR);
@@ -264,7 +258,7 @@ describe("syncSlice", () => {
     it("handles non-Error rejection for syncMetadata", async () => {
       mockSyncMetadata.mockRejectedValue("String error");
 
-      const action = syncMetadata(mockAuthData("test-token"));
+      const action = syncMetadata(mockAuthData());
       await (store.dispatch as any)(action);
 
       const syncState = (store.getState() as any).sync;
@@ -274,7 +268,7 @@ describe("syncSlice", () => {
     it("skips source fetch on no-update sync", async () => {
       mockSyncMetadata.mockResolvedValue(SyncStatus.NOT_MODIFIED);
 
-      await (store.dispatch as any)(syncMetadata(mockAuthData("test-token")));
+      await (store.dispatch as any)(syncMetadata(mockAuthData()));
 
       // Should NOT have called getSourceWithItems
       expect(mockGetSources).not.toHaveBeenCalled();
@@ -283,15 +277,12 @@ describe("syncSlice", () => {
     it("handles 403 forbidden response", async () => {
       mockSyncMetadata.mockResolvedValue(SyncStatus.FORBIDDEN);
 
-      await (store.dispatch as any)(
-        syncMetadata(mockAuthData("invalid-token")),
-      );
+      await (store.dispatch as any)(syncMetadata(mockAuthData()));
 
       const syncState = (store.getState() as any).sync;
       expect(syncState.status).toBe(SyncStatus.FORBIDDEN);
       expect(syncState.error).toBeNull();
       expect(mockSyncMetadata).toHaveBeenCalledWith({
-        authToken: "invalid-token",
         hintedRecords: 0,
         hintedVersion: undefined,
       });
@@ -301,7 +292,7 @@ describe("syncSlice", () => {
     it("stores sync status when sync is successful", async () => {
       mockSyncMetadata.mockResolvedValue(SyncStatus.UPDATED);
 
-      await (store.dispatch as any)(syncMetadata(mockAuthData("test-token")));
+      await (store.dispatch as any)(syncMetadata(mockAuthData()));
 
       const syncState = (store.getState() as any).sync;
       expect(syncState.status).toBe(SyncStatus.UPDATED);
@@ -311,7 +302,7 @@ describe("syncSlice", () => {
     it("stores NOT_MODIFIED status when no changes", async () => {
       mockSyncMetadata.mockResolvedValue(SyncStatus.NOT_MODIFIED);
 
-      await (store.dispatch as any)(syncMetadata(mockAuthData("test-token")));
+      await (store.dispatch as any)(syncMetadata(mockAuthData()));
 
       const syncState = (store.getState() as any).sync;
       expect(syncState.status).toBe(SyncStatus.NOT_MODIFIED);
@@ -320,7 +311,7 @@ describe("syncSlice", () => {
 
     it("passes hintedVersion on first sync after login", async () => {
       const authData = {
-        ...mockAuthData("test-token"),
+        ...mockAuthData(),
         lastHintedVersion: "abc123",
         lastHintedSources: 5,
         lastHintedItems: 10,
@@ -332,7 +323,6 @@ describe("syncSlice", () => {
       await (store.dispatch as any)(syncMetadata(authData));
 
       expect(mockSyncMetadata).toHaveBeenCalledWith({
-        authToken: "test-token",
         hintedRecords: 15,
         hintedVersion: "abc123",
       });
@@ -343,7 +333,7 @@ describe("syncSlice", () => {
 
     it("omits hintedVersion on subsequent syncs", async () => {
       const authData = {
-        ...mockAuthData("test-token"),
+        ...mockAuthData(),
         lastHintedVersion: "abc123",
         lastHintedSources: 5,
         lastHintedItems: 10,
@@ -360,17 +350,15 @@ describe("syncSlice", () => {
       // Second sync — lastSyncStarted is now set, so hintedVersion is omitted
       await (store.dispatch as any)(syncMetadata(authData));
       expect(mockSyncMetadata).toHaveBeenCalledWith({
-        authToken: "test-token",
         hintedRecords: 15,
         hintedVersion: undefined,
       });
     });
 
     it("omits hintedVersion when authData has no lastHintedVersion", async () => {
-      await (store.dispatch as any)(syncMetadata(mockAuthData("test-token")));
+      await (store.dispatch as any)(syncMetadata(mockAuthData()));
 
       expect(mockSyncMetadata).toHaveBeenCalledWith({
-        authToken: "test-token",
         hintedRecords: 0,
         hintedVersion: undefined,
       });

--- a/app/src/renderer/features/sync/syncSlice.ts
+++ b/app/src/renderer/features/sync/syncSlice.ts
@@ -21,7 +21,23 @@ const initialState: SyncState = {
   status: null,
 };
 
-// Async thunk for syncing metadata (sources, journalists, and active conversation)
+// Async thunk called when the main process background sync loop completes a sync
+export const syncComplete = createAsyncThunk(
+  "sync/syncComplete",
+  async (status: SyncStatus, { getState, dispatch }) => {
+    if (status === SyncStatus.UPDATED) {
+      dispatch(fetchSources());
+      dispatch(fetchJournalists());
+      const state = getState() as RootState;
+      if (state.sources.activeSourceUuid) {
+        dispatch(fetchConversation(state.sources.activeSourceUuid));
+      }
+    }
+    return status;
+  },
+);
+
+// Async thunk for manually syncing metadata (sources, journalists, and active conversation)
 export const syncMetadata = createAsyncThunk(
   "sync/syncMetadata",
   async (authData: AuthData, { getState, dispatch }) => {
@@ -39,24 +55,17 @@ export const syncMetadata = createAsyncThunk(
 
     // Sync metadata with the server
     const status: SyncStatus = await window.electronAPI.syncMetadata({
-      authToken: authData.token,
       hintedRecords,
       hintedVersion,
     });
 
     // If there are updates from sync, fetch downstream state
     if (status === SyncStatus.UPDATED) {
-      // Fetch updated sources
       dispatch(fetchSources());
-
-      // Fetch updated journalists
       dispatch(fetchJournalists());
 
-      // Get the active source from Redux state
       const state = getState() as RootState;
       const activeSourceUuid = state.sources.activeSourceUuid;
-
-      // If there's an active source, fetch its conversation
       if (activeSourceUuid) {
         dispatch(fetchConversation(activeSourceUuid));
       }
@@ -83,6 +92,11 @@ export const syncSlice = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(setUnauth, () => initialState)
+      .addCase(syncComplete.fulfilled, (state, action) => {
+        state.lastSyncStarted = state.lastSyncStarted ?? Date.now();
+        state.lastSyncFinished = Date.now();
+        state.status = action.payload;
+      })
       .addCase(syncMetadata.fulfilled, (state, action) => {
         state.lastSyncFinished = Date.now();
         state.status = action.payload;

--- a/app/src/renderer/test-component-setup.tsx
+++ b/app/src/renderer/test-component-setup.tsx
@@ -98,7 +98,7 @@ afterEach(() => {
 beforeEach(() => {
   // Mock the electronAPI before each test
   (window as any).electronAPI = {
-    request: vi.fn().mockResolvedValue({ data: "test" }),
+    login: vi.fn().mockRejectedValue(new Error("mock not implemented")),
     requestStream: vi.fn().mockResolvedValue({ sha256sum: "abc" }),
     getSystemLanguage: vi.fn().mockResolvedValue("en"),
     getCSPNonce: vi.fn().mockResolvedValue("nonce"),
@@ -109,6 +109,7 @@ beforeEach(() => {
       .mockRejectedValue(new Error("mock not implemented")),
     onItemUpdate: vi.fn().mockReturnValue(() => {}),
     onSourceUpdate: vi.fn().mockReturnValue(() => {}),
+    onSyncComplete: vi.fn().mockReturnValue(() => {}),
     onQuitRequested: vi.fn().mockReturnValue(() => {}),
     getItem: vi.fn().mockRejectedValue(new Error("mock not implemented")),
     getSources: vi.fn().mockResolvedValue([

--- a/app/src/renderer/views/Inbox.tsx
+++ b/app/src/renderer/views/Inbox.tsx
@@ -6,6 +6,7 @@ import type { AppDispatch } from "../store";
 import { fetchJournalists } from "../features/journalists/journalistsSlice";
 import {
   syncMetadata,
+  syncComplete,
   selectSyncStatus,
   clearStatus,
 } from "../features/sync/syncSlice";
@@ -64,20 +65,6 @@ function InboxView() {
     }, [session.authData, dispatch, navigate]),
   });
 
-  // Trigger sync in the background every minute
-  useEffect(() => {
-    // Trigger immediately
-    sync();
-    const syncInterval = setInterval(() => {
-      sync();
-    }, 1000 * 60);
-
-    // Clean up interval
-    return () => {
-      clearInterval(syncInterval);
-    };
-  }, [sync]);
-
   // Handle 403 Forbidden errors from sync
   useEffect(() => {
     if (syncStatus === SyncStatus.FORBIDDEN) {
@@ -100,9 +87,15 @@ function InboxView() {
         dispatch(updateSource(source));
       },
     );
+    const unsubscribeSync = window.electronAPI.onSyncComplete(
+      (status: SyncStatus) => {
+        dispatch(syncComplete(status));
+      },
+    );
     return () => {
       unsubscribeItem();
       unsubscribeSource();
+      unsubscribeSync();
     };
   }, [dispatch]);
 

--- a/app/src/renderer/views/Inbox/MainContent/Conversation.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation.test.tsx
@@ -518,7 +518,6 @@ describe("Conversation new message indicator", () => {
             status: SessionStatus.Auth,
             authData: {
               expiration: "2025-01-01T00:00:00Z",
-              token: "token",
               journalistUUID: "journalist-1",
               journalistFirstName: "Test",
               journalistLastName: "User",

--- a/app/src/renderer/views/Inbox/MainContent/Conversation.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation.tsx
@@ -186,11 +186,10 @@ const Conversation = memo(function Conversation({
 
   // Keyboard shortcut: Ctrl+D initiates download for all files
   const downloadAllFiles = useCallback(() => {
-    if (!sourceWithItems || !session.authData?.token) {
+    if (!sourceWithItems || !session.authData) {
       return;
     }
 
-    const token = session.authData.token;
     sourceWithItems.items.forEach((item) => {
       if (
         item.data.kind === "file" &&
@@ -202,7 +201,6 @@ const Conversation = memo(function Conversation({
             sourceUuid: sourceWithItems.uuid,
             itemUuid: item.uuid,
             fetchStatus: FetchStatus.DownloadInProgress,
-            authToken: token,
           }),
         );
       }

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item.tsx
@@ -7,7 +7,7 @@ import "./Item.css";
 import Message from "./Item/Message";
 import Reply from "./Item/Reply";
 import File from "./Item/File";
-import { useAppDispatch, useAppSelector } from "../../../../hooks";
+import { useAppDispatch } from "../../../../hooks";
 import { updateItemFetchStatus } from "../../../../features/conversation/conversationSlice";
 
 import { memo, useCallback } from "react";
@@ -19,7 +19,6 @@ interface ItemProps {
 
 const Item = memo(function ItemComponent({ item, designation }: ItemProps) {
   const dispatch = useAppDispatch();
-  const session = useAppSelector((state) => state.session);
 
   const onFetchStatusUpdate = useCallback(
     async (update: ItemUpdate) => {
@@ -29,12 +28,11 @@ const Item = memo(function ItemComponent({ item, designation }: ItemProps) {
             sourceUuid: item.data.source ?? "",
             itemUuid: update.item_uuid,
             fetchStatus: update.fetch_status!,
-            authToken: session.authData?.token,
           }),
         );
       }
     },
-    [dispatch, item.data.source, session.authData?.token],
+    [dispatch, item.data.source],
   );
 
   const kind = item.data.kind;

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Reply.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Reply.test.tsx
@@ -168,7 +168,6 @@ describe("Reply", () => {
         status: SessionStatus.Auth,
         authData: {
           expiration: "2025-07-16T19:25:44.388054+00:00",
-          token: "test-token-123",
           journalistUUID: "journalist-1", // Current user is journalist-1
           journalistFirstName: "Daniel",
           journalistLastName: "Ellsberg",
@@ -214,7 +213,6 @@ describe("Reply", () => {
           status: SessionStatus.Auth,
           authData: {
             expiration: "2025-07-16T19:25:44.388054+00:00",
-            token: "test-token-123",
             journalistUUID: "journalist-2", // Current user is journalist-2
             journalistFirstName: "",
             journalistLastName: "",
@@ -283,7 +281,6 @@ describe("Reply", () => {
           status: SessionStatus.Auth,
           authData: {
             expiration: "2025-07-16T19:25:44.388054+00:00",
-            token: "test-token-123",
             journalistUUID: "journalist-1", // Same as the reply author
             journalistFirstName: "Daniel",
             journalistLastName: "Ellsberg",
@@ -310,7 +307,6 @@ describe("Reply", () => {
           status: SessionStatus.Auth,
           authData: {
             expiration: "2025-07-16T19:25:44.388054+00:00",
-            token: "test-token-123",
             journalistUUID: "journalist-1", // Same as reply author
             journalistFirstName: "Daniel",
             journalistLastName: "Ellsberg",
@@ -337,7 +333,6 @@ describe("Reply", () => {
           status: SessionStatus.Auth,
           authData: {
             expiration: "2025-07-16T19:25:44.388054+00:00",
-            token: "test-token-123",
             journalistUUID: "journalist-2", // Different from reply author
             journalistFirstName: "Current",
             journalistLastName: "User",
@@ -383,7 +378,6 @@ describe("Reply", () => {
             status: SessionStatus.Auth,
             authData: {
               expiration: "2025-07-16T19:25:44.388054+00:00",
-              token: "test-token-123",
               journalistUUID: "journalist-1",
               journalistFirstName: "Daniel",
               journalistLastName: "Ellsberg",
@@ -410,7 +404,6 @@ describe("Reply", () => {
             status: SessionStatus.Auth,
             authData: {
               expiration: "2025-07-16T19:25:44.388054+00:00",
-              token: "test-token-123",
               journalistUUID: "journalist-99", // Not in journalists list
               journalistFirstName: "New",
               journalistLastName: "User",
@@ -437,7 +430,6 @@ describe("Reply", () => {
             status: SessionStatus.Auth,
             authData: {
               expiration: "2025-07-16T19:25:44.388054+00:00",
-              token: "test-token-123",
               journalistUUID: "journalist-2", // This journalist has no first/last name
               journalistFirstName: "",
               journalistLastName: "",
@@ -464,7 +456,6 @@ describe("Reply", () => {
             status: SessionStatus.Auth,
             authData: {
               expiration: "2025-07-16T19:25:44.388054+00:00",
-              token: "test-token-123",
               journalistUUID: "journalist-99",
               journalistFirstName: "John",
               journalistLastName: "",
@@ -539,7 +530,6 @@ describe("Reply", () => {
         status: SessionStatus.Auth,
         authData: {
           expiration: "2025-07-16T19:25:44.388054+00:00",
-          token: "test-token-123",
           journalistUUID: "journalist-1",
           journalistFirstName: "Daniel",
           journalistLastName: "Ellsberg",
@@ -596,7 +586,6 @@ describe("Reply", () => {
         status: SessionStatus.Auth,
         authData: {
           expiration: "2025-07-16T19:25:44.388054+00:00",
-          token: "test-token-123",
           journalistUUID: "journalist-1",
           journalistFirstName: "Daniel",
           journalistLastName: "Ellsberg",
@@ -686,7 +675,6 @@ describe("Reply", () => {
         status: SessionStatus.Auth,
         authData: {
           expiration: "2025-07-16T19:25:44.388054+00:00",
-          token: "test-token-123",
           journalistUUID: "journalist-1",
           journalistFirstName: "Daniel",
           journalistLastName: "Ellsberg",

--- a/app/src/renderer/views/Inbox/Sidebar/Account/MainMenu.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/Account/MainMenu.test.tsx
@@ -124,7 +124,6 @@ describe("Journalist Menu Component", () => {
         status: SessionStatus.Auth,
         authData: {
           expiration: "2037-07-16T19:25:44.388054+00:00",
-          token: "test-token-123",
           journalistUUID: "journalist-1",
           journalistFirstName: "Daniel",
           journalistLastName: "Ellsberg",

--- a/app/src/renderer/views/SignIn.test.tsx
+++ b/app/src/renderer/views/SignIn.test.tsx
@@ -121,10 +121,11 @@ describe("SignInView Component", () => {
   // Server-side validations
 
   it("fails when server is unreachable", async () => {
-    // Mock window.electronAPI.request to throw an error
-    (window as any).electronAPI.request.mockRejectedValue(
-      new Error("Network error"),
-    );
+    // Mock window.electronAPI.login to return a network error
+    (window as any).electronAPI.login.mockResolvedValue({
+      success: false,
+      errorType: "network",
+    });
 
     renderWithProviders(<SignInView />);
 
@@ -150,21 +151,10 @@ describe("SignInView Component", () => {
   });
 
   it("fails when credentials are invalid", async () => {
-    // Mock window.electronAPI.request to return invalid credentials error
-    (window as any).electronAPI.request.mockResolvedValue({
-      error: true,
-      data: {
-        error: "Forbidden",
-        message: "Token authentication failed.",
-      },
-      status: 403,
-      headers: {
-        "content-length": "73",
-        server: "Werkzeug/2.2.3 Python/3.12.3",
-        connection: "close",
-        "content-type": "application/json",
-        date: "Wed, 16 Jul 2025 17:23:30 GMT",
-      },
+    // Mock window.electronAPI.login to return a credentials error
+    (window as any).electronAPI.login.mockResolvedValue({
+      success: false,
+      errorType: "credentials",
     });
 
     renderWithProviders(<SignInView />);
@@ -191,31 +181,17 @@ describe("SignInView Component", () => {
   });
 
   it("redirects to inbox on success", async () => {
-    // Mock window.electronAPI.request to return success
-    (window as any).electronAPI.request.mockResolvedValue({
-      error: false,
-      data: {
-        expiration: "2025-07-16T19:25:44.388054+00:00",
-        journalist_first_name: null,
-        journalist_last_name: null,
-        journalist_uuid: "7f19192d-c8e3-4518-9d4a-26cb39bc8662",
-        token:
-          "IlNrR0lza1M1TDd6TC1HbVBOTEFlQ1YwSHkxNkplX00wbEN1amlCZ2wtTVEi.aHfglw.XM077FlEYyESuwl_JLeMqPSZsyg",
-        hints: {
-          version:
-            "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
-          sources: 3,
-          items: 10,
-        },
-      },
-      status: 200,
-      headers: {
-        "content-length": "295",
-        date: "Wed, 16 Jul 2025 17:25:44 GMT",
-        connection: "close",
-        server: "Werkzeug/2.2.3 Python/3.12.3",
-        "content-type": "application/json",
-      },
+    // Mock window.electronAPI.login to return success
+    (window as any).electronAPI.login.mockResolvedValue({
+      success: true,
+      expiration: "2025-07-16T19:25:44.388054+00:00",
+      journalistFirstName: null,
+      journalistLastName: null,
+      journalistUUID: "7f19192d-c8e3-4518-9d4a-26cb39bc8662",
+      lastHintedVersion:
+        "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+      lastHintedSources: 3,
+      lastHintedItems: 10,
     });
 
     let currentLocation: any;

--- a/app/src/renderer/views/SignIn.tsx
+++ b/app/src/renderer/views/SignIn.tsx
@@ -6,8 +6,6 @@ import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 
-import type { ProxyRequest } from "../../types";
-import { API_MINOR_VERSION, TokenResponseSchema } from "../../schemas";
 import { useAppDispatch, useAppSelector } from "../hooks";
 import {
   setAuth,
@@ -80,61 +78,36 @@ function SignInView() {
 
     // Authenticate to the API
     try {
-      const res = await window.electronAPI.request({
-        method: "POST",
-        path_query: "/api/v1/token",
-        stream: false,
-        body: JSON.stringify({
-          username: values.username,
-          passphrase: values.passphrase,
-          one_time_code: values.oneTimeCode,
-        }),
-        headers: {
-          Prefer: `securedrop=${API_MINOR_VERSION}`,
-        },
-      } as ProxyRequest);
+      const result = await window.electronAPI.login({
+        username: values.username,
+        passphrase: values.passphrase,
+        oneTimeCode: values.oneTimeCode,
+      });
 
-      // If the credentials were rejected, fail
-      if (res.status == 403) {
-        console.error("Authentication failed:", res.data);
-        setAuthErrorMessage(errorMessageCredentials);
-        setAuthError(true);
-        return;
-      }
-
-      // If it's a non-200 status code, fail too
-      // TODO: use a dedicated error message here that exposes the code
-      if (res.status != 200) {
-        console.error(
-          `Authentication failed with HTTP status ${res.status}`,
-          res.data,
-        );
-        setAuthErrorMessage(errorMessageGeneric);
-        setAuthError(true);
-        return;
-      }
-
-      if (!res.data) {
-        console.error("Authentication failed: no data received");
-        setAuthErrorMessage(errorMessageGeneric);
+      if (!result.success) {
+        console.error("Authentication failed:", result.errorType);
+        if (result.errorType === "credentials") {
+          setAuthErrorMessage(errorMessageCredentials);
+        } else if (result.errorType === "network") {
+          setAuthErrorMessage(errorMessageNetwork);
+        } else {
+          setAuthErrorMessage(errorMessageGeneric);
+        }
         setAuthError(true);
         return;
       }
 
       try {
-        const resp = TokenResponseSchema.parse(res.data);
-
         // Update the session state
         dispatch(
           setAuth({
-            expiration: resp.expiration,
-            token: resp.token,
-            journalistUUID: resp.journalist_uuid,
-            journalistFirstName: resp.journalist_first_name,
-            journalistLastName: resp.journalist_last_name,
-            lastHintedVersion: resp.hints.version,
-            lastHintedSources: resp.hints.sources,
-            lastHintedItems: resp.hints.items,
+            expiration: result.expiration,
+            journalistUUID: result.journalistUUID,
+            journalistFirstName: result.journalistFirstName,
+            journalistLastName: result.journalistLastName,
+            lastHintedVersion: result.lastHintedVersion,
+            lastHintedSources: result.lastHintedSources,
+            lastHintedItems: result.lastHintedItems,
           } as AuthData),
         );
 
@@ -144,14 +117,14 @@ function SignInView() {
         // Redirect to home
         navigate("/");
       } catch (e) {
-        console.error("Failed to validate or update session state:", e);
+        console.error("Failed to update session state:", e);
         dispatch(setUnauth(undefined));
 
         setAuthErrorMessage(errorMessageGeneric);
         setAuthError(true);
       }
     } catch (e) {
-      console.error("Proxy request failed:", e);
+      console.error("Login IPC failed:", e);
       dispatch(setUnauth(undefined));
 
       setAuthErrorMessage(errorMessageNetwork);

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -53,13 +53,45 @@ export enum SyncStatus {
   TIMEOUT = "timeout",
 }
 
-// IPC request for operations while authenticated against a server
-// ex: syncMetadata, fetchDownloads
+// AuthedRequest contains the authToken so that process outside the main
+// process (ie: fetch worker) can also make requests to the server
 export type AuthedRequest = {
   authToken: string;
   hintedRecords?: number;
   hintedVersion?: string;
 };
+
+// IPC request for sync operations sent from the renderer
+export type SyncRequest = {
+  hintedRecords?: number;
+  hintedVersion?: string;
+};
+
+// Credentials sent from the renderer to the main process to authenticate
+export type LoginCredentials = {
+  username: string;
+  passphrase: string;
+  oneTimeCode: string;
+};
+
+// Non-secret session data returned to the renderer after a successful login
+export type LoginSuccess = {
+  success: true;
+  expiration: string;
+  journalistUUID: string;
+  journalistFirstName: string | null;
+  journalistLastName: string | null;
+  lastHintedVersion: string;
+  lastHintedSources: number;
+  lastHintedItems: number;
+};
+
+export type LoginFailure = {
+  success: false;
+  errorType: "credentials" | "generic" | "network";
+};
+
+export type LoginResult = LoginSuccess | LoginFailure;
 
 // Message sent to the fetch worker to abort all active downloads and decryptions for a source
 export type AbortSourceFetch = {


### PR DESCRIPTION
Fixes #3208 
Fixes #3209 

Resolves part of #3318 (though won't mark this PR as fixing since there might be other pieces we want to implement)

Moves the sync loop fully into the main process, looping over sync continuously until there are no more pending events to flush. Once this is complete, then we schedule the next sync for after the sync interval. Manual sync requests from the renderer reset the sync timer.

As part of this, we also create a dedicated `login` IPC and store the auth token in the main process rather than the renderer.

## Test plan
(easier if you modify the getPendingEvents batch size to be `1`)

- Start up SecureDrop Inbox 
- Queue up a number of pending events that is >> getPendingEvents batch size 
- Trigger sync manually or wait for sync to begin on timer 
- See from debug logs and querying the SQLite DB that syncs continue looping immediately as the pending_events queue is slowly drained

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
