### PR TITLE
Have `make build-debs` tag verification be more sophisticated

### DIFF
--- a/scripts/build-debs.sh
+++ b/scripts/build-debs.sh
@@ -10,17 +10,7 @@
 
 set -euxo pipefail
 
-# --- BEGIN keep this section in sync with securedrop, so that build logs from
-# both repositories can be verified in the same way. ---
-
-git --no-pager log -1 --oneline --show-signature --no-color
-# We intentionally want the git tag list to be word-split
-# shellcheck disable=SC2046
-git --no-pager tag -v $(git tag --points-at HEAD)
-# Record if we're building with local (i.e., post-signature) changes present.
-git status --short
-
-# --- END keep this section in sync. ---
+./scripts/print-and-verify-git-tag.py
 
 OCI_RUN_ARGUMENTS="--user=root -v $(pwd):/src:Z"
 

--- a/scripts/print-and-verify-git-tag.py
+++ b/scripts/print-and-verify-git-tag.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Print git commit/tag info and verify signatures.
+# For production release tags (no 'rc'), the tag must be signed exclusively
+# by the production release key.
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def prod_key() -> str:
+    """
+    Extract key from Signed-By block.
+    Lines are indented with one space; empty lines in the key are ` .`
+    """
+    sources = Path("keyring/apt_freedom_press.sources").read_text()
+    key_lines = []
+    in_block = False
+    for line in sources.splitlines():
+        if line.startswith("Signed-By:"):
+            in_block = True
+            continue
+        if in_block:
+            if line.startswith(" "):
+                content = line[1:]
+                key_lines.append("" if content == "." else content)
+            else:
+                break
+    return "\n".join(key_lines) + "\n"
+
+
+print("$ git log -1 --oneline --show-signature")
+subprocess.run(
+    ["git", "--no-pager", "log", "-1", "--oneline", "--show-signature", "--no-color"], check=False
+)
+
+# Record if we're building with local changes present.
+print("$ git status --short")
+subprocess.run(["git", "status", "--short"], check=True)
+
+all_tags = subprocess.run(
+    ["git", "tag", "--points-at", "HEAD"], capture_output=True, text=True, check=False
+).stdout.split()
+
+if len(all_tags) > 1:
+    print(f"ERROR: multiple tags point at HEAD: {' '.join(all_tags)}", file=sys.stderr)
+    sys.exit(1)
+
+tag = all_tags[0] if all_tags else None
+if not tag:
+    # No tag, we're all done
+    sys.exit(0)
+
+if "rc" in tag:
+    # RC tags may be signed by a key not in the local keyring; don't fail.
+    print(f"$ git tag -v {tag}")
+    result = subprocess.run(["git", "--no-pager", "tag", "-v", tag], check=False)
+    if result.returncode == 0:
+        print(f"OK: Tag {tag} verified against local key")
+    else:
+        print(f"WARNING: Tag {tag} failed to verify")
+    sys.exit(0)
+
+print(f"Production release tag detected: {tag}")
+print("Verifying tag is signed by production key from keyring/apt_freedom_press.sources")
+
+
+tmpdir = tempfile.mkdtemp()
+Path(tmpdir).chmod(0o700)
+try:
+    subprocess.run(
+        ["gpg", "--homedir", tmpdir, "--import"], input=prod_key(), text=True, check=True
+    )
+    print(f"$ git tag -v {tag} # against production key")
+    result = subprocess.run(
+        ["git", "--no-pager", "tag", "-v", tag],
+        check=False,
+        env={**os.environ, "GNUPGHOME": tmpdir},
+    )
+    if result.returncode == 0:
+        print(f"OK: Tag {tag} verified against production key")
+    else:
+        print(f"ERROR: Tag {tag} failed verification against production key")
+        sys.exit(1)
+finally:
+    shutil.rmtree(tmpdir)


### PR DESCRIPTION
Currently we expect that you have the PGP key imported into your local keyring and that it's signed, but there's no automated check that prod tags are signed by prod keys.

The new `print-and-verify-git-tag.py` now has logic to verify tags using only the prod key (with a temp GPG keyring) unless it's an RC tag, in which case it's okay if verification fails (might not have all developers' keys).

This will help in two main cases:
1) This adds an extra check in addition to devs verifying prod tag signatures,
   since `make build-debs` will fail if its signed with the wrong key.
2) CI can now verify tag signatures before prepping release artifacts.

This script can be copied to our other repositories, just the implementation of `prod_key()` will differ.

Refs #2454.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] Copy this script to `./scripts/print-and-verify-git-tag2.py`
* [ ] Check out 1.0.0 tag; run `./scripts/print-and-verify-git-tag2.py` - see that prod tag is verified correctly
* [ ] Check out 1.0.0-rc5 tag; run `./scripts/print-and-verify-git-tag2.py` - see that RC tag is verified using local key
* [ ] Go back to main, create an unsigned `test` tag; run `./scripts/print-and-verify-git-tag2.py` - see that it fails verification against the prod tag

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
