### PR TITLE
Remove more references to client/

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,10 +1,10 @@
 ---
 name: Release
-about: Create a tracking ticket for a SecureDrop Client release
+about: Create a tracking ticket for a SecureDrop Inbox release
 
 ---
 
-This issue tracks the SecureDrop Client release [version]. It will be organized by:
+This issue tracks the SecureDrop Inbox release [version]. It will be organized by:
 
 - Release Manager:
 - Deputy Release Manager:
@@ -27,7 +27,7 @@ The following checklist is derived from [the developer documentation](https://de
 - [ ] Check if there are any security bug fixes waiting to be pulled into the RC
 - [ ] Check if there are any translations:
     - [ ] [pending merge](https://github.com/freedomofpress/securedrop-client/pulls/weblate-fpf) into `main`
-    - [ ] pending inclusion as a supported language in [`MANIFEST.in`](https://github.com/freedomofpress/securedrop-client/blob/main/MANIFEST.in)
+    - [ ] pending inclusion as a supported language in [the app locales](https://github.com/freedomofpress/securedrop-client/tree/main/app/src/renderer/locales)
 - [ ] Update changelog
 - [ ] Create test plan
 - [ ] Build and deploy the package to `apt-test`
@@ -35,11 +35,11 @@ The following checklist is derived from [the developer documentation](https://de
 - [ ] Build production package
 - [ ] Sign production package
 - [ ] Perform final pre-flight testing using `apt-qa.freedom.press`
-  - [ ] **Localization:** In a `sd-app`, the locale to a [supported language](https://github.com/freedomofpress/securedrop-client/blob/main/client/MANIFEST.in#L32-L34) (e.g.: `sudo dpkg-reconfigure locales` and select `pt_PT.utf-8` and apply.). Run the Client, and confirm that the application is translated.
+  - [ ] **Localization:** In a `sd-app`, the locale to a [supported language](https://github.com/freedomofpress/securedrop-client/tree/main/app/src/renderer/locales) (e.g.: `sudo dpkg-reconfigure locales` and select `pt_PT.utf-8` and apply.). Run the Inbox, and confirm that the application is translated.
 - [ ] Publish production package
 - [ ] Publicize release via support channels
 
 # Post-release Tasks
-- [ ] Run the updater on a production setup once packages are live, and conduct a smoketest (successful updater run, and basic functionality if updating client packages).
+- [ ] Run the updater on a production setup once packages are live, and conduct a smoketest (successful updater run, and basic functionality if updating Inbox packages).
 - [ ] Backport changelog commit(s) with `git cherry-pick -x` from the release branch into the main development branch, and sign the commit(s).
 - [ ] Run the `./update_version.sh` script to bump the version on main to the next minor version’s rc1. Open a PR with these commits; this PR can close the release tracking issue.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,5 +13,5 @@ This change accounts for:
 - [ ] any needed updates to the [AppArmor profile] for files beyond the application code
 - [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)
 
-[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
-[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
+[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
+[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Install dependencies
         run: |
           poetry -C ${{ matrix.component }} install
-          if [[ "${{ matrix.component }}" == "client" || "${{ matrix.component }}" == "export" ]]; then
+          if [[ "${{ matrix.component }}" == "export" ]]; then
             make -C ${{ matrix.component }} ci-install-deps
           fi
       - name: Run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ env:
   POETRY_VERSION: 2.3.3
 
 jobs:
-  # Run `make test` against all components but client, which is special
+  # Run `make test` against all components
   component:
     strategy:
       fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Generated documentation
-client/docs/
-
 *.sqlite
 
 # Byte-compiled / optimized / DLL files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,6 @@ ignore = [
 # because we're running from the root, isort doesn't know that these
 # are our packages, so tell it explicitly.
 known-first-party = [
-    "securedrop_client",
     "securedrop_export",
     "securedrop_log",
     "securedrop_proxy",
@@ -108,19 +107,6 @@ known-third-party = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"client/securedrop_client/sdk/__init__.py" = [
-    # significant assert use for mypy
-    "S101",
-    # a number of unchecked "We should never reach here" `return false` that
-    # need to be refactored away
-    "SIM103",
-]
-"client/securedrop_client/gui/widgets.py" = [
-    # FIXME: shouldn't be using assert
-    "S101",
-    # Switching Optional[X] hints to X | None
-    "UP007",
-]
 "log/tests/**.py" = [
     # TODO: switch to pytest
     "PT009", "PT027"

--- a/update_version.sh
+++ b/update_version.sh
@@ -14,7 +14,6 @@ if [[ $NEW_VERSION == *~rc* ]]; then
     exit 1
 fi
 
-sed -i'' -r -e "s/^__version__ = \"(.*?)\"/__version__ = \"${NEW_VERSION}\"/" client/securedrop_client/__init__.py
 sed -i'' -r -e "s/^__version__ = \"(.*?)\"/__version__ = \"${NEW_VERSION}\"/" export/securedrop_export/__init__.py
 sed -i'' -r -e 's/"version": ".*?"/"version": "'"${NEW_VERSION}"'"/' app/package.json
 


### PR DESCRIPTION
Missed the first time around, found by Claude.


## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
