### PR TITLE
Install `locales-all` in all VMs

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -58,7 +58,7 @@ Description: This is securedrop Qubes proxy service
 
 Package: securedrop-workstation-config
 Architecture: all
-Depends: python3-qubesdb, rsyslog, mailcap, apparmor, nautilus, securedrop-keyring, xfce4-terminal
+Depends: python3-qubesdb, rsyslog, mailcap, apparmor, nautilus, securedrop-keyring, xfce4-terminal, locales-all
 Description: This is the SecureDrop workstation template configuration package.
  This package provides dependencies and configuration for the Qubes SecureDrop workstation VM Templates.
 


### PR DESCRIPTION
Our minimal VMs have `/etc/default/locale` set to en_US.UTF-8, but that locale isn't actually generated. In bookworm it seems like this was fine, but in trixie some things, notably redis, fail when the configured locale doesn't actually exist.

Solve this by installing all the locales in every VM. This takes up some extra disk space but ensures all locales are present and should make it easier in the future when we have proper locale-switching support.

Fixes #3537.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] have a SDW using trixie templates
* [ ] use try-client-pr to install this
* [ ] open terminal in sd-log, run `sudo systemctl status redis-server` and see that it's active/running and not failed
* [ ] logs are flowing to sd-log
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
