### PR TITLE
[inbox] github action builds mac demo

### DIFF
--- a/.github/workflows/mac-demo.yml
+++ b/.github/workflows/mac-demo.yml
@@ -1,0 +1,61 @@
+name: Mac Demo Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Cancel in-progress builds for the same branch except on main
+concurrency:
+  group: mac-demo-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  mac-demo:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.x"
+          cache: pnpm
+          cache-dependency-path: app/pnpm-lock.yaml
+
+      # Keep version in sync with rust-toolchain.toml
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.90.0
+
+      - name: Install node dependencies
+        working-directory: app
+        run: pnpm install
+
+      - name: Build Mac demo DMG
+        working-directory: app
+        env:
+          # Enable code-signing on PRs (off by default)
+          CSC_FOR_PULL_REQUEST: true
+        run: pnpm build:mac-demo
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: mac-demo
+          path: app/dist/*.dmg

--- a/app/electron-builder.yml
+++ b/app/electron-builder.yml
@@ -35,10 +35,12 @@ mac:
   target:
     - dmg
   category: public.app-category.productivity
-  hardenedRuntime: true
+  # Use ad-hoc signing
+  identity: "-"
+  hardenedRuntime: false
+  entitlements: mac/entitlements.mac.plist
+  entitlementsInherit: mac/entitlements.mac.plist
   gatekeeperAssess: false
-  entitlements: build/entitlements.mac.plist
-  entitlementsInherit: build/entitlements.mac.plist
   extraResources:
     - from: node_modules/@dbmate/darwin-arm64/bin/dbmate
       to: bin/dbmate
@@ -47,5 +49,4 @@ mac:
     - from: scripts/securedrop-test-key.asc
       to: keys/securedrop-test-key.asc
 dmg:
-  sign: true
   title: "${productName}-${version}"

--- a/app/mac/entitlements.mac.plist
+++ b/app/mac/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
Allows us to trigger builds of the mac demo app for UX review via gh action. Builds should be uploaded as a pre-release draft

This was largely generated via Claude Code

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

- Download the DMG from the Mac Demo GitHub action on a Mac machine
- Unpack the `.app`
- Unquarantine the app, either through the Settings portal or with `xattr -cr ./MyApp.app`
- Should be able to run the SecureDrop Inbox and authenticate with demo credentials 
- App should run pointing at the demo server

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
