### PR TITLE
pnpm: add electron to onlyBuiltDependencies

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -113,7 +113,10 @@
   "pnpm": {
     "overrides": {
       "prebuild-install": "file:empty-package"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "electron"
+    ]
   },
   "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748"
 }


### PR DESCRIPTION
Per this issue comment on fixing `Electron failed to install` errors, adding `onlyBuiltDependencies: ["electron"]` to pnpm config

https://github.com/electron/electron/issues/44008#issuecomment-2657941721

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
