### PR TITLE
[inbox] export: do not trigger duplicate export

### DIFF
--- a/app/src/main/export.test.ts
+++ b/app/src/main/export.test.ts
@@ -8,11 +8,12 @@ import {
   PrintExportError,
   PrintState,
   PrintStateMachine,
+  Exporter,
   ExportState,
   ExportStateMachine,
   EXPORT_QUBE,
 } from "./export";
-import { PrintStatus } from "../types";
+import { ExportStatus, PrintStatus } from "../types";
 
 // PrintStateMachine transitions
 describe("PrintStateMachine", () => {
@@ -327,5 +328,122 @@ describe("ArchiveExporter", () => {
       // Metadata file should be cleaned up
       expect(fs.existsSync(path.join(archiveDir, "metadata.json"))).toBe(false);
     });
+  });
+});
+
+// Exports are handled by a single Exporter instance, holding the export FSM state.
+// If concurrent export operations ran, they could mutate that shared singleton
+// state, resulting in invalid state transitions.
+//
+// Export operations should acquire a lock, enforcing that only one export is
+// in progress at a given time.
+describe("Exporter guards against concurrent export operations", () => {
+  // Mock the qrexec process so the test can control when the export operation finishes
+  function mockQrexec() {
+    let release!: () => void;
+    const promise = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    return { promise, release };
+  }
+
+  // Test Exporter that keeps ALL production logic but replaces the real qrexec
+  // transfer with a gated stub, so we can observe shared state mid-transfer.
+  class HarnessExporter extends Exporter {
+    qrexec = mockQrexec();
+    obs: Record<string, unknown> = {};
+
+    // Observe private FSM state for test
+    fsmState(): ExportState {
+      // @ts-expect-error -- fsm is private; we only read it for observation.
+      return this.fsm.state as ExportState;
+    }
+
+    async runQrexecExport(archivePath: string): Promise<void> {
+      const fakeProcess = { kill: () => {}, killed: false };
+      this.process = fakeProcess as unknown as typeof this.process;
+
+      this.obs.archiveExistsAtTransferStart = fs.existsSync(archivePath);
+
+      // Transfer is now "in flight". Block until the test releases us.
+      await this.qrexec.promise;
+
+      this.obs.archiveExistsAtTransferEnd = fs.existsSync(archivePath);
+      this.obs.processHandleAtTransferEnd = this.process;
+    }
+  }
+
+  it("rejects a second export without corrupting the in-flight export", async () => {
+    const src = fs.mkdtempSync(path.join(os.tmpdir(), "sd-race-src-"));
+    const file = path.join(src, "secret.txt");
+    fs.writeFileSync(file, "in-flight payload");
+
+    const exporter = new HarnessExporter();
+
+    // Export A: whistleflow=true takes the exportDirect path: Idle -> Exporting ---
+    const a = exporter.export([file], null, undefined, true);
+
+    // Let Export A reach the gated transfer (archive created, process spawned).
+    await new Promise((r) => setTimeout(r, 50));
+
+    const beforeB = exporter.fsmState();
+    expect(beforeB).toBe(ExportState.Exporting);
+
+    // Export B: a concurrent export against the same instance ---
+    let bError: unknown = null;
+    try {
+      await exporter.export([file], null, undefined, false);
+    } catch (e) {
+      bError = e;
+    }
+
+    const afterB = exporter.fsmState();
+
+    // Release Export A's transfer and let it settle.
+    exporter.qrexec.release();
+    const aResult = await a.then(
+      (v) => ({ status: "fulfilled" as const, value: v }),
+      (e) => ({ status: "rejected" as const, reason: e }),
+    );
+
+    // B must be rejected by the single-flight guard
+    expect(bError).not.toBeNull();
+    expect(String(bError)).toContain("already in progress");
+    // but has not hit an invalid state transition
+    expect(String(bError)).not.toContain("invalid state transition");
+
+    // In-flight Export A is untouched
+    // Archive still present throughout the transfer.
+    expect(exporter.obs.archiveExistsAtTransferStart).toBe(true);
+    expect(exporter.obs.archiveExistsAtTransferEnd).toBe(true);
+    // Process handle still owned by A during the transfer.
+    expect(exporter.obs.processHandleAtTransferEnd).not.toBeNull();
+    // FSM stayed in Exporting
+    expect(afterB).toBe(ExportState.Exporting);
+
+    // A completes successfully
+    expect(aResult.status).toBe("fulfilled");
+    expect(aResult.status === "fulfilled" && aResult.value).toBe(
+      ExportStatus.SUCCESS_EXPORT,
+    );
+  });
+
+  it("allows a fresh export after the previous one completes (lock is released)", async () => {
+    const src = fs.mkdtempSync(path.join(os.tmpdir(), "sd-race-src2-"));
+    const file = path.join(src, "secret.txt");
+    fs.writeFileSync(file, "payload");
+
+    const exporter = new HarnessExporter();
+
+    // First export: release immediately so it completes.
+    exporter.qrexec.release();
+    const first = await exporter.export([file], null, undefined, true);
+    expect(first).toBe(ExportStatus.SUCCESS_EXPORT);
+
+    // A subsequent, non-overlapping export must be allowed (lock was released).
+    exporter.qrexec = mockQrexec();
+    exporter.qrexec.release();
+    const second = await exporter.export([file], null, undefined, true);
+    expect(second).toBe(ExportStatus.SUCCESS_EXPORT);
   });
 });

--- a/app/src/main/export.ts
+++ b/app/src/main/export.ts
@@ -219,8 +219,28 @@ export class ArchiveExporter {
   tmpdir: string | null = null;
   backendQube: string;
 
+  // Track if export is in progress to guard against concurrent updates
+  // to the singleton FSM state.
+  private exportInProgress = false;
+
   constructor(backendQube: string) {
     this.backendQube = backendQube;
+  }
+
+  // Check if there is an export in progress: if so, throws to avoid
+  // concurrent mutation of export state.
+  protected acquireExportLock(): void {
+    if (this.exportInProgress) {
+      throw new PrintExportError(
+        "An export or print operation is already in progress",
+        DeviceErrorStatus.CALLED_PROCESS_ERROR,
+      );
+    }
+    this.exportInProgress = true;
+  }
+
+  protected releaseExportLock(): void {
+    this.exportInProgress = false;
   }
 
   /**
@@ -457,9 +477,11 @@ export class Printer extends ArchiveExporter {
   // Initiate print and run preflight checks to make sure that Export VM is started
   public async initiatePrint(): Promise<DeviceStatus> {
     console.log("Initiating print, beginning printer preflight checks");
-    this.fsm.transition({ action: "initiatePrint" });
+    this.acquireExportLock();
 
     try {
+      this.fsm.transition({ action: "initiatePrint" });
+
       if (!this.tmpdir) {
         this.tmpdir = await mkdtemp(path.join(os.tmpdir(), "sd-export-"));
         await chmodAsync(this.tmpdir, 0o700);
@@ -477,14 +499,18 @@ export class Printer extends ArchiveExporter {
       console.log("Error creating archive for printer preflight", err);
       this._onError();
       return DeviceErrorStatus.UNEXPECTED_RETURN_STATUS;
+    } finally {
+      this.releaseExportLock();
     }
   }
 
   public async print(filepaths: string[]): Promise<DeviceStatus> {
     console.log("Beginning print");
-    this.fsm.transition({ action: "print" });
+    this.acquireExportLock();
 
     try {
+      this.fsm.transition({ action: "print" });
+
       if (!this.tmpdir) {
         this.tmpdir = await mkdtemp(path.join(os.tmpdir(), "sd-export-"));
         await chmodAsync(this.tmpdir, 0o700);
@@ -503,6 +529,8 @@ export class Printer extends ArchiveExporter {
       console.log("Print failed", err);
       this._onError();
       return DeviceErrorStatus.UNEXPECTED_RETURN_STATUS;
+    } finally {
+      this.releaseExportLock();
     }
   }
 
@@ -575,11 +603,13 @@ export class Exporter extends ArchiveExporter {
 
   public async initiateExport(): Promise<DeviceStatus> {
     console.log("Beginning export preflight check");
-    this.fsm.transition({ action: "initiateExport" });
+    this.acquireExportLock();
 
     let status: DeviceStatus = DeviceErrorStatus.UNEXPECTED_RETURN_STATUS;
 
     try {
+      this.fsm.transition({ action: "initiateExport" });
+
       this.tmpdir = await mkdtemp(path.join(os.tmpdir(), "sd-export-"));
       await chmodAsync(this.tmpdir, 0o700);
 
@@ -594,6 +624,8 @@ export class Exporter extends ArchiveExporter {
     } catch (err) {
       console.log("Export preflight check failed", err);
       this._onError();
+    } finally {
+      this.releaseExportLock();
     }
     return status;
   }
@@ -604,6 +636,8 @@ export class Exporter extends ArchiveExporter {
     sourceName?: string,
     whistleflow?: boolean,
   ): Promise<DeviceStatus> {
+    this.acquireExportLock();
+
     let status: DeviceStatus;
     try {
       console.log(`Begin exporting ${filepaths.length} item(s)`);
@@ -647,6 +681,8 @@ export class Exporter extends ArchiveExporter {
       console.log("Export failed", err);
       this._onError();
       throw err;
+    } finally {
+      this.releaseExportLock();
     }
     return status;
   }

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.test.tsx
@@ -67,6 +67,11 @@ describe("ExportWizard Component", () => {
     await userEvent.click(continueButton);
   };
 
+  const close = async () => {
+    const cancelButton = screen.getByRole("button", { name: /cancel/i });
+    await userEvent.click(cancelButton);
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -369,6 +374,9 @@ describe("ExportWizard Component", () => {
           onClose={mockOnClose}
         />,
       );
+
+      await close();
+
       rerender(
         <ExportWizard
           item={mockFilePayload}

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.tsx
@@ -1,4 +1,4 @@
-import { memo, useReducer, useEffect, useRef } from "react";
+import { memo, useEffect, useReducer, useRef } from "react";
 import {
   type ExportPayload,
   DeviceStatus,
@@ -34,14 +34,12 @@ type ExportAction =
   | { type: "START_EXPORT" }
   | { type: "EXPORT_COMPLETE"; deviceStatus: DeviceStatus }
   | { type: "EXPORT_ERROR"; payload: string; deviceStatus?: DeviceStatus }
-  | { type: "CANCEL" }
-  | { type: "UPDATE_UNDOWNLOADED_ITEMS"; value: boolean };
+  | { type: "CANCEL" };
 
 interface ExportContext {
   state: ExportState;
   itemType: ExportPayload["type"];
   filename: string;
-  undownloadedItems: boolean;
   passphrase: string;
   deviceLocked: boolean;
   errorMessage: string;
@@ -54,7 +52,6 @@ const initialContext: ExportContext = {
   state: "PREFLIGHT",
   itemType: "file",
   filename: "",
-  undownloadedItems: false,
   passphrase: "",
   deviceLocked: true,
   errorMessage: "",
@@ -147,9 +144,6 @@ function exportReducer(
       deviceStatus: action.deviceStatus,
       passphrase: "",
     };
-  }
-  if (action.type === "UPDATE_UNDOWNLOADED_ITEMS") {
-    return { ...context, undownloadedItems: action.value };
   }
   if (action.type === "CANCEL") {
     return {
@@ -309,9 +303,11 @@ interface ErrorStateProps extends StateComponentProps {
 }
 
 const ConfirmSourceState = memo(function ConfirmSourceState({
-  context,
+  item,
   t,
 }: StateComponentProps) {
+  const undownloadedItems =
+    item.type === "source" ? item.payload.undownloaded_items : false;
   return (
     <div>
       <div className="flex items-center gap-3 mb-4">
@@ -325,7 +321,7 @@ const ConfirmSourceState = memo(function ConfirmSourceState({
       <hr className="my-4 border-gray-300" />
       <div className="space-y-4">
         <p>{t("exportWizard.sourceExportDescription")}</p>
-        {context.undownloadedItems && (
+        {undownloadedItems && (
           <div>
             <p className="text-yellow-800">
               {t("exportWizard.undownloadedFiles")}
@@ -645,13 +641,11 @@ export const ExportWizard = memo(function ExportWizard({
     itemType: item.type,
     filename: filename,
     whistleflow: whistleflow,
-    undownloadedItems:
-      item.type === "source" ? item.payload.undownloaded_items : false,
   });
 
   // Refs to track in-progress operations
   const preflightInProgress = useRef(false);
-  const exportInProgress = useRef(false);
+  const operationInProgress = useRef(false);
   const errorHeadingRef = useRef<HTMLHeadingElement>(null);
 
   // Reset state when wizard is closed
@@ -660,7 +654,7 @@ export const ExportWizard = memo(function ExportWizard({
       dispatch({ type: "CANCEL" });
       // Reset operation flags when closing
       preflightInProgress.current = false;
-      exportInProgress.current = false;
+      operationInProgress.current = false;
     }
   }, [open]);
 
@@ -675,121 +669,68 @@ export const ExportWizard = memo(function ExportWizard({
     });
   }, [context.state, open]);
 
-  // Sync undownloaded_items to update when items have been downloaded
-  const undownloadedItems =
-    item.type === "source" ? item.payload.undownloaded_items : false;
-  useEffect(() => {
-    dispatch({ type: "UPDATE_UNDOWNLOADED_ITEMS", value: undownloadedItems });
-  }, [undownloadedItems]);
-
-  // Initiate export preflight checks
-  useEffect(() => {
-    // Only run if we're in a preflight state, modal is open, and not already in progress
-    if (
-      !(
-        context.state === "PREFLIGHT" ||
-        context.state === "PREFLIGHT_INSERT_USB"
-      ) ||
-      !open ||
-      preflightInProgress.current
-    ) {
+  const runPreflight = async () => {
+    if (operationInProgress.current) {
       return;
     }
+    operationInProgress.current = true;
+    try {
+      const deviceStatus = await window.electronAPI.initiateExport();
+      dispatch({ type: "PREFLIGHT_COMPLETE", deviceStatus });
+    } catch (error) {
+      console.error("Failed to initiate export during preflight:", error);
+      dispatch({ type: "EXPORT_ERROR", payload: t("wizard.unknownError") });
+    } finally {
+      operationInProgress.current = false;
+    }
+  };
 
-    preflightInProgress.current = true;
-    let isCancelled = false;
-
-    const initiateExport = async () => {
-      try {
-        const deviceStatus = await window.electronAPI.initiateExport();
-        // Only dispatch if operation hasn't been cancelled
-        if (!isCancelled) {
-          dispatch({ type: "PREFLIGHT_COMPLETE", deviceStatus: deviceStatus });
-        }
-      } catch (error) {
-        if (!isCancelled) {
-          console.error("Failed to initiate export during preflight:", error);
-          const errorMessage = t("wizard.unknownError");
-          dispatch({ type: "EXPORT_ERROR", payload: errorMessage });
-        }
-      } finally {
-        preflightInProgress.current = false;
-      }
-    };
-
-    initiateExport();
-
-    // Cleanup function to mark operation as cancelled. This marks operation as
-    // cancelled in the frontend, but does not cancel the async preflight operation
-    // in the backend.
-    return () => {
-      isCancelled = true;
-    };
-  }, [open, context.state, t]);
-
-  // Perform export
-  useEffect(() => {
-    // Only run if we're in EXPORTING state and not already in progress
-    if (context.state !== "EXPORTING" || exportInProgress.current) {
+  const runExport = async (passphrase: string) => {
+    if (operationInProgress.current) {
       return;
     }
-
-    exportInProgress.current = true;
-    let isCancelled = false;
-
-    const performExport = async () => {
-      try {
-        let deviceStatus: DeviceStatus;
-        switch (item.type) {
-          case "file":
-            deviceStatus = await window.electronAPI.export(
-              [item.payload.uuid],
-              context.passphrase,
-              context.whistleflow,
-            );
-            break;
-          case "transcript":
-            deviceStatus = await window.electronAPI.exportTranscript(
-              item.payload.source_uuid,
-              context.passphrase,
-              context.whistleflow,
-            );
-            break;
-          case "source": {
-            deviceStatus = await window.electronAPI.exportSource(
-              item.payload.source_uuid,
-              context.passphrase,
-              context.whistleflow,
-            );
-            break;
-          }
-        }
-        // Only dispatch if operation hasn't been cancelled
-        if (!isCancelled) {
-          dispatch({ type: "EXPORT_COMPLETE", deviceStatus: deviceStatus });
-        }
-      } catch {
-        if (!isCancelled) {
-          const errorMessage = t("wizard.unknownError");
-          dispatch({ type: "EXPORT_ERROR", payload: errorMessage });
-        }
-      } finally {
-        exportInProgress.current = false;
+    operationInProgress.current = true;
+    try {
+      let deviceStatus: DeviceStatus;
+      switch (item.type) {
+        case "file":
+          deviceStatus = await window.electronAPI.export(
+            [item.payload.uuid],
+            passphrase,
+            whistleflow,
+          );
+          break;
+        case "transcript":
+          deviceStatus = await window.electronAPI.exportTranscript(
+            item.payload.source_uuid,
+            passphrase,
+            whistleflow,
+          );
+          break;
+        case "source":
+          deviceStatus = await window.electronAPI.exportSource(
+            item.payload.source_uuid,
+            passphrase,
+            whistleflow,
+          );
+          break;
       }
-    };
+      dispatch({ type: "EXPORT_COMPLETE", deviceStatus: deviceStatus! });
+    } catch {
+      dispatch({ type: "EXPORT_ERROR", payload: t("wizard.unknownError") });
+    } finally {
+      operationInProgress.current = false;
+    }
+  };
 
-    performExport();
-
-    // Cleanup function to mark operation as cancelled. This marks operation as
-    // cancelled in the frontend, but does not cancel the async export operation
-    // in the backend.
-    return () => {
-      isCancelled = true;
-    };
-  }, [context.state, item, context.passphrase, context.whistleflow, t]);
+  if (open && context.state === "PREFLIGHT") {
+    runPreflight();
+  }
+  if (open && context.state === "EXPORTING") {
+    runExport(context.passphrase);
+  }
 
   const handleClose = () => {
-    // Cancel any ongoing export operation
     window.electronAPI.cancelExport();
     dispatch({ type: "CANCEL" });
     onClose();
@@ -827,7 +768,12 @@ export const ExportWizard = memo(function ExportWizard({
           <Button
             key="continue"
             type="primary"
-            onClick={() => dispatch({ type: "START_EXPORT" })}
+            onClick={() => {
+              dispatch({ type: "START_EXPORT" });
+              if (!whistleflow) {
+                runPreflight();
+              }
+            }}
           >
             {t("wizard.continue")}
           </Button>,
@@ -854,6 +800,9 @@ export const ExportWizard = memo(function ExportWizard({
             type="primary"
             onClick={() => {
               dispatch({ type: "PREPARE_USB" });
+              if (context.deviceStatus === ExportStatus.DEVICE_WRITABLE) {
+                runExport(context.passphrase);
+              }
             }}
           >
             {t("wizard.continue")}
@@ -864,13 +813,13 @@ export const ExportWizard = memo(function ExportWizard({
         ];
 
       case "INSERT_USB":
-        // Show cancel button - user needs to insert USB or cancel
         return [
           <Button
             key="continue"
             type="primary"
             onClick={() => {
               dispatch({ type: "RETRY_PREFLIGHT" });
+              runPreflight();
             }}
           >
             {t("wizard.retry")}
@@ -888,10 +837,11 @@ export const ExportWizard = memo(function ExportWizard({
           <Button
             key="export"
             type="primary"
-            disabled={!context.passphrase}
-            onClick={() =>
-              dispatch({ type: "UNLOCK_DEVICE", payload: context.passphrase })
-            }
+            disabled={!context.passphrase?.trim()}
+            onClick={() => {
+              dispatch({ type: "UNLOCK_DEVICE", payload: context.passphrase });
+              runExport(context.passphrase);
+            }}
           >
             {t("wizard.continue")}
           </Button>,

--- a/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useMemo, useEffect } from "react";
+import { memo, useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import {
   type SourceWithItems,
@@ -22,34 +22,16 @@ const SourceMenu = memo(function SourceMenu({
   const { t } = useTranslation("MainContent");
 
   const [whistleflowEnabled, setWhistleflowEnabled] = useState(false);
-  const [exportType, setExportType] = useState<"transcript" | "source">(
-    "transcript",
-  );
   const [exportWhistleflow, setExportWhistleflow] = useState(false);
   const [exportWizardKey, setExportWizardKey] = useState(0);
+  const [exportPayload, setExportPayload] = useState<ExportPayload>({
+    type: "transcript",
+    payload: { source_uuid: sourceWithItems.uuid },
+  });
 
   useEffect(() => {
     window.electronAPI.getWhistleflowEnabled().then(setWhistleflowEnabled);
   }, []);
-
-  const exportPayload = useMemo((): ExportPayload => {
-    if (exportType === "source") {
-      return {
-        type: "source",
-        payload: {
-          source_uuid: sourceWithItems.uuid,
-          undownloaded_items: sourceWithItems.items.some(
-            (i) =>
-              i.data.kind === "file" && i.fetch_status !== FetchStatus.Complete,
-          ),
-        },
-      };
-    }
-    return {
-      type: "transcript",
-      payload: { source_uuid: sourceWithItems.uuid },
-    };
-  }, [exportType, sourceWithItems]);
 
   const printPayload: PrintPayload = {
     type: "transcript",
@@ -63,7 +45,10 @@ const SourceMenu = memo(function SourceMenu({
     switch (e.key) {
       case "exportTranscript":
         try {
-          setExportType("transcript");
+          setExportPayload({
+            type: "transcript",
+            payload: { source_uuid: sourceWithItems.uuid },
+          });
           setExportWhistleflow(false);
           setExportWizardKey((k) => k + 1);
           setExportWizardOpen(true);
@@ -73,7 +58,17 @@ const SourceMenu = memo(function SourceMenu({
         break;
       case "exportSource":
         try {
-          setExportType("source");
+          setExportPayload({
+            type: "source",
+            payload: {
+              source_uuid: sourceWithItems.uuid,
+              undownloaded_items: sourceWithItems.items.some(
+                (i) =>
+                  i.data.kind === "file" &&
+                  i.fetch_status !== FetchStatus.Complete,
+              ),
+            },
+          });
           setExportWhistleflow(false);
           setExportWizardKey((k) => k + 1);
           setExportWizardOpen(true);
@@ -83,7 +78,10 @@ const SourceMenu = memo(function SourceMenu({
         break;
       case "exportTranscriptToWhistleflow":
         try {
-          setExportType("transcript");
+          setExportPayload({
+            type: "transcript",
+            payload: { source_uuid: sourceWithItems.uuid },
+          });
           setExportWhistleflow(true);
           setExportWizardKey((k) => k + 1);
           setExportWizardOpen(true);
@@ -93,7 +91,17 @@ const SourceMenu = memo(function SourceMenu({
         break;
       case "exportSourceToWhistleflow":
         try {
-          setExportType("source");
+          setExportPayload({
+            type: "source",
+            payload: {
+              source_uuid: sourceWithItems.uuid,
+              undownloaded_items: sourceWithItems.items.some(
+                (i) =>
+                  i.data.kind === "file" &&
+                  i.fetch_status !== FetchStatus.Complete,
+              ),
+            },
+          });
           setExportWhistleflow(true);
           setExportWizardKey((k) => k + 1);
           setExportWizardOpen(true);


### PR DESCRIPTION
Fixes #3421

## Test plan
Reproduce initial bug behavior with "Export to Whistleflow"

To set up running with whistleflow:

- set the `WHISTLEFLOW` flag to be true
- create a `whistleflow-view` vm, and 
- enable `qubes.Filecopy` from `sd-app` to `whistleflow-view`

Reproduce duplicate export:

- Open a source with a downloaded file
- Send new messages to this source 
- Initiate export for the download and then trigger a sync with `Ctrl+S`
- Observe that there are duplicate/multiple export archives created in `whistleflow-view`

Verify fix on branch

- Open the same source
- Send new messages to this source
- Initiate export for the download and then trigger a sync with `Ctrl+S`
- `whistleflow-view` should only have a single archive created


## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
