### PR TITLE
[inbox] log sync events + retry with backoff

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -40,6 +40,7 @@ import { Search } from "./search";
 // at the database layer; CSS will handle the rest
 export const MESSAGE_PREVIEW_LENGTH = 200;
 const DEFAULT_ITEM_LIMIT = 100;
+export const DEFAULT_PENDING_EVENTS_LIMIT = 20;
 
 interface KeyObject {
   [key: string]: object;
@@ -1261,8 +1262,10 @@ export class DB {
     })();
   }
 
-  getPendingEvents(): PendingEvent[] {
-    const rows: PendingEventRow[] = this.selectPendingEvents.all({ limit: 20 });
+  getPendingEvents(limit?: number): PendingEvent[] {
+    const rows: PendingEventRow[] = this.selectPendingEvents.all({
+      limit: limit ?? DEFAULT_PENDING_EVENTS_LIMIT,
+    });
     const pendingEvents = rows.map((r) => {
       let target: SourceTarget | ItemTarget;
       if (r.source_uuid) {

--- a/app/src/main/index.test.ts
+++ b/app/src/main/index.test.ts
@@ -73,6 +73,7 @@ const testState = vi.hoisted(() => {
     },
     proxyJSONRequest: vi.fn(),
     lockRun: vi.fn(async (fn: () => unknown) => await fn()),
+    mockSleep: vi.fn(),
     configLoad: vi.fn(() => ({
       sd_submission_key_fpr: "fingerprint",
       is_qubes: false,
@@ -148,6 +149,10 @@ vi.mock("./transcriber", () => ({
   writeTranscript: vi.fn(),
 }));
 
+vi.mock("./timeouts", () => ({
+  sleep: (...args: unknown[]) => testState.mockSleep(...args),
+}));
+
 vi.mock("./fetch/worker?modulePath", () => ({
   default: "mock-worker-path",
 }));
@@ -221,6 +226,8 @@ describe("syncMetadata IPC handler", () => {
     testState.lockRun.mockImplementation(
       async (fn: () => unknown) => await fn(),
     );
+    testState.mockSleep.mockReset();
+    testState.mockSleep.mockResolvedValue(undefined);
     testState.configLoad.mockClear();
     testState.cryptoInitialize.mockClear();
     testState.datastoreClose.mockClear();
@@ -269,5 +276,45 @@ describe("syncMetadata IPC handler", () => {
         authToken: "skip-token",
       },
     });
+  });
+
+  it("retries syncMetadata up to MAX_SYNC_RETRIES times then re-throws", async () => {
+    const err = new Error("network failure");
+    testState.syncModule.syncMetadata.mockRejectedValue(err);
+
+    await loadMainProcessModule();
+    await loginWithToken("retry-token");
+
+    const handler = getSyncMetadataHandler();
+    await expect(handler({}, {})).rejects.toThrow("network failure");
+
+    // 1 initial attempt + 3 retries = 4 total calls
+    expect(testState.syncModule.syncMetadata).toHaveBeenCalledTimes(4);
+    // sleep called between each attempt (not after the final failure)
+    expect(testState.mockSleep).toHaveBeenCalledTimes(3);
+  });
+
+  it("waits with exponential backoff between retries", async () => {
+    const err = new Error("network failure");
+    // Fail 3 times then succeed on the 4th attempt
+    testState.syncModule.syncMetadata
+      .mockRejectedValueOnce(err)
+      .mockRejectedValueOnce(err)
+      .mockRejectedValueOnce(err)
+      .mockResolvedValueOnce(SyncStatus.NOT_MODIFIED);
+
+    await loadMainProcessModule();
+    await loginWithToken("backoff-token");
+
+    const handler = getSyncMetadataHandler();
+    const status = await handler({}, {});
+
+    expect(status).toBe(SyncStatus.NOT_MODIFIED);
+    expect(testState.syncModule.syncMetadata).toHaveBeenCalledTimes(4);
+    expect(testState.mockSleep).toHaveBeenCalledTimes(3);
+    // backoffMs = 1000 * 2^retryCount where retryCount is post-increment (1, 2, 3)
+    expect(testState.mockSleep).toHaveBeenNthCalledWith(1, 2000);
+    expect(testState.mockSleep).toHaveBeenNthCalledWith(2, 4000);
+    expect(testState.mockSleep).toHaveBeenNthCalledWith(3, 8000);
   });
 });

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -926,7 +926,7 @@ if (!gotTheLock) {
 }
 
 // syncWithLock attempts to acquire the sync lock and then perform
-// metadata sync with the server. Retries up to MAX_SYNC_RETRIES time
+// metadata sync with the server. Retries up to MAX_SYNC_RETRIES times
 // with exponential backoff and decreased batch sizes.
 async function syncWithLock(
   syncLock: Lock,
@@ -957,7 +957,7 @@ async function syncWithLock(
         throw error;
       }
       retryCount++;
-      const backoffMs = 1000 * 2 ** retryCount;
+      const backoffMs = (1000 * 2 ** retryCount) as ms;
       console.log(
         `[sync] Sync failed, sleeping for ${backoffMs}ms before retrying...`,
         { error },

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -42,6 +42,7 @@ import { TokenResponseSchema, API_MINOR_VERSION } from "../schemas";
 import { syncMetadata, shouldSkipSync } from "./sync";
 import workerPath from "./fetch/worker?modulePath";
 import { Lock, LockTimeoutError } from "./sync/lock";
+import { sleep } from "./timeouts";
 import { Config } from "./config";
 import { setUmask } from "./umask";
 import { Exporter, Printer } from "./export";
@@ -924,24 +925,44 @@ if (!gotTheLock) {
   });
 }
 
+// syncWithLock attempts to acquire the sync lock and then perform
+// metadata sync with the server. Retries up to MAX_SYNC_RETRIES time
+// with backoff for the batch request timeout.
 async function syncWithLock(
   syncLock: Lock,
   db: Datastore,
   request: AuthedRequest,
 ): Promise<SyncStatus> {
-  let syncStatus: SyncStatus;
-  try {
-    syncStatus = await syncLock.run(async () => {
-      console.log("Acquired lock, syncing metadata");
-      return await syncMetadata(db, request.authToken, request.hintedRecords);
-    }, 1000);
-  } catch (error) {
-    // Check if this is a timeout error from the lock
-    console.log("Failed to acquire lock");
-    if (error instanceof LockTimeoutError) {
-      return SyncStatus.TIMEOUT;
+  const MAX_SYNC_RETRIES = 3;
+
+  let retryCount = 0;
+  while (true) {
+    try {
+      return await syncLock.run(async () => {
+        console.log("[sync] Acquired lock");
+        return await syncMetadata(
+          db,
+          request.authToken,
+          request.hintedRecords,
+          retryCount,
+        );
+      }, 1000);
+    } catch (error) {
+      if (error instanceof LockTimeoutError) {
+        console.log("[sync] Failed to acquire lock");
+        return SyncStatus.TIMEOUT;
+      }
+      if (retryCount >= MAX_SYNC_RETRIES) {
+        console.log("[sync] Exceeded max retries", { error });
+        throw error;
+      }
+      retryCount++;
+      const backoffMs = 1000 * 2 ** retryCount;
+      console.log(
+        `[sync] Sync failed, sleeping for ${backoffMs}ms before retrying...`,
+        { error },
+      );
+      await sleep(backoffMs);
     }
-    throw error;
   }
-  return syncStatus;
 }

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -927,7 +927,7 @@ if (!gotTheLock) {
 
 // syncWithLock attempts to acquire the sync lock and then perform
 // metadata sync with the server. Retries up to MAX_SYNC_RETRIES time
-// with backoff for the batch request timeout.
+// with exponential backoff and decreased batch sizes.
 async function syncWithLock(
   syncLock: Lock,
   db: Datastore,

--- a/app/src/main/proxy.ts
+++ b/app/src/main/proxy.ts
@@ -16,8 +16,8 @@ const DEFAULT_PROXY_VM_NAME = "sd-proxy";
 
 // To avoid timeout confusion, timeouts SHOULD be either the same as or longer
 // than the proxy's request-level timeout.
-export const DEFAULT_PROXY_CMD_TIMEOUT_MS = 10000 as ms;
-export const MESSAGE_REPLY_DOWNLOAD_TIMEOUT_MS = 20000 as ms;
+export const DEFAULT_PROXY_CMD_TIMEOUT_MS = 10_000 as ms;
+export const MESSAGE_REPLY_DOWNLOAD_TIMEOUT_MS = 20_000 as ms;
 
 function parseJSONResponse(response: string): ProxyJSONResponse {
   const result = JSON.parse(response);

--- a/app/src/main/sync/index.ts
+++ b/app/src/main/sync/index.ts
@@ -217,9 +217,12 @@ export async function syncMetadata(
   const currentVersion = db.getVersion();
 
   // Decrease event batch size on retry attempts
-  const pendingEvents = attempt
-    ? db.getPendingEvents(DEFAULT_PENDING_EVENTS_LIMIT / attempt)
-    : db.getPendingEvents();
+  const pendingEvents =
+    attempt && attempt > 0
+      ? db.getPendingEvents(
+          Math.max(1, Math.ceil(DEFAULT_PENDING_EVENTS_LIMIT / attempt)),
+        )
+      : db.getPendingEvents();
 
   const indexResponse = await getServerIndex(
     authToken,

--- a/app/src/main/sync/index.ts
+++ b/app/src/main/sync/index.ts
@@ -6,7 +6,7 @@ import {
   BatchResponse,
   SyncStatus,
 } from "../../types";
-import { DB } from "../database";
+import { DB, DEFAULT_PENDING_EVENTS_LIMIT } from "../database";
 import { Datastore } from "../datastore";
 import {
   API_MINOR_VERSION,
@@ -15,6 +15,8 @@ import {
   BatchResponseSchema,
   BatchResponseSized,
   BatchRequestSchema,
+  sanitizeBatchRequest,
+  sanitizeBatchResponse,
 } from "../../schemas";
 import { estimateTimeout } from "../timeouts";
 
@@ -208,9 +210,17 @@ export async function syncMetadata(
   db: Datastore,
   authToken: string,
   hintedRecords?: number,
+  attempt?: number,
 ): Promise<SyncStatus> {
+  console.log("[sync] syncing ", { hintedRecords, attempt });
+
   const currentVersion = db.getVersion();
-  const pendingEvents = db.getPendingEvents();
+
+  // Decrease event batch size on retry attempts
+  const pendingEvents = attempt
+    ? db.getPendingEvents(DEFAULT_PENDING_EVENTS_LIMIT / attempt)
+    : db.getPendingEvents();
+
   const indexResponse = await getServerIndex(
     authToken,
     currentVersion,
@@ -219,6 +229,7 @@ export async function syncMetadata(
 
   // Check for 403 Forbidden
   if (indexResponse.status === 403) {
+    console.log("[sync] index response 403");
     return SyncStatus.FORBIDDEN;
   }
 
@@ -249,20 +260,33 @@ export async function syncMetadata(
     indexResponse.status === 304 &&
     (!pendingEvents || pendingEvents.length == 0)
   ) {
+    console.log("[sync] index up to date");
     return syncStatus;
   }
 
-  console.debug("Client batch request: ", JSON.stringify(request));
+  console.log(
+    "[sync] batch request:",
+    JSON.stringify(sanitizeBatchRequest(request)),
+  );
   const batchResponse = await submitBatch(authToken, request);
-  console.debug("Server batch response: ", JSON.stringify(batchResponse));
+  console.log(
+    "[sync] batch response:",
+    JSON.stringify(
+      batchResponse.status === 200
+        ? { status: 200, data: sanitizeBatchResponse(batchResponse.data) }
+        : batchResponse,
+    ),
+  );
 
   // Check for 403 Forbidden
   if (batchResponse.status === 403) {
+    console.log("[sync] batch response 403");
     return SyncStatus.FORBIDDEN;
   }
 
   db.updateBatch(batchResponse.data);
 
   syncStatus = SyncStatus.UPDATED;
+  console.log("[sync] updates complete");
   return syncStatus;
 }

--- a/app/src/main/sync/index.ts
+++ b/app/src/main/sync/index.ts
@@ -220,7 +220,7 @@ export async function syncMetadata(
   const pendingEvents =
     attempt && attempt > 0
       ? db.getPendingEvents(
-          Math.max(1, Math.ceil(DEFAULT_PENDING_EVENTS_LIMIT / attempt)),
+          Math.max(1, Math.ceil(DEFAULT_PENDING_EVENTS_LIMIT / (attempt + 1))),
         )
       : db.getPendingEvents();
 

--- a/app/src/main/sync/lock.test.ts
+++ b/app/src/main/sync/lock.test.ts
@@ -123,7 +123,7 @@ describe("Lock", () => {
 
     // Start a long-running operation
     const firstPromise = lock.run(async () => {
-      await new Promise((res) => setTimeout(res, 50));
+      await new Promise((res) => setTimeout(res, 200));
     });
 
     // Try to run with a short timeout - should fail
@@ -197,7 +197,7 @@ describe("Lock", () => {
   it("should fully await completion", async () => {
     const lock = new Lock();
 
-    // Call 1 holds the lock for 500ms
+    // Call 1 holds the lock for 50ms
     const call1 = lock.run(async () => {
       await new Promise((res) => setTimeout(res, 50));
     }, 100);

--- a/app/src/main/sync/lock.test.ts
+++ b/app/src/main/sync/lock.test.ts
@@ -123,7 +123,7 @@ describe("Lock", () => {
 
     // Start a long-running operation
     const firstPromise = lock.run(async () => {
-      await new Promise((res) => setTimeout(res, 200));
+      await new Promise((res) => setTimeout(res, 50));
     });
 
     // Try to run with a short timeout - should fail
@@ -199,7 +199,7 @@ describe("Lock", () => {
 
     // Call 1 holds the lock for 500ms
     const call1 = lock.run(async () => {
-      await new Promise((res) => setTimeout(res, 500));
+      await new Promise((res) => setTimeout(res, 50));
     }, 100);
 
     await call1;

--- a/app/src/main/sync/lock.test.ts
+++ b/app/src/main/sync/lock.test.ts
@@ -193,4 +193,23 @@ describe("Lock", () => {
     // and unblock call 3 before call 1 has finished
     expect(concurrentAccess).toBe(false);
   });
+
+  it("should fully await completion", async () => {
+    const lock = new Lock();
+
+    // Call 1 holds the lock for 500ms
+    const call1 = lock.run(async () => {
+      await new Promise((res) => setTimeout(res, 500));
+    }, 100);
+
+    await call1;
+
+    let call2Ran = false;
+    // Call 2 should immediately be able to acquire the lock
+    await lock.run(async () => {
+      call2Ran = true;
+    });
+
+    expect(call2Ran).toBe(true);
+  });
 });

--- a/app/src/main/timeouts.ts
+++ b/app/src/main/timeouts.ts
@@ -35,7 +35,7 @@ export function estimateSize(schema: SizedSchema, records: number): bytes {
 }
 
 // Estimate a timeout for a request/response schema based on its expected size
-// per record and with exponential backoff for retries
+// per record.
 export function estimateTimeout(schema: SizedSchema, records?: number): ms {
   if (!records) {
     records = 0;
@@ -50,5 +50,5 @@ export function estimateTimeout(schema: SizedSchema, records?: number): ms {
   return timeout;
 }
 
-export const sleep = (ms: number) =>
-  new Promise((resolve) => setTimeout(resolve, ms));
+export const sleep = (duration: ms) =>
+  new Promise<void>((resolve) => setTimeout(resolve, duration));

--- a/app/src/main/timeouts.ts
+++ b/app/src/main/timeouts.ts
@@ -35,7 +35,7 @@ export function estimateSize(schema: SizedSchema, records: number): bytes {
 }
 
 // Estimate a timeout for a request/response schema based on its expected size
-// per record.
+// per record and with exponential backoff for retries
 export function estimateTimeout(schema: SizedSchema, records?: number): ms {
   if (!records) {
     records = 0;
@@ -49,3 +49,6 @@ export function estimateTimeout(schema: SizedSchema, records?: number): ms {
   );
   return timeout;
 }
+
+export const sleep = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));

--- a/app/src/schemas.ts
+++ b/app/src/schemas.ts
@@ -216,3 +216,23 @@ export type SourceTarget = z.infer<typeof SourceTargetSchema>;
 export type ItemTarget = z.infer<typeof ItemTargetSchema>;
 export type PendingEvent = z.infer<typeof PendingEventSchema>;
 export type PendingEventData = z.infer<typeof PendingEventDataSchema>;
+
+// Sanitizes BatchRequest to log only UUID keys and event types
+export function sanitizeBatchRequest(request: BatchRequest): object {
+  return {
+    sources: request.sources, // UUIDs
+    items: request.items, // UUIDs
+    journalists: request.journalists, // UUIDs
+    events: request.events?.map(({ id, type }) => ({ id, type })),
+  };
+}
+
+// Sanitizes BatchResponse to log only UUID keys for logging
+export function sanitizeBatchResponse(response: BatchResponse): object {
+  return {
+    sources: Object.keys(response.sources),
+    items: Object.keys(response.items),
+    journalists: Object.keys(response.journalists),
+    events: response.events,
+  };
+}

--- a/app/src/schemas.ts
+++ b/app/src/schemas.ts
@@ -227,12 +227,14 @@ export function sanitizeBatchRequest(request: BatchRequest): object {
   };
 }
 
-// Sanitizes BatchResponse to log only UUID keys for logging
+// Sanitizes BatchResponse to contain only UUID keys and event status codes
 export function sanitizeBatchResponse(response: BatchResponse): object {
   return {
     sources: Object.keys(response.sources),
     items: Object.keys(response.items),
     journalists: Object.keys(response.journalists),
-    events: response.events,
+    events: Object.fromEntries(
+      Object.entries(response.events).map(([id, [status]]) => [id, status]),
+    ),
   };
 }


### PR DESCRIPTION
- Logs sanitized versions of all sync requests + responses, prefixed with `[sync]`
- Automatically attempts retries on `syncMetadata` requests. Backs off between retries, and attempts with decreased batch sizes

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
