### PR TITLE
fix(sync): reject mismatched item UUID metadata

### DIFF
--- a/app/src/main/database/migrations/20260710153000_item_uuid_matches_metadata.sql
+++ b/app/src/main/database/migrations/20260710153000_item_uuid_matches_metadata.sql
@@ -1,0 +1,43 @@
+-- migrate:up
+-- Keep an item's database identity aligned with its embedded metadata identity.
+
+CREATE TRIGGER items_uuid_matches_metadata_insert
+BEFORE INSERT ON items
+FOR EACH ROW
+WHEN NEW.data IS NOT NULL
+    AND (
+        SELECT count(*) != 1 OR min(value) IS NOT NEW.uuid
+        FROM json_each(NEW.data)
+        WHERE key = 'uuid'
+    )
+BEGIN
+    SELECT RAISE(ABORT, 'items.uuid must match items.data.uuid');
+END;
+
+CREATE TRIGGER items_uuid_matches_metadata_update
+BEFORE UPDATE OF uuid, data ON items
+FOR EACH ROW
+WHEN NEW.data IS NOT NULL
+    AND (
+        SELECT count(*) != 1 OR min(value) IS NOT NEW.uuid
+        FROM json_each(NEW.data)
+        WHERE key = 'uuid'
+    )
+BEGIN
+    SELECT RAISE(ABORT, 'items.uuid must match items.data.uuid');
+END;
+
+-- Refuse to open a database that already contains a mismatched identity.
+UPDATE items
+SET data = data
+WHERE data IS NOT NULL
+    AND (
+        SELECT count(*) != 1 OR min(value) IS NOT items.uuid
+        FROM json_each(items.data)
+        WHERE key = 'uuid'
+    );
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS items_uuid_matches_metadata_update;
+DROP TRIGGER IF EXISTS items_uuid_matches_metadata_insert;

--- a/app/src/main/database/schema.sql
+++ b/app/src/main/database/schema.sql
@@ -273,6 +273,30 @@ WHERE
             pending_events.type = 'source_deleted'
     )
 /* sources_projected(uuid,data,version,has_attachment,is_seen) */;
+CREATE TRIGGER items_uuid_matches_metadata_insert
+BEFORE INSERT ON items
+FOR EACH ROW
+WHEN NEW.data IS NOT NULL
+    AND (
+        SELECT count(*) != 1 OR min(value) IS NOT NEW.uuid
+        FROM json_each(NEW.data)
+        WHERE key = 'uuid'
+    )
+BEGIN
+    SELECT RAISE(ABORT, 'items.uuid must match items.data.uuid');
+END;
+CREATE TRIGGER items_uuid_matches_metadata_update
+BEFORE UPDATE OF uuid, data ON items
+FOR EACH ROW
+WHEN NEW.data IS NOT NULL
+    AND (
+        SELECT count(*) != 1 OR min(value) IS NOT NEW.uuid
+        FROM json_each(NEW.data)
+        WHERE key = 'uuid'
+    )
+BEGIN
+    SELECT RAISE(ABORT, 'items.uuid must match items.data.uuid');
+END;
 -- Dbmate schema migrations
 INSERT INTO "schema_migrations" (version) VALUES
   ('20260203225412'),
@@ -283,4 +307,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20260416000000'),
   ('20260507000000'),
   ('20260511000000'),
-  ('20260624000000');
+  ('20260624000000'),
+  ('20260710153000');

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import os from "os";
@@ -148,6 +149,118 @@ describe("DB Component Tests", () => {
       ).toThrow("items.kind is immutable");
     });
   });
+
+  it("rejects an insert with duplicate embedded item UUID keys", () => {
+    db = new Datastore(crypto, new Storage());
+    const rawDb = db["db"]!;
+    const data =
+      '{"kind":"message","uuid":"item-a","uuid":"item-b","source":"s"}';
+
+    expect(JSON.parse(data).uuid).toBe("item-b");
+    expect(() =>
+      rawDb
+        .prepare("INSERT INTO items (uuid, data) VALUES (?, ?)")
+        .run("item-a", data),
+    ).toThrow("items.uuid must match items.data.uuid");
+  });
+
+  it("rejects non-NULL item data without an embedded UUID key", () => {
+    db = new Datastore(crypto, new Storage());
+    const rawDb = db["db"]!;
+
+    expect(() =>
+      rawDb
+        .prepare("INSERT INTO items (uuid, data) VALUES (?, ?)")
+        .run("item-a", '{"kind":"message","source":"s"}'),
+    ).toThrow("items.uuid must match items.data.uuid");
+  });
+
+  it("rejects an update with duplicate embedded item UUID keys", () => {
+    db = new Datastore(crypto, new Storage());
+    const rawDb = db["db"]!;
+    const data = {
+      kind: "message",
+      uuid: "item-a",
+      source: "s",
+      size: 0,
+      is_read: false,
+      seen_by: [],
+      interaction_count: 0,
+    };
+    const duplicateUuidData =
+      '{"kind":"message","uuid":"item-a","uuid":"item-b","source":"s"}';
+
+    rawDb
+      .prepare("INSERT INTO items (uuid, data) VALUES (?, ?)")
+      .run(data.uuid, JSON.stringify(data));
+
+    expect(() =>
+      rawDb
+        .prepare("UPDATE items SET data = ? WHERE uuid = ?")
+        .run(duplicateUuidData, data.uuid),
+    ).toThrow("items.uuid must match items.data.uuid");
+  });
+
+  it("rejects a legacy database with duplicate embedded item UUID keys", () => {
+    const currentMigration = "20260710153000_item_uuid_matches_metadata.sql";
+    const migrationsDir = path.resolve("src/main/database/migrations");
+    const legacyRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "sdc-item-uuid-legacy-"),
+    );
+    const legacyMigrationsDir = path.join(legacyRoot, "migrations");
+    const legacyDbPath = path.join(legacyRoot, "legacy.sqlite");
+    const dbmatePath = path.resolve("node_modules/.bin/dbmate");
+    try {
+      fs.mkdirSync(legacyMigrationsDir, { recursive: true });
+
+      for (const migration of fs.readdirSync(migrationsDir)) {
+        if (migration.endsWith(".sql") && migration !== currentMigration) {
+          fs.symlinkSync(
+            path.join(migrationsDir, migration),
+            path.join(legacyMigrationsDir, migration),
+          );
+        }
+      }
+
+      const dbmateArgs = (directory: string) => [
+        "--url",
+        `sqlite:${legacyDbPath}`,
+        "--migrations-dir",
+        directory,
+        "--schema-file",
+        "/dev/null",
+        "up",
+      ];
+      const legacyMigration = spawnSync(
+        dbmatePath,
+        dbmateArgs(legacyMigrationsDir),
+        { encoding: "utf8" },
+      );
+      expect(legacyMigration.status, legacyMigration.stderr).toBe(0);
+
+      const duplicateUuidData =
+        '{"kind":"file","uuid":"item-a","uuid":"item-b"}';
+      const insert = spawnSync(
+        "sqlite3",
+        [
+          legacyDbPath,
+          `INSERT INTO items(uuid, data) VALUES ('item-a', '${duplicateUuidData}');`,
+        ],
+        { encoding: "utf8" },
+      );
+      expect(insert.status, insert.stderr).toBe(0);
+
+      const migration = spawnSync(dbmatePath, dbmateArgs(migrationsDir), {
+        encoding: "utf8",
+      });
+      expect(migration.status).toBe(2);
+      expect(migration.stderr).toContain(
+        "items.uuid must match items.data.uuid",
+      );
+    } finally {
+      fs.rmSync(legacyRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("Datastore Method Tests", () => {
@@ -245,6 +358,18 @@ describe("Datastore Method Tests", () => {
       interaction_count: interaction_count,
     };
   }
+
+  it("rejects item metadata whose UUID differs from its map key", () => {
+    const itemUuid = "660e8400-e29b-41d4-a716-446655440001";
+    const metadataUuid = "660e8400-e29b-41d4-a716-446655440002";
+
+    expect(() =>
+      db.updateItems({
+        [itemUuid]: mockItemMetadata(metadataUuid, "source1", "file"),
+      }),
+    ).toThrow("items.uuid must match items.data.uuid");
+    expect(db.getItem(itemUuid)).toBeNull();
+  });
 
   it("getJournalistbyID should return the first matching journalist", () => {
     // Insert two Journalists

--- a/app/src/main/sync/index.test.ts
+++ b/app/src/main/sync/index.test.ts
@@ -162,7 +162,7 @@ describe("syncMetadata", () => {
         [SOURCE_UUID_1]: "abc",
       },
       items: {
-        [SOURCE_UUID_2]: "def",
+        [ITEM_UUID_1]: "def",
       },
       journalists: {
         [JOURNALIST_UUID_1]: "ghi",
@@ -173,7 +173,7 @@ describe("syncMetadata", () => {
         [SOURCE_UUID_1]: mockSourceMetadata(SOURCE_UUID_1),
       },
       items: {
-        [SOURCE_UUID_2]: mockItemMetadata(ITEM_UUID_1, SOURCE_UUID_1),
+        [ITEM_UUID_1]: mockItemMetadata(ITEM_UUID_1, SOURCE_UUID_1),
       },
       journalists: {
         [JOURNALIST_UUID_1]: mockJournalistMetadata(JOURNALIST_UUID_1),
@@ -204,6 +204,33 @@ describe("syncMetadata", () => {
     expect(proxyMock).toHaveBeenCalledTimes(2);
     // Should update sources and items with new data
     expect(db.updateBatch).toHaveBeenCalledWith(batch);
+  });
+
+  it("rejects a batch item whose map key differs from its metadata UUID", async () => {
+    const serverIndex: Index = {
+      sources: {},
+      items: { [ITEM_UUID_2]: "def" },
+      journalists: {},
+    };
+    const batch: BatchResponse = {
+      sources: {},
+      items: {
+        [ITEM_UUID_2]: mockItemMetadata(ITEM_UUID_1, SOURCE_UUID_1),
+      },
+      journalists: {},
+      events: {},
+    };
+    const proxyMock = mockProxyResponses([
+      { status: 200, error: false, data: serverIndex, headers: new Map() },
+      { status: 200, error: false, data: batch, headers: new Map() },
+    ]);
+
+    await expect(syncModule.syncMetadata(db, "")).rejects.toThrow(
+      "Item metadata UUID must match its batch map key",
+    );
+
+    expect(proxyMock).toHaveBeenCalledTimes(2);
+    expect(db.updateBatch).not.toHaveBeenCalled();
   });
 
   it("passes estimated timeouts to proxyJSONRequest", async () => {

--- a/app/src/main/sync/item-uuid-mismatch.test.ts
+++ b/app/src/main/sync/item-uuid-mismatch.test.ts
@@ -1,0 +1,114 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import {
+  Index,
+  ItemMetadata,
+  ProxyJSONResponse,
+  SourceMetadata,
+} from "../../types";
+import { Crypto } from "../crypto";
+import { Datastore } from "../datastore";
+import * as proxyModule from "../proxy";
+import { Storage } from "../storage";
+import { syncMetadata } from ".";
+
+const SOURCE_UUID = "550e8400-e29b-41d4-a716-446655440001";
+const ITEM_UUID_A = "660e8400-e29b-41d4-a716-446655440001";
+const ITEM_UUID_B = "660e8400-e29b-41d4-a716-446655440002";
+
+function sourceMetadata(): SourceMetadata {
+  return {
+    uuid: SOURCE_UUID,
+    journalist_designation: "test journalist",
+    is_starred: false,
+    is_seen: false,
+    has_attachment: true,
+    last_updated: "2026-07-10T00:00:00Z",
+    public_key: "test-public-key",
+    fingerprint: "test-fingerprint",
+  };
+}
+
+function itemMetadata(uuid: string, interactionCount: number): ItemMetadata {
+  return {
+    kind: "file",
+    uuid,
+    source: SOURCE_UUID,
+    size: 1234,
+    is_read: false,
+    seen_by: [],
+    interaction_count: interactionCount,
+  };
+}
+
+describe("item UUID sync invariant", () => {
+  let crypto: Crypto;
+  let db: Datastore;
+  let dbDir: string;
+
+  beforeAll(() => {
+    (Crypto as any).instance = undefined;
+    crypto = Crypto.initialize({
+      isQubes: false,
+      submissionKeyFingerprint: "",
+    });
+  });
+
+  beforeEach(() => {
+    dbDir = fs.mkdtempSync(path.join(os.tmpdir(), "sdc-item-uuid-sync-"));
+    db = new Datastore(crypto, new Storage(), dbDir);
+  });
+
+  afterEach(() => {
+    db.close();
+    fs.rmSync(dbDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("rejects a mismatched server item before it reaches the database", async () => {
+    db.updateSources({ [SOURCE_UUID]: sourceMetadata() });
+    db.updateItems({ [ITEM_UUID_A]: itemMetadata(ITEM_UUID_A, 1) });
+
+    const serverIndex: Index = db.getIndex();
+    serverIndex.items[ITEM_UUID_B] = "new-item-version";
+    const batchResponse = {
+      sources: {},
+      items: { [ITEM_UUID_B]: itemMetadata(ITEM_UUID_A, 2) },
+      journalists: {},
+      events: {},
+    };
+    const proxyMock = vi.spyOn(proxyModule, "proxyJSONRequest");
+    proxyMock
+      .mockResolvedValueOnce({
+        status: 200,
+        error: false,
+        data: serverIndex,
+        headers: new Map(),
+      } satisfies ProxyJSONResponse)
+      .mockResolvedValueOnce({
+        status: 200,
+        error: false,
+        data: batchResponse,
+        headers: new Map(),
+      } satisfies ProxyJSONResponse);
+
+    await expect(syncMetadata(db, "auth-token")).rejects.toThrow(
+      "Item metadata UUID must match its batch map key",
+    );
+
+    expect(proxyMock).toHaveBeenCalledTimes(2);
+    expect(db.getItem(ITEM_UUID_B)).toBeNull();
+    expect(db.getItem(ITEM_UUID_A)?.data.uuid).toBe(ITEM_UUID_A);
+  });
+});

--- a/app/src/schemas.ts
+++ b/app/src/schemas.ts
@@ -101,12 +101,24 @@ export const IndexSized: SizedSchema = {
 };
 
 // Metadata, maps UUIDs to full metadata objects
-export const BatchResponseSchema = z.object({
-  sources: z.record(UUIDSchema, SourceMetadataSchema.nullable()),
-  items: z.record(UUIDSchema, ItemMetadataSchema.nullable()),
-  journalists: z.record(UUIDSchema, JournalistMetadataSchema.nullable()),
-  events: z.record(z.string(), z.tuple([z.number(), z.string().nullable()])),
-});
+export const BatchResponseSchema = z
+  .object({
+    sources: z.record(UUIDSchema, SourceMetadataSchema.nullable()),
+    items: z.record(UUIDSchema, ItemMetadataSchema.nullable()),
+    journalists: z.record(UUIDSchema, JournalistMetadataSchema.nullable()),
+    events: z.record(z.string(), z.tuple([z.number(), z.string().nullable()])),
+  })
+  .superRefine(({ items }, context) => {
+    for (const [itemUuid, metadata] of Object.entries(items)) {
+      if (metadata !== null && metadata.uuid !== itemUuid) {
+        context.addIssue({
+          code: "custom",
+          message: "Item metadata UUID must match its batch map key",
+          path: ["items", itemUuid, "uuid"],
+        });
+      }
+    }
+  });
 
 // Interface for size calculations
 export const BatchResponseSized: SizedSchema = {


### PR DESCRIPTION
## Summary

- reject batch items whose map key differs from embedded metadata UUID
- enforce one unambiguous embedded UUID for persisted non-null item metadata
- cover the real sync path, direct database writes, and legacy migration checks

## Context

Refs https://github.com/freedomofpress/securedrop-client/issues/3565.

This extends the item identity invariants established for item kind in #3173.

## Test plan

```sh
cd app
pnpm exec vitest run --config vitest.config.ts --project=unit \
  src/main/sync/item-uuid-mismatch.test.ts \
  src/main/sync/index.test.ts \
  src/main/datastore.test.ts --reporter=dot
```

Observed: 97 tests passed.

```sh
cd app
tmp_home=$(mktemp -d)
HOME="$tmp_home" pnpm run dbmate:check
```

Observed: all migrations applied and the generated schema matched.

```sh
cd app
pnpm lint
git diff --check origin/main...HEAD
```

Observed: formatting, ESLint, both TypeScript checks, and the diff check passed.

## Notes

The migration fails atomically if an existing non-null item contains a missing,
duplicate, or mismatched embedded UUID. It does not guess which identity should
win or silently rewrite persisted item identity.

## Checklist

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
