### PR TITLE
Enable F1 shortcut when in text entry

### DIFF
--- a/app/src/renderer/shortcuts/shortcutDefinitions.ts
+++ b/app/src/renderer/shortcuts/shortcutDefinitions.ts
@@ -59,7 +59,7 @@ export const shortcuts: ShortcutDefinition[] = [
     categoryKey: "shortcuts.categories.application",
     scope: Scope.GLOBAL,
     displayKeys: [["F1"]],
-    options: { preventDefault: true },
+    options: { preventDefault: true, enableOnFormTags: true },
   },
   {
     id: "sync",


### PR DESCRIPTION
Fixes #3441

## Test plan
Focus on the reply box and press F1. Though help dialog should appear.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
