### PR TITLE
[inbox] addPendingSourceEventBatch from bulk deletion modal

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -776,15 +776,13 @@ export class DB {
     return this.toSource(row);
   }
 
-  getSources(): Source[] {
+  getSources(): Map<string, Source> {
     if (!this.db) {
       throw new Error("Database is not open");
     }
 
     const rows = this.selectAllSources.all();
-    return rows.map((row) => {
-      return this.toSource(row);
-    });
+    return new Map(rows.map((row) => [row.uuid, this.toSource(row)]));
   }
 
   getSourceWithItems(
@@ -1126,6 +1124,20 @@ export class DB {
       }
 
       return snowflakeID;
+    })();
+  }
+
+  addPendingSourceEventBatch(
+    events: Array<{
+      sourceUuid: string;
+      type: PendingEventType;
+      data?: PendingEventData;
+    }>,
+  ): (string | null)[] {
+    return this.db!.transaction(() => {
+      return events.map(({ sourceUuid, type, data }) =>
+        this.addPendingSourceEvent(sourceUuid, type, data),
+      );
     })();
   }
 

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -274,20 +274,16 @@ describe("Datastore Method Tests", () => {
     });
 
     let sources = db.getSources();
-    expect(sources.length).toEqual(3);
-    expect(sources.map((s) => s.uuid)).toEqual([
-      "source1",
-      "source2",
-      "source3",
-    ]);
+    expect(sources.size).toEqual(3);
+    expect([...sources.keys()]).toEqual(["source1", "source2", "source3"]);
 
     // Add pending delete for source3
     db.addPendingSourceEvent("source3", PendingEventType.SourceDeleted);
 
     // getSources should now return only source1, source2
     sources = db.getSources();
-    expect(sources.length).toEqual(2);
-    expect(sources.map((s) => s.uuid)).toEqual(["source1", "source2"]);
+    expect(sources.size).toEqual(2);
+    expect([...sources.keys()]).toEqual(["source1", "source2"]);
   });
 
   it("pending SourceConversationTruncated should remove items up to and including upper_bound", () => {
@@ -425,7 +421,7 @@ describe("Datastore Method Tests", () => {
       source3: mockSourceMetadata("source3"),
     });
     let sources = db.getSources();
-    for (const source of sources) {
+    for (const source of sources.values()) {
       expect(source.data.is_starred).toBe(false);
     }
 
@@ -433,7 +429,7 @@ describe("Datastore Method Tests", () => {
     db.addPendingSourceEvent("source2", PendingEventType.Starred);
 
     sources = db.getSources();
-    for (const source of sources) {
+    for (const source of sources.values()) {
       if (source.uuid === "source1" || source.uuid === "source2") {
         expect(source.data.is_starred).toBeTruthy();
         continue;
@@ -450,7 +446,7 @@ describe("Datastore Method Tests", () => {
       source3: mockSourceMetadata("source3", true),
     });
     let sources = db.getSources();
-    for (const source of sources) {
+    for (const source of sources.values()) {
       expect(source.data.is_starred).toBe(true);
     }
 
@@ -458,7 +454,7 @@ describe("Datastore Method Tests", () => {
     db.addPendingSourceEvent("source2", PendingEventType.Unstarred);
 
     sources = db.getSources();
-    for (const source of sources) {
+    for (const source of sources.values()) {
       if (source.uuid === "source1" || source.uuid === "source2") {
         expect(source.data.is_starred).toBeFalsy();
         continue;
@@ -475,7 +471,7 @@ describe("Datastore Method Tests", () => {
       source3: mockSourceMetadata("source3", true),
     });
     let sources = db.getSources();
-    for (const source of sources) {
+    for (const source of sources.values()) {
       expect(source.data.is_starred).toBe(true);
     }
 
@@ -483,7 +479,7 @@ describe("Datastore Method Tests", () => {
     db.addPendingSourceEvent("source1", PendingEventType.Starred);
 
     sources = db.getSources();
-    for (const source of sources) {
+    for (const source of sources.values()) {
       if (source.uuid === "source1") {
         expect(source.data.is_starred).toBeTruthy();
         continue;
@@ -493,7 +489,7 @@ describe("Datastore Method Tests", () => {
 
     db.addPendingSourceEvent("source1", PendingEventType.Unstarred);
     sources = db.getSources();
-    for (const source of sources) {
+    for (const source of sources.values()) {
       if (source.uuid === "source1") {
         expect(source.data.is_starred).toBeFalsy();
         continue;
@@ -510,7 +506,7 @@ describe("Datastore Method Tests", () => {
       source3: mockSourceMetadata("source3", true),
     });
     let sources = db.getSources();
-    for (const source of sources) {
+    for (const source of sources.values()) {
       expect(source.isRead).toBe(false);
     }
 
@@ -522,14 +518,14 @@ describe("Datastore Method Tests", () => {
 
     // Partially marking items seen should not update source Seen state
     db.addPendingSourceConversationSeen("source1", 2);
-    for (const source of sources) {
+    for (const source of sources.values()) {
       expect(source.isRead).toBe(false);
     }
 
     // Marking all items as seen should update Seen state
     db.addPendingSourceConversationSeen("source1", 3);
     sources = db.getSources();
-    for (const source of sources) {
+    for (const source of sources.values()) {
       if (source.uuid === "source1") {
         expect(source.isRead).toBe(true);
         continue;
@@ -701,11 +697,11 @@ describe("Datastore Method Tests", () => {
 
     await db.addPendingReplySentEvent("reply text", "source1", 1);
     let sources = db.getSources();
-    expect(sources.length).toEqual(1);
+    expect(sources.size).toEqual(1);
 
     db.addPendingSourceEvent("source1", PendingEventType.SourceDeleted);
     sources = db.getSources();
-    expect(sources.length).toEqual(0);
+    expect(sources.size).toEqual(0);
   });
 
   it("pending ReplySent and then pending ItemDeleted should delete reply", async () => {
@@ -1245,10 +1241,10 @@ describe("Datastore Method Tests", () => {
     db.completeFileItem("item4", "/tmp/filename.txt", 2048);
 
     const sources = db.getSources();
-    const s1 = sources.find((s) => s.uuid === "source1");
-    const s2 = sources.find((s) => s.uuid === "source2");
-    const s3 = sources.find((s) => s.uuid === "source3");
-    const s4 = sources.find((s) => s.uuid === "source4");
+    const s1 = sources.get("source1");
+    const s2 = sources.get("source2");
+    const s3 = sources.get("source3");
+    const s4 = sources.get("source4");
 
     expect(s1).not.toBeNull();
     if (s1) {
@@ -1294,7 +1290,7 @@ describe("Datastore Method Tests", () => {
     db.completePlaintextItem("item1", longAsciiMessage);
 
     const sources = db.getSources();
-    const source = sources.find((s) => s.uuid === "source1");
+    const source = sources.get("source1");
     expect(source).not.toBeNull();
     expect(source!.messagePreview).not.toBeNull();
     expect(source!.messagePreview!.plaintext).not.toBeNull();
@@ -1328,7 +1324,7 @@ describe("Datastore Method Tests", () => {
     db.completePlaintextItem("item1", emojiMessage);
 
     const sources = db.getSources();
-    const source = sources.find((s) => s.uuid === "source1");
+    const source = sources.get("source1");
     expect(source).not.toBeNull();
     expect(source!.messagePreview).not.toBeNull();
     expect(source!.messagePreview!.plaintext).not.toBeNull();

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -360,10 +360,12 @@ if (!gotTheLock) {
         },
       );
 
-      ipcMain.handle("getSources", async (_event): Promise<Source[]> => {
-        const sources = db.getSources();
-        return sources;
-      });
+      ipcMain.handle(
+        "getSources",
+        async (_event): Promise<Record<string, Source>> => {
+          return Object.fromEntries(db.getSources());
+        },
+      );
 
       ipcMain.handle(
         "getSourceWithItems",
@@ -464,6 +466,46 @@ if (!gotTheLock) {
         return systemLanguage;
       });
 
+      // Handle cleanup from source event: in cases of deletion or truncation,
+      // we should abort fetches and delete from the fs
+      async function sourceEventCleanup(
+        sourceUuid: string,
+        type: PendingEventType,
+        data?: PendingEventData,
+      ) {
+        // Immediately delete any source files from the fs on pending deletion
+        if (type === PendingEventType.SourceDeleted) {
+          await db.deleteSourceFs(sourceUuid);
+          // Abort any in-flight downloads for this source in the fetch worker
+          if (fetchWorker) {
+            fetchWorker.postMessage({
+              type: "abortSourceFetch",
+              sourceUuid,
+            });
+          }
+        }
+        // For truncation, abort in-flight downloads and delete truncated item files from the fs
+        if (type === PendingEventType.SourceConversationTruncated) {
+          // Abort any in-flight downloads for this source in the fetch worker
+          if (fetchWorker) {
+            fetchWorker.postMessage({
+              type: "abortSourceFetch",
+              sourceUuid,
+            });
+          }
+          if (data?.upper_bound) {
+            const items = db.getSourceWithItems(sourceUuid, {
+              beforeInteractionCount: data?.upper_bound + 1,
+            }).items;
+            const DELETE_BATCH_SIZE = 8;
+            for (let i = 0; i < items.length; i += DELETE_BATCH_SIZE) {
+              const batch = items.slice(i, i + DELETE_BATCH_SIZE);
+              await Promise.all(batch.map((item) => db.deleteItemFs(item)));
+            }
+          }
+        }
+      }
+
       ipcMain.handle(
         "addPendingSourceEvent",
         async (
@@ -472,38 +514,31 @@ if (!gotTheLock) {
           type: PendingEventType,
           data?: PendingEventData,
         ): Promise<string | null> => {
-          // Immediately delete any source files from the fs on pending deletion
-          if (type === PendingEventType.SourceDeleted) {
-            await db.deleteSourceFs(sourceUuid);
-            // Abort any in-flight downloads for this source in the fetch worker
-            if (fetchWorker) {
-              fetchWorker.postMessage({
-                type: "abortSourceFetch",
-                sourceUuid,
-              });
-            }
-          }
-          // For truncation, abort in-flight downloads and delete truncated item files from the fs
-          if (type === PendingEventType.SourceConversationTruncated) {
-            // Abort any in-flight downloads for this source in the fetch worker
-            if (fetchWorker) {
-              fetchWorker.postMessage({
-                type: "abortSourceFetch",
-                sourceUuid,
-              });
-            }
-            if (data?.upper_bound) {
-              const items = db.getSourceWithItems(sourceUuid, {
-                beforeInteractionCount: data?.upper_bound + 1,
-              }).items;
-              const DELETE_BATCH_SIZE = 8;
-              for (let i = 0; i < items.length; i += DELETE_BATCH_SIZE) {
-                const batch = items.slice(i, i + DELETE_BATCH_SIZE);
-                await Promise.all(batch.map((item) => db.deleteItemFs(item)));
-              }
-            }
-          }
+          await sourceEventCleanup(sourceUuid, type, data);
           return db.addPendingSourceEvent(sourceUuid, type, data);
+        },
+      );
+
+      ipcMain.handle(
+        "addPendingSourceEventBatch",
+        async (
+          _event,
+          events: Array<{
+            sourceUuid: string;
+            type: PendingEventType;
+            data?: PendingEventData;
+          }>,
+        ): Promise<(string | null)[]> => {
+          const EVENT_BATCH_SIZE = 8;
+          for (let i = 0; i < events.length; i += EVENT_BATCH_SIZE) {
+            const batch = events.slice(i, i + EVENT_BATCH_SIZE);
+            await Promise.all(
+              batch.map(({ sourceUuid, type, data }) =>
+                sourceEventCleanup(sourceUuid, type, data),
+              ),
+            );
+          }
+          return db.addPendingSourceEventBatch(events);
         },
       );
 

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -62,7 +62,7 @@ const electronAPI = {
     (itemUuid: string, fetchStatus: number, authToken: string) =>
       ipcRenderer.invoke("updateFetchStatus", itemUuid, fetchStatus, authToken),
   ),
-  getSources: logIpcCall<Source[]>("getSources", () =>
+  getSources: logIpcCall<Record<string, Source>>("getSources", () =>
     ipcRenderer.invoke("getSources"),
   ),
   getSourceWithItems: logIpcCall<SourceWithItems>(
@@ -97,6 +97,16 @@ const electronAPI = {
     "addPendingSourceEvent",
     (sourceUuid: string, type: PendingEventType, data?: PendingEventData) =>
       ipcRenderer.invoke("addPendingSourceEvent", sourceUuid, type, data),
+  ),
+  addPendingSourceEventBatch: logIpcCall<(string | null)[]>(
+    "addPendingSourceEventBatch",
+    (
+      events: Array<{
+        sourceUuid: string;
+        type: PendingEventType;
+        data?: PendingEventData;
+      }>,
+    ) => ipcRenderer.invoke("addPendingSourceEventBatch", events),
   ),
   addPendingReplySentEvent: logIpcCall<bigint>(
     "addPendingReplySentEvent",

--- a/app/src/renderer/features/conversation/conversationSlice.test.ts
+++ b/app/src/renderer/features/conversation/conversationSlice.test.ts
@@ -247,7 +247,7 @@ describe("conversationSlice", () => {
         drafts: {},
       },
       sources: {
-        sources: [],
+        sources: {},
         activeSourceUuid: null,
         loading: false,
         error: null,

--- a/app/src/renderer/features/drafts/draftsSlice.test.ts
+++ b/app/src/renderer/features/drafts/draftsSlice.test.ts
@@ -74,8 +74,8 @@ describe("draftsSlice", () => {
           "source-3": "delete this too",
         },
       };
-      const sources: Source[] = [
-        {
+      const sources: Record<string, Source> = {
+        "source-1": {
           uuid: "source-1",
           data: {
             uuid: "source-1",
@@ -91,7 +91,7 @@ describe("draftsSlice", () => {
           hasAttachment: false,
           messagePreview: null,
         },
-      ];
+      };
       const result = draftsReducer(state, fetchSources.fulfilled(sources, ""));
       expect(result.drafts).toEqual({ "source-1": "keep this" });
     });
@@ -100,8 +100,8 @@ describe("draftsSlice", () => {
       const state: DraftsState = {
         drafts: { "source-1": "one", "source-2": "two" },
       };
-      const sources: Source[] = [
-        {
+      const sources: Record<string, Source> = {
+        "source-1": {
           uuid: "source-1",
           data: {
             uuid: "source-1",
@@ -117,7 +117,7 @@ describe("draftsSlice", () => {
           hasAttachment: false,
           messagePreview: null,
         },
-        {
+        "source-2": {
           uuid: "source-2",
           data: {
             uuid: "source-2",
@@ -133,7 +133,7 @@ describe("draftsSlice", () => {
           hasAttachment: false,
           messagePreview: null,
         },
-      ];
+      };
       const result = draftsReducer(state, fetchSources.fulfilled(sources, ""));
       expect(result.drafts).toEqual({ "source-1": "one", "source-2": "two" });
     });

--- a/app/src/renderer/features/drafts/draftsSlice.ts
+++ b/app/src/renderer/features/drafts/draftsSlice.ts
@@ -37,9 +37,8 @@ export const draftsSlice = createSlice({
         state.drafts = {};
       })
       .addCase(fetchSources.fulfilled, (state, action) => {
-        const sourceUuids = new Set(action.payload.map((s) => s.uuid));
         for (const key of Object.keys(state.drafts)) {
-          if (!sourceUuids.has(key)) {
+          if (!(key in action.payload)) {
             delete state.drafts[key];
           }
         }

--- a/app/src/renderer/features/journalists/journalistsSlice.test.ts
+++ b/app/src/renderer/features/journalists/journalistsSlice.test.ts
@@ -200,7 +200,7 @@ describe("journalistsSlice", () => {
       journalists: loadedState,
       session: {} as any, // Mock other state slices
       sources: {
-        sources: [],
+        sources: {},
         activeSourceUuid: null,
         loading: false,
         error: null,

--- a/app/src/renderer/features/sources/sourcesSlice.test.ts
+++ b/app/src/renderer/features/sources/sourcesSlice.test.ts
@@ -63,6 +63,10 @@ const mockSources: SourceType[] = [
   },
 ];
 
+const mockSourcesRecord: Record<string, SourceType> = Object.fromEntries(
+  mockSources.map((s) => [s.uuid, s]),
+);
+
 describe("sourcesSlice", () => {
   let store: ReturnType<typeof configureStore>;
   const mockGetSources = vi.fn();
@@ -91,7 +95,7 @@ describe("sourcesSlice", () => {
     };
 
     // Default mock implementations
-    mockGetSources.mockResolvedValue(mockSources);
+    mockGetSources.mockResolvedValue(mockSourcesRecord);
   });
 
   afterEach(() => {
@@ -102,7 +106,7 @@ describe("sourcesSlice", () => {
     it("has correct initial state", () => {
       const state = (store.getState() as any).sources;
       expect(state).toEqual({
-        sources: [],
+        sources: {},
         activeSourceUuid: null,
         loading: false,
         error: null,
@@ -115,7 +119,7 @@ describe("sourcesSlice", () => {
     it("clears the error state", () => {
       // First, set an error state
       const initialState: SourcesState = {
-        sources: [],
+        sources: {},
         activeSourceUuid: null,
         loading: false,
         error: "Some error message",
@@ -126,7 +130,7 @@ describe("sourcesSlice", () => {
       const newState = sourcesSlice(initialState, action);
 
       expect(newState.error).toBeNull();
-      expect(newState.sources).toEqual([]);
+      expect(newState.sources).toEqual({});
       expect(newState.activeSourceUuid).toBeNull();
       expect(newState.loading).toBe(false);
     });
@@ -135,7 +139,7 @@ describe("sourcesSlice", () => {
   describe("setActiveSource action", () => {
     it("sets the active source UUID", () => {
       const initialState: SourcesState = {
-        sources: [],
+        sources: {},
         activeSourceUuid: null,
         loading: false,
         error: null,
@@ -152,7 +156,7 @@ describe("sourcesSlice", () => {
   describe("clearActiveSource action", () => {
     it("clears the active source UUID", () => {
       const initialState: SourcesState = {
-        sources: [],
+        sources: {},
         activeSourceUuid: "source-1",
         loading: false,
         error: null,
@@ -169,7 +173,7 @@ describe("sourcesSlice", () => {
   describe("conversation indicator actions", () => {
     it("initializes indicator once per source", () => {
       const initialState: SourcesState = {
-        sources: [],
+        sources: {},
         activeSourceUuid: null,
         loading: false,
         error: null,
@@ -201,7 +205,7 @@ describe("sourcesSlice", () => {
 
     it("marks conversation last seen with latest count", () => {
       const initialState: SourcesState = {
-        sources: [],
+        sources: {},
         activeSourceUuid: null,
         loading: false,
         error: null,
@@ -241,7 +245,7 @@ describe("sourcesSlice", () => {
       expect(mockGetSources).toHaveBeenCalledTimes(1);
 
       const state = (store.getState() as any).sources;
-      expect(state.sources).toEqual(mockSources);
+      expect(state.sources).toEqual(mockSourcesRecord);
       expect(state.loading).toBe(false);
       expect(state.error).toBeNull();
     });
@@ -255,17 +259,19 @@ describe("sourcesSlice", () => {
       expect(mockGetSources).toHaveBeenCalledTimes(1);
 
       const state = (store.getState() as any).sources;
-      expect(state.sources).toEqual([]);
+      expect(state.sources).toEqual({});
       expect(state.loading).toBe(false);
       expect(state.error).toBe(errorMessage);
     });
 
     it("sets loading state during fetch", async () => {
       // Create a promise that we can control
-      let resolveGetSources!: (value: SourceType[]) => void;
-      const getSourcesPromise = new Promise<SourceType[]>((resolve) => {
-        resolveGetSources = resolve;
-      });
+      let resolveGetSources!: (value: Record<string, SourceType>) => void;
+      const getSourcesPromise = new Promise<Record<string, SourceType>>(
+        (resolve) => {
+          resolveGetSources = resolve;
+        },
+      );
       mockGetSources.mockReturnValue(getSourcesPromise);
 
       const action = fetchSources();
@@ -276,7 +282,7 @@ describe("sourcesSlice", () => {
       expect((store.getState() as any).sources.error).toBeNull();
 
       // Resolve the promise
-      resolveGetSources!(mockSources);
+      resolveGetSources!(mockSourcesRecord);
       await dispatchPromise;
 
       // Check loading state is false after completion
@@ -299,11 +305,11 @@ describe("sourcesSlice", () => {
       olderItemsLoading: false,
     };
 
-    it("selectSources returns sources array", () => {
+    it("selectSources returns sources map", () => {
       const state = {
         session: mockSessionState,
         sources: {
-          sources: mockSources,
+          sources: mockSourcesRecord,
           activeSourceUuid: null,
           loading: false,
           error: null,
@@ -324,14 +330,14 @@ describe("sourcesSlice", () => {
         drafts: { drafts: {} },
       };
 
-      expect(selectSources(state)).toEqual(mockSources);
+      expect(selectSources(state)).toEqual(mockSourcesRecord);
     });
 
     it("selectActiveSourceUuid returns active source UUID", () => {
       const state = {
         session: mockSessionState,
         sources: {
-          sources: mockSources,
+          sources: mockSourcesRecord,
           activeSourceUuid: "source-1",
           loading: false,
           error: null,
@@ -359,7 +365,7 @@ describe("sourcesSlice", () => {
       const state = {
         session: mockSessionState,
         sources: {
-          sources: [],
+          sources: {},
           activeSourceUuid: null,
           loading: true,
           error: null,
@@ -387,7 +393,7 @@ describe("sourcesSlice", () => {
       const state = {
         session: mockSessionState,
         sources: {
-          sources: [],
+          sources: {},
           activeSourceUuid: null,
           loading: false,
           error: null,
@@ -430,7 +436,7 @@ describe("sourcesSlice", () => {
 
       // Final state should have sources
       const state = (store.getState() as any).sources;
-      expect(state.sources).toEqual(mockSources);
+      expect(state.sources).toEqual(mockSourcesRecord);
       expect(state.loading).toBe(false);
     });
 
@@ -444,7 +450,7 @@ describe("sourcesSlice", () => {
       expect(mockGetSources).toHaveBeenCalledTimes(2);
 
       const state = (store.getState() as any).sources;
-      expect(state.sources).toEqual(mockSources);
+      expect(state.sources).toEqual(mockSourcesRecord);
       expect(state.loading).toBe(false);
       expect(state.error).toBeNull();
     });
@@ -458,7 +464,7 @@ describe("sourcesSlice", () => {
 
       const state = (store.getState() as any).sources;
       expect(state.error).toBe("Network timeout");
-      expect(state.sources).toEqual([]);
+      expect(state.sources).toEqual({});
       expect(state.loading).toBe(false);
 
       expect(mockGetSources).toHaveBeenCalledTimes(1);
@@ -495,12 +501,12 @@ describe("sourcesSlice", () => {
       expect((store.getState() as any).sources.error).toBe("First error");
 
       // Then make a successful call
-      mockGetSources.mockResolvedValue(mockSources);
+      mockGetSources.mockResolvedValue(mockSourcesRecord);
       await (store.dispatch as any)(fetchSources());
 
       const state = (store.getState() as any).sources;
       expect(state.error).toBeNull();
-      expect(state.sources).toEqual(mockSources);
+      expect(state.sources).toEqual(mockSourcesRecord);
     });
   });
 });

--- a/app/src/renderer/features/sources/sourcesSlice.ts
+++ b/app/src/renderer/features/sources/sourcesSlice.ts
@@ -7,7 +7,7 @@ export interface ConversationIndicatorState {
 }
 
 export interface SourcesState {
-  sources: SourceType[];
+  sources: Record<string, SourceType>;
   activeSourceUuid: string | null;
   loading: boolean;
   error: string | null;
@@ -15,7 +15,7 @@ export interface SourcesState {
 }
 
 const initialState: SourcesState = {
-  sources: [],
+  sources: {},
   activeSourceUuid: null,
   loading: false,
   error: null,
@@ -46,12 +46,7 @@ export const sourcesSlice = createSlice({
     },
     updateSource: (state, action) => {
       const updatedSource: SourceType = action.payload;
-      state.sources = state.sources.map((source, _) => {
-        if (source.uuid === updatedSource.uuid) {
-          return updatedSource;
-        }
-        return source;
-      });
+      state.sources[updatedSource.uuid] = updatedSource;
     },
     initializeConversationIndicator: (state, action) => {
       const { sourceUuid, lastSeenInteractionCount } = action.payload;
@@ -80,7 +75,7 @@ export const sourcesSlice = createSlice({
         state.sources = action.payload;
 
         // Update active source UUID in case of deletion
-        if (!state.sources.find((s) => s.uuid === state.activeSourceUuid)) {
+        if (state.activeSourceUuid && !state.sources[state.activeSourceUuid]) {
           state.activeSourceUuid = null;
         }
       })

--- a/app/src/renderer/features/sync/syncSlice.test.ts
+++ b/app/src/renderer/features/sync/syncSlice.test.ts
@@ -57,6 +57,10 @@ const mockSources: SourceType[] = [
   },
 ];
 
+const mockSourcesRecord: Record<string, SourceType> = Object.fromEntries(
+  mockSources.map((s) => [s.uuid, s]),
+);
+
 describe("syncSlice", () => {
   let store: ReturnType<typeof configureStore>;
   const mockGetSources = vi.fn();
@@ -88,7 +92,7 @@ describe("syncSlice", () => {
     };
 
     // Default mock implementations
-    mockGetSources.mockResolvedValue(mockSources);
+    mockGetSources.mockResolvedValue(mockSourcesRecord);
     mockSyncMetadata.mockResolvedValue(SyncStatus.UPDATED);
   });
 
@@ -112,7 +116,7 @@ describe("syncSlice", () => {
 
       const syncState = (store.getState() as any).sync;
       const sourcesState = (store.getState() as any).sources;
-      expect(sourcesState.sources).toEqual(mockSources);
+      expect(sourcesState.sources).toEqual(mockSourcesRecord);
       expect(syncState.error).toBeNull();
       expect(syncState.lastSyncFinished).toBeGreaterThan(0);
     });
@@ -134,7 +138,7 @@ describe("syncSlice", () => {
 
       const syncState = (store.getState() as any).sync;
       const sourcesState = (store.getState() as any).sources;
-      expect(sourcesState.sources).toEqual([]);
+      expect(sourcesState.sources).toEqual({});
       expect(syncState.error).toBe(errorMessage);
     });
 
@@ -150,7 +154,7 @@ describe("syncSlice", () => {
 
       const syncState = (store.getState() as any).sync;
       const sourcesState = (store.getState() as any).sources;
-      expect(sourcesState.sources).toEqual([]);
+      expect(sourcesState.sources).toEqual({});
       expect(syncState.error).toBe(errorMessage);
     });
 
@@ -166,7 +170,7 @@ describe("syncSlice", () => {
 
       const syncState = (store.getState() as any).sync;
       const sourcesState = (store.getState() as any).sources;
-      expect(sourcesState.sources).toEqual([]);
+      expect(sourcesState.sources).toEqual({});
       expect(syncState.error).toBeNull(); // Sync succeeded, sources fetch failed
       expect(sourcesState.error).toBe(errorMessage); // Error is in sources slice
     });
@@ -184,7 +188,7 @@ describe("syncSlice", () => {
         },
         preloadedState: {
           sources: {
-            sources: [],
+            sources: {},
             activeSourceUuid: activeSourceUuid,
             error: null,
             lastFetchTime: null,
@@ -219,7 +223,7 @@ describe("syncSlice", () => {
 
       // Sources should be updated
       const sourcesState = (store.getState() as any).sources;
-      expect(sourcesState.sources).toEqual(mockSources);
+      expect(sourcesState.sources).toEqual(mockSourcesRecord);
     });
 
     it("does not fetch conversations when no active source", async () => {
@@ -233,7 +237,7 @@ describe("syncSlice", () => {
 
       // Sources should still be updated in the store
       const sourcesState = (store.getState() as any).sources;
-      expect(sourcesState.sources).toEqual(mockSources);
+      expect(sourcesState.sources).toEqual(mockSourcesRecord);
     });
 
     it("handles network timeout error during sync", async () => {
@@ -244,7 +248,7 @@ describe("syncSlice", () => {
       const syncState = (store.getState() as any).sync;
       const sourcesState = (store.getState() as any).sources;
       expect(syncState.error).toBe("Network timeout");
-      expect(sourcesState.sources).toEqual([]);
+      expect(sourcesState.sources).toEqual({});
 
       // syncMetadata should be called but getSources should not be called due to network failure
       expect(mockSyncMetadata).toHaveBeenCalledTimes(1);

--- a/app/src/renderer/test-component-setup.tsx
+++ b/app/src/renderer/test-component-setup.tsx
@@ -111,8 +111,8 @@ beforeEach(() => {
     onSourceUpdate: vi.fn().mockReturnValue(() => {}),
     onQuitRequested: vi.fn().mockReturnValue(() => {}),
     getItem: vi.fn().mockRejectedValue(new Error("mock not implemented")),
-    getSources: vi.fn().mockResolvedValue([
-      {
+    getSources: vi.fn().mockResolvedValue({
+      "source-1": {
         uuid: "source-1",
         data: {
           fingerprint: "ABCD1234EFGH5678IJKL9012MNOP3456QRST7890",
@@ -125,7 +125,7 @@ beforeEach(() => {
         },
         isRead: false,
       },
-      {
+      "source-2": {
         uuid: "source-2",
         data: {
           fingerprint: "1234ABCD5678EFGH9012IJKL3456MNOP7890QRST",
@@ -138,7 +138,7 @@ beforeEach(() => {
         },
         isRead: true,
       },
-      {
+      "source-3": {
         uuid: "source-3",
         data: {
           fingerprint: "5678EFGH9012IJKL3456MNOP7890QRST1234ABCD",
@@ -151,7 +151,7 @@ beforeEach(() => {
         },
         isRead: false,
       },
-    ]),
+    }),
     getSourceWithItems: vi.fn().mockResolvedValue({
       uuid: "source-1",
       data: {
@@ -221,6 +221,7 @@ beforeEach(() => {
       },
     ]),
     addPendingSourceEvent: vi.fn().mockResolvedValue(BigInt(123)),
+    addPendingSourceEventBatch: vi.fn().mockResolvedValue(["123"]),
     addPendingReplySentEvent: vi.fn().mockResolvedValue(BigInt(456)),
     addPendingItemEvent: vi.fn().mockResolvedValue(BigInt(789)),
     addPendingSourceConversationSeen: vi.fn().mockResolvedValue(null),

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
@@ -96,8 +96,8 @@ vi.mock("./SourceList/Source", () => ({
 
 describe("Sources Component", () => {
   // Mock sources data with different states for comprehensive testing
-  const mockSources: SourceType[] = [
-    {
+  const mockSources: Record<string, SourceType> = {
+    "source-1": {
       uuid: "source-1",
       data: {
         fingerprint: "fingerprint-1",
@@ -114,7 +114,7 @@ describe("Sources Component", () => {
       messagePreview: null,
       lastInteractionCount: 6,
     },
-    {
+    "source-2": {
       uuid: "source-2",
       data: {
         fingerprint: "fingerprint-2",
@@ -134,7 +134,7 @@ describe("Sources Component", () => {
       },
       lastInteractionCount: 5,
     },
-    {
+    "source-3": {
       uuid: "source-3",
       data: {
         fingerprint: "fingerprint-3",
@@ -151,7 +151,7 @@ describe("Sources Component", () => {
       messagePreview: null,
       lastInteractionCount: 6,
     },
-    {
+    "source-4": {
       uuid: "source-4",
       data: {
         fingerprint: "fingerprint-4",
@@ -168,7 +168,7 @@ describe("Sources Component", () => {
       messagePreview: null,
       lastInteractionCount: 7,
     },
-    {
+    "source-5": {
       uuid: "source-5",
       data: {
         fingerprint: "fingerprint-5",
@@ -185,7 +185,7 @@ describe("Sources Component", () => {
       messagePreview: null,
       lastInteractionCount: 7,
     },
-  ];
+  };
 
   const mockSearchResults: SearchResult[] = [
     {
@@ -786,9 +786,9 @@ describe("Sources Component", () => {
 
   describe("Bulk delete functionality", () => {
     beforeEach(() => {
-      window.electronAPI.addPendingSourceEvent = vi
+      window.electronAPI.addPendingSourceEventBatch = vi
         .fn()
-        .mockResolvedValue(BigInt(123));
+        .mockResolvedValue(["123"]);
     });
 
     it("shows modal when delete button is clicked with single source selected", async () => {
@@ -859,7 +859,7 @@ describe("Sources Component", () => {
       ).toBeInTheDocument();
     });
 
-    it("calls addPendingSourceEvent with SourceDeleted when Delete Account is clicked", async () => {
+    it("calls addPendingSourceEventBatch with SourceDeleted when Delete Account is clicked", async () => {
       renderSourceList();
 
       await waitFor(() => {
@@ -886,15 +886,19 @@ describe("Sources Component", () => {
       await userEvent.click(deleteAccountButton);
 
       await waitFor(() => {
-        expect(window.electronAPI.addPendingSourceEvent).toHaveBeenCalledWith(
-          "source-1",
-          PendingEventType.SourceDeleted,
-          undefined,
-        );
+        expect(
+          window.electronAPI.addPendingSourceEventBatch,
+        ).toHaveBeenCalledWith([
+          {
+            sourceUuid: "source-1",
+            type: PendingEventType.SourceDeleted,
+            data: undefined,
+          },
+        ]);
       });
     });
 
-    it("calls addPendingSourceEvent with SourceConversationTruncated when Delete Conversation is clicked", async () => {
+    it("calls addPendingSourceEventBatch with SourceConversationTruncated when Delete Conversation is clicked", async () => {
       renderSourceList();
 
       await waitFor(() => {
@@ -921,15 +925,19 @@ describe("Sources Component", () => {
       await userEvent.click(deleteConversationButton);
 
       await waitFor(() => {
-        expect(window.electronAPI.addPendingSourceEvent).toHaveBeenCalledWith(
-          "source-1",
-          PendingEventType.SourceConversationTruncated,
-          { upper_bound: 6 },
-        );
+        expect(
+          window.electronAPI.addPendingSourceEventBatch,
+        ).toHaveBeenCalledWith([
+          {
+            sourceUuid: "source-1",
+            type: PendingEventType.SourceConversationTruncated,
+            data: { upper_bound: 6 },
+          },
+        ]);
       });
     });
 
-    it("calls addPendingSourceEvent for all selected sources", async () => {
+    it("calls addPendingSourceEventBatch with all selected sources in a single call", async () => {
       renderSourceList();
 
       await waitFor(() => {
@@ -958,22 +966,27 @@ describe("Sources Component", () => {
       await userEvent.click(deleteAccountsButton);
 
       await waitFor(() => {
-        const addPendingSourceEvent = window.electronAPI.addPendingSourceEvent;
-        expect(addPendingSourceEvent).toHaveBeenCalledTimes(3);
-        expect(addPendingSourceEvent).toHaveBeenCalledWith(
-          "source-1",
-          PendingEventType.SourceDeleted,
-          undefined,
-        );
-        expect(addPendingSourceEvent).toHaveBeenCalledWith(
-          "source-2",
-          PendingEventType.SourceDeleted,
-          undefined,
-        );
-        expect(addPendingSourceEvent).toHaveBeenCalledWith(
-          "source-3",
-          PendingEventType.SourceDeleted,
-          undefined,
+        const addPendingSourceEventBatch =
+          window.electronAPI.addPendingSourceEventBatch;
+        expect(addPendingSourceEventBatch).toHaveBeenCalledTimes(1);
+        expect(addPendingSourceEventBatch).toHaveBeenCalledWith(
+          expect.arrayContaining([
+            {
+              sourceUuid: "source-1",
+              type: PendingEventType.SourceDeleted,
+              data: undefined,
+            },
+            {
+              sourceUuid: "source-2",
+              type: PendingEventType.SourceDeleted,
+              data: undefined,
+            },
+            {
+              sourceUuid: "source-3",
+              type: PendingEventType.SourceDeleted,
+              data: undefined,
+            },
+          ]),
         );
       });
     });
@@ -1002,10 +1015,12 @@ describe("Sources Component", () => {
       const cancelButton = screen.getByTestId("delete-modal-cancel-button");
       await userEvent.click(cancelButton);
 
-      // Wait a bit to ensure addPendingSourceEvent is not called
+      // Wait a bit to ensure addPendingSourceEventBatch is not called
       await new Promise((resolve) => setTimeout(resolve, 100));
 
-      expect(window.electronAPI.addPendingSourceEvent).not.toHaveBeenCalled();
+      expect(
+        window.electronAPI.addPendingSourceEventBatch,
+      ).not.toHaveBeenCalled();
     });
 
     it("clears selection after deleting sources", async () => {
@@ -1043,7 +1058,9 @@ describe("Sources Component", () => {
 
       // Wait for the operation to complete
       await waitFor(() => {
-        expect(window.electronAPI.addPendingSourceEvent).toHaveBeenCalled();
+        expect(
+          window.electronAPI.addPendingSourceEventBatch,
+        ).toHaveBeenCalled();
       });
 
       // Checkboxes should be unchecked
@@ -1056,9 +1073,9 @@ describe("Sources Component", () => {
 
   describe("Keyboard shortcut (Ctrl+Delete)", () => {
     beforeEach(() => {
-      window.electronAPI.addPendingSourceEvent = vi
+      window.electronAPI.addPendingSourceEventBatch = vi
         .fn()
-        .mockResolvedValue(BigInt(123));
+        .mockResolvedValue(["123"]);
       window.electronAPI.getSourceWithItems = vi.fn().mockResolvedValue(null);
     });
 
@@ -1235,11 +1252,14 @@ describe("Sources Component", () => {
     it("calls addPendingSourceEvent with Starred when source is unstarred", async () => {
       // Create a mock source that is not starred
       const unstarredSource = {
-        ...mockSources[0],
-        data: { ...mockSources[0].data, is_starred: false },
+        ...mockSources["source-1"],
+        data: {
+          ...mockSources["source-1"].data,
+          is_starred: false,
+        },
       };
 
-      renderSourceList([unstarredSource]);
+      renderSourceList({ "source-1": unstarredSource });
 
       await waitFor(() => {
         expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
@@ -1259,13 +1279,16 @@ describe("Sources Component", () => {
 
     it("calls addPendingSourceEvent with Unstarred when source is starred", async () => {
       // Create a mock source that is starred
-      const starredSources = [
-        {
-          ...mockSources[0],
-          data: { ...mockSources[0].data, is_starred: true },
+      const starredSources = {
+        ...mockSources,
+        "source-1": {
+          ...mockSources["source-1"],
+          data: {
+            ...mockSources["source-1"].data,
+            is_starred: true,
+          },
         },
-        ...mockSources.slice(1),
-      ];
+      };
 
       // Override getSources mock to return our custom sources
       vi.mocked(window.electronAPI.getSources).mockResolvedValue(
@@ -1291,20 +1314,29 @@ describe("Sources Component", () => {
     });
 
     it("handles multiple star toggles correctly", async () => {
-      const sources = [
-        {
-          ...mockSources[0],
-          data: { ...mockSources[0].data, is_starred: false },
+      const sources = {
+        "source-1": {
+          ...mockSources["source-1"],
+          data: {
+            ...mockSources["source-1"].data,
+            is_starred: false,
+          },
         },
-        {
-          ...mockSources[1],
-          data: { ...mockSources[1].data, is_starred: true },
+        "source-2": {
+          ...mockSources["source-2"],
+          data: {
+            ...mockSources["source-2"].data,
+            is_starred: true,
+          },
         },
-        {
-          ...mockSources[2],
-          data: { ...mockSources[2].data, is_starred: false },
+        "source-3": {
+          ...mockSources["source-3"],
+          data: {
+            ...mockSources["source-3"].data,
+            is_starred: false,
+          },
         },
-      ];
+      };
 
       renderSourceList(sources);
 
@@ -1358,11 +1390,11 @@ describe("Sources Component", () => {
         .mockRejectedValue(new Error("IPC failure"));
 
       const unstarredSource = {
-        ...mockSources[0],
-        data: { ...mockSources[0].data, is_starred: false },
+        ...mockSources["source-1"],
+        data: { ...mockSources["source-1"].data, is_starred: false },
       };
 
-      renderSourceList([unstarredSource]);
+      renderSourceList({ "source-1": unstarredSource });
 
       await waitFor(() => {
         expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
@@ -1384,11 +1416,11 @@ describe("Sources Component", () => {
       consoleErrorSpy.mockRestore();
     });
 
-    it("handles addPendingSourceEvent rejection during delete action", async () => {
+    it("handles addPendingSourceEventBatch rejection during delete action", async () => {
       const consoleErrorSpy = vi
         .spyOn(console, "error")
         .mockImplementation(() => {});
-      window.electronAPI.addPendingSourceEvent = vi
+      window.electronAPI.addPendingSourceEventBatch = vi
         .fn()
         .mockRejectedValue(new Error("IPC failure"));
 
@@ -1412,11 +1444,15 @@ describe("Sources Component", () => {
       );
 
       await waitFor(() => {
-        expect(window.electronAPI.addPendingSourceEvent).toHaveBeenCalledWith(
-          "source-1",
-          PendingEventType.SourceDeleted,
-          undefined,
-        );
+        expect(
+          window.electronAPI.addPendingSourceEventBatch,
+        ).toHaveBeenCalledWith([
+          {
+            sourceUuid: "source-1",
+            type: PendingEventType.SourceDeleted,
+            data: undefined,
+          },
+        ]);
         expect(consoleErrorSpy).toHaveBeenCalledWith(
           "Failed to delete source(s):",
           expect.any(Error),
@@ -1430,15 +1466,22 @@ describe("Sources Component", () => {
 
   describe("Selection behavior with filters and search", () => {
     // Use 3 sources where only source-2 (bob builder) is starred
-    const singleStarredSources = mockSources.slice(0, 3).map((s, i) => ({
-      ...s,
-      data: { ...s.data, is_starred: i === 1 },
-    }));
+    const singleStarredSources = {
+      "source-1": mockSources["source-1"],
+      "source-2": {
+        ...mockSources["source-2"],
+        data: {
+          ...mockSources["source-2"].data,
+          is_starred: true,
+        },
+      },
+      "source-3": mockSources["source-3"],
+    };
 
     beforeEach(() => {
-      window.electronAPI.addPendingSourceEvent = vi
+      window.electronAPI.addPendingSourceEventBatch = vi
         .fn()
-        .mockResolvedValue(BigInt(123));
+        .mockResolvedValue(["123"]);
       window.electronAPI.getSourceWithItems = vi.fn().mockResolvedValue(null);
     });
 
@@ -1460,7 +1503,7 @@ describe("Sources Component", () => {
       expect(screen.getByTestId("source-checkbox-source-2")).toBeChecked();
       expect(screen.getByTestId("source-checkbox-source-3")).toBeChecked();
 
-      // Filter to starred sources (only source-2 is visible)
+      // Filter to starred sources (only source-2 visible)
       await userEvent.click(screen.getByTestId("filter-dropdown"));
       await userEvent.click(screen.getByText("Starred"));
 
@@ -1485,14 +1528,17 @@ describe("Sources Component", () => {
 
       // Only the one starred source should have been submitted for deletion
       await waitFor(() => {
-        expect(window.electronAPI.addPendingSourceEvent).toHaveBeenCalledTimes(
-          1,
-        );
-        expect(window.electronAPI.addPendingSourceEvent).toHaveBeenCalledWith(
-          "source-2",
-          PendingEventType.SourceDeleted,
-          undefined,
-        );
+        expect(
+          window.electronAPI.addPendingSourceEventBatch,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          window.electronAPI.addPendingSourceEventBatch,
+        ).toHaveBeenCalledWith([
+          expect.objectContaining({
+            sourceUuid: "source-2",
+            type: PendingEventType.SourceDeleted,
+          }),
+        ]);
       });
     });
 

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -207,18 +207,18 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
   const handleDeleteAction = useCallback(
     async (eventType: PendingEventType) => {
       try {
-        for (const sourceUuid of pendingDeleteSources) {
-          const sourceToDelete = sources.find((x) => x.uuid === sourceUuid);
-          await window.electronAPI.addPendingSourceEvent(
+        const events = [...pendingDeleteSources].map((sourceUuid) => {
+          const sourceToDelete = sources[sourceUuid];
+          return {
             sourceUuid,
-            eventType,
-            eventType === PendingEventType.SourceConversationTruncated
-              ? {
-                  upper_bound: sourceToDelete?.lastInteractionCount ?? 0,
-                }
-              : undefined,
-          );
-        }
+            type: eventType,
+            data:
+              eventType === PendingEventType.SourceConversationTruncated
+                ? { upper_bound: sourceToDelete?.lastInteractionCount ?? 0 }
+                : undefined,
+          };
+        });
+        await window.electronAPI.addPendingSourceEventBatch(events);
         // If we deleted an account and it was the currently active source, navigate away
         if (
           eventType === PendingEventType.SourceDeleted &&
@@ -274,7 +274,6 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
     let searchedSources: SourceType[] = [];
     if (searchResults !== null) {
       // Dedupe by sourceUuid, keeping the highest-ranked result per source
-      const sourcesByUuid = new Map(sources.map((s) => [s.uuid, s]));
       const seen = new Set<string>();
 
       for (const sr of searchResults) {
@@ -282,7 +281,7 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
           continue;
         }
         seen.add(sr.sourceUuid);
-        const source = sourcesByUuid.get(sr.sourceUuid);
+        const source = sources[sr.sourceUuid];
         if (!source) {
           continue;
         }
@@ -300,7 +299,7 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
         }
       }
     } else {
-      searchedSources = sources;
+      searchedSources = Object.values(sources);
     }
 
     return searchedSources


### PR DESCRIPTION
Fixes #3309 

Implements an `addPendingSourceEventBatch` IPC that allows the deletion modal to send a single IPC to enqueue many deletion events from the bulk deletion modal.

## Test plan

- [x] Select many sources (100s) for deletion 
- [x] Pull up bulk deletion modal 
- [x] Clicking "Delete Conversation"/"Delete Account" should issue only a single IPC and close the dialog window quickly (as compared to on `main`)

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
