### PR TITLE
Strengthen pnpm configuration per semgrep

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,1 +1,2 @@
 node-linker=hoisted
+min-release-age = 7

--- a/app/pnpm-workspace.yaml
+++ b/app/pnpm-workspace.yaml
@@ -4,6 +4,12 @@ packages:
 # 7-day cooldown
 minimumReleaseAge: 10080
 
+# don't allow deps to come in via git or a direct tarball
+blockExoticSubdeps: true
+
+# if packages previously used trusted publishing, they must continue
+trustPolicy: no-downgrade
+
 ignoredBuiltDependencies:
   - "@tailwindcss/oxide"
   - better-sqlite3


### PR DESCRIPTION
* Set pnpm configuration recommended by new semgrep rules.
* Explicitly set 7-day cooldown in npm, even though we don't use it.


## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] CI is green
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
