### PR TITLE
[inbox] gracefully shutdown worker

### DIFF
--- a/app/src/main/fetch/worker.ts
+++ b/app/src/main/fetch/worker.ts
@@ -1,7 +1,7 @@
 import { parentPort, workerData } from "worker_threads";
 
 import { TaskQueue } from "./queue";
-import { AuthedRequest, FetchWorkerMessage } from "../../types";
+import { FetchWorkerMessage } from "../../types";
 import { Crypto } from "../crypto";
 import { Datastore } from "../datastore";
 import { Storage } from "../storage";
@@ -29,11 +29,23 @@ const db = new Datastore(crypto, new Storage());
 const q = new TaskQueue(db, port);
 
 port.on("message", (message: FetchWorkerMessage) => {
-  if ("type" in message && message.type === "cancel") {
-    q.cancelDownload(message.itemId);
-  } else if ("type" in message && message.type === "abortSourceFetch") {
-    q.abortSourceFetch(message.sourceUuid);
-  } else {
-    q.queueFetches(message as AuthedRequest);
+  if (!("type" in message)) {
+    console.error("Unrecognized message: ", message);
+  }
+  switch (message.type) {
+    case "cancel":
+      q.cancelDownload(message.itemId);
+      break;
+    case "abortSourceFetch":
+      q.abortSourceFetch(message.sourceUuid);
+      break;
+    case "authedRequest":
+      q.queueFetches(message.request);
+      break;
+    case "exit": {
+      console.log("Received exit message, shutting down...");
+      db.close();
+      process.exit(0);
+    }
   }
 });

--- a/app/src/main/index.test.ts
+++ b/app/src/main/index.test.ts
@@ -243,7 +243,10 @@ describe("syncMetadata IPC handler", () => {
     expect(testState.syncModule.syncMetadata).toHaveBeenCalledTimes(1);
     expect(testState.workerInstances).toHaveLength(1);
     expect(testState.workerInstances[0]?.postMessage).toHaveBeenCalledWith({
-      authToken: "resume-token",
+      type: "authedRequest",
+      request: {
+        authToken: "resume-token",
+      },
     });
   });
 
@@ -261,7 +264,10 @@ describe("syncMetadata IPC handler", () => {
     expect(testState.syncModule.syncMetadata).not.toHaveBeenCalled();
     expect(testState.workerInstances).toHaveLength(1);
     expect(testState.workerInstances[0]?.postMessage).toHaveBeenCalledWith({
-      authToken: "skip-token",
+      type: "authedRequest",
+      request: {
+        authToken: "skip-token",
+      },
     });
   });
 });

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -266,7 +266,7 @@ if (!gotTheLock) {
       return;
     }
 
-    fetchWorker.postMessage({ authToken } as AuthedRequest);
+    fetchWorker.postMessage({ type: "authedRequest", request: { authToken } });
   }
 
   // This method will be called when Electron has finished
@@ -919,7 +919,7 @@ if (!gotTheLock) {
     isQuitting = true;
     db.close();
     if (fetchWorker) {
-      void fetchWorker.terminate();
+      fetchWorker.postMessage({ type: "exit" });
     }
   });
 }

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -93,6 +93,12 @@ export type LoginFailure = {
 
 export type LoginResult = LoginSuccess | LoginFailure;
 
+// Message sent to fetch worker with authed request
+export type WorkerAuthedRequest = {
+  type: "authedRequest";
+  request: AuthedRequest;
+};
+
 // Message sent to the fetch worker to abort all active downloads and decryptions for a source
 export type AbortSourceFetch = {
   type: "abortSourceFetch";
@@ -105,11 +111,16 @@ export type CancelDownload = {
   itemId: string;
 };
 
+export type Exit = {
+  type: "exit";
+};
+
 // Union of all message types the fetch worker can receive
 export type FetchWorkerMessage =
-  | AuthedRequest
+  | WorkerAuthedRequest
   | AbortSourceFetch
-  | CancelDownload;
+  | CancelDownload
+  | Exit;
 
 // Re-export some types that are derived from zod schemas
 import type {


### PR DESCRIPTION
Fixes #3410 

Rather than calling `terminate` which hard-kills the worker, send an exit message so that the worker can close its DB connection and exit gracefully

## Test plan

_Reproduce unclean shutdown_

- Run Inbox off `main`
- Remove Inbox db and start from fresh client state, with changes to synchronize from the server
- Start up the Inbox 
- Once the initial sync completes + the worker begins processing the downloads and decryptions, kill the Inbox via `Ctrl-C`
- Observe in the logs: `Worker exited with code 1`
- In `.config/SecureDrop`, there should be `db.sqlite`, `db.sqlite-wal`, and `db.sqlite-shm`

_Verify clean shutdown_

- Run inbox from this PR branch
- Again, remove Inbox db and start form fresh client state
- Start up the Inbox
- Once initial sync completes + worker begins processing downloads and decryptions, kill the Inbox via `Ctrl-C`
- Observe in the logs: `Worker exited with code 0`
- In `.config/SecureDrop` there should only be a `db.sqlite` file, no `-wal` or `-shm`

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
