### PR TITLE
Remove unused MANIFEST.in

### DIFF
--- a/export/MANIFEST.in
+++ b/export/MANIFEST.in
@@ -1,9 +1,0 @@
-include LICENSE
-include README.md
-include changelog.md
-include build-requirements.txt
-include securedrop_export/*.py
-include setup.py
-include files/send-to-usb.desktop
-include files/application-x-sd-export.xml
-include files/sd-logo.png

--- a/log/MANIFEST.in
+++ b/log/MANIFEST.in
@@ -1,7 +1,0 @@
-include LICENSE
-include README.md
-include changelog.md
-include build-requirements.txt
-include log_client_files/*
-include log_server/*
-include log_server_files/*

--- a/proxy/MANIFEST.in
+++ b/proxy/MANIFEST.in
@@ -1,8 +1,0 @@
-include LICENSE
-include README.md
-include changelog.md
-include config-example.yaml
-include qubes/securedrop.Proxy
-include build-requirements.txt
-include securedrop_proxy/*.py
-include setup.py


### PR DESCRIPTION
These were needed when we were still building sdists and turning those into wheels, but now we just build the wheel directly.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] Run `make build-debs` with this PR, save the packages somewhere, then `git checkout HEAD~1`, run `make build-debs` again, verify that the two sets of packages are identical
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
