### PR TITLE
Create trixie-nightlies folder in apt-test if needed

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -134,6 +134,7 @@ jobs:
       - name: Prepare packages
         run: |
           cp -v build-bookworm/*.deb securedrop-apt-test/workstation/bookworm-nightlies/
+          mkdir -p securedrop-apt-test/workstation/trixie-nightlies/
           cp -v build-trixie/*.deb securedrop-apt-test/workstation/trixie-nightlies/
       - name: Sign and commit packages
         uses: freedomofpress/actionslib/act/signed-commit@main


### PR DESCRIPTION
It doesn't exist yet.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
