### PR TITLE
Run lint job for trixie too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
       matrix:
         debian_version:
           - bookworm
+          - trixie
     runs-on: ubuntu-latest
     container: debian:${{ matrix.debian_version }}
     steps:


### PR DESCRIPTION
Missed this one earlier.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] the CI job passes
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
