### PR TITLE
[inbox] Quit modal only opens once

### DIFF
--- a/app/src/renderer/components/QuitModal.tsx
+++ b/app/src/renderer/components/QuitModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from "react";
+import { useEffect, useState } from "react";
 import { Modal } from "antd";
 import { useTranslation } from "react-i18next";
 import { useAppSelector } from "../hooks";
@@ -7,45 +7,43 @@ import { setQuitHandler } from "./quitRequester";
 function QuitModal() {
   const { t } = useTranslation("QuitModal");
   const drafts = useAppSelector((state) => state.drafts);
-  const [modal, contextHolder] = Modal.useModal();
-
-  const showQuitModal = useCallback(() => {
-    modal.confirm({
-      getContainer: false,
-      autoFocusButton: "ok",
-      title: t("title"),
-      icon: null,
-      content: Object.keys(drafts.drafts).length > 0 ? t("withDrafts") : "",
-      cancelText: t("goBack"),
-      okText: t(
-        Object.keys(drafts.drafts).length > 0 ? "discardAndQuit" : "Quit",
-      ),
-      onOk() {
-        window.electronAPI.quitApp();
-      },
-      onCancel() {},
-    });
-  }, [modal, t, drafts.drafts]);
+  const [visible, setVisible] = useState(false);
+  const hasDrafts = Object.keys(drafts.drafts).length > 0;
 
   // Expose showQuitModal for imperative calls (e.g. keyboard shortcut)
   useEffect(() => {
-    setQuitHandler(showQuitModal);
+    setQuitHandler(() => setVisible(true));
     return () => {
       setQuitHandler(null);
     };
-  }, [showQuitModal]);
+  }, [setVisible]);
 
   // Listen for quit-requested IPC from the main process
   useEffect(() => {
     const unsubscribe = window.electronAPI.onQuitRequested(() => {
-      showQuitModal();
+      setVisible(true);
     });
     return () => {
       unsubscribe();
     };
-  }, [showQuitModal]);
+  }, [setVisible]);
 
-  return <>{contextHolder}</>;
+  return (
+    <Modal
+      open={visible}
+      getContainer={false}
+      title={t("title")}
+      okText={t(hasDrafts ? "discardAndQuit" : "Quit")}
+      okButtonProps={{ autoFocus: true }}
+      cancelText={t("goBack")}
+      onOk={() => {
+        window.electronAPI.quitApp();
+      }}
+      onCancel={() => setVisible(false)}
+    >
+      {hasDrafts ? t("withDrafts") : ""}
+    </Modal>
+  );
 }
 
 export default QuitModal;


### PR DESCRIPTION
Fixes #3241 

Uses a deeclarative definition of the quit modal where visibility is toggled on/off so that we never display multiple quit modal windows.

## Test plan

- [x] Spam `Ctrl+Q` to attempt to open many quit modals 
- [x] Quit modal window should only appear once 
- [x] Canceling the modal works
- [x] Selecting "Quit" on the modal quits the application

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
