### PR TITLE
Use sparse checkout of apt-test to reduce bandwith consumption

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -78,6 +78,8 @@ jobs:
           repository: "freedomofpress/securedrop-apt-test"
           path: "securedrop-apt-test"
           lfs: true
+          sparse-checkout: workstation/
+          sparse-checkout-cone-mode: false
       - uses: actions/checkout@v6
         with:
           persist-credentials: false


### PR DESCRIPTION
With a sparse checkout we can only clone the part of the repository we plan on using instead of the entire thing, which should allow us to save on git-lfs bandwith costs.

Refs <https://github.com/freedomofpress/infrastructure/issues/6725>.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] https://github.com/freedomofpress/securedrop-client/actions/runs/26642765291/job/78521238564?pr=3459 worked fine
* [ ] In https://github.com/freedomofpress/securedrop-client/actions/runs/26644324744/job/78526730326?pr=3459 I added a `du` call into the "prepare packages" step, which shows that only 2.9G is checked out instead of the 7G the full repo is.
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
