### PR TITLE
Upgrade Rust toolchain to 1.96.0

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Install Rust-specific dependencies for sd-proxy
         run: apt-get install --yes build-essential curl libssl-dev pkg-config
       - name: Install Rust to build sd-proxy
-        uses: dtolnay/rust-toolchain@1.90.0
+        uses: dtolnay/rust-toolchain@1.96.0
       - name: Generate and insert test data
         working-directory: app
         run: |
@@ -174,7 +174,7 @@ jobs:
       - name: Install Rust-specific dependencies for sd-proxy
         run: apt-get install --yes build-essential curl libssl-dev pkg-config
       - name: Install Rust to build sd-proxy
-        uses: dtolnay/rust-toolchain@1.90.0
+        uses: dtolnay/rust-toolchain@1.96.0
       - name: Run integration tests
         working-directory: app
         run: NODE_ENV=ci VITE_HTTPBIN_URL=http://httpbin:80 pnpm integration-test
@@ -209,7 +209,7 @@ jobs:
       # n.b. because this runs on Ubuntu runner directly,
       # build-essential, curl, libssl-dev and pkg-config are already installed
       - name: Install Rust to build sd-proxy
-        uses: dtolnay/rust-toolchain@1.90.0
+        uses: dtolnay/rust-toolchain@1.96.0
       - name: Install ffmpeg for video recording
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
       - name: Prebuild SecureDrop Docker image

--- a/.github/workflows/cargo-vet.yml
+++ b/.github/workflows/cargo-vet.yml
@@ -19,7 +19,7 @@ jobs:
     name: Vet Dependencies
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.90.0
+    container: rust:1.96.0
     env:
       CARGO_VET_VERSION: 0.10.0
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
   rust:
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.90.0
+    container: rust:1.96.0
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/mac-demo.yml
+++ b/.github/workflows/mac-demo.yml
@@ -44,7 +44,7 @@ jobs:
 
       # Keep version in sync with rust-toolchain.toml
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.90.0
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Build Mac demo DMG
         working-directory: app

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,7 @@ jobs:
   rust-audit:
     runs-on: ubuntu-latest
     # Keep version in sync with rust-toolchain.toml
-    container: rust:1.90.0
+    container: rust:1.96.0
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           persist-credentials: false
       # Install Rust, keep in sync with rust-toolchain.toml
-      - uses: dtolnay/rust-toolchain@1.90.0
+      - uses: dtolnay/rust-toolchain@1.96.0
         if: ${{ matrix.component == 'proxy' }}
       - name: Install dependencies
         run: |

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.96.0"

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -16,7 +16,7 @@ RUN sed -i s/##VERSION_CODENAME##/${DISTRO}/ /etc/apt/sources.list.d/qubes_43.so
 COPY nodesource-node24.sources /etc/apt/sources.list.d/
 
 # Keep in sync with rust-toolchain.toml
-ENV RUST_VERSION 1.90.0
+ENV RUST_VERSION 1.96.0
 ENV RUSTUP_VERSION 1.28.2
 ENV RUSTUP_INIT_SHA256 20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c
 ENV RUSTUP_HOME /opt/rustup


### PR DESCRIPTION
## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] CI should sufficiently cover all the proxy behavior already
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
