### PR TITLE
[inbox] pending_events track retry_attempts and last_event_status

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -189,6 +189,14 @@ export class DB {
     { count: number }
   >;
   private deletePendingEvent: Statement<{ snowflake_id: string }, void>;
+  private incrementPendingEventRetry: Statement<
+    { snowflake_id: string; status: number },
+    void
+  >;
+  private setPendingEventStatus: Statement<
+    { snowflake_id: string; status: number },
+    void
+  >;
   private selectPendingEvents: Statement<[{ limit: number }], PendingEventRow>;
   private deletePendingEventsBySourceScope: Statement<
     { source_uuid: string },
@@ -264,7 +272,7 @@ export class DB {
     );
 
     this.selectAllSourceVersion = this.db.prepare(
-      "SELECT uuid, version FROM sources_projected",
+      "SELECT uuid, version FROM sources",
     );
     this.selectUnprojectedSourceVersion = this.db.prepare(
       "SELECT version FROM sources WHERE uuid = @uuid",
@@ -277,7 +285,7 @@ export class DB {
     );
 
     this.selectAllItemVersion = this.db.prepare(
-      "SELECT uuid, version FROM items_projected",
+      "SELECT uuid, version FROM items",
     );
     this.selectUnprojectedItemVersion = this.db.prepare(
       "SELECT version FROM items WHERE uuid = @uuid",
@@ -419,8 +427,22 @@ export class DB {
     this.deletePendingEvent = this.db.prepare(
       `DELETE FROM pending_events WHERE snowflake_id = @snowflake_id`,
     );
+    this.incrementPendingEventRetry = this.db.prepare(`
+      UPDATE pending_events
+      SET retry_attempts = retry_attempts + 1, last_event_status = @status
+      WHERE snowflake_id = @snowflake_id
+    `);
+    this.setPendingEventStatus = this.db.prepare(`
+      UPDATE pending_events
+      SET last_event_status = @status
+      WHERE snowflake_id = @snowflake_id
+    `);
+    // Schedule previously-failed events later, and exclude events already reported
+    // and accepted on the server that are just awaiting completion.
     this.selectPendingEvents = this.db.prepare(`
-      SELECT snowflake_id, source_uuid, item_uuid, type, data FROM pending_events ORDER BY snowflake_id ASC LIMIT @limit
+      SELECT snowflake_id, source_uuid, item_uuid, type, data FROM pending_events
+      WHERE last_event_status IS NOT ${EventStatus.AlreadyReported}
+      ORDER BY retry_attempts ASC, snowflake_id ASC LIMIT @limit
     `);
     this.deletePendingEventsBySourceScope = this.db.prepare(`
       DELETE FROM pending_events
@@ -1338,13 +1360,21 @@ export class DB {
     Object.keys(events).forEach((snowflake_id: string) => {
       const result = events[snowflake_id][0];
       if (result === EventStatus.OK) {
+        // Event has been accepted by the server: apply + remove from pending_events
         appliedEventIDs.push(snowflake_id);
-      }
-      if (
-        result === EventStatus.AlreadyReported ||
-        result === EventStatus.Gone
-      ) {
+      } else if (result === EventStatus.Gone) {
+        // Target no longer exists on the server: remove pending_event.
         eventIDsToRemove.push(snowflake_id);
+      } else if (result === EventStatus.AlreadyReported) {
+        // Already reported to the server but awaiting completion.
+        // Retain the event but record the status so it's excluded from future
+        // sync batches and not re-sent.
+        this.setPendingEventStatus.run({ snowflake_id, status: result });
+      } else {
+        // All other statuses indicate event was submitted but not accepted
+        // Retain and bump the retry counter, recording the status.
+        // This event will be re-scheduled in subsequent batches.
+        this.incrementPendingEventRetry.run({ snowflake_id, status: result });
       }
     });
 

--- a/app/src/main/database/migrations/20260624000000_pending_events_retry_tracking.sql
+++ b/app/src/main/database/migrations/20260624000000_pending_events_retry_tracking.sql
@@ -1,0 +1,14 @@
+-- migrate:up
+-- Track retry attempts and the latest server status for each pending event.
+-- Allows us to de-prioritize previously-failed events when scheduling sync 
+-- batches, and exclude events that have already been reported + accepted by
+-- the server (EventStatus.AlreadyReported).
+ALTER TABLE pending_events
+ADD COLUMN retry_attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE pending_events
+ADD COLUMN last_event_status INTEGER;
+-- migrate:down
+ALTER TABLE pending_events
+DROP COLUMN last_event_status;
+ALTER TABLE pending_events
+DROP COLUMN retry_attempts;

--- a/app/src/main/database/schema.sql
+++ b/app/src/main/database/schema.sql
@@ -38,7 +38,7 @@ CREATE TABLE pending_events (
     source_uuid TEXT REFERENCES sources(uuid) ON DELETE CASCADE,
     item_uuid TEXT REFERENCES items(uuid) ON DELETE CASCADE,
     type TEXT NOT NULL,
-    data JSON,
+    data JSON, retry_attempts INTEGER NOT NULL DEFAULT 0, last_event_status INTEGER,
     CHECK (NOT (source_uuid IS NOT NULL AND item_uuid IS NOT NULL))
 );
 CREATE VIEW state AS
@@ -282,4 +282,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20260331000000'),
   ('20260416000000'),
   ('20260507000000'),
-  ('20260511000000');
+  ('20260511000000'),
+  ('20260624000000');

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -1211,6 +1211,87 @@ describe("Datastore Method Tests", () => {
     expect(events[0].type).toBe(PendingEventType.ItemDeleted);
   });
 
+  it("updatePendingEvents should bump retry_attempts so failed events are scheduled later", () => {
+    db.updateSources({
+      source1: mockSourceMetadata("source1"),
+    });
+    db.updateItems({
+      item1: mockItemMetadata("item1", "source1"),
+    });
+
+    // snowflakeSource is created first, so it sorts before snowflakeItem by
+    // snowflake_id.
+    const snowflakeSource = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.Starred,
+    )!;
+    const snowflakeItem = db.addPendingItemEvent(
+      "item1",
+      PendingEventType.ItemDeleted,
+    )!;
+
+    // With equal retry_attempts, ordering falls back to snowflake_id ascending.
+    let events = db.getPendingEvents();
+    expect(events.map((e) => e.id)).toEqual([snowflakeSource, snowflakeItem]);
+
+    // The earlier (source) event fails to be accepted, bumping its retry count.
+    db.updatePendingEvents({
+      [snowflakeSource.toString()]: [500, "error"],
+    });
+
+    // Should now be scheduled after the never-failed item event.
+    events = db.getPendingEvents();
+    expect(events.map((e) => e.id)).toEqual([snowflakeItem, snowflakeSource]);
+
+    // Verify the counter and last status were persisted.
+    const row = (db as any).db
+      .prepare(
+        "SELECT retry_attempts, last_event_status FROM pending_events WHERE snowflake_id = ?",
+      )
+      .get(snowflakeSource.toString());
+    expect(row.retry_attempts).toBe(1);
+    expect(row.last_event_status).toBe(500);
+  });
+
+  it("updatePendingEvents should retain but exclude AlreadyReported events", () => {
+    db.updateSources({
+      source1: mockSourceMetadata("source1"),
+    });
+    db.updateItems({
+      item1: mockItemMetadata("item1", "source1"),
+    });
+
+    const snowflakeSource = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.Starred,
+    )!;
+    const snowflakeItem = db.addPendingItemEvent(
+      "item1",
+      PendingEventType.ItemDeleted,
+    )!;
+
+    // The server reports the source event as already reported + accepted (208),
+    // and the item event as not yet accepted (500).
+    db.updatePendingEvents({
+      [snowflakeSource.toString()]: [208, null],
+      [snowflakeItem.toString()]: [500, "error"],
+    });
+
+    // The AlreadyReported event must be excluded from future sync batches
+    const events = db.getPendingEvents();
+    expect(events.map((e) => e.id)).toEqual([snowflakeItem]);
+
+    // but event should be retained in the table to preserve projection state
+    // with the status recorded
+    const row = (db as any).db
+      .prepare(
+        "SELECT last_event_status FROM pending_events WHERE snowflake_id = ?",
+      )
+      .get(snowflakeSource.toString());
+    expect(row).toBeDefined();
+    expect(row.last_event_status).toBe(208);
+  });
+
   it("updateItems should upsert items with conflicting uuid", () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),


### PR DESCRIPTION
Fixes #3483 
Fixes #3478 

Tracks `retry_attempts` and `last_event_status` for pending events to de-prioritize previously-failed events when scheduling, and retain but not re-submit events that have been accepted by the server and returned with status `AlreadyReported`.

## Test plan

Simulate "bad" SecureDrop server conditions:

- Run local development SecureDrop server from `2.15.1` (or any pre-2.16.0 version with synchronous deletion)
- Manually add a 120s sleep into the `handle_source_deleted` function
```python
 @staticmethod
  def handle_source_deleted(event: Event, minor: int) -> EventResult:
      # tktk: just for testing 

      import time
      time.sleep(120)
 ```

Reproduce original failure

- Run SecureDrop Inbox off `main` 
- Select a source account for deletion 
- Delete the source account + confirm 
- [x] Source should disappear from the source list 
- Trigger manual sync or wait for the next re-sync 
- [x] Source should re-appear in the source list (oh no!) - the resurrection may take a few seconds after triggering sync because the sync request should time out 


Verify fix
- Run SecureDrop Inbox from branch, optionally nuke db state + apply client migrations
- Select a source account for deletion
- Delete the source account + confirm
- [x] Source should disappear from the source list
- Trigger manual sync or wait for the next re-sync 
- [x] Source should not reappear in the source list
- [x] Inspecting `pending_events` table should show a record for the still-pending deletion event with `last_event_status` of `208` 
- [x] Subsequent sync batches should not send the already-accepted deletion event

Eventual server/client consistency:

- [x] Server logs should eventually show the deletion occurring (after the 2min sleep) 
- [x] On the subsequent client sync, we should delete the underlying source
- [x] Inspect the client DB to see that the source has been deleted from the `sources` table, and that the `pending_event` for the deletion is also deleted
