### PR TITLE
Backport 1.3.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.3.1
+
+This release contains a low-priority security fix. We are not aware of any
+exploitation in the wild.
+
+* Don't follow redirects in the proxy
+
 ## 1.3.0
 
 This release contains bug fixes and improvements to the SecureDrop Inbox.

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ securedrop-client (1.4.0~rc1) unstable; urgency=medium
 
   * see changelog.md
 
- -- SecureDrop Team <securedrop@freedom.press>  Wed, 20 May 2026 15:30:03 -0400
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 28 May 2026 17:01:15 -0400
 
 securedrop-client (1.3.1) unstable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,18 @@ securedrop-client (1.4.0~rc1) unstable; urgency=medium
 
   * see changelog.md
 
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 20 May 2026 15:30:03 -0400
+
+securedrop-client (1.3.1) unstable; urgency=medium
+
+  * see changelog.md
+
+ -- SecureDrop Team <securedrop@freedom.press>  Wed, 27 May 2026 15:56:12 -0400
+
+securedrop-client (1.3.0) unstable; urgency=medium
+
+  * see changelog.md
+
  -- SecureDrop Team <securedrop@freedom.press>  Wed, 20 May 2026 17:18:17 -0400
 
 securedrop-client (1.3.0~rc1) unstable; urgency=medium

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -3,6 +3,7 @@
 use anyhow::{bail, Result};
 use futures_util::StreamExt;
 use reqwest::header::HeaderMap;
+use reqwest::redirect::Policy as RedirectPolicy;
 use reqwest::{Client, Method, Proxy, Response};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -149,15 +150,15 @@ async fn proxy() -> Result<()> {
         bail! {"request would escape configured origin"}
     }
 
+    // Do not follow any redirects
+    let mut builder = Client::builder().redirect(RedirectPolicy::none());
     // Ability to disable tor explicitly (for dev/testing purposes)
-    let client = if config::read(DISABLE_TOR).is_ok() {
-        Client::new()
-    } else {
-        Client::builder()
+    if config::read(DISABLE_TOR).is_err() {
+        builder = builder
             // the *h* in socks5h has the proxy (i.e. Tor) resolve DNS (*h*ostnames)
-            .proxy(Proxy::http("socks5h://127.0.0.1:9150")?)
-            .build()?
-    };
+            .proxy(Proxy::all("socks5h://127.0.0.1:9150")?);
+    }
+    let client = builder.build()?;
 
     let mut req =
         client.request(Method::from_str(&incoming_request.method)?, url);

--- a/proxy/tests/test_proxy.py
+++ b/proxy/tests/test_proxy.py
@@ -32,6 +32,22 @@ def test_status_codes(proxy_request, status_code):
     assert response["status"] == status_code
 
 
+@pytest.mark.parametrize("status_code", range(301, 309))
+def test_redirect(proxy_request, status_code):
+    """Redirects are not followed: the status code, headers (including `Location`), and response
+    are proxied unmodified."""
+    test_input = {
+        "method": "GET",
+        "path_query": f"/redirect-to?url=https://example.org&status_code={status_code}",
+        "stream": False,
+    }
+    result = proxy_request(input=test_input)
+    assert result.returncode == 0
+    response = json.loads(result.stdout.decode())
+    assert response["status"] == status_code
+    assert response["headers"]["location"] == "https://example.org"
+
+
 def test_query_parameters(proxy_request):
     test_input = {
         "method": "GET",


### PR DESCRIPTION


## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] contains everything in the 1.3.1 release
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
