### PR TITLE
Revert "Bump pnpm/action-setup from 4 to 6.0.5"

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@v6.0.5
+        uses: pnpm/action-setup@v4
         with:
           version: 10
       - name: Install node
@@ -91,7 +91,7 @@ jobs:
           path: "securedrop-server"
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@v6.0.5
+        uses: pnpm/action-setup@v4
         with:
           version: 10
       - name: Install node
@@ -156,7 +156,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@v6.0.5
+        uses: pnpm/action-setup@v4
         with:
           version: 10
       - name: Install node
@@ -191,7 +191,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install pnpm
-        uses: pnpm/action-setup@v6.0.5
+        uses: pnpm/action-setup@v4
         with:
           version: 10
       - name: Install node


### PR DESCRIPTION
Reverts freedomofpress/securedrop-client#3396

Flaky for reasons I don't understand, shouldn't block the release.