### PR TITLE
Build Debian packages for trixie

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,12 @@ jobs:
       matrix:
         debian_version:
           - bookworm
+          - trixie
     runs-on: ubuntu-latest
     container: debian:${{ matrix.debian_version }}
     steps:
       - run: |
-          apt-get update && apt-get install --yes git git-lfs sudo make
+          apt-get update && apt-get install --yes git git-lfs sudo make gnupg
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
@@ -54,6 +55,7 @@ jobs:
       matrix:
         debian_version:
           - bookworm
+          - trixie
         what:
           - main
     runs-on: ubuntu-latest
@@ -86,6 +88,7 @@ jobs:
       matrix:
         debian_version:
           - bookworm
+          - trixie
         what:
           - main
     runs-on: ubuntu-latest
@@ -116,8 +119,9 @@ jobs:
       matrix:
         debian_version:
           - bookworm
+          - trixie
     runs-on: ubuntu-latest
-    container: debian:bookworm
+    container: debian:trixie
     needs:
       - build-debs
       - lintian
@@ -154,6 +158,7 @@ jobs:
           - proxy
         debian_version:
           - bookworm
+          - trixie
     runs-on: ubuntu-latest
     needs:
       - build-debs

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -28,6 +28,7 @@ jobs:
       matrix:
         debian_version:
           - bookworm
+          - trixie
     runs-on: ubuntu-latest
     outputs:
       artifact_id: ${{ steps.upload.outputs.artifact-id }}
@@ -72,6 +73,11 @@ jobs:
         with:
           name: build-bookworm
           path: build-bookworm
+      - name: Download trixie artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-trixie
+          path: build-trixie
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
@@ -100,6 +106,8 @@ jobs:
           cp -v build-*/*.buildinfo "build-logs/buildinfo/$(date +%Y)"
           mkdir -p "build-logs/workstation/bookworm/nightlies"
           cp -v build-bookworm/*.log "build-logs/workstation/bookworm/nightlies/"
+          mkdir -p "build-logs/workstation/trixie/nightlies"
+          cp -v build-trixie/*.log "build-logs/workstation/trixie/nightlies/"
       - name: Sign and commit buildinfo files
         uses: freedomofpress/actionslib/act/signed-commit@main
         with:
@@ -126,10 +134,11 @@ jobs:
       - name: Prepare packages
         run: |
           cp -v build-bookworm/*.deb securedrop-apt-test/workstation/bookworm-nightlies/
+          cp -v build-trixie/*.deb securedrop-apt-test/workstation/trixie-nightlies/
       - name: Sign and commit packages
         uses: freedomofpress/actionslib/act/signed-commit@main
         with:
-          files: workstation/bookworm-nightlies/
+          files: workstation/
           repo-path: securedrop-apt-test
           message: |
             Automated SecureDrop workstation build

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,11 @@ Source: securedrop-client
 Section: unknown
 Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Build-Depends: debhelper-compat (= 11), dh-apparmor, dh-exec, python3-venv, libssl-dev, pkgconf, libclang-dev, qubesdb-dev, nodejs,
+Build-Depends: debhelper-compat (= 11), dh-apparmor, dh-exec, python3-venv, python3-setuptools,
+# python3-wheel is only needed on bookworm; setuptools >= 70.1 (trixie+) bundles bdist_wheel.
+# Drop the "| python3-wheel" alternative once bookworm support is removed.
+ python3-setuptools (>= 70.1) | python3-wheel,
+ libssl-dev, pkgconf, libclang-dev, qubesdb-dev, nodejs,
  libasound2, libatk-bridge2.0-0, libatk1.0-0, libatspi2.0-0, libcairo2,
  libcups2, libdbus-1-3, libexpat1, libgbm1, libglib2.0-0, libgtk-3-0,
  libnspr4, libnss3, libpango-1.0-0, libx11-6, libxcb1, libxcomposite1,

--- a/debian/securedrop-export.install
+++ b/debian/securedrop-export.install
@@ -2,4 +2,4 @@ export/files/application-x-sd-export.xml usr/share/mime/packages
 export/files/send-to-usb.desktop usr/share/applications
 export/files/sd-logo.png usr/share/securedrop/icons
 export/files/tcrypt.conf etc/udisks2
-export/systemd/60-securedrop-export.preset lib/systemd/system-preset/
+export/systemd/60-securedrop-export.preset usr/lib/systemd/system-preset/

--- a/debian/securedrop-proxy.install
+++ b/debian/securedrop-proxy.install
@@ -4,4 +4,4 @@ target/release/securedrop-proxy usr/bin/
 proxy/usr.bin.securedrop-proxy /etc/apparmor.d/
 proxy/configure_onion_service.py => usr/bin/securedrop-configure-onion-service
 proxy/share /usr/
-proxy/systemd/tor@default.service.d/35_securedrop.conf lib/systemd/system/tor@default.service.d
+proxy/systemd/tor@default.service.d/35_securedrop.conf usr/lib/systemd/system/tor@default.service.d

--- a/debian/setup-venv.sh
+++ b/debian/setup-venv.sh
@@ -3,15 +3,10 @@
 set -euxo pipefail
 
 NAME=$1
-if [[ $NAME == "export" || $NAME == "log" ]]; then
-    VENV_ARGS="--system-site-packages"
-else
-    VENV_ARGS=""
-fi
 WHEELS_DIR="/builder/securedrop-${NAME}/wheels"
-PIP_ARGS="--ignore-installed --no-index --find-links ${WHEELS_DIR} --no-deps --no-cache-dir --no-use-pep517"
+PIP_ARGS="--ignore-installed --no-index --find-links ${WHEELS_DIR} --no-deps --no-cache-dir --no-build-isolation"
 
-/usr/bin/python3 -m venv $VENV_ARGS ./debian/securedrop-${NAME}/opt/venvs/securedrop-${NAME}
+/usr/bin/python3 -m venv --system-site-packages ./debian/securedrop-${NAME}/opt/venvs/securedrop-${NAME}
 ./debian/securedrop-${NAME}/opt/venvs/securedrop-${NAME}/bin/pip install $PIP_ARGS --require-hashes \
     -r ${NAME}/build-requirements.txt
 ./debian/securedrop-${NAME}/opt/venvs/securedrop-${NAME}/bin/pip install $PIP_ARGS ./${NAME}

--- a/export/pyproject.toml
+++ b/export/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
 [project]
 requires-python = ">=3.11"
 name = "securedrop-export"
@@ -9,6 +13,12 @@ authors = [
 license = {text = "AGPLv3+"}
 readme = "README.md"
 dependencies = ["pexpect >= 4.9.0, <5.0"]
+
+[project.scripts]
+send-to-usb = "securedrop_export.main:entrypoint"
+
+[tool.setuptools.packages.find]
+exclude = ["docs*", "tests*"]
 
 [tool.poetry]
 requires-poetry = ">=2.3.3,<3.0.0"

--- a/export/setup.py
+++ b/export/setup.py
@@ -1,26 +1,4 @@
 import setuptools
 
-with open("README.md") as fh:
-    long_description = fh.read()
-
-setuptools.setup(
-    name="securedrop-export",
-    version="0.0.0",
-    author="Freedom of the Press Foundation",
-    author_email="securedrop@freedom.press",
-    description="SecureDrop Qubes export scripts",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    license="GPLv3+",
-    url="https://github.com/freedomofpress/securedrop-export",
-    packages=setuptools.find_packages(exclude=["docs", "tests"]),
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Programming Language :: Python :: 3",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-        "Intended Audience :: Developers",
-        "Operating System :: OS Independent",
-    ],
-    entry_points={"console_scripts": ["send-to-usb = securedrop_export.main:entrypoint"]},
-)
+# Stub file for securedrop-builder
+setuptools.setup(name="securedrop-export")

--- a/log/pyproject.toml
+++ b/log/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
 [project]
 requires-python = ">=3.11"
 name = "securedrop-log"
@@ -8,6 +12,13 @@ authors = [
     ]
 license = {text = "AGPLv3+"}
 readme = "README.md"
+
+[project.scripts]
+securedrop-log-saver = "log_server.log_saver:main"
+securedrop-redis-log = "log_server.redis_log:main"
+
+[tool.setuptools.packages.find]
+exclude = ["docs*", "tests*"]
 
 [tool.poetry]
 requires-poetry = ">=2.3.3,<3.0.0"

--- a/log/setup.py
+++ b/log/setup.py
@@ -1,31 +1,4 @@
 import setuptools
 
-with open("README.md") as fh:
-    long_description = fh.read()
-
-setuptools.setup(
-    name="securedrop-log",
-    version="0.0.0",
-    author="Freedom of the Press Foundation",
-    author_email="securedrop@freedom.press",
-    description="SecureDrop Qubes logging scripts",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    license="GPLv3+",
-    packages=setuptools.find_packages(exclude=["docs", "tests"]),
-    url="https://github.com/freedomofpress/securedrop-log",
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Programming Language :: Python :: 3",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-        "Intended Audience :: Developers",
-        "Operating System :: POSIX :: Linux",
-    ],
-    entry_points={
-        "console_scripts": [
-            "securedrop-log-saver = log_server.log_saver:main",
-            "securedrop-redis-log = log_server.redis_log:main",
-        ]
-    },
-)
+# Stub file for securedrop-builder
+setuptools.setup(name="securedrop-log")


### PR DESCRIPTION
In this PR - see commit messages for a bit more detail:
* Install files into /usr/lib instead of /lib
   * This is a no-op, even in bookworm /lib was a symlink to /usr/lib. But the packaging tools want us to explicitly specify /usr/lib now
* Fix virtualenv creation in trixie
   * This is the most involved, the newer pip + setuptools requires some adjustment.
* Add trixie to package building CI + nightlies
   * Pretty straightforward IMO

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] Package build + piuparts CI passes; I've done basic testing of these packages and it mostly works. I think that should be good enough for now and we can iteratively fix any other issues if they arise.
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
