### PR TITLE
SecureDrop 1.5.0-rc1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 1.5.0
+
+This release, along with SecureDrop Workstation 1.8.0, switches to Debian 13 (trixie).
+
+* Debian 13 (trixie) support:
+  * Handle JPEG XL files (#3539)
+  * Disable GPG smartcard support (#3544)
+  * Switch to gnome-text-editor (#3524)
+  * Install `locales-all` in all VMs (#3535)
+  * Build Debian packages for trixie (#3509, #3525, #3536)
+  * Use packaged version of python3-redis (#3518)
+  * pkgconf has replaced pkg-config (#3522)
+  * Run lint job for trixie too (#3526)
+* Other user-facing changes:
+  * Enable F1 shortcut when in text entry (#3498)
+  * Support 1366x768 resolution (#3506)
+* Internal and development:
+  * Remove more references to client/ (#3514)
+  * Build against Qubes 4.3 qubesdb-dev (#3507)
+  * Add vitest-axe + accessibility unit tests (#3453)
+  * Strengthen pnpm configuration per semgrep (#3551)
+
 ## 1.4.0
 
 This release focuses on accessibility improvements to the SecureDrop Inbox
@@ -40,7 +62,7 @@ along with sync reliability fixes and dependency updates.
 
 ## 1.3.2
 
-This release adds extra warnings and safeguards to the bulk deletion 
+This release adds extra warnings and safeguards to the bulk deletion
 dialog when attempt to delete a very large number of sources.
 
  * Delete confirmation guards (#3475).
@@ -88,7 +110,7 @@ This release contains bug fixes and improvements to the SecureDrop Inbox.
 
 ## 1.1.0
 
-This release contains fixes and dependency updates to the SecureDrop Inbox. It also 
+This release contains fixes and dependency updates to the SecureDrop Inbox. It also
 enables a feature flag-gated custom export to Whistleflow option.
 
 * Enable export to Whistleflow via feature flag (#3340)


### PR DESCRIPTION


## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] base is release/1.5.0
* [ ] not missing anything major
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
