### PR TITLE
Upgrade to Electron 41 and better-sqlite 12.8

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -38,6 +38,7 @@
   "keywords": [],
   "license": "AGPL-3.0-or-later",
   "//": {
+    "better-sqlite": "12.9.1 doesn't have electron prebuilds working right now: https://github.com/WiseLibs/better-sqlite3/releases/tag/v12.9.1",
     "electron-builder": "pinned to 26.3.0 because of regressions: https://github.com/freedomofpress/securedrop-client/issues/2996"
   },
   "devDependencies": {
@@ -63,7 +64,7 @@
     "@vitejs/plugin-react": "^5.1.2",
     "@vitest/coverage-v8": "^3.2.4",
     "antd": "^5.29.3",
-    "electron": "^40.7.0",
+    "electron": "^41",
     "electron-builder": "<26.3.1",
     "electron-devtools-installer": "^4.0.0",
     "electron-vite": "^5.0.0",
@@ -100,7 +101,7 @@
     "@electron-toolkit/utils": "^4.0.0",
     "@sapphire/snowflake": "^3.5.5",
     "better-queue": "^3.8.12",
-    "better-sqlite3": "^12.6.0",
+    "better-sqlite3": "~12.8.0",
     "blakejs": "^1.2.1",
     "dbmate": "^2.29.3",
     "liquidjs": "^10.25.5",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
     dependencies:
       '@electron-toolkit/utils':
         specifier: ^4.0.0
-        version: 4.0.0(electron@40.8.5)
+        version: 4.0.0(electron@41.5.0)
       '@sapphire/snowflake':
         specifier: ^3.5.5
         version: 3.5.5
@@ -21,8 +21,8 @@ importers:
         specifier: ^3.8.12
         version: 3.8.12
       better-sqlite3:
-        specifier: ^12.6.0
-        version: 12.6.2
+        specifier: ~12.8.0
+        version: 12.8.0
       blakejs:
         specifier: ^1.2.1
         version: 1.2.1
@@ -59,7 +59,7 @@ importers:
         version: 3.1.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@electron-toolkit/preload':
         specifier: ^3.0.2
-        version: 3.0.2(electron@40.8.5)
+        version: 3.0.2(electron@41.5.0)
       '@electron-toolkit/tsconfig':
         specifier: ^2.0.0
         version: 2.0.0(@types/node@24.10.1)
@@ -112,8 +112,8 @@ importers:
         specifier: ^5.29.3
         version: 5.29.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       electron:
-        specifier: ^40.7.0
-        version: 40.8.5
+        specifier: ^41
+        version: 41.5.0
       electron-builder:
         specifier: <26.3.1
         version: 26.3.0(electron-builder-squirrel-windows@26.0.12)
@@ -161,7 +161,7 @@ importers:
         version: 0.562.0(react@19.2.3)
       node-abi:
         specifier: ^4.24.0
-        version: 4.24.0
+        version: 4.31.0
       otpauth:
         specifier: ^9.4.1
         version: 9.4.1
@@ -350,10 +350,6 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.27.1':
-    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
@@ -369,11 +365,6 @@ packages:
   '@babel/helpers@7.28.6':
     resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.27.5':
-    resolution: {integrity: sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.28.5':
     resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
@@ -421,10 +412,6 @@ packages:
 
   '@babel/traverse@7.28.6':
     resolution: {integrity: sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.27.6':
-    resolution: {integrity: sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.28.5':
@@ -1051,10 +1038,6 @@ packages:
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
-  '@jridgewell/gen-mapping@0.3.8':
-    resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
-    engines: {node: '>=6.0.0'}
-
   '@jridgewell/remapping@2.3.5':
     resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
@@ -1062,18 +1045,11 @@ packages:
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/set-array@1.2.1':
-    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
-    engines: {node: '>=6.0.0'}
-
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
-
-  '@jridgewell/trace-mapping@0.3.25':
-    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
@@ -2072,8 +2048,8 @@ packages:
   better-queue@3.8.12:
     resolution: {integrity: sha512-D9KZ+Us+2AyaCz693/9AyjTg0s8hEmkiM/MB3i09cs4MdK1KgTSGJluXRYmOulR69oLZVo2XDFtqsExDt8oiLA==}
 
-  better-sqlite3@12.6.2:
-    resolution: {integrity: sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==}
+  better-sqlite3@12.8.0:
+    resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
 
   bidi-js@1.0.3:
@@ -2528,8 +2504,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@40.8.5:
-    resolution: {integrity: sha512-pgTY/VPQKaiU4sTjfU96iyxCXrFm4htVPCMRT4b7q9ijNTRgtLmLvcmzp2G4e7xDrq9p7OLHSmu1rBKFf6Y1/A==}
+  electron@41.5.0:
+    resolution: {integrity: sha512-x9j9//PubUA4EjDtQbZhtk3prolandqCKgit0uCIqc1jb8FTskPbnJtxcDFB1aejczJcuERgjPixBUaMwoWyJg==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -3628,10 +3604,6 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
-  minimatch@5.1.6:
-    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
-    engines: {node: '>=10'}
-
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
@@ -3734,12 +3706,12 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  node-abi@3.87.0:
-    resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
+  node-abi@3.92.0:
+    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
     engines: {node: '>=10'}
 
-  node-abi@4.24.0:
-    resolution: {integrity: sha512-u2EC1CeNe25uVtX3EZbdQ275c74zdZmmpzrHEQh2aIYqoVjlglfUpOX9YY85x1nlBydEKDVaSmMNhR7N82Qj8A==}
+  node-abi@4.31.0:
+    resolution: {integrity: sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==}
     engines: {node: '>=22.12.0'}
 
   node-addon-api@1.7.2:
@@ -3907,10 +3879,6 @@ packages:
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.2:
-    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
@@ -4957,10 +4925,12 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   verror@1.10.1:
@@ -5197,8 +5167,8 @@ snapshots:
 
   '@ampproject/remapping@2.3.0':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.8
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@ant-design/colors@7.2.1':
     dependencies:
@@ -5337,8 +5307,8 @@ snapshots:
 
   '@babel/generator@7.28.5':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.28.6
+      '@babel/types': 7.28.6
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -5372,7 +5342,7 @@ snapshots:
   '@babel/helper-module-imports@7.27.1':
     dependencies:
       '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/types': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -5405,8 +5375,6 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
-  '@babel/helper-validator-identifier@7.27.1': {}
-
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-option@7.27.1': {}
@@ -5414,16 +5382,12 @@ snapshots:
   '@babel/helpers@7.28.4':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/types': 7.28.6
 
   '@babel/helpers@7.28.6':
     dependencies:
       '@babel/template': 7.28.6
       '@babel/types': 7.28.6
-
-  '@babel/parser@7.27.5':
-    dependencies:
-      '@babel/types': 7.27.6
 
   '@babel/parser@7.28.5':
     dependencies:
@@ -5453,8 +5417,8 @@ snapshots:
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.28.6
+      '@babel/types': 7.28.6
 
   '@babel/template@7.28.6':
     dependencies:
@@ -5467,9 +5431,9 @@ snapshots:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.5
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.28.6
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/types': 7.28.6
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -5485,11 +5449,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.27.6':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
 
   '@babel/types@7.28.5':
     dependencies:
@@ -5575,17 +5534,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron-toolkit/preload@3.0.2(electron@40.8.5)':
+  '@electron-toolkit/preload@3.0.2(electron@41.5.0)':
     dependencies:
-      electron: 40.8.5
+      electron: 41.5.0
 
   '@electron-toolkit/tsconfig@2.0.0(@types/node@24.10.1)':
     dependencies:
       '@types/node': 24.10.1
 
-  '@electron-toolkit/utils@4.0.0(electron@40.8.5)':
+  '@electron-toolkit/utils@4.0.0(electron@41.5.0)':
     dependencies:
-      electron: 40.8.5
+      electron: 41.5.0
 
   '@electron/asar@3.2.18':
     dependencies:
@@ -5597,7 +5556,7 @@ snapshots:
     dependencies:
       commander: 5.1.0
       glob: 7.2.3
-      minimatch: 3.1.2
+      minimatch: 3.1.5
 
   '@electron/fuses@1.8.0':
     dependencies:
@@ -5674,7 +5633,7 @@ snapshots:
       detect-libc: 2.1.2
       fs-extra: 10.1.0
       got: 11.8.6
-      node-abi: 3.87.0
+      node-abi: 3.92.0
       node-api-version: 0.2.1
       ora: 5.4.1
       read-binary-file-arch: 1.0.6
@@ -5693,7 +5652,7 @@ snapshots:
       detect-libc: 2.1.2
       got: 11.8.6
       graceful-fs: 4.2.11
-      node-abi: 4.24.0
+      node-abi: 4.31.0
       node-api-version: 0.2.1
       node-gyp: 11.5.0
       ora: 5.4.1
@@ -5723,7 +5682,7 @@ snapshots:
       debug: 4.4.3
       dir-compare: 4.2.0
       fs-extra: 11.3.3
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       plist: 3.1.0
     transitivePeerDependencies:
       - supports-color
@@ -6046,12 +6005,6 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@jridgewell/gen-mapping@0.3.8':
-    dependencies:
-      '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.25
-
   '@jridgewell/remapping@2.3.5':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -6059,16 +6012,9 @@ snapshots:
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
-  '@jridgewell/set-array@1.2.1': {}
-
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
-
-  '@jridgewell/trace-mapping@0.3.25':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
@@ -6755,12 +6701,12 @@ snapshots:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
       ast-v8-to-istanbul: 0.3.3
-      debug: 4.4.1
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.1.7
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       magicast: 0.3.5
       std-env: 3.9.0
       test-exclude: 7.0.1
@@ -6781,7 +6727,7 @@ snapshots:
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
-      magic-string: 0.30.17
+      magic-string: 0.30.21
     optionalDependencies:
       vite: 7.0.8(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.2)
 
@@ -6798,7 +6744,7 @@ snapshots:
   '@vitest/snapshot@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/spy@3.2.4':
@@ -7118,7 +7064,7 @@ snapshots:
 
   ast-v8-to-istanbul@0.3.3:
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 9.0.1
 
@@ -7200,7 +7146,7 @@ snapshots:
       node-eta: 0.9.0
       uuid: 9.0.1
 
-  better-sqlite3@12.6.2:
+  better-sqlite3@12.8.0:
     dependencies:
       bindings: 1.5.0
       prebuild-install: empty-package@file:empty-package
@@ -7634,7 +7580,7 @@ snapshots:
 
   dir-compare@4.2.0:
     dependencies:
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       p-limit: 3.1.0
 
   dmg-builder@26.3.0(electron-builder-squirrel-windows@26.0.12):
@@ -7795,7 +7741,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@40.8.5:
+  electron@41.5.0:
     dependencies:
       '@electron/get': 2.0.3
       '@types/node': 24.10.1
@@ -8258,7 +8204,7 @@ snapshots:
 
   filelist@1.0.4:
     dependencies:
-      minimatch: 5.1.6
+      minimatch: 5.1.9
 
   fill-range@7.1.1:
     dependencies:
@@ -8412,7 +8358,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -8422,7 +8368,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -8754,8 +8700,8 @@ snapshots:
 
   istanbul-lib-source-maps@5.0.6:
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      debug: 4.4.1
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -9037,13 +8983,13 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.27.5
-      '@babel/types': 7.27.6
+      '@babel/parser': 7.28.6
+      '@babel/types': 7.28.6
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.7.4
 
   make-fetch-happen@10.2.1:
     dependencies:
@@ -9128,10 +9074,6 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.12
-
-  minimatch@5.1.6:
-    dependencies:
-      brace-expansion: 2.0.2
 
   minimatch@5.1.9:
     dependencies:
@@ -9223,11 +9165,11 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  node-abi@3.87.0:
+  node-abi@3.92.0:
     dependencies:
       semver: 7.7.4
 
-  node-abi@4.24.0:
+  node-abi@4.31.0:
     dependencies:
       semver: 7.7.2
 
@@ -9404,8 +9346,6 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
-
-  picomatch@4.0.2: {}
 
   picomatch@4.0.3: {}
 
@@ -9917,7 +9857,7 @@ snapshots:
 
   readdir-glob@1.1.3:
     dependencies:
-      minimatch: 5.1.6
+      minimatch: 5.1.9
 
   redent@3.0.0:
     dependencies:
@@ -10443,7 +10383,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 10.5.0
-      minimatch: 9.0.5
+      minimatch: 9.0.9
 
   testcontainers@11.9.0:
     dependencies:
@@ -10706,7 +10646,7 @@ snapshots:
   vite-node@3.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1
+      debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.0.8(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.2)
@@ -10751,15 +10691,15 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.2.0
-      debug: 4.4.1
+      debug: 4.4.3
       expect-type: 1.2.1
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.2
+      picomatch: 4.0.3
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 7.0.8(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.2)

--- a/app/scripts/download-sqlite-binaries.py
+++ b/app/scripts/download-sqlite-binaries.py
@@ -179,7 +179,7 @@ def verify_node_checksum(node_file_path, runtime, args) -> None:
     print(f"✓ Checksum verified: {checksum_key}")
 
 
-def download_and_extract_binary(runtime, base_path, args, verify_checksum=True):
+def download_and_extract_binary(runtime, base_path, args, verify_checksum=True, force=False):
     """Download and extract a binary for the given runtime"""
     url = build_download_url(runtime, args)
     filename = Path(url).name
@@ -191,7 +191,7 @@ def download_and_extract_binary(runtime, base_path, args, verify_checksum=True):
     final_path = target_dir / "better_sqlite3.node"
 
     # Check if file already exists
-    if final_path.exists():
+    if not force and final_path.exists():
         print(f"Binary already exists: {final_path}")
         if verify_checksum:
             verify_node_checksum(final_path, runtime, args)
@@ -297,7 +297,7 @@ def main():
             # Node.js binary
             node_args = dict(**platform_args, abi=node_abi)
             node_path = download_and_extract_binary(
-                "node", base_path, node_args, verify_checksum=False
+                "node", base_path, node_args, verify_checksum=False, force=True
             )
             checksum_key = get_checksum_key("node", node_args)
             checksums[checksum_key] = calculate_checksum(node_path)
@@ -306,7 +306,7 @@ def main():
             # Electron binary
             electron_args = dict(**platform_args, abi=electron_abi)
             electron_path = download_and_extract_binary(
-                "electron", base_path, electron_args, verify_checksum=False
+                "electron", base_path, electron_args, verify_checksum=False, force=True
             )
             checksum_key = get_checksum_key("electron", electron_args)
             checksums[checksum_key] = calculate_checksum(electron_path)
@@ -325,14 +325,22 @@ def main():
     if os.environ.get("DEB_BUILD_OPTIONS") is None:
         # Download Node.js binary
         results["node"] = download_and_extract_binary(
-            "node", base_path, dict(**args, abi=node_abi), verify_checksum=True
+            "node",
+            base_path,
+            dict(**args, abi=node_abi),
+            verify_checksum=True,
+            force=args_parsed.update_checksums,
         )
     else:
         print("Not downloading node.js version for package build")
 
     # Download Electron binary
     results["electron"] = download_and_extract_binary(
-        "electron", base_path, dict(**args, abi=electron_abi), verify_checksum=True
+        "electron",
+        base_path,
+        dict(**args, abi=electron_abi),
+        verify_checksum=True,
+        force=args_parsed.update_checksums,
     )
 
     print()

--- a/app/scripts/sqlite-checksums.json
+++ b/app/scripts/sqlite-checksums.json
@@ -1,10 +1,10 @@
 {
-  "better-sqlite3-v12.6.2-electron-v143-darwin-arm64.node": "ca99f36d13643334c367a2d52a07e6eff50d431342e2c3648b4b47eb52876ed7",
-  "better-sqlite3-v12.6.2-electron-v143-darwin-x64.node": "15b8c57a250d79f1d0afe9f8ce9a913fb0be25e80042fc532435104040867f4e",
-  "better-sqlite3-v12.6.2-electron-v143-linux-arm64.node": "3234b08c0e54b3bca398889277f1acf3651e9a1d6582eff87bf2827808d2d8b3",
-  "better-sqlite3-v12.6.2-electron-v143-linux-x64.node": "0a9876cc0c893c9d1c09c9e1db2b34b61acd1cea4fb592c5a4a5f4d0da52ca95",
-  "better-sqlite3-v12.6.2-node-v137-darwin-arm64.node": "f4ab8ddc57768a1342fad1a948c7ff943fe553ebd73671054cd58c1f7cd33021",
-  "better-sqlite3-v12.6.2-node-v137-darwin-x64.node": "94360f9f3d8d924f161e8a93ab5599f9d4954950c8e1105b0991d5a3108e28bb",
-  "better-sqlite3-v12.6.2-node-v137-linux-arm64.node": "145193b7aad7e02d51ae9c6376c81de1e05af4af9cf9c7097b5eb38d4b22f036",
-  "better-sqlite3-v12.6.2-node-v137-linux-x64.node": "0ce99d60cc96c6aeea33438748d6c0a8d585f8dec24a10dbe5c68dcaed29ef83"
+  "better-sqlite3-v12.8.0-electron-v145-darwin-arm64.node": "5b6495c81a46204d80043ea0829aa15f450d6b32a3f3ffaaa7ad301c2c7db3d6",
+  "better-sqlite3-v12.8.0-electron-v145-darwin-x64.node": "145afec1e1579b1881db3e37af001a5d59788be9d27c96a47fb38ba057761e3b",
+  "better-sqlite3-v12.8.0-electron-v145-linux-arm64.node": "e00047885b81ac27f43a4f9bcc25ca39c60022d87762b06d861e1cf3f4952342",
+  "better-sqlite3-v12.8.0-electron-v145-linux-x64.node": "f507060e7934a78a1173592d6b7626670e2c0d3abee0d03f4d2409ad490cddbb",
+  "better-sqlite3-v12.8.0-node-v137-darwin-arm64.node": "7fd5c877dee29bd0cad8850eff93e82589d55f118934d9b333095fe64bb6faca",
+  "better-sqlite3-v12.8.0-node-v137-darwin-x64.node": "4f4782e3b6f75fecc796f7a5eca8da73f15e5fc6905c54b553cd53c288f8a86e",
+  "better-sqlite3-v12.8.0-node-v137-linux-arm64.node": "59076f58524ca20436960cbbcc2e6ba76bb574653e21334079ca85e37da6c19d",
+  "better-sqlite3-v12.8.0-node-v137-linux-x64.node": "dbd4e853e912261d8e7e50da6d25f5fa31d429ab2b250a8c6cf9da91c9a20e64"
 }

--- a/debian/securedrop-app.lintian-overrides
+++ b/debian/securedrop-app.lintian-overrides
@@ -2,7 +2,6 @@
 securedrop-app: embedded-library freetype [usr/lib/securedrop-app/securedrop-app]
 securedrop-app: embedded-library lcms2 [usr/lib/securedrop-app/securedrop-app]
 securedrop-app: embedded-library libjpeg [usr/lib/securedrop-app/securedrop-app]
-securedrop-app: embedded-library libjsoncpp [usr/lib/securedrop-app/securedrop-app]
 securedrop-app: embedded-library openjpeg [usr/lib/securedrop-app/securedrop-app]
 securedrop-app: embedded-library srtp [usr/lib/securedrop-app/securedrop-app]
 securedrop-app: embedded-library tiff [usr/lib/securedrop-app/securedrop-app]


### PR DESCRIPTION
See <https://www.electronjs.org/blog/electron-41-0>; it doesn't appear that we need to make any changes for this upgrade.

better-sqlite is being held at 12.8.x because 12.9.1 has some issues with the Electron prebuilds.


## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] Smoke test in Qubes w/ try-client-pr
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
