### PR TITLE
Remove unused JournalistRow.version

### DIFF
--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -207,7 +207,6 @@ export type ItemRow = {
 export type JournalistRow = {
   uuid: string;
   data: string; // JSON stringified JournalistMetadata
-  version: string;
 };
 
 export type PendingEventRow = {


### PR DESCRIPTION
This type was out of sync with the SQL column, but more importantly it was never actually queried nor read.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] CI is happy
