### PR TITLE
[inbox] disable file downloads in offline mode

### DIFF
--- a/app/src/renderer/locales/en.json
+++ b/app/src/renderer/locales/en.json
@@ -191,6 +191,7 @@
     "retry": "Retry",
     "cancel": "Cancel",
     "filenameTooltip": "Filename available after downloading",
+    "offlineFilenameTooltip": "Download disabled in offline mode. Filename available after downloading",
     "viewFile": "View",
     "exportToUSB": "Export to USB",
     "exportToWhistleflow": "Export to Whistleflow",

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
@@ -36,6 +36,11 @@ import FileVideoFilled from "./FileVideoFilled";
 import FileAudioFilled from "./FileAudioFilled";
 import { ExportWizard } from "./Export";
 import { PrintWizard } from "./Print";
+import { useAppSelector } from "../../../../../hooks";
+import {
+  getSessionState,
+  SessionStatus,
+} from "../../../../../features/session/sessionSlice";
 
 const EXCEL_EXTENSIONS = new Set([
   ".xls",
@@ -194,6 +199,9 @@ const File = memo(function File({ item, designation, onUpdate }: FileProps) {
   const fetchStatus = item.fetch_status;
   const [isHovered, setIsHovered] = useState(false);
 
+  const session = useAppSelector(getSessionState);
+  const disableFetch = session.status !== SessionStatus.Auth;
+
   let FileInner;
   switch (fetchStatus) {
     case FetchStatus.Initial:
@@ -274,7 +282,11 @@ const File = memo(function File({ item, designation, onUpdate }: FileProps) {
             setIsHovered(false)
           }
         >
-          <FileInner item={item} onUpdate={onUpdate} />
+          <FileInner
+            item={item}
+            onUpdate={onUpdate}
+            disableFetch={disableFetch}
+          />
         </div>
       </div>
     </div>
@@ -284,11 +296,13 @@ const File = memo(function File({ item, designation, onUpdate }: FileProps) {
 interface FileViewProps {
   item: Item;
   onUpdate: (update: ItemUpdate) => void;
+  disableFetch: boolean;
 }
 
 const InitialFile = memo(function InitialFile({
   item,
   onUpdate,
+  disableFetch,
 }: FileViewProps) {
   const { t } = useTranslation("Item");
   const fileSize = prettyPrintBytes(item.data.size);
@@ -317,6 +331,7 @@ const InitialFile = memo(function InitialFile({
             type="text"
             size="large"
             icon={<Download size={20} onClick={scheduleDownload} />}
+            disabled={disableFetch}
           />
         </div>
       </div>
@@ -327,6 +342,7 @@ const InitialFile = memo(function InitialFile({
 const InProgressFile = memo(function InProgressFile({
   item,
   onUpdate,
+  disableFetch,
 }: FileViewProps) {
   const { t } = useTranslation("Item");
   const progressBytes = item.fetch_progress ?? 0;
@@ -386,15 +402,30 @@ const InProgressFile = memo(function InProgressFile({
           </p>
           <div className="flex gap-1">
             {item.fetch_status === FetchStatus.DownloadInProgress ? (
-              <Button size="small" type="link" onClick={pauseDownload}>
+              <Button
+                size="small"
+                type="link"
+                onClick={pauseDownload}
+                disabled={disableFetch}
+              >
                 {t("pause")}
               </Button>
             ) : (
-              <Button size="small" type="link" onClick={resumeDownload}>
+              <Button
+                size="small"
+                type="link"
+                onClick={resumeDownload}
+                disabled={disableFetch}
+              >
                 {t("resume")}
               </Button>
             )}
-            <Button size="small" type="link" onClick={cancelDownload}>
+            <Button
+              size="small"
+              type="link"
+              onClick={cancelDownload}
+              disabled={disableFetch}
+            >
               {t("cancel")}
             </Button>
           </div>
@@ -553,7 +584,11 @@ const CompleteFile = memo(function CompleteFile({ item }: { item: Item }) {
   );
 });
 
-const FailedFile = memo(function FailedFile({ item, onUpdate }: FileViewProps) {
+const FailedFile = memo(function FailedFile({
+  item,
+  onUpdate,
+  disableFetch,
+}: FileViewProps) {
   const { t } = useTranslation("Item");
   const { token } = theme.useToken();
 
@@ -586,10 +621,20 @@ const FailedFile = memo(function FailedFile({ item, onUpdate }: FileViewProps) {
         </div>
       </div>
       <div className="flex gap-2">
-        <Button type="link" size="small" onClick={retryDownload}>
+        <Button
+          type="link"
+          size="small"
+          onClick={retryDownload}
+          disabled={disableFetch}
+        >
           {t("retry")}
         </Button>
-        <Button type="link" size="small" onClick={cancelDownload}>
+        <Button
+          type="link"
+          size="small"
+          onClick={cancelDownload}
+          disabled={disableFetch}
+        >
           {t("cancel")}
         </Button>
       </div>

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
@@ -199,6 +199,7 @@ const File = memo(function File({ item, designation, onUpdate }: FileProps) {
   const fetchStatus = item.fetch_status;
   const [isHovered, setIsHovered] = useState(false);
 
+  // Disable downloading of files in offline mode
   const session = useAppSelector(getSessionState);
   const disableFetch = session.status !== SessionStatus.Auth;
 
@@ -227,6 +228,9 @@ const File = memo(function File({ item, designation, onUpdate }: FileProps) {
   }
 
   const handleClick = () => {
+    if (disableFetch) {
+      return;
+    }
     if (
       fetchStatus === FetchStatus.Initial ||
       fetchStatus === FetchStatus.Cancelled
@@ -272,11 +276,13 @@ const File = memo(function File({ item, designation, onUpdate }: FileProps) {
           style={fileBoxStyle}
           onClick={handleClick}
           onMouseEnter={() =>
+            !disableFetch &&
             (fetchStatus === FetchStatus.Initial ||
               fetchStatus === FetchStatus.Cancelled) &&
             setIsHovered(true)
           }
           onMouseLeave={() =>
+            !disableFetch &&
             (fetchStatus === FetchStatus.Initial ||
               fetchStatus === FetchStatus.Cancelled) &&
             setIsHovered(false)
@@ -316,7 +322,9 @@ const InitialFile = memo(function InitialFile({
   };
 
   return (
-    <Tooltip title={t("filenameTooltip")}>
+    <Tooltip
+      title={disableFetch ? t("offlineFilenameTooltip") : t("filenameTooltip")}
+    >
       <div className="flex items-center justify-between pt-2 pb-2">
         <div className="flex items-center">
           <FileIcon size={30} strokeWidth={1} className="file-icon" />


### PR DESCRIPTION
Fixes #3274

Disables the file download buttons (and retry/cancel) when the user is in offline mode

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

- [ ] Start the SecureDrop Inbox 
- [ ] If not already, sync so that file metadata is available for submissions
- [ ] Enter offline mode 
- [ ] File download button should be disabled and not clickable 
- [ ] Sign in, file download button should be enabled and should initiate + complete file download

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
