### PR TITLE
pkgconf has replaced pkg-config

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: securedrop-client
 Section: unknown
 Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
-Build-Depends: debhelper-compat (= 11), dh-apparmor, dh-exec, python3-venv, libssl-dev, pkg-config, libclang-dev, qubesdb-dev, nodejs,
+Build-Depends: debhelper-compat (= 11), dh-apparmor, dh-exec, python3-venv, libssl-dev, pkgconf, libclang-dev, qubesdb-dev, nodejs,
  libasound2, libatk-bridge2.0-0, libatk1.0-0, libatspi2.0-0, libcairo2,
  libcups2, libdbus-1-3, libexpat1, libgbm1, libglib2.0-0, libgtk-3-0,
  libnspr4, libnss3, libpango-1.0-0, libx11-6, libxcb1, libxcomposite1,


### PR DESCRIPTION
lintian now warns about this in trixie.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] visit https://packages.debian.org/bookworm/pkg-config and see it's just a transitional package
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
