### PR TITLE
Pin to node 24.15.x

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v6
         with:
-          node-version: "24.x"
+          node-version: "24.15.x"
           cache: pnpm
           cache-dependency-path: app/pnpm-lock.yaml
       - name: Install node dependencies
@@ -97,7 +97,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v6
         with:
-          node-version: "24.x"
+          node-version: "24.15.x"
           cache: pnpm
           cache-dependency-path: app/pnpm-lock.yaml
       - name: Install node dependencies
@@ -162,7 +162,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v6
         with:
-          node-version: "24.x"
+          node-version: "24.15.x"
           cache: pnpm
           cache-dependency-path: app/pnpm-lock.yaml
       - name: Install node dependencies
@@ -197,7 +197,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v6
         with:
-          node-version: "24.x"
+          node-version: "24.15.x"
           cache: pnpm
           cache-dependency-path: app/pnpm-lock.yaml
       - name: Install node dependencies

--- a/.github/workflows/mac-demo.yml
+++ b/.github/workflows/mac-demo.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "24.x"
+          node-version: "24.15.x"
           cache: pnpm
           cache-dependency-path: app/pnpm-lock.yaml
 


### PR DESCRIPTION
Matches Electron v41 (see https://releases.electronjs.org/release/v41.5.0). Works around
<https://github.com/electron/electron/issues/51619>.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] CI passes
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
