### PR TITLE
Default to building trixie packages

### DIFF
--- a/.github/workflows/piuparts/Dockerfile
+++ b/.github/workflows/piuparts/Dockerfile
@@ -1,4 +1,4 @@
-ARG DISTRO=bookworm
+ARG DISTRO=trixie
 FROM debian:$DISTRO
 
 # ARGs must be repeated for every different build stage

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,4 +1,4 @@
-ARG DISTRO=bookworm
+ARG DISTRO=trixie
 FROM debian:$DISTRO
 
 # ARGs must be repeated for every different build stage

--- a/scripts/build-debs.sh
+++ b/scripts/build-debs.sh
@@ -3,7 +3,7 @@
 # Build packages! This script is configured by environment variables:
 # `BUILDER`: relative path to the securedrop-builder repository,
 #            defaults to "../securedrop-builder"
-# `DEBIAN_VERSION`: codename to build for, defaults to "bookworm"
+# `DEBIAN_VERSION`: codename to build for, defaults to "trixie"
 # `NIGHTLY`: if set, add current time to the version number
 
 # This script runs *outside* the container.
@@ -37,7 +37,7 @@ to ${BUILDER} or set the BUILDER variable"
 fi
 
 export BUILDER
-export DEBIAN_VERSION="${DEBIAN_VERSION:-bookworm}"
+export DEBIAN_VERSION="${DEBIAN_VERSION:-trixie}"
 export OCI_RUN_ARGUMENTS
 export OCI_BIN
 export CONTAINER="fpf.local/sd-client-builder-${DEBIAN_VERSION}"

--- a/scripts/lintian/Dockerfile
+++ b/scripts/lintian/Dockerfile
@@ -1,4 +1,4 @@
-ARG DISTRO=bookworm
+ARG DISTRO=trixie
 FROM debian:$DISTRO
 
 RUN apt-get update && apt-get --yes upgrade && apt-get install --yes lintian


### PR DESCRIPTION
Can still opt-in to bookworm with `DEBIAN_VERSION=bookworm` if needed.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] `FAST=1 make build-debs` spits out trixie packages
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
