### PR TITLE
Switch to gnome-text-editor

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -64,5 +64,5 @@ Description: This is the SecureDrop workstation template configuration package.
 
 Package: securedrop-workstation-viewer
 Architecture: all
-Depends: securedrop-workstation-config,securedrop-workstation-grsec,apparmor-profiles,apparmor-profiles-extra,apparmor-utils,audacious,eog,evince,file-roller,gedit,totem,heif-gdk-pixbuf,libreoffice
+Depends: securedrop-workstation-config,securedrop-workstation-grsec,apparmor-profiles,apparmor-profiles-extra,apparmor-utils,audacious,eog,evince,file-roller,gnome-text-editor,totem,heif-gdk-pixbuf,libreoffice
 Description: This is the SecureDrop workstation SecureDrop Viewer Disposable VM template configuration package. This package provides dependencies and configuration for the Qubes SecureDrop workstation sd-viewer Template VM.

--- a/workstation-config/mimeapps.list.sd-viewer
+++ b/workstation-config/mimeapps.list.sd-viewer
@@ -1,5 +1,5 @@
 [Default Applications]
-text/plain=org.gnome.gedit.desktop
+text/plain=org.gnome.TextEditor.desktop
 text/csv=libreoffice-base.desktop
 application/vnd.oasis.opendocument.text=libreoffice-base.desktop
 application/vnd.oasis.opendocument.spreadsheet=libreoffice-base.desktop
@@ -11,7 +11,7 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document=libreoff
 application/vnd.openxmlformats-officedocument.spreadsheetml.sheet=libreoffice-base.desktop
 application/vnd.openxmlformats-officedocument.presentationml.presentation=libreoffice-base.desktop
 application/pdf=org.gnome.Evince.desktop
-application/x-desktop=org.gnome.gedit.desktop
+application/x-desktop=org.gnome.TextEditor.desktop
 audio/mp4=audacious.desktop
 audio/mpeg=audacious.desktop
 audio/x-vorbis+ogg=audacious.desktop


### PR DESCRIPTION
Refs #3462.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] have a SDW that's using trixie
* [x] Use try-client-pr to install this PR
* [x] send a plain text file (.txt.)
* [x] open the plain text file, it should open in gnome-text-editor (in the menu bar it should say "Text Editor" and not "gedit")

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
