### PR TITLE
Run guarddog in GitHub Actions

### DIFF
--- a/.github/scripts/guarddog_scan_matrix.py
+++ b/.github/scripts/guarddog_scan_matrix.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Build the GuardDog scan matrix from a git-pkgs diff.
+
+Reads `git pkgs diff -f json` on stdin and prints a JSON array on stdout, one
+object per npm / PyPI / GitHub Actions add-or-upgrade. That array becomes the
+GitHub Actions job matrix, so one scan job is spawned per dependency. The
+GuardDog scan itself runs inline in the workflow (see guarddog.yml), so this
+script -- and therefore a repo checkout -- is only needed in the discover job.
+
+Each emitted object has:
+  ecosystem  git-pkgs ecosystem name (npm, pypi, github-actions) -- for display
+  scanner    GuardDog scan subcommand to run (npm, pypi, github_action)
+  name       package, or owner/repo for an action
+  version    resolved version / ref to scan
+  change     added | modified
+
+See: https://developers.securedrop.org/en/latest/dependency_updates.html
+"""
+
+import json
+import os
+import sys
+
+# git-pkgs ecosystem name -> GuardDog scan subcommand. Note the strings differ
+# on both sides for Actions: git-pkgs says "github-actions", GuardDog's
+# subcommand is "github_action". Ecosystems GuardDog can't scan (cargo, ...)
+# aren't in this map and are reported as skipped.
+ECOSYSTEMS = {"npm": "npm", "pypi": "pypi", "github-actions": "github_action"}
+
+
+def step_summary(line: str = "") -> None:
+    """Append a line to the GitHub Actions job summary (and the log on stderr).
+
+    Writes to stderr (not stdout) so stdout stays reserved for the matrix JSON.
+    """
+    print(line, file=sys.stderr)
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if path:
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+
+
+def normalize_github_action(name: str) -> str | None:
+    """Reduce a `uses:` reference to the `owner/repo` GuardDog can scan.
+
+    git-pkgs may include a subpath (e.g. `github/codeql-action/upload-sarif`),
+    but GuardDog scans the whole repo and only accepts `owner/repo`. Local
+    (`./...`) and `docker://` actions can't be fetched from GitHub, so they are
+    dropped (return None).
+    """
+    if name.startswith(".") or "://" in name:
+        return None
+    parts = name.split("/")
+    if len(parts) < 2:
+        return None
+    return "/".join(parts[:2])
+
+
+def collect_packages(diff: dict) -> list[dict]:
+    """Pull added + modified entries from a git-pkgs diff, deduped."""
+    seen: set[tuple[str, str, str]] = set()
+    packages: list[dict] = []
+    for change in ("added", "modified"):
+        for entry in diff.get(change, []):
+            ecosystem = entry.get("ecosystem", "")
+            name = entry.get("name", "")
+            # to_requirement is the *new* resolved version for both added and
+            # modified entries; that is what we want to scan.
+            version = entry.get("to_requirement", "")
+            if ecosystem == "github-actions":
+                # Collapse subpaths to owner/repo (and drop local/docker
+                # actions) so GuardDog can scan them and so two actions from the
+                # same repo dedupe to a single scan.
+                name = normalize_github_action(name)
+                if name is None:
+                    continue
+            key = (ecosystem, name, version)
+            if not name or not version or key in seen:
+                continue
+            seen.add(key)
+            packages.append(
+                {
+                    "ecosystem": ecosystem,
+                    "name": name,
+                    "version": version,
+                    "change": change,
+                }
+            )
+    return packages
+
+
+def main() -> int:
+    raw = sys.stdin.read().strip()
+    # With nothing to compare, git-pkgs prints this sentinel even with -f json.
+    if not raw or raw == "No dependency changes.":
+        step_summary("## GuardDog dependency scan\n\nNo dependency changes. ✅")
+        print("[]")
+        return 0
+    try:
+        diff = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        step_summary(f"Could not parse git-pkgs diff JSON: {exc}")
+        print("[]")
+        return 1
+
+    packages = collect_packages(diff)
+    scannable = [
+        {**p, "scanner": ECOSYSTEMS[p["ecosystem"]]}
+        for p in packages
+        if p["ecosystem"] in ECOSYSTEMS
+    ]
+    skipped = [p for p in packages if p["ecosystem"] not in ECOSYSTEMS]
+
+    step_summary("## GuardDog dependency scan")
+    step_summary()
+    if scannable:
+        step_summary(f"Spawning a scan job for {len(scannable)} package(s):")
+        step_summary()
+        for p in scannable:
+            step_summary(f"- `{p['name']}` ({p['ecosystem']} {p['version']}, {p['change']})")
+    else:
+        step_summary("No npm/PyPI/Actions additions or upgrades to scan. ✅")
+    if skipped:
+        others = ", ".join(sorted({p["ecosystem"] for p in skipped}))
+        step_summary(f"\n_Skipped unsupported ecosystems: {others}._")
+
+    # stdout: only the matrix, so the workflow can capture it cleanly.
+    print(json.dumps(scannable))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/guarddog.yml
+++ b/.github/workflows/guarddog.yml
@@ -1,0 +1,149 @@
+name: GuardDog
+on:
+  pull_request:
+    paths:
+      # GuardDog supports PyPI, NPM and GitHub Actions
+      - '**/pnpm-lock.yaml'
+      - '**/poetry.lock'
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+# A given PR only needs the latest scan.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GIT_PKGS_VERSION: 0.16.2
+
+jobs:
+  # Stage 1: figure out which packages changed and emit them as a job matrix.
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.discover.outputs.packages }}
+      any: ${{ steps.discover.outputs.any }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # Need both the base and head commits for `git pkgs diff`.
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Note: This job never runs against main, so most likely there'll be no
+      # cached version available; it'll only be on PR updates we see cache hits
+      - name: Cache git-pkgs
+        id: cache-git-pkgs
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/git-pkgs
+          key: git-pkgs-${{ runner.os }}-${{ env.GIT_PKGS_VERSION }}
+
+      - name: Install git-pkgs
+        if: steps.cache-git-pkgs.outputs.cache-hit != 'true'
+        env:
+          VERSION: ${{ env.GIT_PKGS_VERSION }}
+        run: |
+          set -euo pipefail
+          base="https://github.com/git-pkgs/git-pkgs/releases/download/v${VERSION}"
+          tarball="git-pkgs_${VERSION}_linux_amd64.tar.gz"
+          curl -fsSL "${base}/${tarball}" -o "${tarball}"
+          curl -fsSL "${base}/checksums.txt" -o checksums.txt
+          # Verify the download before trusting the binary.
+          grep " ${tarball}\$" checksums.txt | sha256sum --check --strict -
+          tar -xzf "${tarball}" git-pkgs
+          install -m 0755 git-pkgs /usr/local/bin/git-pkgs
+          rm -f "${tarball}" checksums.txt git-pkgs
+
+      - name: Discover changed packages
+        id: discover
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # `git pkgs diff` reads the two refs' lockfiles directly, so no
+          # one-time `git pkgs init` of the whole history is needed.
+          git pkgs diff --from "${BASE_SHA}" --to "${HEAD_SHA}" -f json > diff.json
+          packages="$(python .github/scripts/guarddog_scan_matrix.py < diff.json)"
+          echo "packages=${packages}" >> "$GITHUB_OUTPUT"
+          if [ "$(jq 'length' <<<"${packages}")" -gt 0 ]; then
+            echo "any=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "any=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Stage 2: one job per changed package, scanned independently.
+  scan:
+    needs: discover
+    if: needs.discover.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      # Scan every package even if one finds something.
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.discover.outputs.packages) }}
+    name: "Scan ${{ matrix.package.ecosystem }}:${{ matrix.package.name }}@${{ matrix.package.version }}"
+    steps:
+      # No checkout: GuardDog scans remote packages, so this job needs nothing
+      # from the repo. The matrix already carries everything the scan needs.
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install latest version of GuardDog
+        run: |
+          pip install guarddog semgrep
+          guarddog --version
+          semgrep --version
+
+      - name: Scan with GuardDog
+        env:
+          SCANNER: ${{ matrix.package.scanner }}
+          NAME: ${{ matrix.package.name }}
+          VERSION: ${{ matrix.package.version }}
+        shell: python
+        run: |
+          import json, os, subprocess, sys
+
+          scanner, name, version = os.environ["SCANNER"], os.environ["NAME"], os.environ["VERSION"]
+          label = f"{name}@{version}"
+
+          # GuardDog fails quietly, so always run with debug logging and inspect
+          # the JSON report ourselves, failing closed on findings, a scan error,
+          # or a missing report.
+          cmd = [
+            "guarddog", "--log-level", "debug", scanner, "scan", name,
+            "--version", version, "--output-format", "json"
+          ]
+          print("Running: " + " ".join(cmd))
+          proc = subprocess.run(
+              cmd, capture_output=True, text=True, check=False
+          )
+          sys.stderr.write(proc.stderr)  # debug logs -> job log
+          print(f"----- GuardDog report: {label} (exit {proc.returncode}) -----")
+          print(proc.stdout)
+
+          def fail(message):
+              # Workflow commands (::error::) are only parsed from stdout.
+              print(f"::error::{message}")
+              sys.exit(1)
+
+          try:
+              result = json.loads(proc.stdout)
+          except json.JSONDecodeError:
+              fail(f"GuardDog produced no JSON report for {label}.")
+
+          issues = int(result.get("issues", 0) or 0)
+          errors = result.get("errors") or {}
+          if issues > 0:
+              print(json.dumps(result.get("results", {}), indent=2))
+              fail(f"GuardDog flagged {issues} finding(s) in {label}.")
+          if errors:
+              print(json.dumps(errors, indent=2))
+              fail(f"GuardDog could not scan {label}; failing closed.")
+          print(f"{label}: clean")


### PR DESCRIPTION
We use [git-pkgs](https://github.com/git-pkgs/git-pkgs) to calculate what packages have changed in a PR, and
then queue jobs for each one. It will run when there are changes to
Poetry's lockfile, pnpm's lockfile, and any GHA workflow.

The job outputs the exact guarddog command so it's straightforward to
run locally if you want to examine it or double-check GHA's output.

If a job fails, it's up to a human to review the output and most likely,
ignore it as acceptable, or stop the upgrade.

If this works well, we can turn it into a reusable workflow and add it
to our other repositories.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] in this PR it triggers jobs for the new actions that are added
* [ ] https://github.com/freedomofpress/securedrop-client/actions/runs/27150678306?pr=3490 was an example run in which I upgraded protobufjs (which I knew triggered a guarddog check) to show a failing job
   * also I fixed the nodejs 20 deprecation warnings already that show up in this run
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
