### PR TITLE
Disable GPG smartcard support

### DIFF
--- a/debian/securedrop-gpg-config.install
+++ b/debian/securedrop-gpg-config.install
@@ -1,3 +1,4 @@
 #!/usr/bin/dh-exec --with=install
 gpg-config/profile.d/sd-gpg-hide-prompt.sh etc/profile.d/
+gpg-config/gpg-agent.conf etc/gnupg/
 gpg-config/securedrop-get-secret-keys.sh => usr/bin/securedrop-get-secret-keys

--- a/debian/securedrop-gpg-config.lintian-overrides
+++ b/debian/securedrop-gpg-config.lintian-overrides
@@ -7,6 +7,7 @@ securedrop-gpg-config: control-file-is-empty [conffiles]
 # profile.d scripts do not need exec bit (they are sourced)
 securedrop-gpg-config: script-not-executable [etc/profile.d/sd-gpg-hide-prompt.sh]
 securedrop-gpg-config: file-in-etc-not-marked-as-conffile [etc/profile.d/sd-gpg-hide-prompt.sh]
+securedrop-gpg-config: file-in-etc-not-marked-as-conffile [etc/gnupg/gpg-agent.conf]
 
 # Not needed
 securedrop-gpg-config: extended-description-is-empty

--- a/gpg-config/gpg-agent.conf
+++ b/gpg-config/gpg-agent.conf
@@ -1,0 +1,2 @@
+# we don't use smartcards, disable it to avoid logspam from it not being installed
+disable-scdaemon


### PR DESCRIPTION
We don't use this; in trixie the scdaemon is a separate package, so when it's not installed there's a ton of logspam about being unable to connect to it.

Fixes #3538.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] have a SDW w/ trixie templates
* [ ] use try-client-pr to install this
* [ ] run `sudo journalctl -f` in sd-gpg
* [ ] open the Inbox and have it download + decrypt messages/files
* [ ] observe no log entries like https://github.com/freedomofpress/securedrop-client/issues/3538
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
