### PR TITLE
Remove legacy client from update_version + pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,6 @@ ignore = [
 # because we're running from the root, isort doesn't know that these
 # are our packages, so tell it explicitly.
 known-first-party = [
-    "securedrop_client",
     "securedrop_export",
     "securedrop_log",
     "securedrop_proxy",
@@ -108,18 +107,6 @@ known-third-party = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"client/securedrop_client/sdk/__init__.py" = [
-    # significant assert use for mypy
-    "S101",
-    # a number of unchecked "We should never reach here" `return false` that
-    # need to be refactored away
-    "SIM103",
-]
-"client/securedrop_client/gui/widgets.py" = [
-    # FIXME: shouldn't be using assert
-    "S101",
-    # Switching Optional[X] hints to X | None
-    "UP007",
 ]
 "log/tests/**.py" = [
     # TODO: switch to pytest

--- a/update_version.sh
+++ b/update_version.sh
@@ -14,7 +14,6 @@ if [[ $NEW_VERSION == *~rc* ]]; then
     exit 1
 fi
 
-sed -i'' -r -e "s/^__version__ = \"(.*?)\"/__version__ = \"${NEW_VERSION}\"/" client/securedrop_client/__init__.py
 sed -i'' -r -e "s/^__version__ = \"(.*?)\"/__version__ = \"${NEW_VERSION}\"/" export/securedrop_export/__init__.py
 sed -i'' -r -e 's/"version": ".*?"/"version": "'"${NEW_VERSION}"'"/' app/package.json
 


### PR DESCRIPTION
Removes legacy client paths from update_version script, and references in `pyproject.toml`

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
