### PR TITLE
Add source counts to the UI

### DIFF
--- a/app/src/renderer/App.tsx
+++ b/app/src/renderer/App.tsx
@@ -13,7 +13,7 @@ function App() {
   return (
     <>
       {!__IS_PRODUCTION__ && (
-        <div className="fixed bottom-1 left-1 z-50 bg-red-700 text-white text-xs font-bold py-1 px-4 leading-tight rounded">
+        <div className="fixed bottom-1 right-1 z-50 bg-red-700 text-white text-xs font-bold py-1 px-4 leading-tight rounded">
           {t("nonProduction")}
         </div>
       )}

--- a/app/src/renderer/locales/en.json
+++ b/app/src/renderer/locales/en.json
@@ -111,6 +111,14 @@
           "keepAccountsButton": "Delete Conversations"
         }
       },
+      "counts": {
+        "total_one": "{{count}} total source",
+        "total_other": "{{count}} total sources",
+        "visible_one": "{{count}} visible",
+        "visible_other": "{{count}} visible",
+        "selected_one": "{{count}} selected",
+        "selected_other": "{{count}} selected"
+      },
       "search": {
         "placeholder": "Search"
       },

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -13,6 +13,7 @@ import {
 } from "../../../features/sources/sourcesSlice";
 import { fetchConversation } from "../../../features/conversation/conversationSlice";
 import Toolbar, { type filterOption } from "./SourceList/Toolbar";
+import Counts from "./SourceList/Counts";
 import {
   PendingEventType,
   SearchResult,
@@ -454,6 +455,14 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
           className="select-none"
         />
       </div>
+
+      {/* Source counts */}
+      <Counts
+        totalCount={Object.keys(sources).length}
+        visibleCount={filteredSources.length}
+        selectedCount={selectedSources.size}
+        isFiltered={filter !== "all" || searchResults !== null}
+      />
 
       {/* Delete confirmation modal */}
       <Modal

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList/Counts.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList/Counts.tsx
@@ -1,0 +1,37 @@
+import { memo, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+interface CountsProps {
+  totalCount: number;
+  visibleCount: number;
+  selectedCount: number;
+  isFiltered: boolean;
+}
+
+const Counts = memo(function Counts({
+  totalCount,
+  visibleCount,
+  selectedCount,
+  isFiltered,
+}: CountsProps) {
+  const { t } = useTranslation("Sidebar");
+
+  const text = useMemo(() => {
+    const parts = [t("sourcelist.counts.total", { count: totalCount })];
+    if (isFiltered) {
+      parts.push(t("sourcelist.counts.visible", { count: visibleCount }));
+    }
+    if (selectedCount > 0) {
+      parts.push(t("sourcelist.counts.selected", { count: selectedCount }));
+    }
+    return parts.join(", ");
+  }, [t, totalCount, visibleCount, selectedCount, isFiltered]);
+
+  return (
+    <div className="px-4 py-2 text-xs text-gray-500 border-t border-gray-100 flex-shrink-0">
+      {text}
+    </div>
+  );
+});
+
+export default Counts;


### PR DESCRIPTION
Fixes #3298

This adds source counts to the bottom-left, beneath the source list, that looks something like:

- 13 total sources
- 13 total sources, 10 visible
- 13 total sources, 10 visible, 3 selected
- 13 total sources, 3 selected

In dev mode, I moved the "WARNING: non-production mode" label to the bottom right, so you can see the new counts.

<img width="1200" height="900" alt="image" src="https://github.com/user-attachments/assets/c39c5ccf-5e37-43d0-b482-7cbeabccecc6" />


## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
