### PR TITLE
Handle JPEG XL files

### DIFF
--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
@@ -59,6 +59,7 @@ const IMAGE_EXTENSIONS = new Set([
   ".png",
   ".jpg",
   ".jpeg",
+  ".jxl",
   ".gif",
   ".bmp",
   ".tif",


### PR DESCRIPTION
JPEG XL aka `.jxl` is supported by both EOG and Loupe in trixie, the only thing we need to do is mark it as an image so the Inbox shows the image icon.

Refs #3462.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] on a SDW w/ trixie VMs, install this PR with try-client-pr
* [ ] download https://github.com/OpenPrinting/sample-files/blob/main/jxl/tabloid-portrait-vector-srgb.jxl and send it as a source
* [ ] after downloading the file in the Inbox tie icon should be the picture one instead of the generic document one (send a normal JPG file to see what it should look like)
* [ ] open the file, it should display correctly in the dispVM
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
