### PR TITLE
fix(`login`): save metadata hints along with the authentication token

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -261,6 +261,7 @@ if (!gotTheLock) {
   let fetchWorker: Worker | null = null;
   let authToken: string | null = null;
   let syncLoopTimer: NodeJS.Timeout | null = null;
+  let lastHintedRecords: number | undefined;
 
   function wakeFetchWorkerIfNeeded(): void {
     if (!fetchWorker || !authToken) {
@@ -389,10 +390,11 @@ if (!gotTheLock) {
               return { success: false, errorType: "generic" };
             }
             authToken = resp.data.token;
+            lastHintedRecords = resp.data.hints.sources + resp.data.hints.items;
 
             // Initiate sync loop
             if (import.meta.env.MODE != "test") {
-              void runSyncLoop({});
+              void runSyncLoop({ hintedRecords: lastHintedRecords });
             }
 
             return {
@@ -859,7 +861,7 @@ if (!gotTheLock) {
 
         syncLoopTimer = setTimeout(() => {
           if (authToken) {
-            void runSyncLoop({});
+            void runSyncLoop({ hintedRecords: lastHintedRecords });
           }
         }, 1000 * 60);
       }


### PR DESCRIPTION
Fixes #3494 by allowing `runSyncLoop()` to calculate hint-based timeouts for background syncs the same way the front end does for user-initiated syncs.


## Test plan

1. Log into the Inbox and wait for initial sync to complete.
2. <kbd>Ctrl</kbd>-<kbd>S</kbd> to initiate a sync.
3. [ ] Observe in the log (e.g.):
    ```
    [sync] Acquired lock
    [sync] syncing  { hintedRecords: 74, attempt: 0 }
    Expecting index of ~74 records to be ~7844 bytes within ~10236 ms
    [sync] index up to date
    ```
4. Wait for a background sync to take place.
5. [ ] Observe in the log (e.g.):
    ```
    [sync] Acquired lock
    [sync] syncing  { hintedRecords: 74, attempt: 0 }
    Expecting index of ~74 records to be ~7844 bytes within ~10236 ms
    [sync] index up to date
    ```