### PR TITLE
inbox: address electron postinst ci flake

### DIFF
--- a/app/scripts/download-sqlite-binaries.py
+++ b/app/scripts/download-sqlite-binaries.py
@@ -48,15 +48,15 @@ def get_electron_abi() -> str:
     """
     script_dir = Path(__file__).parent.parent
 
-    version_file = script_dir / "node_modules" / "electron" / "dist" / "version"
+    electron_pkg = script_dir / "node_modules" / "electron" / "package.json"
     node_abi_path = script_dir / "node_modules" / "node-abi"
 
-    if not version_file.exists():
-        raise RuntimeError("Electron version file not found")
+    if not electron_pkg.exists():
+        raise RuntimeError("Electron package not found in node_modules")
     if not node_abi_path.exists():
         raise RuntimeError("node-abi module not found")
 
-    electron_version = version_file.read_text().strip()
+    electron_version = json.loads(electron_pkg.read_text())["version"]
 
     # Shell out to nodejs to invoke the node-abi library
     result = subprocess.run(


### PR DESCRIPTION
Fixes #3467 

Read Electron version from `package.json` rather than `node_modules/*`, a Claude-suggested fix.

## Test plan
As of now, don't have an excellent test plan since I'm not sure how to reliably reproduce the CI flake. It seems to mostly fail on merge queue PRs, but rebasing a recently failing PR off main doesn't fail the CI check on the branch.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
