### PR TITLE
fix(crypto): publish decrypted files only after gzip validation

### DIFF
--- a/app/src/main/__tests__/crypto.gpg.test.ts
+++ b/app/src/main/__tests__/crypto.gpg.test.ts
@@ -10,9 +10,10 @@ import {
 import * as path from "path";
 import * as fs from "fs";
 import * as openpgp from "openpgp";
-import { execSync, spawn } from "child_process";
+import { execFileSync, execSync, spawn } from "child_process";
 import { EventEmitter } from "events";
 import { PassThrough } from "stream";
+import { gzipSync } from "zlib";
 import { Crypto, CryptoError, encryptMessage } from "../crypto";
 import {
   createGpgTestEnvironment,
@@ -254,6 +255,57 @@ and symbols: !@#$%^&*()_+-={}[]|\\:";'<>?,./`;
         expect(decryptedContent).toBe(originalContent);
       } finally {
         cleanup();
+      }
+    });
+
+    it("should not leave plaintext when malformed gzip decompression fails", async () => {
+      const fixtureDirectory = fs.mkdtempSync(
+        path.join(itemDirectory.path, "encrypted-fixture-"),
+      );
+      const malformedGzipPath = path.join(fixtureDirectory, "malformed-output");
+      const encryptedPath = `${malformedGzipPath}.gpg`;
+      const plaintext = Buffer.alloc(4 * 1024 * 1024, 0x41);
+      const gzipPayload = gzipSync(plaintext, { level: 9 });
+      fs.writeFileSync(
+        malformedGzipPath,
+        gzipPayload.subarray(0, gzipPayload.length - 8),
+      );
+      execFileSync("gpg", [
+        "--homedir",
+        gpgEnv.homedir,
+        "--batch",
+        "--trust-model",
+        "always",
+        "--encrypt",
+        "-r",
+        testKeyId,
+        "--output",
+        encryptedPath,
+        malformedGzipPath,
+      ]);
+
+      const finalOutputPath = itemDirectory.join("malformed-output");
+      try {
+        await expect(
+          crypto.decryptFile(storage, itemDirectory, encryptedPath),
+        ).rejects.toThrow("Failed to decompress decrypted file");
+
+        const finalOutputExists = fs.existsSync(finalOutputPath);
+        expect({
+          finalOutputExists,
+          finalOutputBytes: finalOutputExists
+            ? fs.statSync(finalOutputPath).size
+            : 0,
+          itemDirectoryEntries: fs
+            .readdirSync(itemDirectory.path)
+            .filter((entry) => entry !== path.basename(fixtureDirectory)),
+        }).toEqual({
+          finalOutputExists: false,
+          finalOutputBytes: 0,
+          itemDirectoryEntries: [],
+        });
+      } finally {
+        fs.rmSync(fixtureDirectory, { recursive: true, force: true });
       }
     });
 

--- a/app/src/main/__tests__/crypto.gpg.test.ts
+++ b/app/src/main/__tests__/crypto.gpg.test.ts
@@ -10,9 +10,10 @@ import {
 import * as path from "path";
 import * as fs from "fs";
 import * as openpgp from "openpgp";
-import { execSync, spawn } from "child_process";
+import { execFileSync, execSync, spawn } from "child_process";
 import { EventEmitter } from "events";
 import { PassThrough } from "stream";
+import { gzipSync } from "zlib";
 import { Crypto, CryptoError, encryptMessage, isPgpEncrypted } from "../crypto";
 import {
   createGpgTestEnvironment,
@@ -257,6 +258,57 @@ and symbols: !@#$%^&*()_+-={}[]|\\:";'<>?,./`;
         expect(decryptedContent).toBe(originalContent);
       } finally {
         cleanup();
+      }
+    });
+
+    it("should not leave plaintext when malformed gzip decompression fails", async () => {
+      const fixtureDirectory = fs.mkdtempSync(
+        path.join(itemDirectory.path, "encrypted-fixture-"),
+      );
+      const malformedGzipPath = path.join(fixtureDirectory, "malformed-output");
+      const encryptedPath = `${malformedGzipPath}.gpg`;
+      const plaintext = Buffer.alloc(4 * 1024 * 1024, 0x41);
+      const gzipPayload = gzipSync(plaintext, { level: 9 });
+      fs.writeFileSync(
+        malformedGzipPath,
+        gzipPayload.subarray(0, gzipPayload.length - 8),
+      );
+      execFileSync("gpg", [
+        "--homedir",
+        gpgEnv.homedir,
+        "--batch",
+        "--trust-model",
+        "always",
+        "--encrypt",
+        "-r",
+        testKeyId,
+        "--output",
+        encryptedPath,
+        malformedGzipPath,
+      ]);
+
+      const finalOutputPath = itemDirectory.join("malformed-output");
+      try {
+        await expect(
+          crypto.decryptFile(storage, itemDirectory, encryptedPath),
+        ).rejects.toThrow("Failed to decompress decrypted file");
+
+        const finalOutputExists = fs.existsSync(finalOutputPath);
+        expect({
+          finalOutputExists,
+          finalOutputBytes: finalOutputExists
+            ? fs.statSync(finalOutputPath).size
+            : 0,
+          itemDirectoryEntries: fs
+            .readdirSync(itemDirectory.path)
+            .filter((entry) => entry !== path.basename(fixtureDirectory)),
+        }).toEqual({
+          finalOutputExists: false,
+          finalOutputBytes: 0,
+          itemDirectoryEntries: [],
+        });
+      } finally {
+        fs.rmSync(fixtureDirectory, { recursive: true, force: true });
       }
     });
 

--- a/app/src/main/__tests__/crypto.integration.test.ts
+++ b/app/src/main/__tests__/crypto.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { spawn } from "child_process";
-import { EventEmitter } from "events";
 import * as fs from "fs";
+import { Writable } from "stream";
 import { Crypto, CryptoError } from "../crypto";
 import { Storage, PathBuilder, UnsafePathComponent } from "../storage";
 
@@ -30,6 +30,19 @@ type CryptoWithPrivateMethods = {
   ): Promise<void>;
   readFileHeader(filePath: string): Promise<Buffer>;
 };
+
+// Stand-in for the fs.WriteStream that GPG's stdout is piped to. Pass
+// `flushError` to simulate output that fails to reach disk on close.
+function makeMockWriteStream(flushError?: Error): Writable {
+  return new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+    final(callback) {
+      callback(flushError ?? null);
+    },
+  });
+}
 
 describe("Crypto Integration Tests", () => {
   let mockProcess: {
@@ -207,14 +220,9 @@ describe("Crypto Integration Tests", () => {
   describe("File Decryption", () => {
     beforeEach(() => {
       // Mock filesystem operations
-      const mockWriteStream = Object.assign(new EventEmitter(), {
-        end: vi.fn(),
-        destroy: vi.fn(function (this: EventEmitter) {
-          setImmediate(() => this.emit("close"));
-        }),
-        writable: true,
-      });
-      mockFs.createWriteStream.mockReturnValue(mockWriteStream as never);
+      mockFs.createWriteStream.mockImplementation(
+        () => makeMockWriteStream() as never,
+      );
 
       mockFs.createReadStream.mockReturnValue({
         pipe: vi.fn(),
@@ -405,6 +413,84 @@ describe("Crypto Integration Tests", () => {
       await expect(
         crypto.decryptFile(storage, itemDirectory, testFilePath),
       ).rejects.toThrow("Failed to decompress decrypted file");
+    });
+
+    it("should handle failure to flush GPG output to disk", async () => {
+      const crypto = Crypto.initialize({
+        isQubes: false,
+        submissionKeyFingerprint: "",
+      });
+
+      const testFilePath = "/path/to/encrypted-file.gpg";
+
+      // Mock successful GPG process
+      mockProcess.on.mockImplementation(
+        (event: string, callback: (code: number) => void) => {
+          if (event === "close") {
+            setTimeout(() => callback(0), 10);
+          }
+          return mockProcess;
+        },
+      );
+
+      mockProcess.stderr.on.mockImplementation(() => mockProcess);
+
+      mockFs.createWriteStream.mockImplementation(
+        () =>
+          makeMockWriteStream(
+            new Error("ENOSPC: no space left on device"),
+          ) as never,
+      );
+
+      mockSpawn.mockReturnValue(mockProcess as never);
+
+      await expect(
+        crypto.decryptFile(storage, itemDirectory, testFilePath),
+      ).rejects.toThrow("Failed to write decrypted GPG output to disk");
+    });
+
+    it("should prefer the GPG error when the output flush also fails", async () => {
+      const crypto = Crypto.initialize({
+        isQubes: false,
+        submissionKeyFingerprint: "",
+      });
+
+      const testFilePath = "/path/to/encrypted-file.gpg";
+
+      // Mock failed GPG process. A GPG failure is the likely *cause* of the
+      // flush failure, so its error should be the one reported.
+      mockProcess.on.mockImplementation(
+        (event: string, callback: (code: number) => void) => {
+          if (event === "close") {
+            setTimeout(() => callback(2), 10);
+          }
+          return mockProcess;
+        },
+      );
+
+      mockProcess.stderr.on.mockImplementation(
+        (event: string, callback: (data: Buffer) => void) => {
+          if (event === "data") {
+            setTimeout(
+              () => callback(Buffer.from("GPG file decryption error")),
+              5,
+            );
+          }
+          return mockProcess;
+        },
+      );
+
+      mockFs.createWriteStream.mockImplementation(
+        () => makeMockWriteStream(new Error("EPIPE: broken pipe")) as never,
+      );
+
+      mockSpawn.mockReturnValue(mockProcess as never);
+
+      await expect(
+        crypto.decryptFile(storage, itemDirectory, testFilePath),
+      ).rejects.toThrow(
+        'GPG file decryption failed (exit code 2): "GPG file decryption error"',
+      );
     });
   });
 

--- a/app/src/main/crypto.ts
+++ b/app/src/main/crypto.ts
@@ -401,8 +401,11 @@ export class Crypto {
             originalFilename || path.basename(filepath, ".gpg");
           const finalAbsolutePath = itemDirectory.join(finalFilename);
 
-          // Stream decompress the gzipped content to final file
-          await this.streamDecompressGzipFile(tempGpgOutput, finalAbsolutePath);
+          await this.decompressGzipFileAtomically(
+            tempGpgOutput,
+            itemDirectory,
+            finalAbsolutePath,
+          );
 
           // Clean up temporary GPG output file
           fs.unlink(tempGpgOutput, () => {});
@@ -461,10 +464,28 @@ export class Crypto {
     outputPath: string,
   ): Promise<void> {
     const readStream = fs.createReadStream(gzipFilePath);
-    const writeStream = fs.createWriteStream(outputPath);
+    const writeStream = fs.createWriteStream(outputPath, { flags: "wx" });
     const gunzip = createGunzip();
 
     await pipeline(readStream, gunzip, writeStream);
+  }
+
+  private async decompressGzipFileAtomically(
+    gzipFilePath: string,
+    itemDirectory: PathBuilder,
+    finalOutputPath: string,
+  ): Promise<void> {
+    const temporaryDirectory = fs.mkdtempSync(
+      itemDirectory.join(".securedrop-decrypt-"),
+    );
+    const temporaryOutputPath = path.join(temporaryDirectory, "plaintext");
+
+    try {
+      await this.streamDecompressGzipFile(gzipFilePath, temporaryOutputPath);
+      fs.renameSync(temporaryOutputPath, finalOutputPath);
+    } finally {
+      fs.rmSync(temporaryDirectory, { force: true, recursive: true });
+    }
   }
 
   /**

--- a/app/src/main/crypto.ts
+++ b/app/src/main/crypto.ts
@@ -649,8 +649,11 @@ export class Crypto {
             originalFilename || path.basename(filepath, ".gpg");
           const finalAbsolutePath = itemDirectory.join(finalFilename);
 
-          // Stream decompress the gzipped content to final file
-          await this.streamDecompressGzipFile(tempGpgOutput, finalAbsolutePath);
+          await this.decompressGzipFileAtomically(
+            tempGpgOutput,
+            itemDirectory,
+            finalAbsolutePath,
+          );
 
           // Clean up temporary GPG output file
           fs.unlink(tempGpgOutput, () => {});
@@ -755,10 +758,37 @@ export class Crypto {
     outputPath: string,
   ): Promise<void> {
     const readStream = fs.createReadStream(gzipFilePath);
-    const writeStream = fs.createWriteStream(outputPath);
+    const writeStream = fs.createWriteStream(outputPath, { flags: "wx" });
     const gunzip = createGunzip();
 
     await pipeline(readStream, gunzip, writeStream);
+  }
+
+  /**
+   * Wrap streamDecompressGzipFile() so that the `finalOutputPath` is guaranteed
+   * to be complete if it exists.  The file is decompressed first to a file
+   * called `plaintext` in a temporary subdirectory of `itemDirectory`, then
+   * moved atomically to the `finalOutputPath`.
+   *
+   * NB. This operation is effectively an upsert: If `finalOutputPath` already
+   * exists, this function will overwrite it.
+   */
+  private async decompressGzipFileAtomically(
+    gzipFilePath: string,
+    itemDirectory: PathBuilder,
+    finalOutputPath: string,
+  ): Promise<void> {
+    const temporaryDirectory = fs.mkdtempSync(
+      itemDirectory.join(".securedrop-decrypt-"),
+    );
+    const temporaryOutputPath = path.join(temporaryDirectory, "plaintext");
+
+    try {
+      await this.streamDecompressGzipFile(gzipFilePath, temporaryOutputPath);
+      fs.renameSync(temporaryOutputPath, finalOutputPath);
+    } finally {
+      fs.rmSync(temporaryDirectory, { force: true, recursive: true });
+    }
   }
 
   /**

--- a/app/src/main/crypto.ts
+++ b/app/src/main/crypto.ts
@@ -601,7 +601,18 @@ export class Crypto {
         }
 
         signal?.removeEventListener("abort", abortListener);
+
+        // Try to flush the write to the `gpgOutputFile`.  If this fails, save
+        // the error but check other error conditions (which are likely *why*
+        // this has failed) first.
         gpgOutputFile.end();
+        let flushError: unknown = null;
+        try {
+          await finished(gpgOutputFile);
+        } catch (error) {
+          flushError = error;
+        }
+
         const errorMessage = stderr.toString("utf8");
 
         if (signal?.aborted) {
@@ -634,6 +645,22 @@ export class Crypto {
             // and could be the result of some sort of injection attack
             new CryptoError(
               `GPG file decryption emitted stderr: ${JSON.stringify(errorMessage.trim())}`,
+            ),
+          );
+          return;
+        }
+
+        // If flushing the write to `gpgOutputFile` failed for some other
+        // reason, report it as such.
+        if (flushError) {
+          await destroyAndCleanup();
+          isSettled = true;
+          reject(
+            new CryptoError(
+              "Failed to write decrypted GPG output to disk",
+              flushError instanceof Error
+                ? flushError
+                : new Error(String(flushError)),
             ),
           );
           return;


### PR DESCRIPTION
## Summary

- write decompressed plaintext to an operation-owned temporary directory
- publish the final item path only after gzip validation completes
- cover malformed encrypted gzip input through the real GPG decrypt path

## Context

Refs https://github.com/freedomofpress/securedrop-client/issues/3566.

This complements the failed-decryption cleanup in #3534 by covering errors from
the outer gzip decompression stage.

## Test plan

```sh
cd app
pnpm exec vitest run --config vitest.config.ts --project=unit \
  src/main/__tests__/crypto.gpg.test.ts --reporter=verbose
```

Observed: 23 tests passed.

```sh
cd app
pnpm lint
```

Observed: Prettier, ESLint, and both TypeScript checks passed with no warnings.

```sh
git diff --check origin/main...HEAD
```

Observed: passed with no output.

## Notes

Qubes testing has not been run. Independent local verification also exercised
late gzip failure after 32 MiB of output, existing destination paths, temporary
path creation failure, permissions failure, rename failure, and successful
decryption.

## Checklist

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
