### PR TITLE
[inbox] add vitest-axe + accessibility unit tests

### DIFF
--- a/app/eslint.config.ts
+++ b/app/eslint.config.ts
@@ -9,7 +9,54 @@ import importPlugin from "eslint-plugin-import";
 import i18next from "eslint-plugin-i18next";
 import jsxA11y from "eslint-plugin-jsx-a11y";
 
-export default defineConfig([
+// Local rule: test files that call renderWithProviders must also call
+// renderAndCheckA11y so every rendered component is checked for accessibility.
+const requireA11yInTests = {
+  meta: {
+    type: "suggestion" as const,
+    docs: {
+      description:
+        "Test files that call renderWithProviders must also call renderAndCheckA11y.",
+    },
+    schema: [],
+    messages: {
+      missingA11yCall:
+        "This test file calls renderWithProviders but never calls " +
+        "renderAndCheckA11y. Add at least one renderAndCheckA11y(...) call " +
+        "to verify accessibility.",
+    },
+  },
+  create(context: { report: (d: object) => void }) {
+    let usesRenderWithProviders = false;
+    let usesRenderAndCheckA11y = false;
+    let programNode: object | null = null;
+    return {
+      Program(node: object) {
+        programNode = node;
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      CallExpression(node: any) {
+        const name =
+          node.callee.type === "Identifier" ? node.callee.name : null;
+        if (name === "renderWithProviders") {
+          usesRenderWithProviders = true;
+        }
+        if (name === "renderAndCheckA11y") {
+          usesRenderAndCheckA11y = true;
+        }
+      },
+      "Program:exit"() {
+        if (usesRenderWithProviders && !usesRenderAndCheckA11y) {
+          context.report({ node: programNode!, messageId: "missingA11yCall" });
+        }
+      },
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+
+export default tseslint.config(
   {
     ignores: [
       "eslint.config.ts",
@@ -74,4 +121,18 @@ export default defineConfig([
       "@typescript-eslint/no-explicit-any": "off",
     },
   },
-]);
+  // Require renderAndCheckA11y in every renderer test that calls renderWithProviders.
+  {
+    files: ["src/renderer/**/*.test.ts", "src/renderer/**/*.test.tsx"],
+    plugins: {
+      local: {
+        rules: {
+          "require-a11y-in-tests": requireA11yInTests,
+        },
+      },
+    },
+    rules: {
+      "local/require-a11y-in-tests": "error",
+    },
+  },
+);

--- a/app/package.json
+++ b/app/package.json
@@ -97,7 +97,8 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.53.0",
     "vite": "^7.0.8",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "vitest-axe": "^0.1.0"
   },
   "dependencies": {
     "@electron-toolkit/utils": "^4.0.0",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@24.10.1)(jiti@2.7.0)(jsdom@27.2.0(postcss@8.5.6))(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.2)
+      vitest-axe:
+        specifier: ^0.1.0
+        version: 0.1.0(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.10.1)(jiti@2.7.0)(jsdom@27.2.0(postcss@8.5.6))(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.2))
 
 packages:
 
@@ -2203,6 +2206,10 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
@@ -3520,6 +3527,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
@@ -5054,6 +5064,11 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  vitest-axe@0.1.0:
+    resolution: {integrity: sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==}
+    peerDependencies:
+      vitest: '>=0.16.0'
 
   vitest@3.2.4:
     resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
@@ -7454,6 +7469,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
   check-error@2.1.1: {}
 
   chownr@1.1.4: {}
@@ -9058,6 +9075,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.18.1: {}
 
   lodash.camelcase@4.3.0: {}
 
@@ -10829,6 +10848,16 @@ snapshots:
       lightningcss: 1.30.1
       tsx: 4.20.5
       yaml: 2.8.2
+
+  vitest-axe@0.1.0(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.10.1)(jiti@2.7.0)(jsdom@27.2.0(postcss@8.5.6))(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.2)):
+    dependencies:
+      aria-query: 5.3.2
+      axe-core: 4.11.4
+      chalk: 5.6.2
+      dom-accessibility-api: 0.5.16
+      lodash-es: 4.18.1
+      redent: 3.0.0
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@24.10.1)(jiti@2.7.0)(jsdom@27.2.0(postcss@8.5.6))(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.2)
 
   vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.10.1)(jiti@2.7.0)(jsdom@27.2.0(postcss@8.5.6))(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.2):
     dependencies:

--- a/app/src/renderer/App.test.tsx
+++ b/app/src/renderer/App.test.tsx
@@ -1,7 +1,10 @@
 import { screen, waitFor } from "@testing-library/react";
 import { expect } from "vitest";
 import App from "./App";
-import { renderWithProviders } from "./test-component-setup";
+import {
+  renderWithProviders,
+  renderAndCheckA11y,
+} from "./test-component-setup";
 import {
   unauthSessionState,
   SessionStatus,
@@ -18,6 +21,15 @@ vi.mock("./views/SignIn", () => ({
   // eslint-disable-next-line i18next/no-literal-string
   default: () => <div data-testid="signin-view">Sign In View</div>,
 }));
+
+describe("App accessibility", () => {
+  it("has no axe violations on the sign-in redirect (unauthenticated)", async () => {
+    await renderAndCheckA11y(<App />, {
+      initialEntries: ["/"],
+      preloadedState: { session: unauthSessionState },
+    });
+  });
+});
 
 describe("App Component", () => {
   it("renders inbox view when user has valid session and navigates to root", async () => {

--- a/app/src/renderer/components/FirstRunPopup.test.tsx
+++ b/app/src/renderer/components/FirstRunPopup.test.tsx
@@ -2,7 +2,30 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, vi, beforeEach } from "vitest";
 import { FirstRunPopup } from "./FirstRunPopup";
-import { renderWithProviders } from "../test-component-setup";
+import {
+  renderWithProviders,
+  renderAndCheckA11y,
+} from "../test-component-setup";
+
+describe("FirstRunPopup accessibility", () => {
+  it("has no axe violations when no popup is shown (null status)", async () => {
+    window.electronAPI.getFirstRunStatus = vi.fn().mockResolvedValue(null);
+    await renderAndCheckA11y(<FirstRunPopup />);
+  });
+
+  it("has no axe violations when the new-user popup is visible", async () => {
+    window.electronAPI.getFirstRunStatus = vi
+      .fn()
+      .mockResolvedValue("new_user");
+    const result = await renderAndCheckA11y(<FirstRunPopup />);
+    // Wait for the async popup to appear and re-check
+    await waitFor(() => {
+      expect(
+        result.getByText("Welcome to SecureDrop Inbox"),
+      ).toBeInTheDocument();
+    });
+  });
+});
 
 describe("FirstRunPopup Component", () => {
   beforeEach(() => {

--- a/app/src/renderer/components/TruncatedText.test.tsx
+++ b/app/src/renderer/components/TruncatedText.test.tsx
@@ -1,8 +1,22 @@
 import { screen } from "@testing-library/react";
 import { expect, describe, it } from "vitest";
 import userEvent from "@testing-library/user-event";
-import { renderWithProviders, testMemoization } from "../test-component-setup";
+import {
+  renderWithProviders,
+  renderAndCheckA11y,
+  testMemoization,
+} from "../test-component-setup";
 import TruncatedText from "./TruncatedText";
+
+describe("TruncatedText accessibility", () => {
+  it("has no axe violations on short text", async () => {
+    await renderAndCheckA11y(<TruncatedText text="Short message" />);
+  });
+
+  it("has no axe violations on truncated text", async () => {
+    await renderAndCheckA11y(<TruncatedText text={"a".repeat(3500)} />);
+  });
+});
 
 describe("TruncatedText Component Memoization", () => {
   const cases: Array<[{ text: string; maxCodePoints?: number }, number]> = [

--- a/app/src/renderer/test-a11y.d.ts
+++ b/app/src/renderer/test-a11y.d.ts
@@ -1,0 +1,4 @@
+// Augments Vitest's Vi.Assertion with axe accessibility matchers so that
+// expect(axeResults).toHaveNoViolations() is correctly typed everywhere in
+// the renderer test compilation.
+import "vitest-axe/extend-expect";

--- a/app/src/renderer/test-component-setup.tsx
+++ b/app/src/renderer/test-component-setup.tsx
@@ -2,6 +2,9 @@
 import { expect, afterEach, beforeEach, vi } from "vitest";
 import { cleanup, render, type RenderResult } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
+import { configureAxe } from "vitest-axe";
+import * as vitestAxeMatchers from "vitest-axe/matchers";
+import "vitest-axe/extend-expect";
 import { MemoryRouter, useLocation } from "react-router";
 import { Provider } from "react-redux";
 import React, { memo } from "react";
@@ -53,6 +56,8 @@ global.ResizeObserver = class {
 
 // extends Vitest's expect with jest-dom matchers
 expect.extend(matchers);
+// extends Vitest's expect with axe accessibility matchers
+expect.extend(vitestAxeMatchers);
 
 // Mock window.matchMedia for Ant components
 Object.defineProperty(window, "matchMedia", {
@@ -247,6 +252,46 @@ beforeEach(() => {
     getAppVersion: vi.fn().mockResolvedValue("testVersion"),
   } as ElectronAPI;
 });
+
+// Accessibility testing helpers
+
+export const checkA11y = configureAxe({
+  rules: {
+    // Disable color-contrast: jsdom does not compute CSS so this would produce
+    // false positives.
+    "color-contrast": { enabled: false },
+  },
+});
+
+export const renderAndCheckA11y = async (
+  ui: React.ReactElement,
+  options?: Parameters<typeof renderWithProviders>[1],
+  // Axe rule IDs that this call site is currently expected to violate.
+  // This way, we can mute pre-existing failures to avoid blocking CI while
+  // still catching + fixing new violations + new rules.
+  // Should mark each mute-site with a TODO and aim to eventually remove all
+  // knownViolations and this param.
+  knownViolations: string[] = [],
+): Promise<RenderResult & { store: ReturnType<typeof setupStore> }> => {
+  const result = renderWithProviders(ui, options);
+  const results = await checkA11y(result.container);
+  const violations = results.violations ?? [];
+  const firing = new Set(violations.map((v) => v.id));
+
+  // Unexpected violations still fail CI.
+  const unexpected = violations.filter((v) => !knownViolations.includes(v.id));
+  expect({ ...results, violations: unexpected }).toHaveNoViolations();
+
+  // If we had previously muted a violation but it has since been fixed,
+  // should alert so that we remember to clean up the knownViolations list.
+  const stale = knownViolations.filter((id) => !firing.has(id));
+  expect(
+    stale,
+    `These a11y rules no longer fail: remove from knownViolations: ${stale.join(", ")}`,
+  ).toEqual([]);
+
+  return result;
+};
 
 // Component to track react-router location changes for testing
 export const LocationTracker = ({

--- a/app/src/renderer/views/Inbox.test.tsx
+++ b/app/src/renderer/views/Inbox.test.tsx
@@ -1,7 +1,19 @@
 import { screen } from "@testing-library/react";
 import { expect } from "vitest";
 import InboxView from "./Inbox";
-import { renderWithProviders } from "../test-component-setup";
+import {
+  renderWithProviders,
+  renderAndCheckA11y,
+} from "../test-component-setup";
+
+describe("InboxView accessibility", () => {
+  it("has no axe violations on initial render", async () => {
+    // TODO(a11y): ARIA input field is missing an accessible name.
+    await renderAndCheckA11y(<InboxView />, undefined, [
+      "aria-input-field-name",
+    ]);
+  });
+});
 
 describe("InboxView Component", () => {
   it('says the string "Select a source"', () => {

--- a/app/src/renderer/views/Inbox/MainContent.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent.test.tsx
@@ -4,7 +4,10 @@ import { Routes, Route, useNavigate } from "react-router";
 import { useEffect } from "react";
 import MainContent from "./MainContent";
 import type { SourceWithItems } from "../../../types";
-import { renderWithProviders } from "../../test-component-setup";
+import {
+  renderWithProviders,
+  renderAndCheckA11y,
+} from "../../test-component-setup";
 import { fetchConversation } from "../../features/conversation/conversationSlice";
 
 const testNav: { current: ReturnType<typeof useNavigate> | null } = {
@@ -96,6 +99,38 @@ const mockSourceWithItems: SourceWithItems = {
     },
   ],
 };
+
+describe("MainContent accessibility", () => {
+  beforeEach(() => {
+    (window as any).electronAPI = {
+      getSourceWithItems: vi.fn().mockResolvedValue(null),
+      addPendingItemsSeenBatch: vi.fn().mockResolvedValue(undefined),
+      getWhistleflowEnabled: vi.fn().mockResolvedValue(false),
+    };
+  });
+
+  it("has no axe violations on the empty state (no source selected)", async () => {
+    await renderAndCheckA11y(
+      <Routes>
+        <Route path="/" element={<MainContent />} />
+        <Route path="/source/:sourceUuid" element={<MainContent />} />
+      </Routes>,
+      {
+        initialEntries: ["/"],
+        preloadedState: {
+          conversation: {
+            conversation: null,
+            loading: false,
+            error: null,
+            lastFetchTime: null,
+            hasMoreHistoricalItems: false,
+            olderItemsLoading: false,
+          },
+        },
+      },
+    );
+  });
+});
 
 describe("MainContent Component", () => {
   beforeEach(() => {

--- a/app/src/renderer/views/Inbox/MainContent/Conversation.a11y.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation.a11y.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, vi } from "vitest";
+import React from "react";
+import Conversation from "./Conversation";
+import { renderAndCheckA11y } from "../../../test-component-setup";
+import type { SourceWithItems } from "../../../../types";
+
+// Stub out Element.prototype.scrollTo so the conversation scroll logic doesn't
+// error in jsdom, which doesn't implement it.
+Element.prototype.scrollTo = vi.fn(function (
+  this: Element,
+  optionsOrX?: ScrollToOptions | number,
+) {
+  if (
+    typeof optionsOrX === "object" &&
+    optionsOrX !== null &&
+    "top" in optionsOrX &&
+    optionsOrX.top !== undefined
+  ) {
+    (this as HTMLElement).scrollTop = optionsOrX.top;
+  }
+}) as unknown as typeof Element.prototype.scrollTo;
+
+// Mirror the react-window mock from Conversation.test.tsx so the virtual list
+// renders rows and the useConversationScroll hooks (useDynamicRowHeight,
+// useListCallbackRef) are provided without DOM measurement.
+vi.mock("react-window", () => {
+  return {
+    List: ({
+      rowComponent: RowComponent,
+      rowCount,
+      rowProps,
+      listRef,
+    }: {
+      rowComponent: (props: {
+        index: number;
+        style: React.CSSProperties;
+        [k: string]: unknown;
+      }) => React.ReactNode;
+      rowCount: number;
+      rowHeight: unknown;
+      rowProps: Record<string, unknown>;
+      listRef?: (api: unknown) => void;
+      [k: string]: unknown;
+    }) => {
+      const containerRef = React.useRef<HTMLDivElement>(null);
+      React.useEffect(() => {
+        if (listRef && containerRef.current) {
+          const el = containerRef.current;
+          listRef({
+            get element() {
+              return el;
+            },
+            scrollToRow({ index, align }: { index?: number; align?: string }) {
+              if (el) {
+                if (align === "end") {
+                  el.scrollTop = el.scrollHeight;
+                } else if (align === "center" && index !== undefined) {
+                  const rowEl = el.children[index] as HTMLElement | undefined;
+                  if (rowEl) {
+                    el.scrollTop = Math.max(
+                      0,
+                      rowEl.offsetTop - el.clientHeight / 2,
+                    );
+                  }
+                }
+              }
+            },
+          });
+        }
+      }, [listRef]);
+      return (
+        <div ref={containerRef} data-testid="conversation-items-container">
+          {Array.from({ length: rowCount }, (_, i) => (
+            <div key={i}>
+              <RowComponent index={i} style={{}} {...rowProps} />
+            </div>
+          ))}
+        </div>
+      );
+    },
+    useDynamicRowHeight: () =>
+      React.useMemo(
+        () => ({
+          getAverageRowHeight: () => 400,
+          getRowHeight: () => 400,
+          setRowHeight: () => {},
+          observeRowElements: () => () => {},
+        }),
+        [],
+      ),
+    useListCallbackRef: () => React.useState<null>(null),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Shared fixture data
+// ---------------------------------------------------------------------------
+
+const makeSource = (items: SourceWithItems["items"] = []): SourceWithItems => ({
+  uuid: "source-1",
+  data: {
+    uuid: "source-1",
+    journalist_designation: "test source",
+    is_starred: false,
+    is_seen: false,
+    has_attachment: false,
+    last_updated: "2025-01-15T10:00:00Z",
+    public_key: "test-public-key",
+    fingerprint: "test-fingerprint",
+  },
+  items,
+});
+
+const messageItem = (
+  uuid: string,
+  interactionCount: number,
+): SourceWithItems["items"][number] => ({
+  uuid,
+  data: {
+    kind: "message",
+    uuid,
+    source: "source-1",
+    size: 1024,
+    seen_by: [],
+    is_read: false,
+    interaction_count: interactionCount,
+  },
+  plaintext: "Hello from a source",
+  filename: null,
+  decrypted_size: null,
+  fetch_progress: 1024,
+  fetch_status: 3,
+});
+
+const replyItem = (
+  uuid: string,
+  interactionCount: number,
+): SourceWithItems["items"][number] => ({
+  uuid,
+  data: {
+    kind: "reply",
+    uuid,
+    source: "source-1",
+    size: 512,
+    journalist_uuid: "journalist-1",
+    seen_by: [],
+    is_deleted_by_source: false,
+    interaction_count: interactionCount,
+  },
+  plaintext: "Reply from journalist",
+  filename: null,
+  decrypted_size: null,
+  fetch_progress: 512,
+  fetch_status: 3,
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Conversation accessibility", () => {
+  it("has no axe violations when no source is selected (renders nothing)", async () => {
+    // When sourceWithItems is null the component returns null — nothing to
+    // scan, but the wrapper container itself should still be clean.
+    await renderAndCheckA11y(<Conversation sourceWithItems={null} />);
+  });
+
+  it("has no axe violations on an empty conversation (no items yet)", async () => {
+    await renderAndCheckA11y(<Conversation sourceWithItems={makeSource([])} />);
+  });
+
+  it("has no axe violations with messages and replies loaded", async () => {
+    // TODO(a11y): ARIA role not contained by its required parent.
+    await renderAndCheckA11y(
+      <Conversation
+        sourceWithItems={makeSource([
+          messageItem("item-1", 1),
+          replyItem("reply-1", 2),
+          messageItem("item-2", 3),
+        ])}
+      />,
+      undefined,
+      ["aria-required-parent"],
+    );
+  });
+
+  it("has no axe violations with a pre-populated reply draft", async () => {
+    // TODO(a11y): ARIA role not contained by its required parent.
+    await renderAndCheckA11y(
+      <Conversation sourceWithItems={makeSource([messageItem("item-1", 1)])} />,
+      {
+        preloadedState: {
+          drafts: {
+            drafts: { "source-1": "draft reply text" },
+          },
+        },
+      },
+      ["aria-required-parent"],
+    );
+  });
+});

--- a/app/src/renderer/views/Inbox/MainContent/Conversation.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation.test.tsx
@@ -6,6 +6,7 @@ import Conversation from "./Conversation";
 import {
   testMemoization,
   renderWithProviders,
+  renderAndCheckA11y,
 } from "../../../test-component-setup";
 import { SessionStatus } from "../../../features/session/sessionSlice";
 import type { ItemUpdate, SourceWithItems } from "../../../../types";
@@ -174,6 +175,17 @@ const withItems = (items: SourceWithItems["items"]): SourceWithItems => ({
   ...mockSourceWithItems,
   data: { ...mockSourceWithItems.data },
   items,
+});
+
+describe("Conversation accessibility", () => {
+  it("has no axe violations on an empty conversation", async () => {
+    // TODO(a11y): ARIA role not contained by its required parent.
+    await renderAndCheckA11y(
+      <Conversation sourceWithItems={mockSourceWithItems} />,
+      undefined,
+      ["aria-required-parent"],
+    );
+  });
 });
 
 describe("Conversation Component Memoization", () => {

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.test.tsx
@@ -9,7 +9,50 @@ import {
   type Item,
   type ExportPayload,
 } from "../../../../../../types";
-import { renderWithProviders } from "../../../../../test-component-setup";
+import {
+  renderWithProviders,
+  renderAndCheckA11y,
+} from "../../../../../test-component-setup";
+
+describe("ExportWizard accessibility", () => {
+  const mockItem: Item = {
+    uuid: "test-item-uuid",
+    data: {
+      uuid: "test-item-uuid",
+      kind: "file",
+      seen_by: [],
+      size: 1024,
+      source: "source-1",
+      is_read: false,
+      interaction_count: 0,
+    },
+    fetch_status: FetchStatus.Complete,
+    fetch_progress: null,
+    plaintext: null,
+    filename: "/path/to/testfile.pdf",
+    decrypted_size: null,
+  };
+
+  it("has no axe violations when the wizard is closed", async () => {
+    await renderAndCheckA11y(
+      <ExportWizard
+        item={{ type: "file", payload: mockItem }}
+        open={false}
+        onClose={vi.fn()}
+      />,
+    );
+  });
+
+  it("has no axe violations when the wizard is open (preflight step)", async () => {
+    await renderAndCheckA11y(
+      <ExportWizard
+        item={{ type: "file", payload: mockItem }}
+        open={true}
+        onClose={vi.fn()}
+      />,
+    );
+  });
+});
 
 describe("ExportWizard Component", () => {
   const mockItem: Item = {

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.test.tsx
@@ -3,6 +3,7 @@ import { expect, describe, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import File from "./File";
 import {
+  renderAndCheckA11y,
   renderWithProviders,
   testMemoization,
 } from "../../../../../test-component-setup";
@@ -389,5 +390,73 @@ describe("File Component", () => {
     // which should make the button visible so keyboard users can see it.
     fireEvent.focus(trashButton);
     expect(wrapper.style.opacity).toBe("1");
+  });
+});
+
+describe("File Component Accessibility", () => {
+  const mockOnUpdate = vi.fn();
+  const mockOnDelete = vi.fn();
+
+  const makeItem = (overrides: Partial<Item> = {}): Item => ({
+    uuid: "item-1",
+    data: {
+      uuid: "item-1",
+      kind: "file",
+      seen_by: [],
+      size: 1024,
+      source: "source-1",
+      is_read: false,
+      interaction_count: 0,
+    },
+    plaintext: null,
+    filename: null,
+    fetch_progress: null,
+    decrypted_size: null,
+    fetch_status: FetchStatus.Initial,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("has no axe violations for undownloaded file", async () => {
+    // TODO(a11y): file row nests interactive controls.
+    await renderAndCheckA11y(
+      <File
+        item={makeItem()}
+        designation="Test Source"
+        onUpdate={mockOnUpdate}
+        onDelete={mockOnDelete}
+      />,
+      {
+        preloadedState: {
+          session: { status: SessionStatus.Auth } as any,
+        },
+      },
+      ["nested-interactive"],
+    );
+  });
+
+  it("has no axe violations for downloaded file", async () => {
+    // TODO(a11y): file row nests interactive controls.
+    await renderAndCheckA11y(
+      <File
+        item={makeItem({
+          fetch_status: FetchStatus.Complete,
+          filename: "/path/to/document.pdf",
+          decrypted_size: 2048,
+        })}
+        designation="Test Source"
+        onUpdate={mockOnUpdate}
+        onDelete={mockOnDelete}
+      />,
+      {
+        preloadedState: {
+          session: { status: SessionStatus.Auth } as any,
+        },
+      },
+      ["nested-interactive"],
+    );
   });
 });

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.test.tsx
@@ -5,6 +5,7 @@ import Message from "./Message";
 import {
   testMemoization,
   renderWithProviders,
+  renderAndCheckA11y,
 } from "../../../../../test-component-setup";
 import type {
   Item,
@@ -14,6 +15,38 @@ import type {
 import { FetchStatus } from "../../../../../../types";
 import { SessionStatus } from "../../../../../features/session/sessionSlice";
 import type { RootState } from "../../../../../store";
+
+describe("Message accessibility", () => {
+  const mockItem: Item = {
+    uuid: "item-a11y",
+    data: {
+      uuid: "item-a11y",
+      kind: "message",
+      seen_by: [],
+      size: 512,
+      source: "source-1",
+      is_read: false,
+      interaction_count: 1,
+    },
+    plaintext: "Hello, this is a message",
+    filename: null,
+    fetch_status: null,
+    fetch_progress: null,
+    decrypted_size: null,
+  };
+
+  it("has no axe violations for a message item", async () => {
+    await renderAndCheckA11y(
+      <Message
+        kind="message"
+        item={mockItem}
+        designation="Test Source"
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+  });
+});
 
 describe("Message Component Memoization", () => {
   const mockItem: Item = {

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Print.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Print.test.tsx
@@ -8,7 +8,50 @@ import {
   type Item,
   type PrintPayload,
 } from "../../../../../../types";
-import { renderWithProviders } from "../../../../../test-component-setup";
+import {
+  renderWithProviders,
+  renderAndCheckA11y,
+} from "../../../../../test-component-setup";
+
+describe("PrintWizard accessibility", () => {
+  const mockItem: Item = {
+    uuid: "print-a11y-uuid",
+    data: {
+      uuid: "print-a11y-uuid",
+      kind: "file",
+      seen_by: [],
+      size: 1024,
+      source: "source-1",
+      is_read: false,
+      interaction_count: 0,
+    },
+    fetch_status: FetchStatus.Complete,
+    fetch_progress: null,
+    plaintext: null,
+    filename: "/path/to/testfile.pdf",
+    decrypted_size: null,
+  };
+
+  it("has no axe violations when closed", async () => {
+    await renderAndCheckA11y(
+      <PrintWizard
+        item={{ type: "file", payload: mockItem }}
+        open={false}
+        onClose={vi.fn()}
+      />,
+    );
+  });
+
+  it("has no axe violations when open (preflight step)", async () => {
+    await renderAndCheckA11y(
+      <PrintWizard
+        item={{ type: "file", payload: mockItem }}
+        open={true}
+        onClose={vi.fn()}
+      />,
+    );
+  });
+});
 
 describe("PrintWizard Component", () => {
   const mockItem: Item = {

--- a/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.test.tsx
@@ -5,8 +5,32 @@ import SourceMenu from "./SourceMenu";
 import {
   testMemoization,
   renderWithProviders,
+  renderAndCheckA11y,
 } from "../../../../test-component-setup";
 import { FetchStatus, type SourceWithItems } from "../../../../../types";
+
+describe("SourceMenu accessibility", () => {
+  const mockSourceWithItemsA11y: SourceWithItems = {
+    uuid: "source-1",
+    data: {
+      fingerprint: "ABCD1234EFGH5678IJKL9012MNOP3456QRST7890",
+      is_starred: false,
+      journalist_designation: "durian smoothie",
+      last_updated: "2024-01-15T10:30:00Z",
+      public_key: "-----BEGIN PGP PUBLIC KEY BLOCK-----\n...\n-----END-----",
+      uuid: "source-1",
+      is_seen: true,
+      has_attachment: false,
+    },
+    items: [],
+  };
+
+  it("has no axe violations on initial render", async () => {
+    await renderAndCheckA11y(
+      <SourceMenu sourceWithItems={mockSourceWithItemsA11y} />,
+    );
+  });
+});
 
 describe("SourceMenu Component", () => {
   beforeEach(() => {

--- a/app/src/renderer/views/Inbox/Sidebar/Account/KeyboardHelp.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/Account/KeyboardHelp.test.tsx
@@ -2,7 +2,16 @@ import { describe, it, expect } from "vitest";
 import { screen } from "@testing-library/react";
 import KeyboardHelp from "./KeyboardHelp";
 import { shortcuts } from "../../../../shortcuts/shortcutDefinitions";
-import { renderWithProviders } from "../../../../test-component-setup";
+import {
+  renderWithProviders,
+  renderAndCheckA11y,
+} from "../../../../test-component-setup";
+
+describe("KeyboardHelp accessibility", () => {
+  it("has no axe violations", async () => {
+    await renderAndCheckA11y(<KeyboardHelp />);
+  });
+});
 
 describe("KeyboardHelp", () => {
   it("renders all shortcuts from the registry", () => {

--- a/app/src/renderer/views/Inbox/Sidebar/Account/MainMenu.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/Account/MainMenu.test.tsx
@@ -1,7 +1,10 @@
 import { screen, waitFor } from "@testing-library/react";
 import { expect, describe, it, vi, beforeEach, afterEach } from "vitest";
 import userEvent from "@testing-library/user-event";
-import { renderWithProviders } from "../../../../test-component-setup";
+import {
+  renderWithProviders,
+  renderAndCheckA11y,
+} from "../../../../test-component-setup";
 
 import { SessionStatus } from "../../../../features/session/sessionSlice";
 import { RootState } from "../../../../store";
@@ -21,6 +24,16 @@ vi.mock("react-router", async (importOriginal) => {
     ...actual,
     useNavigate: () => mockNavigate,
   };
+});
+
+describe("MainMenu accessibility", () => {
+  it("has no axe violations in offline mode", async () => {
+    await renderAndCheckA11y(<MainMenu />, {
+      preloadedState: {
+        session: { status: SessionStatus.Unauth, authData: undefined },
+      },
+    });
+  });
 });
 
 describe("Journalist Menu Component", () => {

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.a11y.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.a11y.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, vi } from "vitest";
+import React from "react";
+import { Routes, Route } from "react-router";
+import SourceList from "./SourceList";
+import type { Source as SourceType } from "../../../../types";
+import { renderAndCheckA11y } from "../../../test-component-setup";
+
+// Mirror the react-window mock from SourceList.test.tsx so the virtual list
+// actually renders its rows instead of relying on DOM measurements.
+// The Source child component is intentionally NOT mocked here — we want axe
+// to analyse the real accessible markup produced by each source row.
+vi.mock("react-window", () => ({
+  List: <RowProps extends object>({
+    rowComponent: RowComponent,
+    rowCount,
+    rowProps,
+    className,
+  }: {
+    rowComponent: (
+      props: { index: number; style: React.CSSProperties } & RowProps,
+    ) => React.ReactNode;
+    rowCount: number;
+    rowHeight: number;
+    rowProps: RowProps;
+    className?: string;
+  }) => (
+    <div className={className}>
+      {Array.from({ length: rowCount }, (_, index) => (
+        <div key={index}>
+          <RowComponent index={index} style={{}} {...rowProps} />
+        </div>
+      ))}
+    </div>
+  ),
+  useListRef: () => ({ current: null }),
+}));
+
+const mockSources: Record<string, SourceType> = {
+  "source-1": {
+    uuid: "source-1",
+    data: {
+      fingerprint: "ABCD1234EFGH5678IJKL9012MNOP3456QRST7890",
+      is_starred: false,
+      is_seen: false,
+      has_attachment: false,
+      journalist_designation: "alice wonderland",
+      last_updated: "2024-01-15T10:30:00Z",
+      public_key: "key-1",
+      uuid: "source-1",
+    },
+    isRead: false,
+    hasAttachment: false,
+    messagePreview: null,
+    lastInteractionCount: 3,
+  },
+  "source-2": {
+    uuid: "source-2",
+    data: {
+      fingerprint: "EFGH5678IJKL9012MNOP3456QRST7890ABCD1234",
+      is_starred: true,
+      is_seen: true,
+      has_attachment: true,
+      journalist_designation: "bob marley",
+      last_updated: "2024-01-14T15:45:00Z",
+      public_key: "key-2",
+      uuid: "source-2",
+    },
+    isRead: true,
+    hasAttachment: true,
+    messagePreview: { kind: "message", plaintext: "Hello there" },
+    lastInteractionCount: 1,
+  },
+};
+
+// Shared preloaded state builder.
+const sourcesState = (sources: Record<string, SourceType> = mockSources) => ({
+  sources: {
+    sources,
+    activeSourceUuid: null,
+    loading: false,
+    error: null,
+    conversationIndicators: {},
+  },
+});
+
+// SourceList must live inside a router that provides :sourceUuid so that
+// useParams works. renderAndCheckA11y wraps the given element in a
+// MemoryRouter (via TestWrapper), so we just need Routes/Route inside it.
+const sourceListUi = (
+  <Routes>
+    <Route path="/" element={<SourceList focusedPanel="sidebar" />} />
+    <Route
+      path="/source/:sourceUuid"
+      element={<SourceList focusedPanel="sidebar" />}
+    />
+  </Routes>
+);
+
+describe("SourceList accessibility", () => {
+  it("has no axe violations with a populated source list", async () => {
+    // TODO(a11y): source rows have unnamed buttons, unlabeled form controls,
+    // nested interactive controls, and an ARIA role outside its required parent.
+    await renderAndCheckA11y(
+      sourceListUi,
+      {
+        preloadedState: sourcesState(),
+      },
+      ["aria-required-parent", "button-name", "label", "nested-interactive"],
+    );
+  });
+
+  it("has no axe violations with an empty source list", async () => {
+    await renderAndCheckA11y(sourceListUi, {
+      preloadedState: sourcesState({}),
+    });
+  });
+
+  it("has no axe violations with an active source selected", async () => {
+    // TODO(a11y): source rows have unnamed buttons, unlabeled form controls,
+    // nested interactive controls, and an ARIA role outside its required parent.
+    await renderAndCheckA11y(
+      sourceListUi,
+      {
+        initialEntries: ["/source/source-1"],
+        preloadedState: sourcesState(),
+      },
+      ["aria-required-parent", "button-name", "label", "nested-interactive"],
+    );
+  });
+});

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
@@ -7,7 +7,10 @@ import SourceList from "./SourceList";
 import type { SearchResult, Source as SourceType } from "../../../../types";
 import { PendingEventType } from "../../../../types";
 import type { SourceProps } from "./SourceList/Source";
-import { renderWithProviders } from "../../../test-component-setup";
+import {
+  renderWithProviders,
+  renderAndCheckA11y,
+} from "../../../test-component-setup";
 
 // Mock react-window to render all items instead of virtualizing
 vi.mock("react-window", () => ({
@@ -93,6 +96,31 @@ vi.mock("./SourceList/Source", () => ({
     </div>
   ),
 }));
+
+describe("SourceList accessibility", () => {
+  it("has no axe violations with no sources", async () => {
+    await renderAndCheckA11y(
+      <Routes>
+        <Route path="/" element={<SourceList focusedPanel="sidebar" />} />
+        <Route
+          path="/source/:sourceUuid"
+          element={<SourceList focusedPanel="sidebar" />}
+        />
+      </Routes>,
+      {
+        preloadedState: {
+          sources: {
+            sources: {},
+            activeSourceUuid: null,
+            loading: false,
+            error: null,
+            conversationIndicators: {},
+          },
+        },
+      },
+    );
+  });
+});
 
 describe("Sources Component", () => {
   // Mock sources data with different states for comprehensive testing

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.test.tsx
@@ -3,6 +3,7 @@ import { expect, describe, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import {
   renderWithProviders,
+  renderAndCheckA11y,
   testMemoization,
 } from "../../../../test-component-setup";
 import Source from "./Source";
@@ -48,6 +49,24 @@ const defaultProps = {
   onSelect: mockOnSelect,
   onToggleStar: mockOnToggleStar,
 };
+
+describe("Source accessibility", () => {
+  it("has no axe violations on a basic unread source", async () => {
+    // TODO(a11y): source row has unnamed buttons, unlabeled form controls,
+    // nested interactive controls, and an ARIA role outside its required parent.
+    await renderAndCheckA11y(
+      <Source
+        source={createMockSource()}
+        isSelected={false}
+        isActive={false}
+        onSelect={vi.fn()}
+        onToggleStar={vi.fn()}
+      />,
+      undefined,
+      ["aria-required-parent", "button-name", "label", "nested-interactive"],
+    );
+  });
+});
 
 describe("Source Component", () => {
   beforeEach(() => {

--- a/app/src/renderer/views/SignIn.a11y.test.tsx
+++ b/app/src/renderer/views/SignIn.a11y.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SignInView from "./SignIn";
+import {
+  checkA11y,
+  renderAndCheckA11y,
+  renderWithProviders,
+} from "../test-component-setup";
+
+describe("SignIn accessibility", () => {
+  it("has no axe violations on initial render", async () => {
+    await renderAndCheckA11y(<SignInView />);
+  });
+
+  it("has no axe violations when showing client-side validation errors", async () => {
+    const { container, getByTestId } = renderWithProviders(<SignInView />);
+
+    // Submit empty form to trigger all three required-field errors at once
+    await userEvent.click(getByTestId("sign-in-button"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Please enter your username."),
+      ).toBeInTheDocument();
+    });
+
+    const results = await checkA11y(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it("has no axe violations when showing a credential error", async () => {
+    (window as any).electronAPI.login.mockResolvedValue({
+      success: false,
+      errorType: "credentials",
+    });
+
+    const { container, getByTestId } = renderWithProviders(<SignInView />);
+
+    await userEvent.type(getByTestId("username-input"), "nelliebly");
+    await userEvent.type(
+      getByTestId("passphrase-input"),
+      "validPassphrase12345",
+    );
+    await userEvent.type(getByTestId("one-time-code-input"), "123456");
+    await userEvent.click(getByTestId("sign-in-button"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Those credentials didn't work."),
+      ).toBeInTheDocument();
+    });
+
+    const results = await checkA11y(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it("has no axe violations when showing a network error", async () => {
+    (window as any).electronAPI.login.mockResolvedValue({
+      success: false,
+      errorType: "network",
+    });
+
+    const { container, getByTestId } = renderWithProviders(<SignInView />);
+
+    await userEvent.type(getByTestId("username-input"), "nelliebly");
+    await userEvent.type(
+      getByTestId("passphrase-input"),
+      "validPassphrase12345",
+    );
+    await userEvent.type(getByTestId("one-time-code-input"), "123456");
+    await userEvent.click(getByTestId("sign-in-button"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Could not reach the SecureDrop server."),
+      ).toBeInTheDocument();
+    });
+
+    const results = await checkA11y(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/app/src/renderer/views/SignIn.test.tsx
+++ b/app/src/renderer/views/SignIn.test.tsx
@@ -2,8 +2,17 @@ import { screen, waitFor } from "@testing-library/react";
 import { expect } from "vitest";
 import userEvent from "@testing-library/user-event";
 import SignInView from "./SignIn";
-import { renderWithProviders } from "../test-component-setup";
+import {
+  renderWithProviders,
+  renderAndCheckA11y,
+} from "../test-component-setup";
 import { SessionStatus } from "../features/session/sessionSlice";
+
+describe("SignInView accessibility", () => {
+  it("has no axe violations on initial render", async () => {
+    await renderAndCheckA11y(<SignInView />);
+  });
+});
 
 describe("SignInView Component", () => {
   describe("passphrase visibility toggle", () => {

--- a/app/src/test-setup.ts
+++ b/app/src/test-setup.ts
@@ -1,9 +1,14 @@
 import { expect, afterEach } from "vitest";
 import { cleanup } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
+import * as vitestAxeMatchers from "vitest-axe/matchers";
+import "vitest-axe/extend-expect";
 
 // extends Vitest's expect with jest-dom matchers
 expect.extend(matchers);
+
+// extend Vitest's expect with axe a11y matchers
+expect.extend(vitestAxeMatchers);
 
 // runs a cleanup after each test case (e.g. clearing jsdom)
 afterEach(() => {

--- a/app/src/test-types.d.ts
+++ b/app/src/test-types.d.ts
@@ -2,10 +2,14 @@
 /// <reference types="vite/client" />
 
 import type { TestingLibraryMatchers } from "@testing-library/jest-dom/matchers";
+import type { AxeMatchers } from "vitest-axe/matchers";
 
 declare module "vitest" {
   interface Assertion<T = unknown>
-    extends jest.Matchers<void>, TestingLibraryMatchers<T, void> {}
+    extends jest.Matchers<void>, TestingLibraryMatchers<T, void>, AxeMatchers {}
   interface AsymmetricMatchersContaining
-    extends jest.Matchers<void>, TestingLibraryMatchers<unknown, void> {}
+    extends
+      jest.Matchers<void>,
+      TestingLibraryMatchers<unknown, void>,
+      AxeMatchers {}
 }

--- a/app/tsconfig.web.json
+++ b/app/tsconfig.web.json
@@ -1,6 +1,7 @@
 {
   "extends": "@electron-toolkit/tsconfig/tsconfig.web.json",
   "include": [
+    "src/renderer/test-component-setup.tsx",
     "src/renderer/env.d.ts",
     "src/renderer/**/*",
     "src/renderer/**/*.tsx",


### PR DESCRIPTION
Adds [`vitest-axe`](https://github.com/chaance/vitest-axe), a library enabling testing with accessibility tool [axe](https://github.com/dequelabs/axe-core) in vitest. This lets us write unit tests for basic accessibility checks so we can find issues during development. Also configures a basic eslint rule to try and ensure that rendered components have a basic accessibility test.

Contains a `knownViolations` parameter when calling the `renderAndCheckA11y` function that allows us to mute current expected failures, while still catching + failing on new violations. We should eventually address all the current failures, but this way we can merge in the tests + lint rules without breaking CI.

`*.a11y.test.tsx` files generated with Claude, along with eslint rule for new a11y tests

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
CI is green + `pnpm test` works locally 


## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
