### PR TITLE
Run lintian on the build distribution

### DIFF
--- a/scripts/build-debs.sh
+++ b/scripts/build-debs.sh
@@ -71,8 +71,8 @@ mkdir -p build
 cp ${BUILD_DEST}/* build/
 
 if [[ -z $FAST ]]; then
-    CONTAINER2="fpf.local/sd-client-lintian"
-    $OCI_BIN build scripts/lintian -t $CONTAINER2
+    CONTAINER2="fpf.local/sd-client-lintian-${DEBIAN_VERSION}"
+    $OCI_BIN build scripts/lintian -t $CONTAINER2 --build-arg DISTRO=$DEBIAN_VERSION
     # Display verbose info, and fail on warnings and errors.
     $OCI_BIN run --rm $OCI_RUN_ARGUMENTS -v "${BUILD_DEST}:/build:Z" $CONTAINER2 \
         bash -c \

--- a/scripts/lintian/Dockerfile
+++ b/scripts/lintian/Dockerfile
@@ -1,3 +1,4 @@
-FROM debian:bookworm
+ARG DISTRO=bookworm
+FROM debian:$DISTRO
 
 RUN apt-get update && apt-get --yes upgrade && apt-get install --yes lintian


### PR DESCRIPTION
Instead of hardcoding bookworm.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] visual review is fine
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
