### PR TITLE
fix(database): reject updates to source public_key or fingerprint

### DIFF
--- a/app/src/main/database/migrations/20260709000000_immutable_source_key.sql
+++ b/app/src/main/database/migrations/20260709000000_immutable_source_key.sql
@@ -1,0 +1,21 @@
+-- migrate:up
+-- Source key material is trust-on-first-use: once a source row has key
+-- metadata, the server must not be able to replace it through later syncs.
+
+CREATE TRIGGER sources_key_material_immutable
+BEFORE UPDATE OF data ON sources
+FOR EACH ROW
+WHEN (
+    json_extract(OLD.data, '$.public_key') IS NOT NULL
+    AND json_extract(NEW.data, '$.public_key') IS NOT json_extract(OLD.data, '$.public_key')
+) OR (
+    json_extract(OLD.data, '$.fingerprint') IS NOT NULL
+    AND json_extract(NEW.data, '$.fingerprint') IS NOT json_extract(OLD.data, '$.fingerprint')
+)
+BEGIN
+    SELECT RAISE(ABORT, 'sources key material is immutable');
+END;
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS sources_key_material_immutable;

--- a/app/src/main/database/migrations/20260805000000_immutable_source_key.sql
+++ b/app/src/main/database/migrations/20260805000000_immutable_source_key.sql
@@ -1,0 +1,21 @@
+-- migrate:up
+-- Source key material is trust-on-first-use: once a source row has key
+-- metadata, the server must not be able to replace it through later syncs.
+
+CREATE TRIGGER sources_key_material_immutable
+BEFORE UPDATE OF data ON sources
+FOR EACH ROW
+WHEN (
+    json_extract(OLD.data, '$.public_key') IS NOT NULL
+    AND json_extract(NEW.data, '$.public_key') IS NOT json_extract(OLD.data, '$.public_key')
+) OR (
+    json_extract(OLD.data, '$.fingerprint') IS NOT NULL
+    AND json_extract(NEW.data, '$.fingerprint') IS NOT json_extract(OLD.data, '$.fingerprint')
+)
+BEGIN
+    SELECT RAISE(ABORT, 'sources key material is immutable');
+END;
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS sources_key_material_immutable;

--- a/app/src/main/database/schema.sql
+++ b/app/src/main/database/schema.sql
@@ -273,6 +273,19 @@ WHERE
             pending_events.type = 'source_deleted'
     )
 /* sources_projected(uuid,data,version,has_attachment,is_seen) */;
+CREATE TRIGGER sources_key_material_immutable
+BEFORE UPDATE OF data ON sources
+FOR EACH ROW
+WHEN (
+    json_extract(OLD.data, '$.public_key') IS NOT NULL
+    AND json_extract(NEW.data, '$.public_key') IS NOT json_extract(OLD.data, '$.public_key')
+) OR (
+    json_extract(OLD.data, '$.fingerprint') IS NOT NULL
+    AND json_extract(NEW.data, '$.fingerprint') IS NOT json_extract(OLD.data, '$.fingerprint')
+)
+BEGIN
+    SELECT RAISE(ABORT, 'sources key material is immutable');
+END;
 -- Dbmate schema migrations
 INSERT INTO "schema_migrations" (version) VALUES
   ('20260203225412'),
@@ -283,4 +296,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20260416000000'),
   ('20260507000000'),
   ('20260511000000'),
-  ('20260624000000');
+  ('20260624000000'),
+  ('20260709000000');

--- a/app/src/main/database/schema.sql
+++ b/app/src/main/database/schema.sql
@@ -283,6 +283,19 @@ SELECT
     ) AS rn
 FROM items_projected
 /* sorted_items(uuid,data,version,plaintext,filename,kind,is_read,last_updated,source_uuid,fetch_progress,fetch_status,fetch_last_updated_at,fetch_retry_attempts,interaction_count,decrypted_size,double_encrypted_key_fingerprint,rn) */;
+CREATE TRIGGER sources_key_material_immutable
+BEFORE UPDATE OF data ON sources
+FOR EACH ROW
+WHEN (
+    json_extract(OLD.data, '$.public_key') IS NOT NULL
+    AND json_extract(NEW.data, '$.public_key') IS NOT json_extract(OLD.data, '$.public_key')
+) OR (
+    json_extract(OLD.data, '$.fingerprint') IS NOT NULL
+    AND json_extract(NEW.data, '$.fingerprint') IS NOT json_extract(OLD.data, '$.fingerprint')
+)
+BEGIN
+    SELECT RAISE(ABORT, 'sources key material is immutable');
+END;
 -- Dbmate schema migrations
 INSERT INTO "schema_migrations" (version) VALUES
   ('20260203225412'),
@@ -295,4 +308,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20260511000000'),
   ('20260624000000'),
   ('20260710151500'),
-  ('20260730000000');
+  ('20260730000000'),
+  ('20260805000000');

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -148,6 +148,111 @@ describe("DB Component Tests", () => {
       ).toThrow("items.kind is immutable");
     });
   });
+
+  describe("sources_key_material_immutable trigger", () => {
+    const sourceUuid = "11111111-1111-4111-8111-111111111111";
+
+    function sourceData({
+      designation = "alpha bravo",
+      publicKey = "source-public-key-a",
+      fingerprint = "source-fingerprint-a",
+    } = {}) {
+      return JSON.stringify({
+        uuid: sourceUuid,
+        journalist_designation: designation,
+        is_starred: false,
+        is_seen: false,
+        has_attachment: false,
+        last_updated: "2026-07-09T00:00:00Z",
+        public_key: publicKey,
+        fingerprint,
+      });
+    }
+
+    function sourceMetadata(options = {}): SourceMetadata {
+      return JSON.parse(sourceData(options)) as SourceMetadata;
+    }
+
+    it("allows TOFU initial source key write", () => {
+      db = new Datastore(crypto, new Storage());
+      const rawDb = db["db"]!;
+
+      rawDb
+        .prepare("INSERT INTO sources (uuid, data) VALUES (?, NULL)")
+        .run(sourceUuid);
+
+      expect(() =>
+        rawDb
+          .prepare("UPDATE sources SET data = ? WHERE uuid = ?")
+          .run(sourceData(), sourceUuid),
+      ).not.toThrow();
+    });
+
+    it("allows source metadata updates when key material is unchanged", () => {
+      db = new Datastore(crypto, new Storage());
+      const rawDb = db["db"]!;
+
+      rawDb
+        .prepare("INSERT INTO sources (uuid, data) VALUES (?, ?)")
+        .run(sourceUuid, sourceData());
+
+      expect(() =>
+        rawDb
+          .prepare("UPDATE sources SET data = ? WHERE uuid = ?")
+          .run(sourceData({ designation: "charlie delta" }), sourceUuid),
+      ).not.toThrow();
+    });
+
+    it("rejects source public key replacement", () => {
+      db = new Datastore(crypto, new Storage());
+      const rawDb = db["db"]!;
+
+      rawDb
+        .prepare("INSERT INTO sources (uuid, data) VALUES (?, ?)")
+        .run(sourceUuid, sourceData());
+
+      expect(() =>
+        rawDb.prepare("UPDATE sources SET data = ? WHERE uuid = ?").run(
+          sourceData({
+            publicKey: "source-public-key-b",
+          }),
+          sourceUuid,
+        ),
+      ).toThrow("sources key material is immutable");
+    });
+
+    it("rejects source fingerprint replacement", () => {
+      db = new Datastore(crypto, new Storage());
+      const rawDb = db["db"]!;
+
+      rawDb
+        .prepare("INSERT INTO sources (uuid, data) VALUES (?, ?)")
+        .run(sourceUuid, sourceData());
+
+      expect(() =>
+        rawDb.prepare("UPDATE sources SET data = ? WHERE uuid = ?").run(
+          sourceData({
+            fingerprint: "source-fingerprint-b",
+          }),
+          sourceUuid,
+        ),
+      ).toThrow("sources key material is immutable");
+    });
+
+    it("rejects source key replacement through the source upsert path", () => {
+      db = new Datastore(crypto, new Storage());
+
+      db.updateSources({ [sourceUuid]: sourceMetadata() });
+
+      expect(() =>
+        db.updateSources({
+          [sourceUuid]: sourceMetadata({
+            publicKey: "source-public-key-b",
+          }),
+        }),
+      ).toThrow("sources key material is immutable");
+    });
+  });
 });
 
 describe("Datastore Method Tests", () => {

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -206,6 +206,111 @@ describe("DB Component Tests", () => {
       ).toThrow("items.kind is immutable");
     });
   });
+
+  describe("sources_key_material_immutable trigger", () => {
+    const sourceUuid = "11111111-1111-4111-8111-111111111111";
+
+    function sourceData({
+      designation = "alpha bravo",
+      publicKey = "source-public-key-a",
+      fingerprint = "source-fingerprint-a",
+    } = {}) {
+      return JSON.stringify({
+        uuid: sourceUuid,
+        journalist_designation: designation,
+        is_starred: false,
+        is_seen: false,
+        has_attachment: false,
+        last_updated: "2026-07-09T00:00:00Z",
+        public_key: publicKey,
+        fingerprint,
+      });
+    }
+
+    function sourceMetadata(options = {}): SourceMetadata {
+      return JSON.parse(sourceData(options)) as SourceMetadata;
+    }
+
+    it("allows TOFU initial source key write", () => {
+      db = new Datastore(crypto, new Storage());
+      const rawDb = db["db"]!;
+
+      rawDb
+        .prepare("INSERT INTO sources (uuid, data) VALUES (?, NULL)")
+        .run(sourceUuid);
+
+      expect(() =>
+        rawDb
+          .prepare("UPDATE sources SET data = ? WHERE uuid = ?")
+          .run(sourceData(), sourceUuid),
+      ).not.toThrow();
+    });
+
+    it("allows source metadata updates when key material is unchanged", () => {
+      db = new Datastore(crypto, new Storage());
+      const rawDb = db["db"]!;
+
+      rawDb
+        .prepare("INSERT INTO sources (uuid, data) VALUES (?, ?)")
+        .run(sourceUuid, sourceData());
+
+      expect(() =>
+        rawDb
+          .prepare("UPDATE sources SET data = ? WHERE uuid = ?")
+          .run(sourceData({ designation: "charlie delta" }), sourceUuid),
+      ).not.toThrow();
+    });
+
+    it("rejects source public key replacement", () => {
+      db = new Datastore(crypto, new Storage());
+      const rawDb = db["db"]!;
+
+      rawDb
+        .prepare("INSERT INTO sources (uuid, data) VALUES (?, ?)")
+        .run(sourceUuid, sourceData());
+
+      expect(() =>
+        rawDb.prepare("UPDATE sources SET data = ? WHERE uuid = ?").run(
+          sourceData({
+            publicKey: "source-public-key-b",
+          }),
+          sourceUuid,
+        ),
+      ).toThrow("sources key material is immutable");
+    });
+
+    it("rejects source fingerprint replacement", () => {
+      db = new Datastore(crypto, new Storage());
+      const rawDb = db["db"]!;
+
+      rawDb
+        .prepare("INSERT INTO sources (uuid, data) VALUES (?, ?)")
+        .run(sourceUuid, sourceData());
+
+      expect(() =>
+        rawDb.prepare("UPDATE sources SET data = ? WHERE uuid = ?").run(
+          sourceData({
+            fingerprint: "source-fingerprint-b",
+          }),
+          sourceUuid,
+        ),
+      ).toThrow("sources key material is immutable");
+    });
+
+    it("rejects source key replacement through the source upsert path", () => {
+      db = new Datastore(crypto, new Storage());
+
+      db.updateSources({ [sourceUuid]: sourceMetadata() });
+
+      expect(() =>
+        db.updateSources({
+          [sourceUuid]: sourceMetadata({
+            publicKey: "source-public-key-b",
+          }),
+        }),
+      ).toThrow("sources key material is immutable");
+    });
+  });
 });
 
 describe("Datastore Method Tests", () => {


### PR DESCRIPTION
## Summary

- add a SQLite trigger that rejects later changes to `sources.data.public_key`
  or `sources.data.fingerprint`
- add the dbmate migration and regenerated schema snapshot
- add datastore tests for the initial TOFU write, unchanged-key metadata updates,
  direct replacement rejection, and the `updateSources()` upsert path

## Context

Fixes https://github.com/freedomofpress/securedrop-client/issues/2955.

This follows the same database-level TOFU pattern used for immutable
`items.data.kind` in https://github.com/freedomofpress/securedrop-client/pull/3173.

## Test plan

```sh
pnpm install --frozen-lockfile
```

```sh
tmp_home=$(mktemp -d /tmp/sd-dbmate-home.XXXXXX)
mkdir -p "$tmp_home/.config/SecureDrop"
HOME="$tmp_home" pnpm run dbmate up
HOME="$tmp_home" pnpm run dbmate dump
```

```sh
pnpm exec vitest run --config vitest.config.ts --project=unit src/main/datastore.test.ts
pnpm exec prettier src/main/datastore.test.ts --check
git diff --check
```

## Notes

This draft focuses on the database-level source key immutability check. It still
uses TOFU semantics, so the first synchronized source key is trusted. It also
does not yet add a cryptographic check that `fingerprint` matches `public_key`;
I kept that separate because it likely belongs in the sync/OpenPGP parsing path
rather than inside a self-contained SQLite migration.

## Checklist

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to
  cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the
  application code
- [x] any needed [self-contained] database migrations (including testing against
  a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
