### PR TITLE
[inbox] improve keyboard nav for accessibility

### DIFF
--- a/app/src/renderer/locales/en.json
+++ b/app/src/renderer/locales/en.json
@@ -46,6 +46,8 @@
     "successReplyTooltip": "Reply sent successfully",
     "seenReplyTooltip": "Reply seen and deleted by source",
     "alreadyRunning": "The SecureDrop Inbox is already running",
+    "deleteMessage": "Delete message",
+    "deleteReply": "Delete reply",
     "deleteItemModal": {
       "title": "Delete item?",
       "content": "Are you sure you want to delete this item? Deleting is not reversible and will affect all users.",
@@ -95,6 +97,7 @@
       "actions": {
         "bulkDelete": "Delete selected sources"
       },
+      "selectAll": "Select all sources",
       "deleteDialog": {
         "warning": "If you delete a source's account, they will no longer be able to sign in and send you messages. To communicate with this source in the future, they must create a new account.",
         "countingItems": "Calculating items to delete...",
@@ -135,7 +138,8 @@
     "source": {
       "encryptedFile": "Encrypted File",
       "encryptedMessage": "Encrypted Message",
-      "toggleStar": "Toggle star"
+      "toggleStar": "Toggle star",
+      "selectSource": "Select {{designation}}"
     },
     "shortcuts": {
       "quit": "Quit SecureDrop",
@@ -170,7 +174,9 @@
     "passphrase": {
       "label": "Passphrase",
       "required": "Please enter your passphrase.",
-      "invalidLength": "That passphrase won't work. It should be between 14 and 128 characters long."
+      "invalidLength": "That passphrase won't work. It should be between 14 and 128 characters long.",
+      "showPassphrase": "Show passphrase",
+      "hidePassphrase": "Hide passphrase"
     },
     "twoFactorCode": {
       "label": "Two-Factor Code",
@@ -201,6 +207,7 @@
   },
   "Item": {
     "encryptedFile": "Encrypted File",
+    "downloadFile": "Download file",
     "pause": "Pause",
     "resume": "Resume",
     "of": "of",
@@ -209,10 +216,12 @@
     "cancel": "Cancel",
     "filenameTooltip": "Filename available after downloading",
     "offlineFilenameTooltip": "Download disabled in offline mode. Filename available after downloading",
+    "fileActions": "File actions",
     "viewFile": "View",
     "exportToUSB": "Export to USB",
     "exportToWhistleflow": "Export to Whistleflow",
     "printFile": "Print",
+    "deleteFile": "Delete item",
     "wizard": {
       "malwareTitle": "Malware",
       "malwareWarning": "This workstation lets you open files securely. If you open files on another computer, any embedded malware may spread to your computer or network. If you are unsure how to manage this risk, please print the file, or contact your administrator.",

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.test.tsx
@@ -1,7 +1,17 @@
-import { describe, it, vi } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import { expect, describe, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
 import File from "./File";
-import { testMemoization } from "../../../../../test-component-setup";
-import { FetchStatus, type Item } from "../../../../../../types";
+import {
+  renderWithProviders,
+  testMemoization,
+} from "../../../../../test-component-setup";
+import {
+  FetchStatus,
+  ItemUpdateType,
+  type Item,
+} from "../../../../../../types";
+import { SessionStatus } from "../../../../../features/session/sessionSlice";
 
 describe("File Component Memoization", () => {
   const mockOnUpdate = vi.fn();
@@ -105,4 +115,279 @@ describe("File Component Memoization", () => {
   ];
 
   it("should handle memoization correctly", testMemoization(File, cases));
+});
+
+describe("File Component", () => {
+  const mockOnUpdate = vi.fn();
+  const mockOnDelete = vi.fn();
+
+  const makeItem = (overrides: Partial<Item> = {}): Item => ({
+    uuid: "item-1",
+    data: {
+      uuid: "item-1",
+      kind: "file",
+      seen_by: [],
+      size: 1024,
+      source: "source-1",
+      is_read: false,
+      interaction_count: 0,
+    },
+    plaintext: null,
+    filename: null,
+    fetch_progress: null,
+    decrypted_size: null,
+    fetch_status: FetchStatus.Initial,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("download button has an accessible label", () => {
+    renderWithProviders(
+      <File
+        item={makeItem()}
+        designation="Test Source"
+        onUpdate={mockOnUpdate}
+        onDelete={mockOnDelete}
+      />,
+      {
+        preloadedState: {
+          session: { status: SessionStatus.Auth } as any,
+        },
+      },
+    );
+
+    const downloadButton = screen.getByRole("button", {
+      name: "Download file",
+    });
+    expect(downloadButton).toBeInTheDocument();
+  });
+
+  it("download button triggers onUpdate when activated by keyboard", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <File
+        item={makeItem()}
+        designation="Test Source"
+        onUpdate={mockOnUpdate}
+        onDelete={mockOnDelete}
+      />,
+      {
+        preloadedState: {
+          session: { status: SessionStatus.Auth } as any,
+        },
+      },
+    );
+
+    const downloadButton = screen.getByRole("button", {
+      name: "Download file",
+    });
+    downloadButton.focus();
+    await user.keyboard("{Enter}");
+
+    expect(mockOnUpdate).toHaveBeenCalledWith({
+      item_uuid: "item-1",
+      type: ItemUpdateType.FetchStatus,
+      fetch_status: FetchStatus.DownloadInProgress,
+    });
+  });
+
+  it("download button is disabled and not triggerable in offline mode", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <File
+        item={makeItem()}
+        designation="Test Source"
+        onUpdate={mockOnUpdate}
+        onDelete={mockOnDelete}
+      />,
+      {
+        preloadedState: {
+          session: { status: SessionStatus.Offline } as any,
+        },
+      },
+    );
+
+    const downloadButton = screen.getByRole("button", {
+      name: "Download file",
+    });
+    expect(downloadButton).toBeDisabled();
+
+    await user.click(downloadButton);
+    expect(mockOnUpdate).not.toHaveBeenCalled();
+  });
+
+  it("'Delete item' in dropdown is keyboard-accessible", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <File
+        item={makeItem({
+          fetch_status: FetchStatus.Complete,
+          filename: "/path/to/document.pdf",
+          decrypted_size: 2048,
+        })}
+        designation="Test Source"
+        onUpdate={mockOnUpdate}
+        onDelete={mockOnDelete}
+      />,
+      {
+        preloadedState: {
+          session: { status: SessionStatus.Auth } as any,
+        },
+      },
+    );
+
+    const actionsButton = screen.getByRole("button", { name: "File actions" });
+    actionsButton.focus();
+    await user.keyboard("{Enter}");
+
+    const deleteItem = await screen.findByRole("menuitem", {
+      name: "Delete item",
+    });
+    expect(deleteItem).toBeInTheDocument();
+  });
+
+  it("'Delete item' does not appear in file actions dropdown in offline mode", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <File
+        item={makeItem({
+          fetch_status: FetchStatus.Complete,
+          filename: "/path/to/document.pdf",
+          decrypted_size: 2048,
+        })}
+        designation="Test Source"
+        onUpdate={mockOnUpdate}
+        onDelete={mockOnDelete}
+      />,
+      {
+        preloadedState: {
+          session: { status: SessionStatus.Offline } as any,
+        },
+      },
+    );
+
+    // In offline mode the "File actions" button is still rendered (View/Export/Print
+    // remain available), but the destructive "Delete item" must not appear in the menu.
+    const actionsButton = screen.getByRole("button", { name: "File actions" });
+    await user.click(actionsButton);
+
+    expect(
+      screen.queryByRole("menuitem", { name: "Delete item" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("download button click does not dispatch action twice (no double-dispatch)", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <File
+        item={makeItem()}
+        designation="Test Source"
+        onUpdate={mockOnUpdate}
+        onDelete={mockOnDelete}
+      />,
+      {
+        preloadedState: {
+          session: { status: SessionStatus.Auth } as any,
+        },
+      },
+    );
+
+    const downloadButton = screen.getByRole("button", {
+      name: "Download file",
+    });
+    await user.click(downloadButton);
+
+    // The action should be dispatched exactly once even though the button is
+    // inside a fileBox div that also has an onClick handler.
+    expect(mockOnUpdate).toHaveBeenCalledOnce();
+  });
+
+  it("encrypted file info area is keyboard-focusable so tooltip is reachable", () => {
+    const { container } = renderWithProviders(
+      <File
+        item={makeItem()}
+        designation="Test Source"
+        onUpdate={mockOnUpdate}
+        onDelete={mockOnDelete}
+      />,
+      {
+        preloadedState: {
+          session: { status: SessionStatus.Auth } as any,
+        },
+      },
+    );
+
+    // Check that tabIndex=0 is properly set so keyboard users can focus the tooltip
+    const tooltipTrigger = container.querySelector(
+      ".flex.items-center[tabindex='0']",
+    );
+    expect(tooltipTrigger).not.toBeNull();
+    expect(tooltipTrigger).toHaveAttribute("tabindex", "0");
+  });
+
+  it("hover-reveal trash button is always in the tab order", () => {
+    const { container } = renderWithProviders(
+      <File
+        item={makeItem({
+          fetch_status: FetchStatus.Complete,
+          filename: "/path/to/document.pdf",
+          decrypted_size: 2048,
+        })}
+        designation="Test Source"
+        onUpdate={mockOnUpdate}
+        onDelete={mockOnDelete}
+      />,
+      {
+        preloadedState: {
+          session: { status: SessionStatus.Auth } as any,
+        },
+      },
+    );
+
+    // The trash button starts hidden (opacity 0) when not hovered, but it must
+    // remain in the tab order so keyboard users can reach and trigger it.
+    const trashButton = container.querySelector(
+      "[data-testid='file-delete-button']",
+    );
+    expect(trashButton).not.toBeNull();
+    // check that it has a discoverable tabindex (not -1)
+    expect(trashButton).not.toHaveAttribute("tabindex", "-1");
+  });
+
+  it("hover-reveal trash button becomes visible when focused", () => {
+    const { container } = renderWithProviders(
+      <File
+        item={makeItem({
+          fetch_status: FetchStatus.Complete,
+          filename: "/path/to/document.pdf",
+          decrypted_size: 2048,
+        })}
+        designation="Test Source"
+        onUpdate={mockOnUpdate}
+        onDelete={mockOnDelete}
+      />,
+      {
+        preloadedState: {
+          session: { status: SessionStatus.Auth } as any,
+        },
+      },
+    );
+
+    const trashButton = container.querySelector(
+      "[data-testid='file-delete-button']",
+    ) as HTMLElement;
+    expect(trashButton).not.toBeNull();
+
+    // Before focus the wrapper is opacity 0
+    const wrapper = trashButton.closest(".transition-opacity") as HTMLElement;
+    expect(wrapper.style.opacity).toBe("0");
+
+    // fireEvent.focus triggers the React onFocus handler and flushes state,
+    // which should make the button visible so keyboard users can see it.
+    fireEvent.focus(trashButton);
+    expect(wrapper.style.opacity).toBe("1");
+  });
 });

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.test.tsx
@@ -322,7 +322,7 @@ describe("File Component", () => {
 
     // Check that tabIndex=0 is properly set so keyboard users can focus the tooltip
     const tooltipTrigger = container.querySelector(
-      ".flex.items-center[tabindex='0']",
+      ".w-80.file-box[tabindex='0']",
     );
     expect(tooltipTrigger).not.toBeNull();
     expect(tooltipTrigger).toHaveAttribute("tabindex", "0");

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
@@ -217,6 +217,10 @@ const File = memo(function File({
     (fetchStatus === FetchStatus.Initial ||
       fetchStatus === FetchStatus.Cancelled);
 
+  const isInitialState =
+    fetchStatus === FetchStatus.Initial ||
+    fetchStatus === FetchStatus.Cancelled;
+
   let FileInner;
   switch (fetchStatus) {
     case FetchStatus.Initial:
@@ -283,28 +287,42 @@ const File = memo(function File({
           <span className="author">{titleCaseDesignation ?? ""}</span>
         </div>
         <div className="flex items-center gap-1">
-          <div
-            role="button"
-            tabIndex={isClickable ? 0 : undefined}
-            className="w-80 file-box"
-            style={fileBoxStyle}
-            onClick={handleClick}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                handleClick();
-              }
-            }}
-            onMouseEnter={() => setIsFileBoxHovered(true)}
-            onMouseLeave={() => setIsFileBoxHovered(false)}
+          <Tooltip
+            title={
+              isInitialState
+                ? disableFetch
+                  ? t("offlineFilenameTooltip")
+                  : t("filenameTooltip")
+                : undefined
+            }
+            trigger={["hover", "focus"]}
           >
-            <FileInner
-              disableFetch={disableFetch}
-              item={item}
-              onUpdate={onUpdate}
-              onDelete={onDelete}
-            />
-          </div>
+            <div
+              role="button"
+              tabIndex={isClickable || isInitialState ? 0 : undefined}
+              className="w-80 file-box"
+              style={fileBoxStyle}
+              onClick={handleClick}
+              onKeyDown={(e) => {
+                if (
+                  e.target === e.currentTarget &&
+                  (e.key === "Enter" || e.key === " ")
+                ) {
+                  e.preventDefault();
+                  handleClick();
+                }
+              }}
+              onMouseEnter={() => setIsFileBoxHovered(true)}
+              onMouseLeave={() => setIsFileBoxHovered(false)}
+            >
+              <FileInner
+                disableFetch={disableFetch}
+                item={item}
+                onUpdate={onUpdate}
+                onDelete={onDelete}
+              />
+            </div>
+          </Tooltip>
           {!disableFetch && (
             <div
               className="flex-shrink-0 transition-opacity group-hover:opacity-100"
@@ -355,25 +373,18 @@ const InitialFile = memo(function InitialFile({
 
   return (
     <div className="flex items-center justify-between pt-2 pb-2">
-      <Tooltip
-        title={
-          disableFetch ? t("offlineFilenameTooltip") : t("filenameTooltip")
-        }
-        trigger={["hover", "focus"]}
-      >
-        <div className="flex items-center">
-          <FileIcon
-            size={30}
-            strokeWidth={1}
-            className="file-icon"
-            aria-hidden="true"
-          />
-          <div className="ml-2">
-            <p className="italic">{t("encryptedFile")}</p>
-            <p className="italic">{fileSize}</p>
-          </div>
+      <div className="flex items-center">
+        <FileIcon
+          size={30}
+          strokeWidth={1}
+          className="file-icon"
+          aria-hidden="true"
+        />
+        <div className="ml-2">
+          <p className="italic">{t("encryptedFile")}</p>
+          <p className="italic">{fileSize}</p>
         </div>
-      </Tooltip>
+      </div>
 
       <div className="flex ml-8">
         <Button
@@ -383,7 +394,6 @@ const InitialFile = memo(function InitialFile({
           onClick={scheduleDownload}
           disabled={disableFetch}
           aria-label={t("downloadFile")}
-          tabIndex={0}
         />
       </div>
     </div>

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
@@ -200,10 +200,13 @@ const File = memo(function File({
   onUpdate,
   onDelete,
 }: FileProps) {
+  const { t } = useTranslation("Item");
   const { token } = theme.useToken();
   const titleCaseDesignation = toTitleCase(designation);
   const fetchStatus = item.fetch_status;
   const [isFileBoxHovered, setIsFileBoxHovered] = useState(false);
+  const [isDeleteFocused, setIsDeleteFocused] = useState(false);
+  const showDelete = isFileBoxHovered || isDeleteFocused;
 
   // Disable downloading of files in offline mode
   const session = useAppSelector(getSessionState);
@@ -299,16 +302,24 @@ const File = memo(function File({
               disableFetch={disableFetch}
               item={item}
               onUpdate={onUpdate}
+              onDelete={onDelete}
             />
           </div>
           {!disableFetch && (
-            <div className="flex-shrink-0 transition-opacity opacity-0 group-hover:opacity-100">
+            <div
+              className="flex-shrink-0 transition-opacity group-hover:opacity-100"
+              style={{ opacity: showDelete ? 1 : 0 }}
+            >
               <Button
                 type="text"
                 size="small"
                 danger
                 icon={<Trash size={16} />}
                 onClick={onDelete}
+                aria-label={t("deleteFile")}
+                onFocus={() => setIsDeleteFocused(true)}
+                onBlur={() => setIsDeleteFocused(false)}
+                data-testid="file-delete-button"
               />
             </div>
           )}
@@ -322,6 +333,7 @@ interface FileViewProps {
   item: Item;
   onUpdate: (update: ItemUpdate) => void;
   disableFetch: boolean;
+  onDelete?: () => void;
 }
 
 const InitialFile = memo(function InitialFile({
@@ -332,7 +344,8 @@ const InitialFile = memo(function InitialFile({
   const { t } = useTranslation("Item");
   const fileSize = prettyPrintBytes(item.data.size);
 
-  const scheduleDownload = () => {
+  const scheduleDownload = (e: React.MouseEvent) => {
+    e.stopPropagation();
     onUpdate({
       item_uuid: item.uuid,
       type: ItemUpdateType.FetchStatus,
@@ -341,28 +354,39 @@ const InitialFile = memo(function InitialFile({
   };
 
   return (
-    <Tooltip
-      title={disableFetch ? t("offlineFilenameTooltip") : t("filenameTooltip")}
-    >
-      <div className="flex items-center justify-between pt-2 pb-2">
+    <div className="flex items-center justify-between pt-2 pb-2">
+      <Tooltip
+        title={
+          disableFetch ? t("offlineFilenameTooltip") : t("filenameTooltip")
+        }
+        trigger={["hover", "focus"]}
+      >
         <div className="flex items-center">
-          <FileIcon size={30} strokeWidth={1} className="file-icon" />
+          <FileIcon
+            size={30}
+            strokeWidth={1}
+            className="file-icon"
+            aria-hidden="true"
+          />
           <div className="ml-2">
             <p className="italic">{t("encryptedFile")}</p>
             <p className="italic">{fileSize}</p>
           </div>
         </div>
+      </Tooltip>
 
-        <div className="flex ml-8">
-          <Button
-            type="text"
-            size="large"
-            icon={<Download size={20} onClick={scheduleDownload} />}
-            disabled={disableFetch}
-          />
-        </div>
+      <div className="flex ml-8">
+        <Button
+          type="text"
+          size="large"
+          icon={<Download size={20} />}
+          onClick={scheduleDownload}
+          disabled={disableFetch}
+          aria-label={t("downloadFile")}
+          tabIndex={0}
+        />
       </div>
-    </Tooltip>
+    </div>
   );
 });
 
@@ -462,7 +486,15 @@ const InProgressFile = memo(function InProgressFile({
   );
 });
 
-const CompleteFile = memo(function CompleteFile({ item }: { item: Item }) {
+const CompleteFile = memo(function CompleteFile({
+  item,
+  onDelete,
+  disableFetch,
+}: {
+  item: Item;
+  onDelete?: () => void;
+  disableFetch: boolean;
+}) {
   const { t } = useTranslation("Item");
   const [whistleflowEnabled, setWhistleflowEnabled] = useState(false);
   const [exportWizardOpen, setExportWizardOpen] = useState(false);
@@ -557,6 +589,17 @@ const CompleteFile = memo(function CompleteFile({ item }: { item: Item }) {
       label: t("printFile"),
       onClick: handlePrintClick,
     },
+    ...(onDelete && !disableFetch
+      ? [
+          { type: "divider" as const },
+          {
+            key: "delete",
+            label: t("deleteFile"),
+            danger: true,
+            onClick: onDelete,
+          },
+        ]
+      : []),
   ];
 
   return (
@@ -565,12 +608,13 @@ const CompleteFile = memo(function CompleteFile({ item }: { item: Item }) {
         <div className="flex items-center">
           <Icon style={{ fontSize: 30, color }} className="file-icon" />
           <div className="ml-2">
-            <Tooltip title={tooltipTitle}>
+            <Tooltip title={tooltipTitle} trigger={["hover", "focus"]}>
               <Button
                 size="small"
                 type="link"
                 className="file-namebtn"
                 onClick={handleOpenFile}
+                aria-label={filename}
               >
                 {formattedFilename}
               </Button>
@@ -590,6 +634,7 @@ const CompleteFile = memo(function CompleteFile({ item }: { item: Item }) {
               type="text"
               size="small"
               icon={<MoreOutlined style={{ fontSize: 18 }} />}
+              aria-label={t("fileActions")}
             />
           </Dropdown>
         </div>

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.test.tsx
@@ -1,4 +1,6 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { screen, fireEvent } from "@testing-library/react";
 import Message from "./Message";
 import {
   testMemoization,
@@ -1046,5 +1048,148 @@ describe("Reply", () => {
       expect(getByTestId("sent-reply-icon")).toBeInTheDocument();
       expect(queryByTestId("seen-reply-icon")).not.toBeInTheDocument();
     });
+  });
+});
+
+describe("Message and Reply delete button keyboard accessibility", () => {
+  const mockOnDelete = vi.fn();
+
+  const authState: Partial<import("../../../../../store").RootState> = {
+    session: {
+      status: SessionStatus.Auth,
+      authData: {
+        expiration: "2025-07-16T19:25:44.388054+00:00",
+        journalistUUID: "journalist-1",
+        journalistFirstName: "Daniel",
+        journalistLastName: "Ellsberg",
+      },
+    },
+    journalists: { journalists: [], loading: false, error: null },
+  };
+
+  const mockMessageItem: Item = {
+    uuid: "msg-1",
+    data: {
+      uuid: "msg-1",
+      kind: "message",
+      seen_by: [],
+      size: 512,
+      source: "source-1",
+      is_read: false,
+      interaction_count: 0,
+    },
+    plaintext: "Hello",
+    filename: null,
+    fetch_status: null,
+    fetch_progress: null,
+    decrypted_size: null,
+  };
+
+  const mockReplyItem: Item = {
+    uuid: "reply-1",
+    data: {
+      kind: "reply",
+      uuid: "reply-1",
+      source: "source-1",
+      size: 1024,
+      journalist_uuid: "journalist-1",
+      is_deleted_by_source: false,
+      seen_by: [],
+      interaction_count: 1,
+    } as import("../../../../../../types").ReplyMetadata,
+    plaintext: "A reply",
+    filename: null,
+    fetch_status: null,
+    fetch_progress: null,
+    decrypted_size: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("message delete button has an accessible label", () => {
+    renderWithProviders(
+      <Message
+        kind="message"
+        item={mockMessageItem}
+        designation="Test Source"
+        onUpdate={vi.fn()}
+        onDelete={mockOnDelete}
+      />,
+      { preloadedState: authState },
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Delete message" }),
+    ).toBeInTheDocument();
+  });
+
+  it("reply delete button has an accessible label", () => {
+    renderWithProviders(
+      <Message kind="reply" item={mockReplyItem} onDelete={mockOnDelete} />,
+      { preloadedState: authState },
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Delete reply" }),
+    ).toBeInTheDocument();
+  });
+
+  it("message delete button is reachable by keyboard and becomes visible on focus", async () => {
+    renderWithProviders(
+      <Message
+        kind="message"
+        item={mockMessageItem}
+        designation="Test Source"
+        onUpdate={vi.fn()}
+        onDelete={mockOnDelete}
+      />,
+      { preloadedState: authState },
+    );
+
+    const deleteBtn = screen.getByRole("button", { name: "Delete message" });
+    const wrapper = deleteBtn.closest(".transition-opacity") as HTMLElement;
+
+    // Starts hidden
+    expect(wrapper.style.opacity).toBe("0");
+
+    fireEvent.focus(deleteBtn);
+    expect(wrapper.style.opacity).toBe("1");
+  });
+
+  it("reply delete button is reachable by keyboard and becomes visible on focus", () => {
+    renderWithProviders(
+      <Message kind="reply" item={mockReplyItem} onDelete={mockOnDelete} />,
+      { preloadedState: authState },
+    );
+
+    const deleteBtn = screen.getByRole("button", { name: "Delete reply" });
+    const wrapper = deleteBtn.closest(".transition-opacity") as HTMLElement;
+
+    expect(wrapper.style.opacity).toBe("0");
+
+    fireEvent.focus(deleteBtn);
+    expect(wrapper.style.opacity).toBe("1");
+  });
+
+  it("message delete button calls onDelete when activated by keyboard", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <Message
+        kind="message"
+        item={mockMessageItem}
+        designation="Test Source"
+        onUpdate={vi.fn()}
+        onDelete={mockOnDelete}
+      />,
+      { preloadedState: authState },
+    );
+
+    const deleteBtn = screen.getByRole("button", { name: "Delete message" });
+    deleteBtn.focus();
+    await user.keyboard("{Enter}");
+
+    expect(mockOnDelete).toHaveBeenCalledOnce();
   });
 });

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useState } from "react";
 import {
   FetchStatus,
   ItemUpdateType,
@@ -49,6 +49,8 @@ const Message = memo(function Message(props: MessageProps) {
   const { kind, item, onDelete } = props;
   const { t } = useTranslation("MainContent");
   const { token } = theme.useToken();
+  const [isDeleteFocused, setIsDeleteFocused] = useState(false);
+  const showDelete = isDeleteFocused;
 
   const sessionState = useAppSelector(getSessionState);
   const disableDelete = sessionState.status !== SessionStatus.Auth;
@@ -204,13 +206,19 @@ const Message = memo(function Message(props: MessageProps) {
               {displayMessage()}
             </div>
             {!disableDelete && (
-              <div className="flex-shrink-0 transition-opacity opacity-0 group-hover:opacity-100">
+              <div
+                className="flex-shrink-0 transition-opacity group-hover:opacity-100"
+                style={{ opacity: showDelete ? 1 : 0 }}
+              >
                 <Button
                   type="text"
                   size="small"
                   danger
                   icon={<Trash size={16} />}
                   onClick={onDelete}
+                  aria-label={t("deleteMessage")}
+                  onFocus={() => setIsDeleteFocused(true)}
+                  onBlur={() => setIsDeleteFocused(false)}
                 />
               </div>
             )}
@@ -231,13 +239,19 @@ const Message = memo(function Message(props: MessageProps) {
         </div>
         <div className="flex items-center gap-1">
           {!disableDelete && (
-            <div className="flex-shrink-0 transition-opacity opacity-0 group-hover:opacity-100">
+            <div
+              className="flex-shrink-0 transition-opacity group-hover:opacity-100"
+              style={{ opacity: showDelete ? 1 : 0 }}
+            >
               <Button
                 type="text"
                 size="small"
                 danger
                 icon={<Trash size={16} />}
                 onClick={onDelete}
+                aria-label={t("deleteReply")}
+                onFocus={() => setIsDeleteFocused(true)}
+                onBlur={() => setIsDeleteFocused(false)}
               />
             </div>
           )}

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.tsx
@@ -111,7 +111,7 @@ const Source = memo(function Source({
       />
 
       {/* Star button */}
-      <Tooltip title={t("source.toggleStar")}>
+      <Tooltip title={t("source.toggleStar")} trigger={["hover", "focus"]}>
         <Button
           type="text"
           size="large"

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList/Toolbar.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList/Toolbar.tsx
@@ -95,17 +95,22 @@ const Toolbar = memo(function Toolbar({
           indeterminate={selectedCount > 0 && selectedCount < totalCount}
           onChange={(e) => onSelectAll(e.target.checked)}
           data-testid="select-all-checkbox"
+          aria-label={t("sourcelist.selectAll")}
         />
 
         {/* Only display action buttons if sources are selected */}
         {selectedCount > 0 && (
           <>
-            <Tooltip title={t("sourcelist.actions.bulkDelete")}>
+            <Tooltip
+              title={t("sourcelist.actions.bulkDelete")}
+              trigger={["hover", "focus"]}
+            >
               <Button
                 type="text"
                 icon={<Trash size={18} />}
                 onClick={onBulkDelete}
                 data-testid="bulk-delete-button"
+                aria-label={t("sourcelist.actions.bulkDelete")}
               />
             </Tooltip>
           </>
@@ -134,7 +139,10 @@ const Toolbar = memo(function Toolbar({
           </Button>
         </Dropdown>
 
-        <Tooltip title={t("sourcelist.sort.tooltip")}>
+        <Tooltip
+          title={t("sourcelist.sort.tooltip")}
+          trigger={["hover", "focus"]}
+        >
           <Button
             type="text"
             icon={
@@ -146,6 +154,7 @@ const Toolbar = memo(function Toolbar({
             }
             onClick={onToggleSort}
             data-testid="sort-button"
+            aria-label={t("sourcelist.sort.tooltip")}
           />
         </Tooltip>
       </div>

--- a/app/src/renderer/views/SignIn.test.tsx
+++ b/app/src/renderer/views/SignIn.test.tsx
@@ -6,6 +6,72 @@ import { renderWithProviders } from "../test-component-setup";
 import { SessionStatus } from "../features/session/sessionSlice";
 
 describe("SignInView Component", () => {
+  describe("passphrase visibility toggle", () => {
+    it("has an accessible toggle button with show label by default", async () => {
+      renderWithProviders(<SignInView />);
+
+      const toggleButton = screen.getByRole("button", {
+        name: "Show passphrase",
+      });
+      expect(toggleButton).toBeInTheDocument();
+    });
+
+    it("shows passphrase and updates aria-label when toggle is clicked", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SignInView />);
+
+      const passphraseInput = screen.getByTestId("passphrase-input");
+      const toggleButton = screen.getByRole("button", {
+        name: "Show passphrase",
+      });
+
+      await user.click(toggleButton);
+
+      expect(passphraseInput).toHaveAttribute("type", "text");
+      expect(
+        screen.getByRole("button", { name: "Hide passphrase" }),
+      ).toBeInTheDocument();
+    });
+
+    it("toggle button is keyboard operable via Enter", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SignInView />);
+
+      const passphraseInput = screen.getByTestId("passphrase-input");
+      const toggleButton = screen.getByRole("button", {
+        name: "Show passphrase",
+      });
+
+      toggleButton.focus();
+      await user.keyboard("{Enter}");
+
+      expect(passphraseInput).toHaveAttribute("type", "text");
+    });
+
+    it("toggle button has aria-pressed=false when passphrase is hidden", () => {
+      renderWithProviders(<SignInView />);
+
+      const toggleButton = screen.getByRole("button", {
+        name: "Show passphrase",
+      });
+      expect(toggleButton).toHaveAttribute("aria-pressed", "false");
+    });
+
+    it("toggle button has aria-pressed=true when passphrase is visible", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SignInView />);
+
+      const toggleButton = screen.getByRole("button", {
+        name: "Show passphrase",
+      });
+      await user.click(toggleButton);
+
+      expect(
+        screen.getByRole("button", { name: "Hide passphrase" }),
+      ).toHaveAttribute("aria-pressed", "true");
+    });
+  });
+
   it("says title and version", async () => {
     renderWithProviders(<SignInView />);
 

--- a/app/src/renderer/views/SignIn.tsx
+++ b/app/src/renderer/views/SignIn.tsx
@@ -2,7 +2,7 @@ import { Button, Input, Form, theme } from "antd";
 import type { FormProps, InputRef } from "antd";
 import { Eye, EyeOff } from "lucide-react";
 import { CloseOutlined, CloseCircleFilled } from "@ant-design/icons";
-import { useState, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
 
@@ -56,6 +56,11 @@ function SignInView() {
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const [hasValidationErrors, setHasValidationErrors] =
     useState<boolean>(false);
+  const [passwordVisible, setPasswordVisible] = useState<boolean>(false);
+
+  const togglePasswordVisibility = useCallback(() => {
+    setPasswordVisible((v) => !v);
+  }, []);
 
   // Focus the username input on mount
   useEffect(() => {
@@ -280,11 +285,24 @@ function SignInView() {
                 },
               ]}
             >
-              <Input.Password
+              <Input
                 data-testid="passphrase-input"
+                type={passwordVisible ? "text" : "password"}
                 placeholder="••••••••••••••••••••••••"
-                iconRender={(visible) =>
-                  visible ? <Eye size={18} /> : <EyeOff size={18} />
+                suffix={
+                  <button
+                    type="button"
+                    className="flex items-center text-gray-400 hover:text-gray-600 bg-transparent border-0 p-0 cursor-pointer rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500"
+                    onClick={togglePasswordVisibility}
+                    aria-pressed={passwordVisible}
+                    aria-label={
+                      passwordVisible
+                        ? t("passphrase.hidePassphrase")
+                        : t("passphrase.showPassphrase")
+                    }
+                  >
+                    {passwordVisible ? <Eye size={18} /> : <EyeOff size={18} />}
+                  </button>
                 }
               />
             </Form.Item>


### PR DESCRIPTION
- Fixes https://github.com/freedomofpress/securedrop-client/issues/3389
- Fixes https://github.com/freedomofpress/securedrop-client/issues/3382 
- Fixes https://github.com/freedomofpress/securedrop-client/issues/3381
- Fixes https://github.com/freedomofpress/securedrop-client/issues/3385 
- Fixes https://github.com/freedomofpress/securedrop-client/issues/3388
- Allow individual message/file deletion button to be accessible via keyboard navigation, and adds file deletion to the dropdown
- Adds aria-labels to the select-all/bulk-action buttons and checkboxes

## Test plan

- Open SecureDrop Inbox
- Using keyboard navigation, toggle the password visibility icon
- Tab over to the "sort order" toggle button. The `Toggle sort order` tooltip should appear
- Keyboard nav to the star button on a source. The `Toggle star` tooltip should appear
- Navigate within a conversation with an undownloaded file.
- Focusing the file with keyboard actions should bring up the `Filename available after download` tooltip
-  Keyboard nav to the file download button and initiate download
- Keyboard nav to the delete icon and delete a file
- Keyboard nav to the delete icon for an individual message and delete a message

