### PR TITLE
[inbox] sources_projected: update has_attachment and read on truncation

### DIFF
--- a/app/src/main/database/migrations/20260511000000_fix_sources_projected_pending_truncation.sql
+++ b/app/src/main/database/migrations/20260511000000_fix_sources_projected_pending_truncation.sql
@@ -1,0 +1,169 @@
+-- migrate:up
+-- Fix sources_projected to correctly project has_attachment and is_seen when
+-- a source_conversation_truncated event is pending.
+DROP VIEW IF EXISTS sources_projected;
+CREATE VIEW
+    sources_projected AS
+WITH
+    latest_starred AS (
+        SELECT
+            source_uuid,
+            CASE
+                WHEN type = 'source_starred' THEN true
+                WHEN type = 'source_unstarred' THEN false
+            END AS starred_value
+        FROM
+            (
+                SELECT
+                    source_uuid,
+                    type,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY
+                            source_uuid
+                        ORDER BY
+                            snowflake_id DESC
+                    ) AS rn
+                FROM
+                    pending_events
+                WHERE
+                    type IN ('source_starred', 'source_unstarred') AND
+                    source_uuid IS NOT NULL
+            ) latest
+        WHERE
+            rn = 1
+    )
+SELECT
+    sources.uuid,
+    CASE
+        WHEN latest_starred.starred_value IS NOT NULL THEN json_set (sources.data, '$.is_starred', starred_value)
+        ELSE sources.data
+    END AS data,
+    sources.version,
+    -- Use server has_attachment by default; override only when there are pending events
+    CASE
+        WHEN EXISTS (
+            SELECT
+                1
+            FROM
+                pending_events pe
+            WHERE
+                pe.source_uuid = sources.uuid
+        ) THEN CASE
+            WHEN EXISTS (
+                SELECT
+                    1
+                FROM
+                    items_projected ip
+                WHERE
+                    ip.source_uuid = sources.uuid AND
+                    ip.kind = 'file'
+            ) THEN 1
+            ELSE 0
+        END
+        ELSE sources.has_attachment
+    END AS has_attachment,
+    -- Use server is_seen by default; override only when there are pending events
+    CASE
+        WHEN EXISTS (
+            SELECT
+                1
+            FROM
+                pending_events pe
+            WHERE
+                pe.source_uuid = sources.uuid
+        ) THEN CASE
+            WHEN EXISTS (
+                SELECT
+                    1
+                FROM
+                    items_projected ip
+                WHERE
+                    ip.source_uuid = sources.uuid AND
+                    ip.is_read = 0 AND
+                    ip.kind != 'reply'
+            ) THEN 0
+            ELSE 1
+        END
+        ELSE sources.is_seen
+    END AS is_seen
+FROM
+    sources
+    LEFT JOIN latest_starred ON latest_starred.source_uuid = sources.uuid
+WHERE
+    NOT EXISTS (
+        SELECT
+            1
+        FROM
+            pending_events
+        WHERE
+            pending_events.source_uuid = sources.uuid AND
+            pending_events.type = 'source_deleted'
+    );
+-- migrate:down
+DROP VIEW IF EXISTS sources_projected;
+CREATE VIEW
+    sources_projected AS
+WITH
+    latest_starred AS (
+        SELECT
+            source_uuid,
+            CASE
+                WHEN type = 'source_starred' THEN true
+                WHEN type = 'source_unstarred' THEN false
+            END AS starred_value
+        FROM
+            (
+                SELECT
+                    source_uuid,
+                    type,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY
+                            source_uuid
+                        ORDER BY
+                            snowflake_id DESC
+                    ) AS rn
+                FROM
+                    pending_events
+                WHERE
+                    type IN ('source_starred', 'source_unstarred') AND
+                    source_uuid IS NOT NULL
+            ) latest
+        WHERE
+            rn = 1
+    )
+SELECT
+    sources.uuid,
+    CASE
+        WHEN latest_starred.starred_value IS NOT NULL THEN json_set (sources.data, '$.is_starred', starred_value)
+        ELSE sources.data
+    END AS data,
+    sources.version,
+    sources.has_attachment,
+    CASE
+    -- if there are unread items for this source in items_projected, 
+    -- then the source is unread
+        WHEN EXISTS (
+            SELECT
+                1
+            FROM
+                items_projected ip
+            WHERE
+                ip.source_uuid = sources.uuid AND
+                ip.is_read = 0
+        ) THEN 0
+        -- otherwise, the source is read
+        ELSE 1
+    END AS is_seen
+FROM
+    sources
+    LEFT JOIN latest_starred ON latest_starred.source_uuid = sources.uuid
+WHERE
+    NOT EXISTS (
+        SELECT
+            1
+        FROM
+            pending_events
+        WHERE
+            pending_events.source_uuid = sources.uuid AND
+            pending_events.type = 'source_deleted'
+    );

--- a/app/src/main/database/schema.sql
+++ b/app/src/main/database/schema.sql
@@ -167,57 +167,6 @@ WHERE pending_events.type = 'reply_sent'
         AND later.snowflake_id > pending_events.snowflake_id
     )
 /* items_projected(uuid,data,version,plaintext,filename,kind,is_read,last_updated,source_uuid,fetch_progress,fetch_status,fetch_last_updated_at,fetch_retry_attempts,interaction_count,decrypted_size) */;
-CREATE VIEW sources_projected AS
-WITH latest_starred AS (
-    SELECT
-        source_uuid,
-        CASE
-            WHEN type = 'source_starred' THEN true
-            WHEN type = 'source_unstarred' THEN false
-        END AS starred_value
-    FROM (
-        SELECT
-            source_uuid,
-            type,
-            ROW_NUMBER() OVER (
-                PARTITION BY source_uuid
-                ORDER BY snowflake_id DESC
-            ) AS rn
-        FROM pending_events
-        WHERE type IN ('source_starred', 'source_unstarred')
-            AND source_uuid IS NOT NULL
-    ) latest
-    WHERE rn = 1
-)
-SELECT
-    sources.uuid,
-    CASE
-        WHEN latest_starred.starred_value IS NOT NULL THEN json_set(sources.data, '$.is_starred', starred_value)
-        ELSE sources.data
-    END AS data,
-    sources.version,
-    sources.has_attachment,
-    CASE
-        WHEN sources.is_seen THEN 1
-        WHEN EXISTS (
-            SELECT 1 FROM items_projected ip
-            WHERE ip.source_uuid = sources.uuid AND ip.is_read = 0
-        ) THEN 0
-        WHEN NOT EXISTS (
-            SELECT 1 FROM items_projected ip
-            WHERE ip.source_uuid = sources.uuid
-        ) THEN 0
-        ELSE 1
-    END AS is_seen
-FROM sources
-LEFT JOIN latest_starred ON latest_starred.source_uuid = sources.uuid
-WHERE NOT EXISTS (
-    SELECT 1
-    FROM pending_events
-    WHERE pending_events.source_uuid = sources.uuid
-        AND pending_events.type = 'source_deleted'
-)
-/* sources_projected(uuid,data,version,has_attachment,is_seen) */;
 CREATE VIEW sorted_items AS
 SELECT
     *,
@@ -227,6 +176,103 @@ SELECT
     ) AS rn
 FROM items_projected
 /* sorted_items(uuid,data,version,plaintext,filename,kind,is_read,last_updated,source_uuid,fetch_progress,fetch_status,fetch_last_updated_at,fetch_retry_attempts,interaction_count,decrypted_size,rn) */;
+CREATE VIEW sources_projected AS
+WITH
+    latest_starred AS (
+        SELECT
+            source_uuid,
+            CASE
+                WHEN type = 'source_starred' THEN true
+                WHEN type = 'source_unstarred' THEN false
+            END AS starred_value
+        FROM
+            (
+                SELECT
+                    source_uuid,
+                    type,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY
+                            source_uuid
+                        ORDER BY
+                            snowflake_id DESC
+                    ) AS rn
+                FROM
+                    pending_events
+                WHERE
+                    type IN ('source_starred', 'source_unstarred') AND
+                    source_uuid IS NOT NULL
+            ) latest
+        WHERE
+            rn = 1
+    )
+SELECT
+    sources.uuid,
+    CASE
+        WHEN latest_starred.starred_value IS NOT NULL THEN json_set (sources.data, '$.is_starred', starred_value)
+        ELSE sources.data
+    END AS data,
+    sources.version,
+    -- Use server has_attachment by default; override only when there are pending events
+    CASE
+        WHEN EXISTS (
+            SELECT
+                1
+            FROM
+                pending_events pe
+            WHERE
+                pe.source_uuid = sources.uuid
+        ) THEN CASE
+            WHEN EXISTS (
+                SELECT
+                    1
+                FROM
+                    items_projected ip
+                WHERE
+                    ip.source_uuid = sources.uuid AND
+                    ip.kind = 'file'
+            ) THEN 1
+            ELSE 0
+        END
+        ELSE sources.has_attachment
+    END AS has_attachment,
+    -- Use server is_seen by default; override only when there are pending events
+    CASE
+        WHEN EXISTS (
+            SELECT
+                1
+            FROM
+                pending_events pe
+            WHERE
+                pe.source_uuid = sources.uuid
+        ) THEN CASE
+            WHEN EXISTS (
+                SELECT
+                    1
+                FROM
+                    items_projected ip
+                WHERE
+                    ip.source_uuid = sources.uuid AND
+                    ip.is_read = 0 AND
+                    ip.kind != 'reply'
+            ) THEN 0
+            ELSE 1
+        END
+        ELSE sources.is_seen
+    END AS is_seen
+FROM
+    sources
+    LEFT JOIN latest_starred ON latest_starred.source_uuid = sources.uuid
+WHERE
+    NOT EXISTS (
+        SELECT
+            1
+        FROM
+            pending_events
+        WHERE
+            pending_events.source_uuid = sources.uuid AND
+            pending_events.type = 'source_deleted'
+    )
+/* sources_projected(uuid,data,version,has_attachment,is_seen) */;
 -- Dbmate schema migrations
 INSERT INTO "schema_migrations" (version) VALUES
   ('20260203225412'),
@@ -235,4 +281,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20260326182530'),
   ('20260331000000'),
   ('20260416000000'),
-  ('20260507000000');
+  ('20260507000000'),
+  ('20260511000000');

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -413,6 +413,103 @@ describe("Datastore Method Tests", () => {
     expect(source1Item2).not.toBeNull();
   });
 
+  it("pending SourceConversationTruncated should update has_attachment based on remaining items", () => {
+    db.updateSources({
+      source1: { ...mockSourceMetadata("source1"), has_attachment: true },
+    });
+
+    db.updateItems({
+      item1: mockItemMetadata("item1", "source1", "file", 1),
+      item2: mockItemMetadata("item2", "source1", "message", 2),
+    });
+
+    let sources = db.getSources();
+    expect(sources.get("source1")!.hasAttachment).toBe(true);
+
+    // Truncate only the file item
+    db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 1 },
+    );
+
+    sources = db.getSources();
+    expect(sources.get("source1")!.hasAttachment).toBe(false);
+  });
+
+  it("pending SourceConversationTruncated should preserve has_attachment when file items remain", () => {
+    db.updateSources({
+      source1: { ...mockSourceMetadata("source1"), has_attachment: true },
+    });
+
+    db.updateItems({
+      item1: mockItemMetadata("item1", "source1", "file", 1),
+      item2: mockItemMetadata("item2", "source1", "file", 2),
+      item3: mockItemMetadata("item3", "source1", "message", 3),
+    });
+
+    // Truncate only first file item; second file item remains
+    db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 1 },
+    );
+
+    const sources = db.getSources();
+    expect(sources.get("source1")!.hasAttachment).toBe(true);
+  });
+
+  it("pending SourceConversationTruncated should mark source as read when all items removed", () => {
+    db.updateSources({
+      source1: mockSourceMetadata("source1"),
+    });
+
+    db.updateItems({
+      item1: mockItemMetadata("item1", "source1", "message", 1),
+      item2: mockItemMetadata("item2", "source1", "message", 2),
+    });
+
+    let sources = db.getSources();
+    expect(sources.get("source1")!.isRead).toBe(false);
+
+    // Truncate all items
+    db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 2 },
+    );
+
+    sources = db.getSources();
+    expect(sources.get("source1")!.isRead).toBe(true);
+  });
+
+  it("pending SourceConversationTruncated should mark source as read when remaining items are all read", () => {
+    db.updateSources({
+      source1: mockSourceMetadata("source1"),
+    });
+
+    db.updateItems({
+      // ic=2 stays after upper_bound=1 truncation, is_read=true
+      item1: {
+        ...mockItemMetadata("item1", "source1", "message", 2),
+        kind: "message",
+        is_read: true,
+      },
+      // ic=1 removed by upper_bound=1, is_read=false
+      item2: mockItemMetadata("item2", "source1", "message", 1),
+    });
+
+    // Only remove item2 (the unread item with ic=1)
+    db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 1 },
+    );
+
+    const sources = db.getSources();
+    expect(sources.get("source1")!.isRead).toBe(true);
+  });
+
   it("pending Starred event should star sources", () => {
     // Insert three sources
     db.updateSources({
@@ -499,22 +596,22 @@ describe("Datastore Method Tests", () => {
   });
 
   it("pending Seen event should mark seen", () => {
-    // Insert three sources
+    // Insert source
     db.updateSources({
       source1: mockSourceMetadata("source1", true),
-      source2: mockSourceMetadata("source2", true),
-      source3: mockSourceMetadata("source3", true),
     });
-    let sources = db.getSources();
-    for (const source of sources.values()) {
-      expect(source.isRead).toBe(false);
-    }
 
     db.updateItems({
       item1: mockItemMetadata("item1", "source1", "message", 1),
       item2: mockItemMetadata("item2", "source1", "message", 2),
       item3: mockItemMetadata("item3", "source1", "message", 3),
     });
+
+    let sources = db.getSources();
+    for (const source of sources.values()) {
+      expect(source.uuid).toBe("source1");
+      expect(source.isRead).toBe(false);
+    }
 
     // Partially marking items seen should not update source Seen state
     db.addPendingSourceConversationSeen("source1", 2);
@@ -526,11 +623,8 @@ describe("Datastore Method Tests", () => {
     db.addPendingSourceConversationSeen("source1", 3);
     sources = db.getSources();
     for (const source of sources.values()) {
-      if (source.uuid === "source1") {
-        expect(source.isRead).toBe(true);
-        continue;
-      }
-      expect(source.isRead).toBe(false);
+      expect(source.uuid).toBe("source1");
+      expect(source.isRead).toBe(true);
     }
   });
 


### PR DESCRIPTION
Fixes #3237 
Fixes #3308

## Test plan

- [x] Start SecureDrop Inbox with an unread source with attachments 
- [x] Source list should show source as unread (bolded) and has_attachment (file icon)
- [x] Select the source and "Delete Conversation"
- [x] Source should now immediately show as read (unbolded) and the file icon should disappear

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
