### PR TITLE
Fix pnpm/action-setup

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -42,19 +42,15 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "24.15.x"
-      - name: Install pnpm
+      - name: Install pnpm and dependencies
         uses: pnpm/action-setup@v6.0.8
         with:
           version: 10
-      - name: Set up Node.js w/ caching
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24.15.x"
-          cache: pnpm
-          cache-dependency-path: app/pnpm-lock.yaml
-      - name: Install node dependencies
-        working-directory: app
-        run: pnpm install
+          cache: true
+          cache_dependency_path: |
+            app/pnpm-lock.yaml
+          run_install: |
+            - cwd: app
       - name: Lint
         working-directory: app
         run: pnpm lint
@@ -98,19 +94,15 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "24.15.x"
-      - name: Install pnpm
+      - name: Install pnpm and dependencies
         uses: pnpm/action-setup@v6.0.8
         with:
           version: 10
-      - name: Set up Node.js w/ caching
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24.15.x"
-          cache: pnpm
-          cache-dependency-path: app/pnpm-lock.yaml
-      - name: Install node dependencies
-        working-directory: app
-        run: pnpm install
+          cache: true
+          cache_dependency_path: |
+            app/pnpm-lock.yaml
+          run_install: |
+            - cwd: app
       - name: Install Rust-specific dependencies for sd-proxy
         run: apt-get install --yes build-essential curl libssl-dev pkg-config
       - name: Install Rust to build sd-proxy
@@ -167,19 +159,15 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "24.15.x"
-      - name: Install pnpm
+      - name: Install pnpm and dependencies
         uses: pnpm/action-setup@v6.0.8
         with:
           version: 10
-      - name: Set up Node.js w/ caching
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24.15.x"
-          cache: pnpm
-          cache-dependency-path: app/pnpm-lock.yaml
-      - name: Install node dependencies
-        working-directory: app
-        run: pnpm install
+          cache: true
+          cache_dependency_path: |
+            app/pnpm-lock.yaml
+          run_install: |
+            - cwd: app
       - name: Install Rust-specific dependencies for sd-proxy
         run: apt-get install --yes build-essential curl libssl-dev pkg-config
       - name: Install Rust to build sd-proxy
@@ -206,19 +194,15 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "24.15.x"
-      - name: Install pnpm
+      - name: Install pnpm and dependencies
         uses: pnpm/action-setup@v6.0.8
         with:
           version: 10
-      - name: Set up Node.js w/ caching
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24.15.x"
-          cache: pnpm
-          cache-dependency-path: app/pnpm-lock.yaml
-      - name: Install node dependencies
-        working-directory: app
-        run: pnpm install
+          cache: true
+          cache_dependency_path: |
+            app/pnpm-lock.yaml
+          run_install: |
+            - cwd: app
       # n.b. because this runs on Ubuntu runner directly,
       # build-essential, curl, libssl-dev and pkg-config are already installed
       - name: Install Rust to build sd-proxy

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -38,11 +38,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Bootstrap node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.15.x"
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v6.0.8
         with:
           version: 10
-      - name: Install node
+      - name: Set up Node.js w/ caching
         uses: actions/setup-node@v6
         with:
           node-version: "24.15.x"
@@ -90,11 +94,15 @@ jobs:
           repository: "freedomofpress/securedrop"
           path: "securedrop-server"
           persist-credentials: false
+      - name: Bootstrap node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.15.x"
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v6.0.8
         with:
           version: 10
-      - name: Install node
+      - name: Set up Node.js w/ caching
         uses: actions/setup-node@v6
         with:
           node-version: "24.15.x"
@@ -155,11 +163,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Bootstrap node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.15.x"
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v6.0.8
         with:
           version: 10
-      - name: Install node
+      - name: Set up Node.js w/ caching
         uses: actions/setup-node@v6
         with:
           node-version: "24.15.x"
@@ -190,11 +202,15 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+      - name: Bootstrap node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.15.x"
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v6.0.8
         with:
           version: 10
-      - name: Install node
+      - name: Set up Node.js w/ caching
         uses: actions/setup-node@v6
         with:
           node-version: "24.15.x"

--- a/.github/workflows/mac-demo.yml
+++ b/.github/workflows/mac-demo.yml
@@ -32,25 +32,19 @@ jobs:
         with:
           node-version: "24.15.x"
 
-      - name: Install pnpm
+      - name: Install pnpm and dependencies
         uses: pnpm/action-setup@v6.0.8
         with:
           version: 10
-
-      - name: Set up Node.js w/ caching
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24.15.x"
-          cache: pnpm
-          cache-dependency-path: app/pnpm-lock.yaml
+          cache: true
+          cache_dependency_path: |
+            app/pnpm-lock.yaml
+          run_install: |
+            - cwd: app
 
       # Keep version in sync with rust-toolchain.toml
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.90.0
-
-      - name: Install node dependencies
-        working-directory: app
-        run: pnpm install
 
       - name: Build Mac demo DMG
         working-directory: app

--- a/.github/workflows/mac-demo.yml
+++ b/.github/workflows/mac-demo.yml
@@ -27,12 +27,17 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Bootstrap node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.15.x"
+
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v6.0.8
         with:
           version: 10
 
-      - name: Set up Node.js
+      - name: Set up Node.js w/ caching
         uses: actions/setup-node@v6
         with:
           node-version: "24.15.x"


### PR DESCRIPTION
* Bootstrap actions/setup-node first so nodejs/npm exist.
* Pin pnpm/action-setup to v6.0.8 instead of a floating v6.

Fixes #3412.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
CI passes, no "spawn npm ENOENT" errors
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
