### PR TITLE
Fix screen reader issues from 2026 Accessibility Audit

### DIFF
--- a/app/src/renderer/locales/en-XA.json
+++ b/app/src/renderer/locales/en-XA.json
@@ -166,6 +166,7 @@
     "viewFile": "[View]",
     "encryptedFile": "[!Encrypted File!]",
     "of": "[of]",
+    "filePositionAriaLabel": "[!!File {{index}} of {{total}}!!]",
     "pause": "[Pause]",
     "filenameTooltip": "[!!!Filename available after downloading!!!]",
     "downloadFailed": "[!Download Failed!]",
@@ -228,7 +229,10 @@
     "conversation": {
       "sendButton": "[Send]",
       "newMessagesDivider": "[!new messages!]",
-      "messagePlaceholder": "[!!Message {{designation}}...!!]"
+      "messagePlaceholder": "[!!Message {{designation}}...!!]",
+      "messageHistoryAriaLabel": "[!!Conversation messages!!]",
+      "messagePositionAriaLabel": "[!!Message {{index}} of {{total}}!!]",
+      "replyPositionAriaLabel": "[!!Reply {{index}} of {{total}}!!]"
     },
     "emptyState": "[!!!!!!!!!<bold>Select a source</bold> from the list to read messages, retrieve files, or send responses.!!!!!!!!!]",
     "alreadyRunning": "[!!!The SecureDrop Inbox is already running!!!]",

--- a/app/src/renderer/locales/en.json
+++ b/app/src/renderer/locales/en.json
@@ -23,7 +23,10 @@
     "conversation": {
       "sendButton": "Send",
       "messagePlaceholder": "Message {{designation}}...",
-      "newMessagesDivider": "new messages"
+      "newMessagesDivider": "new messages",
+      "messageHistoryAriaLabel": "Conversation messages",
+      "messagePositionAriaLabel": "Message {{index}} of {{total}}",
+      "replyPositionAriaLabel": "Reply {{index}} of {{total}}"
     },
     "menu": {
       "exportTranscript": "Export Transcript",
@@ -219,6 +222,7 @@
     "downloadFailed": "Download Failed",
     "retry": "Retry",
     "cancel": "Cancel",
+    "filePositionAriaLabel": "File {{index}} of {{total}}",
     "filenameTooltip": "Filename available after downloading",
     "offlineFilenameTooltip": "Download disabled in offline mode. Filename available after downloading",
     "fileActions": "File actions",

--- a/app/src/renderer/views/Inbox/MainContent/Conversation.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation.tsx
@@ -41,6 +41,8 @@ type VirtualRow =
 interface ConversationRowProps {
   virtualRows: VirtualRow[];
   designation: string;
+  itemPositionsByRowIndex: Array<number | null>;
+  totalConversationItems: number;
 }
 
 // memo is ineffective here because shared rowProps change reference on every selection
@@ -51,14 +53,23 @@ function ConversationRow({
   style,
   virtualRows,
   designation,
+  itemPositionsByRowIndex,
+  totalConversationItems,
 }: RowComponentProps<ConversationRowProps>) {
   const row = virtualRows[index];
+  const itemPosition = itemPositionsByRowIndex[index] ?? undefined;
+
   return (
     <div style={style} className="px-4">
       {row.kind === "divider" ? (
         <NewMessagesDivider />
       ) : (
-        <Item item={row.item} designation={designation} />
+        <Item
+          item={row.item}
+          designation={designation}
+          positionInConversation={itemPosition}
+          totalConversationItems={totalConversationItems}
+        />
       )}
     </div>
   );
@@ -221,6 +232,23 @@ const Conversation = memo(function Conversation({
     return rows;
   }, [oldItems, newItems, dividerIndex]);
 
+  const itemPositionsByRowIndex = useMemo((): Array<number | null> => {
+    let currentPosition = 0;
+    return virtualRows.map((row) => {
+      if (row.kind !== "item") {
+        return null;
+      }
+      currentPosition += 1;
+      return currentPosition;
+    });
+  }, [virtualRows]);
+
+  const totalConversationItems = useMemo(
+    () =>
+      itemPositionsByRowIndex.filter((position) => position !== null).length,
+    [itemPositionsByRowIndex],
+  );
+
   // Load older messages when the user scrolls near the top
   useEffect(() => {
     if (!scrollElement) {
@@ -266,8 +294,17 @@ const Conversation = memo(function Conversation({
             rowCount={virtualRows.length}
             rowHeight={dynamicRowHeight}
             rowComponent={ConversationRow}
-            rowProps={{ virtualRows, designation: designation || "" }}
+            rowProps={{
+              virtualRows,
+              designation: designation || "",
+              itemPositionsByRowIndex,
+              totalConversationItems,
+            }}
             listRef={listRef}
+            role="log"
+            aria-live="polite"
+            aria-relevant="additions"
+            aria-label={t("conversation.messageHistoryAriaLabel")}
             style={{
               height: "100%",
               visibility: heightsReady ? "visible" : "hidden",

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item.tsx
@@ -20,9 +20,16 @@ import React, { memo, useCallback } from "react";
 interface ItemProps {
   item: Item;
   designation: string;
+  positionInConversation?: number;
+  totalConversationItems?: number;
 }
 
-const Item = memo(function ItemComponent({ item, designation }: ItemProps) {
+const Item = memo(function ItemComponent({
+  item,
+  designation,
+  positionInConversation,
+  totalConversationItems,
+}: ItemProps) {
   const dispatch = useAppDispatch();
   const { t } = useTranslation("MainContent");
   const [modal, contextHolder] = Modal.useModal();
@@ -71,6 +78,8 @@ const Item = memo(function ItemComponent({ item, designation }: ItemProps) {
         designation={designation}
         onUpdate={onFetchStatusUpdate}
         onDelete={onDeleteClick}
+        positionInConversation={positionInConversation}
+        totalConversationItems={totalConversationItems}
       />
     );
   } else if (kind === "file") {
@@ -80,10 +89,20 @@ const Item = memo(function ItemComponent({ item, designation }: ItemProps) {
         designation={designation}
         onUpdate={onFetchStatusUpdate}
         onDelete={onDeleteClick}
+        positionInConversation={positionInConversation}
+        totalConversationItems={totalConversationItems}
       />
     );
   } else if (kind === "reply") {
-    content = <Message kind="reply" item={item} onDelete={onDeleteClick} />;
+    content = (
+      <Message
+        kind="reply"
+        item={item}
+        onDelete={onDeleteClick}
+        positionInConversation={positionInConversation}
+        totalConversationItems={totalConversationItems}
+      />
+    );
   }
 
   if (content === null) {

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Export.tsx
@@ -304,6 +304,10 @@ interface StateComponentProps {
   t: (key: string, options?: Record<string, unknown>) => string;
 }
 
+interface ErrorStateProps extends StateComponentProps {
+  headingRef: React.RefObject<HTMLHeadingElement | null>;
+}
+
 const ConfirmSourceState = memo(function ConfirmSourceState({
   context,
   t,
@@ -554,7 +558,8 @@ const PartialSuccessState = memo(function PartialSuccessState({
 const ErrorState = memo(function ErrorState({
   context,
   t,
-}: StateComponentProps) {
+  headingRef,
+}: ErrorStateProps) {
   const getErrorMessage = () => {
     // If we have a device status, try to get a user-friendly message
     if (context.deviceStatus) {
@@ -582,7 +587,7 @@ const ErrorState = memo(function ErrorState({
       <div className="flex items-center gap-3 mb-4">
         <FileX2 size={24} strokeWidth={2} className="text-red-500" />
         <div className="ml-3">
-          <h3 className="text-lg font-semibold">
+          <h3 className="text-lg font-semibold" ref={headingRef} tabIndex={-1}>
             {t("exportWizard.exportFailed")}
           </h3>
         </div>
@@ -647,6 +652,7 @@ export const ExportWizard = memo(function ExportWizard({
   // Refs to track in-progress operations
   const preflightInProgress = useRef(false);
   const exportInProgress = useRef(false);
+  const errorHeadingRef = useRef<HTMLHeadingElement>(null);
 
   // Reset state when wizard is closed
   useEffect(() => {
@@ -657,6 +663,17 @@ export const ExportWizard = memo(function ExportWizard({
       exportInProgress.current = false;
     }
   }, [open]);
+
+  // Move focus to the error heading so screen readers announce failures immediately.
+  useEffect(() => {
+    if (!open || context.state !== "ERROR") {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      errorHeadingRef.current?.focus();
+    });
+  }, [context.state, open]);
 
   // Sync undownloaded_items to update when items have been downloaded
   const undownloadedItems =
@@ -799,7 +816,7 @@ export const ExportWizard = memo(function ExportWizard({
       case "PARTIAL_SUCCESS":
         return <PartialSuccessState {...stateProps} />;
       case "ERROR":
-        return <ErrorState {...stateProps} />;
+        return <ErrorState {...stateProps} headingRef={errorHeadingRef} />;
     }
   };
 

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
@@ -131,6 +131,8 @@ interface FileProps {
   designation: string;
   onUpdate: (update: ItemUpdate) => void;
   onDelete: () => void;
+  positionInConversation?: number;
+  totalConversationItems?: number;
 }
 
 function getFileIconAndColor(filename: string): {
@@ -199,6 +201,8 @@ const File = memo(function File({
   designation,
   onUpdate,
   onDelete,
+  positionInConversation,
+  totalConversationItems,
 }: FileProps) {
   const { t } = useTranslation("Item");
   const { token } = theme.useToken();
@@ -276,10 +280,24 @@ const File = memo(function File({
     transition: "background-color 0.2s ease",
   };
 
+  const listItemAriaProps =
+    positionInConversation && totalConversationItems
+      ? {
+          role: "listitem" as const,
+          "aria-posinset": positionInConversation,
+          "aria-setsize": totalConversationItems,
+          "aria-label": t("filePositionAriaLabel", {
+            index: positionInConversation,
+            total: totalConversationItems,
+          }),
+        }
+      : {};
+
   return (
     <div
       className="flex items-start mb-4 justify-start group"
       data-testid={`item-${item.uuid}`}
+      {...listItemAriaProps}
     >
       <Avatar designation={titleCaseDesignation ?? ""} isActive={false} />
       <div className="ml-3">

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.tsx
@@ -38,11 +38,15 @@ type MessageProps =
       designation: string;
       onUpdate: (update: ItemUpdate) => void;
       onDelete: () => void;
+      positionInConversation?: number;
+      totalConversationItems?: number;
     }
   | {
       kind: "reply";
       item: Item;
       onDelete: () => void;
+      positionInConversation?: number;
+      totalConversationItems?: number;
     };
 
 const Message = memo(function Message(props: MessageProps) {
@@ -189,12 +193,34 @@ const Message = memo(function Message(props: MessageProps) {
 
   const authorDisplay = getAuthorDisplay();
   const statusIcon = getStatusIcon();
+  const positionInConversation = props.positionInConversation;
+  const totalConversationItems = props.totalConversationItems;
+
+  const listItemAriaProps =
+    positionInConversation && totalConversationItems
+      ? {
+          role: "listitem" as const,
+          "aria-posinset": positionInConversation,
+          "aria-setsize": totalConversationItems,
+          "aria-label":
+            kind === "reply"
+              ? t("conversation.replyPositionAriaLabel", {
+                  index: positionInConversation,
+                  total: totalConversationItems,
+                })
+              : t("conversation.messagePositionAriaLabel", {
+                  index: positionInConversation,
+                  total: totalConversationItems,
+                }),
+        }
+      : {};
 
   if (kind === "message") {
     return (
       <div
         className="flex items-start mb-4 justify-start group"
         data-testid={`item-${item.uuid}`}
+        {...listItemAriaProps}
       >
         <Avatar designation={authorDisplay} isActive={false} />
         <div className="ml-3">
@@ -232,6 +258,7 @@ const Message = memo(function Message(props: MessageProps) {
     <div
       className="flex items-start mb-4 justify-end group"
       data-testid={`item-${item.uuid}`}
+      {...listItemAriaProps}
     >
       <div>
         <div className="flex items-center justify-start mb-1 gap-1">

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Print.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Print.test.tsx
@@ -335,6 +335,30 @@ describe("PrintWizard Component", () => {
       });
     });
 
+    it("moves focus to the error heading when print fails", async () => {
+      vi.mocked(window.electronAPI.print).mockResolvedValueOnce(
+        PrintStatus.ERROR_PRINT,
+      );
+
+      renderWithProviders(
+        <PrintWizard
+          item={mockPrintPayload}
+          open={true}
+          onClose={mockOnClose}
+        />,
+      );
+
+      await navigateToPrinting();
+
+      await waitFor(() => {
+        expect(screen.getByText("Print Failed")).toBeInTheDocument();
+      });
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(screen.getByText("Print Failed"));
+      });
+    });
+
     it("shows Close button and closes modal on click", async () => {
       vi.mocked(window.electronAPI.print).mockResolvedValueOnce(
         PrintStatus.ERROR_PRINT,

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Print.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Print.tsx
@@ -168,6 +168,10 @@ interface StateComponentProps {
   t: (key: string) => string;
 }
 
+interface ErrorStateProps extends StateComponentProps {
+  headingRef: React.RefObject<HTMLHeadingElement | null>;
+}
+
 const PreflightState = memo(function PreflightState({
   context,
   t,
@@ -267,7 +271,8 @@ const PrintingState = memo(function PrintingState({ t }: StateComponentProps) {
 const ErrorState = memo(function ErrorState({
   context,
   t,
-}: StateComponentProps) {
+  headingRef,
+}: ErrorStateProps) {
   const getErrorMessage = () => {
     // If we have a device status, try to get a user-friendly message
     if (context.deviceStatus) {
@@ -296,7 +301,7 @@ const ErrorState = memo(function ErrorState({
       <div className="flex items-center gap-3 mb-4">
         <FileX2 size={24} strokeWidth={2} className="text-red-500" />
         <div className="ml-3">
-          <h3 className="text-lg font-semibold">
+          <h3 className="text-lg font-semibold" ref={headingRef} tabIndex={-1}>
             {t("printWizard.printFailed")}
           </h3>
         </div>
@@ -342,6 +347,7 @@ export const PrintWizard = memo(function PrintWizard({
   const [context, dispatch] = useReducer(printReducer, {
     ...initialContext,
   });
+  const errorHeadingRef = useRef<HTMLHeadingElement>(null);
 
   // Refs to track in-progress operations
   const preflightInProgress = useRef(false);
@@ -461,6 +467,17 @@ export const PrintWizard = memo(function PrintWizard({
     }
   }, [context.state, onClose]);
 
+  // Move focus to the error heading so screen readers announce failures immediately.
+  useEffect(() => {
+    if (!open || context.state !== "ERROR") {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      errorHeadingRef.current?.focus();
+    });
+  }, [context.state, open]);
+
   const handleClose = () => {
     // Cancel any ongoing print operation
     window.electronAPI.cancelPrint();
@@ -481,7 +498,7 @@ export const PrintWizard = memo(function PrintWizard({
       case "PRINTING":
         return <PrintingState {...stateProps} />;
       case "ERROR":
-        return <ErrorState {...stateProps} />;
+        return <ErrorState {...stateProps} headingRef={errorHeadingRef} />;
       default:
         return null;
     }

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/useConversationScroll.ts
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/useConversationScroll.ts
@@ -301,11 +301,18 @@ export function useConversationScroll(
       return;
     }
     const handleScroll = () => {
-      if (isAutoScrollingValueRef.current) {
-        return;
-      }
       const distanceToBottom =
         el.scrollHeight - (el.scrollTop + el.clientHeight);
+
+      // While auto-scrolling, ignore intermediate scroll events but still process
+      // the final bottom position so unseen messages can be acknowledged.
+      if (
+        isAutoScrollingValueRef.current &&
+        distanceToBottom > NEW_MESSAGE_SEEN_THRESHOLD
+      ) {
+        return;
+      }
+
       isAtBottomRef.current = distanceToBottom <= NEW_MESSAGE_SEEN_THRESHOLD;
       if (isAtBottomRef.current) {
         if (dividerItemUuid) {

--- a/app/src/renderer/views/Inbox/MainContent/Header.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Header.tsx
@@ -32,7 +32,9 @@ const Header = memo(function Header({
       <Flex>
         <Avatar designation={designation} isActive={false} />
         <div className="ml-2">
-          <p data-testid="conversation-header-designation">{designation}</p>
+          <h2 data-testid="conversation-header-designation" tabIndex={-1}>
+            {designation}
+          </h2>
           <p
             className="text-sm text-gray-600"
             data-testid="conversation-header-last-activity"

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
@@ -859,6 +859,31 @@ describe("Sources Component", () => {
       ).toBeInTheDocument();
     });
 
+    it("focuses dialog title when modal opens", async () => {
+      renderSourceList();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByTestId("source-checkbox-source-1"));
+      await userEvent.click(screen.getByTestId("bulk-delete-button"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("delete-modal")).toBeInTheDocument();
+      });
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(
+          screen.getByTestId("delete-modal-title"),
+        );
+      });
+
+      expect(
+        screen.getByTestId("delete-modal-cancel-button"),
+      ).toBeInTheDocument();
+    });
+
     it("calls addPendingSourceEventBatch with SourceDeleted when Delete Account is clicked", async () => {
       renderSourceList();
 

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -74,7 +74,7 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [deleteModalLoading, setDeleteModalLoading] = useState(false);
-  const cancelButtonRef = useRef<HTMLButtonElement | null>(null);
+  const deleteModalTitleRef = useRef<HTMLHeadingElement | null>(null);
   // Sources targeted for deletion
   const [pendingDeleteSources, setPendingDeleteSources] = useState<Set<string>>(
     new Set(),
@@ -500,26 +500,29 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
         closable={false}
         afterOpenChange={(open) => {
           if (open) {
-            cancelButtonRef.current?.focus();
+            requestAnimationFrame(() => {
+              deleteModalTitleRef.current?.focus();
+            });
           }
         }}
         title={
-          <span data-testid="delete-modal-title">
+          <h2
+            data-testid="delete-modal-title"
+            tabIndex={-1}
+            ref={deleteModalTitleRef}
+          >
             {pendingDeleteSources.size === 1
               ? t("sourcelist.deleteDialog.single.message")
               : t("sourcelist.deleteDialog.multiple.message", {
                   count: pendingDeleteSources.size,
                 })}
-          </span>
+          </h2>
         }
         getContainer={() => document.getElementById("root") || document.body}
         onCancel={handleDeleteModalCancel}
         footer={[
           <Button
             key="cancel"
-            ref={(node) => {
-              cancelButtonRef.current = node as HTMLButtonElement | null;
-            }}
             data-testid="delete-modal-cancel-button"
             onClick={handleDeleteModalCancel}
           >

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { expect, describe, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import {
@@ -239,6 +239,28 @@ describe("Source Component", () => {
       await user.click(sourceElement);
 
       expect(mockNavigate).toHaveBeenCalledWith("/source/test-uuid-123");
+    });
+
+    it("moves focus to conversation heading after selecting a source", async () => {
+      const user = userEvent.setup();
+      const source = createMockSource();
+      const { container } = renderWithProviders(
+        <Source source={source} {...defaultProps} isActive={false} />,
+      );
+
+      const heading = document.createElement("h2");
+      heading.setAttribute("data-testid", "conversation-header-designation");
+      heading.tabIndex = -1;
+      document.body.appendChild(heading);
+
+      const sourceElement = container.firstChild as HTMLElement;
+      await user.click(sourceElement);
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(heading);
+      });
+
+      heading.remove();
     });
 
     it("navigates to home when clicked and already active", async () => {

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.tsx
@@ -45,19 +45,26 @@ const Source = memo(function Source({
     [source.data.last_updated, i18n.language, tCommon],
   );
 
-  const focusConversationHeading = useCallback((attempt = 0) => {
-    const heading = document.querySelector<HTMLElement>(
-      '[data-testid="conversation-header-designation"]',
-    );
-    if (heading) {
-      heading.focus();
-      return;
-    }
+  const focusConversationHeading = useCallback(() => {
+    let attempt = 0;
 
-    // Wait briefly for route transition + content render before giving up.
-    if (attempt < 5) {
-      window.setTimeout(() => focusConversationHeading(attempt + 1), 50);
-    }
+    const tryFocusHeading = () => {
+      const heading = document.querySelector<HTMLElement>(
+        '[data-testid="conversation-header-designation"]',
+      );
+      if (heading) {
+        heading.focus();
+        return;
+      }
+
+      // Wait briefly for route transition + content render before giving up.
+      if (attempt < 5) {
+        attempt += 1;
+        window.setTimeout(tryFocusHeading, 50);
+      }
+    };
+
+    tryFocusHeading();
   }, []);
 
   const handleClick = useCallback(() => {

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.tsx
@@ -45,6 +45,21 @@ const Source = memo(function Source({
     [source.data.last_updated, i18n.language, tCommon],
   );
 
+  const focusConversationHeading = useCallback((attempt = 0) => {
+    const heading = document.querySelector<HTMLElement>(
+      '[data-testid="conversation-header-designation"]',
+    );
+    if (heading) {
+      heading.focus();
+      return;
+    }
+
+    // Wait briefly for route transition + content render before giving up.
+    if (attempt < 5) {
+      window.setTimeout(() => focusConversationHeading(attempt + 1), 50);
+    }
+  }, []);
+
   const handleClick = useCallback(() => {
     if (isActive) {
       // If already active, clear active source and navigate back to inbox home
@@ -54,8 +69,9 @@ const Source = memo(function Source({
       // Set active source and navigate to the source route
       dispatch(setActiveSource(source.uuid));
       navigate(`/source/${source.uuid}`);
+      focusConversationHeading();
     }
-  }, [isActive, navigate, source.uuid, dispatch]);
+  }, [isActive, navigate, source.uuid, dispatch, focusConversationHeading]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>) => {


### PR DESCRIPTION
Fixes #3393
Fixes #3370
Fixes #3364
Fixes #3386 
Fixes #3387

This PR fixes all of screen reader accessibility issues.

I decided to develop this on a Mac using VoiceOver, rather than in Qubes using Orca in the sd-dev VM. This is because I actually couldn't figure out Orca. I've never used a screen reader before, and VoiceOver gave a nice tutorial when I started it. With Orca, I did get it running in sd-dev, but I couldn't immediately figure out what the focus keyboard shortcut was, so I just decided to use it in Mac. As I pointed out in Slack, Qubes itself isn't very accessible to screen readers, so I think this was reasonable.

## Test plan

Turn on the screen reader (like VoiceOver in macOS).

- Using the keyboard with a screen reader, navigate to a conversation. It should now list the conversation messages in a log, allowing you to tell the total number of messages, and the count of which message is being read as you focus on it.
- Using the keyboard, select a source. It should automatically focus the header at the top of the conversation view, starting with the source codename and the last source activity timestamp.
- Using the keyboard, check boxes next to sources and then choose delete sources. It should auto-focus on the heading of the delete modal. Pressing tab once should then focus on the cancel button.
- Open the Inbox app with `--no-qubes` to help trigger an error. Using the keyboard, navigate to a source, download a file, select the menu and choose print. In the dialog choose continue. It should auto-focus on the error message.


## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
