### PR TITLE
Support 1366x768 resolution

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -178,9 +178,9 @@ if (!gotTheLock) {
   function createWindow(): BrowserWindow {
     const mainWindow = new BrowserWindow({
       width: is.dev && process.env["NODE_ENV"] != "production" ? 1500 : 1200,
-      height: 900,
+      height: 700,
       minWidth: 1200,
-      minHeight: 900,
+      minHeight: 700,
       title: "SecureDrop Inbox",
       icon: join(__dirname, "../../resources/images/logo.png"),
       show: false,

--- a/app/src/renderer/components/KeyboardHelpModal.css
+++ b/app/src/renderer/components/KeyboardHelpModal.css
@@ -1,0 +1,6 @@
+.keyboard-help-modal .ant-modal-body {
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 200px);
+  overflow: hidden;
+}

--- a/app/src/renderer/components/KeyboardHelpModal.tsx
+++ b/app/src/renderer/components/KeyboardHelpModal.tsx
@@ -3,6 +3,7 @@ import { Modal, Button } from "antd";
 import { useTranslation } from "react-i18next";
 import { setHelpHandler } from "./helpRequester";
 import KeyboardHelp from "../views/Inbox/Sidebar/Account/KeyboardHelp";
+import "./KeyboardHelpModal.css";
 
 function KeyboardHelpModal() {
   const { t } = useTranslation("Sidebar");
@@ -22,7 +23,7 @@ function KeyboardHelpModal() {
   return (
     <Modal
       getContainer={() => document.getElementById("root") || document.body}
-      wrapClassName="about-modal-container"
+      wrapClassName="about-modal-container keyboard-help-modal"
       className="about-modal-content"
       title=""
       closable={false}

--- a/app/src/renderer/views/Inbox/Sidebar/Account/KeyboardHelp.css
+++ b/app/src/renderer/views/Inbox/Sidebar/Account/KeyboardHelp.css
@@ -1,0 +1,4 @@
+.keyboard-help-body {
+  overflow-y: auto;
+  flex: 1;
+}

--- a/app/src/renderer/views/Inbox/Sidebar/Account/KeyboardHelp.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/Account/KeyboardHelp.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { shortcuts } from "../../../../shortcuts/shortcutDefinitions";
+import "./KeyboardHelp.css";
 
 // Keyboard Shortcuts Modal Content
 function KeyboardHelp() {
@@ -47,7 +48,7 @@ function KeyboardHelp() {
       </div>
 
       {/* Body */}
-      <div className="px-[24px] pt-[16px] pb-[4px]">
+      <div className="keyboard-help-body px-[24px] pt-[16px] pb-[4px]">
         {grouped.map((group, gi) => (
           <div key={group.categoryKey}>
             <div


### PR DESCRIPTION
Fixes #3487

This PR does two things:

- Sets the minimum and default window height to 700, to fit in a 1366x768 screen
- Updates the keyboard shortcuts dialog to have an internal scrollbar -- otherwise, when you open that dialog, the entire window scrolls vertically

Here are screenshots showing the full screen in Qubes at 1366x768:

<img width="1368" height="768" alt="Screenshot_2026-06-16_09-06-28" src="https://github.com/user-attachments/assets/ffcf63e6-296f-42d9-84b7-34e527499cf2" />

<img width="1368" height="768" alt="Screenshot_2026-06-16_09-06-46" src="https://github.com/user-attachments/assets/3e9fc0ee-09f0-4876-9771-7610875298d9" />


## Test plan

Apply this diff to make it so when you start in dev mode, it doesn't make the window wider or open dev tools:

```diff
diff --git a/app/src/main/index.ts b/app/src/main/index.ts
index e1d0a558..a0d69f8c 100644
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -177,7 +177,7 @@ if (!gotTheLock) {
 
   function createWindow(): BrowserWindow {
     const mainWindow = new BrowserWindow({
-      width: is.dev && process.env["NODE_ENV"] != "production" ? 1500 : 1200,
+      width: 1200, // is.dev && process.env["NODE_ENV"] != "production" ? 1500 : 1200,
       height: 700,
       minWidth: 1200,
       minHeight: 700,
@@ -197,9 +197,9 @@ if (!gotTheLock) {
       // Default open DevTools in development
       // We're checking for both is.dev and NODE_ENV isn't production so that `pnpm start`, which previews
       // the production build, doesn't open DevTools
-      if (is.dev && process.env["NODE_ENV"] != "production") {
-        mainWindow.webContents.openDevTools();
-      }
+      // if (is.dev && process.env["NODE_ENV"] != "production") {
+      //   mainWindow.webContents.openDevTools();
+      // }
     });
 
     // HMR for renderer base on electron-vite cli.
```

Then start the app. Without changing the window size, click around, and everything should fit.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
