### PR TITLE
[inbox] enable export to whistleflow

### DIFF
--- a/app/src/main/config.ts
+++ b/app/src/main/config.ts
@@ -22,6 +22,9 @@ export class Config {
       gnupghome: readEnvironment("GNUPGHOME", ""),
       // TODO: implement SD_PROXY_VM_NAME
       is_qubes: isQubes,
+      // This is a temporary workaround solely for The Guardian so they
+      // don't need to maintain a custom fork just for this; it'll go
+      // away once we have proper "export to VM" capability.
       whistleflow: read(isQubes, "WHISTLEFLOW", "false") === "true",
     };
   }

--- a/app/src/main/config.ts
+++ b/app/src/main/config.ts
@@ -10,6 +10,7 @@ export class Config {
   readonly is_qubes!: boolean;
   readonly qubes_gpg_domain!: string;
   readonly sd_submission_key_fpr!: string;
+  readonly whistleflow!: boolean;
 
   public static load(noQubes: boolean): Config {
     const isQubes = noQubes ? !noQubes : detectQubes();
@@ -21,6 +22,7 @@ export class Config {
       gnupghome: readEnvironment("GNUPGHOME", ""),
       // TODO: implement SD_PROXY_VM_NAME
       is_qubes: isQubes,
+      whistleflow: read(isQubes, "WHISTLEFLOW", "false") === "true",
     };
   }
 }

--- a/app/src/main/export.ts
+++ b/app/src/main/export.ts
@@ -17,6 +17,12 @@ import {
   PrintStatus,
 } from "../types";
 
+const WHISTLEFLOW_ARGS = [
+  "whistleflow-view",
+  "qubes.Filecopy",
+  "/usr/lib/qubes/qfile-agent",
+];
+
 const mkdtemp = promisify(mkdtempCb);
 const chmodAsync = promisify(chmod);
 
@@ -121,6 +127,7 @@ export type ExportEvent =
   | { action: "initiateExport" }
   | { action: "preflightSuccess" }
   | { action: "export" }
+  | { action: "exportDirect" }
   | { action: "exportSuccess" }
   | { action: "fail"; error: Error; status?: DeviceStatus }
   | { action: "cancel" };
@@ -147,6 +154,9 @@ export class ExportStateMachine implements StateMachine<
       case ExportState.Error:
         if (event.action === "initiateExport") {
           next = ExportState.ExportPreflight;
+        }
+        if (event.action === "exportDirect") {
+          next = ExportState.Exporting;
         }
         break;
       case ExportState.ExportPreflight:
@@ -313,18 +323,23 @@ export class ArchiveExporter {
     return archivePath;
   }
 
-  async runQrexecExport(archivePath: string): Promise<void> {
+  async runQrexecExport(
+    archivePath: string,
+    overrideArgs?: string[],
+  ): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       this.processStderr = ""; // Reset buffer at start
       // args uses positional values, we intentionally avoid shell.
       const qrexec = "/usr/bin/qrexec-client-vm";
       const args = [
         "--",
-        this.backendQube,
-        "qubes.OpenInVM",
-        "/usr/lib/qubes/qopen-in-vm",
-        "--view-only",
-        "--",
+        ...(overrideArgs ?? [
+          this.backendQube,
+          "qubes.OpenInVM",
+          "/usr/lib/qubes/qopen-in-vm",
+          "--view-only",
+          "--",
+        ]),
         archivePath,
       ];
 
@@ -587,11 +602,12 @@ export class Exporter extends ArchiveExporter {
     filepaths: string[],
     passphrase: string | null,
     sourceName?: string,
+    whistleflow?: boolean,
   ): Promise<DeviceStatus> {
     let status: DeviceStatus;
     try {
       console.log(`Begin exporting ${filepaths.length} item(s)`);
-      this.fsm.transition({ action: "export" });
+      this.fsm.transition({ action: whistleflow ? "exportDirect" : "export" });
 
       const metadata = { ...Exporter.DISK_METADATA } as Record<string, unknown>;
       if (passphrase) {
@@ -601,16 +617,32 @@ export class Exporter extends ArchiveExporter {
       this.tmpdir = await mkdtemp(path.join(os.tmpdir(), "sd-export-"));
       await chmodAsync(this.tmpdir, 0o700);
 
+      let filename = Exporter.DISK_FILENAME;
+      if (whistleflow) {
+        const now = new Date();
+        const isoString: string = now.toISOString();
+        filename = `export-${isoString}.tar`;
+      }
+
       const archivePath = await this.createArchive({
         archiveDir: this.tmpdir,
-        archiveFilename: Exporter.DISK_FILENAME,
+        archiveFilename: filename,
         metadata,
         filepaths,
         sourceName,
       });
 
-      await this.runQrexecExport(archivePath);
-      status = this._onComplete(false);
+      if (whistleflow) {
+        await this.runQrexecExport(archivePath, WHISTLEFLOW_ARGS);
+        this.cleanupTmpdir();
+        this.fsm.transition({ action: "exportSuccess" });
+        this.process = null;
+        this.processStderr = "";
+        status = ExportStatus.SUCCESS_EXPORT;
+      } else {
+        await this.runQrexecExport(archivePath);
+        status = this._onComplete(false);
+      }
     } catch (err) {
       console.log("Export failed", err);
       this._onError();

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -128,13 +128,14 @@ if (!gotTheLock) {
   const noFirstRun = args.includes("--no-first-run");
   const shouldAutoLogin = args.includes("--login");
 
-  function initializeMainDependencies(noQubesMode: boolean): {
+  // Load config
+  const config = Config.load(noQubes);
+
+  function initializeMainDependencies(): {
     db: Datastore;
     cryptoConfig: CryptoConfig;
   } {
     try {
-      const config = Config.load(noQubesMode);
-
       // Create crypto config + initialize
       const configForCrypto: CryptoConfig = {
         submissionKeyFingerprint: config.sd_submission_key_fpr,
@@ -157,7 +158,7 @@ if (!gotTheLock) {
     }
   }
 
-  const { db, cryptoConfig } = initializeMainDependencies(noQubes);
+  const { db, cryptoConfig } = initializeMainDependencies();
 
   // Generate a CSP nonce for this session (used by Ant Design)
   const cspNonce = randomBytes(32).toString("base64");
@@ -547,6 +548,13 @@ if (!gotTheLock) {
         return is.dev && shouldAutoLogin;
       });
 
+      ipcMain.handle(
+        "getWhistleflowEnabled",
+        async (_event): Promise<boolean> => {
+          return config.whistleflow;
+        },
+      );
+
       ipcMain.handle("getCSPNonce", async (_event): Promise<string> => {
         return cspNonce;
       });
@@ -601,6 +609,7 @@ if (!gotTheLock) {
           _event,
           sourceUuid: string,
           passphrase: string,
+          whistleflow?: boolean,
         ): Promise<DeviceStatus> => {
           try {
             const filePath: string = await writeTranscript(sourceUuid, db);
@@ -610,7 +619,12 @@ if (!gotTheLock) {
             }
             const sourceWithItems = db.getSourceWithItems(sourceUuid);
             const sourceName = sourceWithItems.data.journalist_designation;
-            return await exporter.export([filePath], passphrase, sourceName);
+            return await exporter.export(
+              [filePath],
+              passphrase,
+              sourceName,
+              whistleflow,
+            );
           } catch (error) {
             console.error(
               `Failed to export transcript for source: ${sourceUuid}:`,
@@ -627,6 +641,7 @@ if (!gotTheLock) {
           _event,
           itemUuids: string[],
           passphrase: string,
+          whistleflow?: boolean,
         ): Promise<DeviceStatus> => {
           const filenames: string[] = [];
           let sourceName: string | undefined;
@@ -648,7 +663,12 @@ if (!gotTheLock) {
               sourceName = source.data.journalist_designation;
             }
           }
-          return await exporter.export(filenames, passphrase, sourceName);
+          return await exporter.export(
+            filenames,
+            passphrase,
+            sourceName,
+            whistleflow,
+          );
         },
       );
 
@@ -658,6 +678,7 @@ if (!gotTheLock) {
           _event,
           sourceUuid: string,
           passphrase: string,
+          whistleflow?: boolean,
         ): Promise<DeviceStatus> => {
           try {
             const transcriptPath: string = await writeTranscript(
@@ -682,7 +703,12 @@ if (!gotTheLock) {
               }
             }
             const sourceName = sourceWithItems.data.journalist_designation;
-            return await exporter.export(filenames, passphrase, sourceName);
+            return await exporter.export(
+              filenames,
+              passphrase,
+              sourceName,
+              whistleflow,
+            );
           } catch (error) {
             console.error(`Failed to export source: ${sourceUuid}:`, error);
             throw error;

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -150,18 +150,26 @@ const electronAPI = {
   ),
   exportTranscript: logIpcCall<DeviceStatus>(
     "exportTranscript",
-    (sourceUuid: string, passphrase: string) =>
-      ipcRenderer.invoke("exportTranscript", sourceUuid, passphrase),
+    (sourceUuid: string, passphrase: string, whistleflow?: boolean) =>
+      ipcRenderer.invoke(
+        "exportTranscript",
+        sourceUuid,
+        passphrase,
+        whistleflow,
+      ),
   ),
   export: logIpcCall<DeviceStatus>(
     "export",
-    (itemUuids: string[], passphrase: string) =>
-      ipcRenderer.invoke("export", itemUuids, passphrase),
+    (itemUuids: string[], passphrase: string, whistleflow?: boolean) =>
+      ipcRenderer.invoke("export", itemUuids, passphrase, whistleflow),
   ),
   exportSource: logIpcCall<DeviceStatus>(
     "exportSource",
-    (sourceUuid: string, passphrase: string) =>
-      ipcRenderer.invoke("exportSource", sourceUuid, passphrase),
+    (sourceUuid: string, passphrase: string, whistleflow?: boolean) =>
+      ipcRenderer.invoke("exportSource", sourceUuid, passphrase, whistleflow),
+  ),
+  getWhistleflowEnabled: logIpcCall<boolean>("getWhistleflowEnabled", () =>
+    ipcRenderer.invoke("getWhistleflowEnabled"),
   ),
   initiatePrint: logIpcCall<DeviceStatus>("initiatePrint", () =>
     ipcRenderer.invoke("initiatePrint"),

--- a/app/src/renderer/locales/en.json
+++ b/app/src/renderer/locales/en.json
@@ -27,7 +27,9 @@
     },
     "menu": {
       "exportTranscript": "Export Transcript",
+      "exportTranscriptToWhistleflow": "Export Transcript to Whistleflow",
       "exportSource": "Export Transcript and Files",
+      "exportSourceToWhistleflow": "Export Transcript and Files to Whistleflow",
       "printTranscript": "Print Transcript",
       "clickToOpen": "Click to open"
     },
@@ -191,6 +193,7 @@
     "filenameTooltip": "Filename available after downloading",
     "viewFile": "View",
     "exportToUSB": "Export to USB",
+    "exportToWhistleflow": "Export to Whistleflow",
     "printFile": "Print",
     "wizard": {
       "malwareTitle": "Malware",

--- a/app/src/renderer/test-component-setup.tsx
+++ b/app/src/renderer/test-component-setup.tsx
@@ -224,6 +224,7 @@ beforeEach(() => {
     shouldAutoLogin: vi.fn().mockResolvedValue(false),
     clearClipboard: vi.fn().mockResolvedValue(null),
     openFile: vi.fn().mockResolvedValue(undefined),
+    getWhistleflowEnabled: vi.fn().mockResolvedValue(false),
     initiateExport: vi.fn().mockResolvedValue(ExportStatus.DEVICE_LOCKED),
     exportTranscript: vi.fn().mockResolvedValue(ExportStatus.SUCCESS_EXPORT),
     exportSource: vi.fn().mockResolvedValue(ExportStatus.SUCCESS_EXPORT),

--- a/app/src/renderer/views/Inbox/MainContent.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent.test.tsx
@@ -102,6 +102,7 @@ describe("MainContent Component", () => {
     (window as any).electronAPI = {
       getSourceWithItems: vi.fn().mockResolvedValue(mockSourceWithItems),
       addPendingItemsSeenBatch: vi.fn().mockResolvedValue(undefined),
+      getWhistleflowEnabled: vi.fn().mockResolvedValue(false),
     };
   });
 

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.test.tsx
@@ -294,6 +294,7 @@ describe("ExportWizard Component", () => {
         expect(exportMock).toHaveBeenCalledWith(
           [mockFilePayload.payload.uuid],
           testPassphrase,
+          undefined,
         );
       });
     });

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.tsx
@@ -47,6 +47,7 @@ interface ExportContext {
   errorMessage: string;
   deviceStatus?: DeviceStatus;
   unlockError: boolean;
+  whistleflow?: boolean;
 }
 
 const initialContext: ExportContext = {
@@ -59,6 +60,7 @@ const initialContext: ExportContext = {
   errorMessage: "",
   deviceStatus: undefined,
   unlockError: false,
+  whistleflow: undefined,
 };
 
 // Unrecoverable errors that should show error page
@@ -160,7 +162,10 @@ function exportReducer(
     case "CONFIRM_SOURCE":
       switch (action.type) {
         case "START_EXPORT":
-          return { ...context, state: "PREFLIGHT" };
+          return {
+            ...context,
+            state: context.whistleflow ? "EXPORTING" : "PREFLIGHT",
+          };
         default:
           return context;
       }
@@ -588,12 +593,14 @@ interface ExportWizardProps {
   item: ExportPayload;
   open: boolean;
   onClose: () => void;
+  whistleflow?: boolean;
 }
 
 export const ExportWizard = memo(function ExportWizard({
   item,
   open,
   onClose,
+  whistleflow,
 }: ExportWizardProps) {
   const { t } = useTranslation("Item");
 
@@ -614,11 +621,19 @@ export const ExportWizard = memo(function ExportWizard({
       break;
   }
 
+  const initialState: ExportState =
+    item.type === "source"
+      ? "CONFIRM_SOURCE"
+      : whistleflow
+        ? "EXPORTING"
+        : "PREFLIGHT";
+
   const [context, dispatch] = useReducer(exportReducer, {
     ...initialContext,
-    state: item.type === "source" ? "CONFIRM_SOURCE" : "PREFLIGHT",
+    state: initialState,
     itemType: item.type,
     filename: filename,
+    whistleflow: whistleflow,
     undownloadedItems:
       item.type === "source" ? item.payload.undownloaded_items : false,
   });
@@ -707,18 +722,21 @@ export const ExportWizard = memo(function ExportWizard({
             deviceStatus = await window.electronAPI.export(
               [item.payload.uuid],
               context.passphrase,
+              context.whistleflow,
             );
             break;
           case "transcript":
             deviceStatus = await window.electronAPI.exportTranscript(
               item.payload.source_uuid,
               context.passphrase,
+              context.whistleflow,
             );
             break;
           case "source": {
             deviceStatus = await window.electronAPI.exportSource(
               item.payload.source_uuid,
               context.passphrase,
+              context.whistleflow,
             );
             break;
           }
@@ -745,7 +763,7 @@ export const ExportWizard = memo(function ExportWizard({
     return () => {
       isCancelled = true;
     };
-  }, [context.state, item, context.passphrase, t]);
+  }, [context.state, item, context.passphrase, context.whistleflow, t]);
 
   const handleClose = () => {
     // Cancel any ongoing export operation

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo, useState, useEffect } from "react";
 import {
   FetchStatus,
   ItemUpdate,
@@ -406,8 +406,15 @@ const InProgressFile = memo(function InProgressFile({
 
 const CompleteFile = memo(function CompleteFile({ item }: { item: Item }) {
   const { t } = useTranslation("Item");
+  const [whistleflowEnabled, setWhistleflowEnabled] = useState(false);
   const [exportWizardOpen, setExportWizardOpen] = useState(false);
+  const [exportWizardKey, setExportWizardKey] = useState(0);
+  const [exportWhistleflow, setExportWhistleflow] = useState(false);
   const [printWizardOpen, setPrintWizardOpen] = useState(false);
+
+  useEffect(() => {
+    window.electronAPI.getWhistleflowEnabled().then(setWhistleflowEnabled);
+  }, []);
 
   const filename = item.filename
     ? item.filename.substring(item.filename.lastIndexOf("/") + 1)
@@ -442,6 +449,14 @@ const CompleteFile = memo(function CompleteFile({ item }: { item: Item }) {
   };
 
   const handleExportClick = () => {
+    setExportWhistleflow(false);
+    setExportWizardKey((k) => k + 1);
+    setExportWizardOpen(true);
+  };
+
+  const handleExportToWhistleflowClick = () => {
+    setExportWhistleflow(true);
+    setExportWizardKey((k) => k + 1);
     setExportWizardOpen(true);
   };
 
@@ -470,6 +485,15 @@ const CompleteFile = memo(function CompleteFile({ item }: { item: Item }) {
       label: t("exportToUSB"),
       onClick: handleExportClick,
     },
+    ...(whistleflowEnabled
+      ? [
+          {
+            key: "exportToWhistleflow",
+            label: t("exportToWhistleflow"),
+            onClick: handleExportToWhistleflowClick,
+          },
+        ]
+      : []),
     {
       key: "print",
       label: t("printFile"),
@@ -514,9 +538,11 @@ const CompleteFile = memo(function CompleteFile({ item }: { item: Item }) {
       </div>
 
       <ExportWizard
+        key={exportWizardKey}
         item={exportPayload}
         open={exportWizardOpen}
         onClose={handleExportWizardClose}
+        whistleflow={exportWhistleflow}
       />
       <PrintWizard
         item={printPayload}

--- a/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.test.tsx
@@ -224,7 +224,7 @@ describe("SourceMenu Component", () => {
       await userEvent.click(menuButton);
 
       const exportSourceItem = screen.getByRole("menuitem", {
-        name: /export transcript and files/i,
+        name: "Export Transcript and Files",
       });
       await userEvent.click(exportSourceItem);
 
@@ -262,7 +262,7 @@ describe("SourceMenu Component", () => {
       await userEvent.click(menuButton);
 
       const exportSourceItem = screen.getByRole("menuitem", {
-        name: /export transcript and files/i,
+        name: "Export Transcript and Files",
       });
       await userEvent.click(exportSourceItem);
 

--- a/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useMemo } from "react";
+import { memo, useState, useMemo, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import {
   type SourceWithItems,
@@ -21,10 +21,16 @@ const SourceMenu = memo(function SourceMenu({
 }: SourceMenuProps) {
   const { t } = useTranslation("MainContent");
 
+  const [whistleflowEnabled, setWhistleflowEnabled] = useState(false);
   const [exportType, setExportType] = useState<"transcript" | "source">(
     "transcript",
   );
+  const [exportWhistleflow, setExportWhistleflow] = useState(false);
   const [exportWizardKey, setExportWizardKey] = useState(0);
+
+  useEffect(() => {
+    window.electronAPI.getWhistleflowEnabled().then(setWhistleflowEnabled);
+  }, []);
 
   const exportPayload = useMemo((): ExportPayload => {
     if (exportType === "source") {
@@ -58,6 +64,7 @@ const SourceMenu = memo(function SourceMenu({
       case "exportTranscript":
         try {
           setExportType("transcript");
+          setExportWhistleflow(false);
           setExportWizardKey((k) => k + 1);
           setExportWizardOpen(true);
         } catch (error) {
@@ -67,6 +74,27 @@ const SourceMenu = memo(function SourceMenu({
       case "exportSource":
         try {
           setExportType("source");
+          setExportWhistleflow(false);
+          setExportWizardKey((k) => k + 1);
+          setExportWizardOpen(true);
+        } catch (error) {
+          console.error("Failed to export:", error);
+        }
+        break;
+      case "exportTranscriptToWhistleflow":
+        try {
+          setExportType("transcript");
+          setExportWhistleflow(true);
+          setExportWizardKey((k) => k + 1);
+          setExportWizardOpen(true);
+        } catch (error) {
+          console.error("Failed to export:", error);
+        }
+        break;
+      case "exportSourceToWhistleflow":
+        try {
+          setExportType("source");
+          setExportWhistleflow(true);
           setExportWizardKey((k) => k + 1);
           setExportWizardOpen(true);
         } catch (error) {
@@ -102,11 +130,29 @@ const SourceMenu = memo(function SourceMenu({
       label: t("menu.exportTranscript"),
       disabled: !hasConversation,
     },
+    ...(whistleflowEnabled
+      ? [
+          {
+            key: "exportTranscriptToWhistleflow",
+            label: t("menu.exportTranscriptToWhistleflow"),
+            disabled: !hasConversation,
+          },
+        ]
+      : []),
     {
       key: "exportSource",
       label: t("menu.exportSource"),
       disabled: !hasConversation,
     },
+    ...(whistleflowEnabled
+      ? [
+          {
+            key: "exportSourceToWhistleflow",
+            label: t("menu.exportSourceToWhistleflow"),
+            disabled: !hasConversation,
+          },
+        ]
+      : []),
     {
       key: "printTranscript",
       label: t("menu.printTranscript"),
@@ -138,6 +184,7 @@ const SourceMenu = memo(function SourceMenu({
         item={exportPayload}
         open={exportWizardOpen}
         onClose={handleExportWizardClose}
+        whistleflow={exportWhistleflow}
       />
       <PrintWizard
         item={printPayload}


### PR DESCRIPTION
Fixes #3190

Adds export profiles, which allow us to define a custom qube and RPC to use on export. The first instance of these export profiles is the export to whistleflow, which will be enabled only for the Guardian. In the future, we may have a more generic "export to VM" option.

TODO

- [ ] Implement feature flag

## Test plan
* [ ] Install this PR using try-client-pr, verify normal export to USB still works
* [ ] in dom0, run `qvm-features sd-app vm-config.WHISTLEFLOW true`, restart sd-app
* [ ] see that you now have extra whistleflow buttons
* [ ] create a new VM called whistleflow-view (maybe set RPC policies? TK), see that exporting to whistleflow works

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
