### PR TITLE
Show different messages in delete dialog when deleting empty sources

### DIFF
--- a/app/src/renderer/locales/en-XA.json
+++ b/app/src/renderer/locales/en-XA.json
@@ -7,12 +7,14 @@
       "deleteDialog": {
         "single": {
           "message": "[!!!!!!Do you want to delete the source's account or just the conversation?!!!!!!]",
+          "emptyMessage": "[!!!!Do you want to delete the source's account?!!!!]",
           "keepAccountButton": "[!Delete Conversation!]",
           "deleteAccountButton": "[!Delete Account!]"
         },
         "multiple": {
           "keepAccountsButton": "[!!Delete Conversations!!]",
           "deleteAccountsButton": "[!Delete Accounts!]",
+          "emptyMessage": "[!!!!!Do you want to delete these {{count}} source accounts?!!!!!]",
           "message": "[!!!!!!!!Do you want to delete these {{count}} source accounts or just the conversations?!!!!!!!!]"
         },
         "cancelButton": "[Cancel]",

--- a/app/src/renderer/locales/en.json
+++ b/app/src/renderer/locales/en.json
@@ -108,11 +108,13 @@
         "cancelButton": "Cancel",
         "single": {
           "message": "Do you want to delete the source's account or just the conversation?",
+          "emptyMessage": "Do you want to delete the source's account?",
           "deleteAccountButton": "Delete Account",
           "keepAccountButton": "Delete Conversation"
         },
         "multiple": {
           "message": "Do you want to delete these {{count}} source accounts or just the conversations?",
+          "emptyMessage": "Do you want to delete these {{count}} source accounts?",
           "deleteAccountsButton": "Delete Accounts",
           "keepAccountsButton": "Delete Conversations"
         }

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
@@ -238,6 +238,9 @@ describe("Sources Component", () => {
         ),
       syncMetadata: vi.fn().mockResolvedValue(undefined),
       onSourceUpdate: vi.fn().mockResolvedValue(undefined),
+      getSourceItemCounts: vi
+        .fn()
+        .mockResolvedValue({ messages: 1, files: 0, replies: 0 }),
     } as Partial<typeof window.electronAPI> as typeof window.electronAPI;
   });
 
@@ -854,6 +857,63 @@ describe("Sources Component", () => {
       expect(
         screen.getByTestId("delete-modal-delete-conversation-button"),
       ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("delete-modal-delete-account-button"),
+      ).toBeInTheDocument();
+    });
+
+    it("shows account-only modal for a single empty source", async () => {
+      window.electronAPI.getSourceItemCounts = vi
+        .fn()
+        .mockResolvedValue({ messages: 0, files: 0, replies: 0 });
+
+      renderSourceList();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByTestId("source-checkbox-source-1"));
+      await userEvent.click(screen.getByTestId("bulk-delete-button"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("delete-modal-title")).toHaveTextContent(
+          "Do you want to delete the source's account?",
+        );
+      });
+
+      expect(
+        screen.queryByTestId("delete-modal-delete-conversation-button"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId("delete-modal-delete-account-button"),
+      ).toBeInTheDocument();
+    });
+
+    it("shows account-only modal for multiple empty sources", async () => {
+      window.electronAPI.getSourceItemCounts = vi
+        .fn()
+        .mockResolvedValue({ messages: 0, files: 0, replies: 0 });
+
+      renderSourceList();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByTestId("source-checkbox-source-1"));
+      await userEvent.click(screen.getByTestId("source-checkbox-source-2"));
+      await userEvent.click(screen.getByTestId("bulk-delete-button"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("delete-modal-title")).toHaveTextContent(
+          "Do you want to delete these 2 source accounts?",
+        );
+      });
+
+      expect(
+        screen.queryByTestId("delete-modal-delete-conversation-button"),
+      ).not.toBeInTheDocument();
       expect(
         screen.getByTestId("delete-modal-delete-account-button"),
       ).toBeInTheDocument();

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -83,6 +83,7 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
     files: number;
     replies: number;
   }>({ messages: 0, files: 0, replies: 0 });
+  const [deleteCountsLoaded, setDeleteCountsLoaded] = useState(false);
 
   // Debounce search term to avoid excessive filtering
   const debouncedSearchTerm = useDebounce(searchTerm, 300);
@@ -169,15 +170,18 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
     setPendingDeleteSources(sources);
     setDeleteModalOpen(true);
     setDeleteModalLoading(true);
+    setDeleteCountsLoaded(false);
 
     try {
       const counts = await window.electronAPI.getSourceItemCounts(
         Array.from(sources),
       );
       setDeleteCounts(counts);
+      setDeleteCountsLoaded(true);
     } catch (error) {
       console.error("Error fetching source item counts:", error);
       setDeleteCounts({ messages: 0, files: 0, replies: 0 });
+      setDeleteCountsLoaded(false);
     } finally {
       setDeleteModalLoading(false);
     }
@@ -203,6 +207,7 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
   const handleDeleteModalCancel = useCallback(() => {
     setPendingDeleteSources(new Set());
     setDeleteModalOpen(false);
+    setDeleteCountsLoaded(false);
   }, []);
 
   const handleDeleteAction = useCallback(
@@ -220,6 +225,7 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
           };
         });
         await window.electronAPI.addPendingSourceEventBatch(events);
+        setDeleteCountsLoaded(false);
         // If we deleted an account and it was the currently active source, navigate away
         if (
           eventType === PendingEventType.SourceDeleted &&
@@ -416,6 +422,28 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
     enabled: focusedPanel === "sidebar",
   });
 
+  const hasItemsToDelete =
+    deleteCounts.messages > 0 ||
+    deleteCounts.files > 0 ||
+    deleteCounts.replies > 0;
+  const isDeletingEmptySources =
+    deleteCountsLoaded && !deleteModalLoading && !hasItemsToDelete;
+  const deleteDialogTitle =
+    pendingDeleteSources.size === 1
+      ? t(
+          isDeletingEmptySources
+            ? "sourcelist.deleteDialog.single.emptyMessage"
+            : "sourcelist.deleteDialog.single.message",
+        )
+      : t(
+          isDeletingEmptySources
+            ? "sourcelist.deleteDialog.multiple.emptyMessage"
+            : "sourcelist.deleteDialog.multiple.message",
+          {
+            count: pendingDeleteSources.size,
+          },
+        );
+
   return (
     <div className="flex-1 flex flex-col min-h-0">
       {/* Toolbar with controls and actions */}
@@ -470,13 +498,7 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
         data-testid="delete-modal"
         closable={false}
         title={
-          <span data-testid="delete-modal-title">
-            {pendingDeleteSources.size === 1
-              ? t("sourcelist.deleteDialog.single.message")
-              : t("sourcelist.deleteDialog.multiple.message", {
-                  count: pendingDeleteSources.size,
-                })}
-          </span>
+          <span data-testid="delete-modal-title">{deleteDialogTitle}</span>
         }
         getContainer={() => document.getElementById("root") || document.body}
         onCancel={handleDeleteModalCancel}
@@ -489,18 +511,20 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
           >
             {t("sourcelist.deleteDialog.cancelButton")}
           </Button>,
-          <Button
-            key="deleteConversation"
-            data-testid="delete-modal-delete-conversation-button"
-            type="primary"
-            onClick={() =>
-              handleDeleteAction(PendingEventType.SourceConversationTruncated)
-            }
-          >
-            {pendingDeleteSources.size === 1
-              ? t("sourcelist.deleteDialog.single.keepAccountButton")
-              : t("sourcelist.deleteDialog.multiple.keepAccountsButton")}
-          </Button>,
+          !isDeletingEmptySources && (
+            <Button
+              key="deleteConversation"
+              data-testid="delete-modal-delete-conversation-button"
+              type="primary"
+              onClick={() =>
+                handleDeleteAction(PendingEventType.SourceConversationTruncated)
+              }
+            >
+              {pendingDeleteSources.size === 1
+                ? t("sourcelist.deleteDialog.single.keepAccountButton")
+                : t("sourcelist.deleteDialog.multiple.keepAccountsButton")}
+            </Button>
+          ),
           <Button
             key="deleteAccount"
             data-testid="delete-modal-delete-account-button"
@@ -522,9 +546,7 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
             </p>
           ) : (
             <>
-              {(deleteCounts.messages > 0 ||
-                deleteCounts.files > 0 ||
-                deleteCounts.replies > 0) && (
+              {hasItemsToDelete && (
                 <div className="mt-3">
                   <p className="font-medium text-gray-800">
                     {t("sourcelist.deleteDialog.itemCountsHeader")}


### PR DESCRIPTION
Fixes #3310

## Test plan

- Start a fresh dev server, delete `~/.config/SecureDrop`, and start the app
- Select the first two sources and click delete. The dialog should look like this, giving you the option to delete accounts or conversations:

<img width="535" height="332" alt="Screenshot 2026-05-29 at 12 26 35 PM" src="https://github.com/user-attachments/assets/64a3d635-1d51-45a6-a7c9-c96622f52d3c" />

- Delete the conversations
- Select one empty source and click delete. It should look like this (different title text, and no delete conversation button):

<img width="540" height="201" alt="Screenshot 2026-05-29 at 12 26 57 PM" src="https://github.com/user-attachments/assets/3f09bdb4-5ca3-432d-9302-c443c842df91" />

- Select multiple empty sources and click delete. It should look like this:

<img width="541" height="201" alt="Screenshot 2026-05-29 at 12 27 15 PM" src="https://github.com/user-attachments/assets/8d02409f-7e53-44a9-b88b-69021a9b999e" />

- Select a single or multiple sources that include messages. It should look as it did before.

<img width="536" height="327" alt="Screenshot 2026-05-29 at 12 27 38 PM" src="https://github.com/user-attachments/assets/99027eec-3245-4520-8482-277474bf5fb7" />

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
