### PR TITLE
[inbox] crypto: return null on empty gz header filename

### DIFF
--- a/app/src/main/__tests__/crypto.unit.test.ts
+++ b/app/src/main/__tests__/crypto.unit.test.ts
@@ -105,7 +105,28 @@ describe("Crypto", () => {
       expect(result?.path).toBe(filename);
     });
 
-    it("should return empty string when no filename in header", () => {
+    it("should return null when gzip header filename is empty string", () => {
+      const gzipHeader = Buffer.from([
+        0x1f,
+        0x8b, // gzip magic
+        0x08, // compression method
+        0x08, // flags (FNAME bit set)
+        0x00,
+        0x00,
+        0x00,
+        0x00, // mtime
+        0x00, // extra flags
+        0x03, // OS
+        0x00, // empty filename (just the null terminator)
+      ]);
+
+      const result = (
+        crypto as unknown as CryptoWithPrivateMethods
+      ).readGzipHeaderFilename(gzipHeader);
+      expect(result).toBe(null);
+    });
+
+    it("should return null when no filename in header", () => {
       const gzipHeader = Buffer.from([
         0x1f,
         0x8b, // gzip magic

--- a/app/src/main/crypto.ts
+++ b/app/src/main/crypto.ts
@@ -550,6 +550,10 @@ export class Crypto {
       const filename = data
         .subarray(filenameStart, filenameEnd)
         .toString("utf8");
+
+      if (filename.trim().length === 0) {
+        return null;
+      }
       return new UnsafePathComponent(filename);
     }
 


### PR DESCRIPTION
Fixes #3193

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
