### PR TITLE
fix(database): prevent item source reassignment

### DIFF
--- a/app/src/main/database/migrations/20260710151500_immutable_item_source.sql
+++ b/app/src/main/database/migrations/20260710151500_immutable_item_source.sql
@@ -1,0 +1,15 @@
+-- migrate:up
+-- Source identity: Don't allow `items.data.source` to change after it's been set.
+
+CREATE TRIGGER items_source_immutable
+BEFORE UPDATE OF data ON items
+FOR EACH ROW
+WHEN json_extract(OLD.data, '$.source') IS NOT NULL
+    AND json_extract(NEW.data, '$.source') IS NOT json_extract(OLD.data, '$.source')
+BEGIN
+    SELECT RAISE(ABORT, 'items.source is immutable');
+END;
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS items_source_immutable;

--- a/app/src/main/database/schema.sql
+++ b/app/src/main/database/schema.sql
@@ -273,6 +273,14 @@ WHERE
             pending_events.type = 'source_deleted'
     )
 /* sources_projected(uuid,data,version,has_attachment,is_seen) */;
+CREATE TRIGGER items_source_immutable
+BEFORE UPDATE OF data ON items
+FOR EACH ROW
+WHEN json_extract(OLD.data, '$.source') IS NOT NULL
+    AND json_extract(NEW.data, '$.source') IS NOT json_extract(OLD.data, '$.source')
+BEGIN
+    SELECT RAISE(ABORT, 'items.source is immutable');
+END;
 -- Dbmate schema migrations
 INSERT INTO "schema_migrations" (version) VALUES
   ('20260203225412'),
@@ -283,4 +291,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20260416000000'),
   ('20260507000000'),
   ('20260511000000'),
-  ('20260624000000');
+  ('20260624000000'),
+  ('20260710151500');

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -337,9 +337,9 @@ describe("Datastore Method Tests", () => {
     });
 
     db.updateItems({
-      item1: mockItemMetadata("item1", "source2", "message", 1),
-      item2: mockItemMetadata("item2", "source2", "message", 2),
-      item3: mockItemMetadata("item3", "source2", "message", 3),
+      item4: mockItemMetadata("item4", "source2", "message", 1),
+      item5: mockItemMetadata("item5", "source2", "message", 2),
+      item6: mockItemMetadata("item6", "source2", "message", 3),
     });
     sourceWithItems = db.getSourceWithItems("source2");
     expect(sourceWithItems.items.length).toEqual(3);
@@ -1336,6 +1336,29 @@ describe("Datastore Method Tests", () => {
     expect(sourceWithItems.items[0].data.interaction_count).toBe(42);
     expect(sourceWithItems.items[0].plaintext).toBe("plaintext");
     expect(sourceWithItems.items[0].fetch_status).toBe(FetchStatus.Complete);
+  });
+
+  it("updateItems should reject source reassignment for a conflicting uuid", () => {
+    db.updateSources({
+      source1: mockSourceMetadata("source1"),
+      source2: mockSourceMetadata("source2"),
+    });
+    db.updateItems({
+      item1: mockItemMetadata("item1", "source1", "message"),
+    });
+    db.completePlaintextItem("item1", "plaintext");
+
+    expect(() =>
+      db.updateItems({
+        item1: mockItemMetadata("item1", "source2", "message"),
+      }),
+    ).toThrow("items.source is immutable");
+
+    const source1 = db.getSourceWithItems("source1");
+    const source2 = db.getSourceWithItems("source2");
+    expect(source1.items).toHaveLength(1);
+    expect(source1.items[0].plaintext).toBe("plaintext");
+    expect(source2.items).toHaveLength(0);
   });
 
   it("getSource should return correct message preview", () => {


### PR DESCRIPTION
## Summary

- reject changes to an existing item's source UUID at the database boundary
- preserve one-time initialization when the stored source is null or missing
- cover reassignment rejection and preservation of decrypted local state

## Context

Fixes #3564.

This follows the database-level immutability pattern used for item kind in #3173.

## Test plan

```sh
cd app
pnpm exec vitest run --config vitest.config.ts --project=unit \
  src/main/datastore.test.ts --poolOptions.forks.singleFork
```

Observed: 68 tests passed.

```sh
cd app
pnpm test
```

Observed: 889 tests passed across 52 files.

```sh
cd app
tmp_home=$(mktemp -d)
HOME="$tmp_home" pnpm run dbmate:check
```

Observed: all migrations applied and the generated schema matched.

```sh
cd app
pnpm lint
git diff --check origin/main...HEAD
```

Observed: formatting, ESLint, both TypeScript checks, and the diff check passed.

## Checklist

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
