### PR TITLE
fix(fetch): remove ciphertext on terminal ETag failure

### DIFF
--- a/app/src/main/fetch/queue.etag-cleanup.test.ts
+++ b/app/src/main/fetch/queue.etag-cleanup.test.ts
@@ -264,17 +264,26 @@ describe("TaskQueue ETag ciphertext cleanup", () => {
     const targetPath = queue.storage.downloadFilePath(metadata, {
       id: itemId,
     });
-    const targetDirectory = path.dirname(targetPath);
+    const cleanupFailure = new Error(
+      "permission denied",
+    ) as NodeJS.ErrnoException;
+    cleanupFailure.code = "EACCES";
+    const realRm = fs.promises.rm.bind(fs.promises);
+    vi.spyOn(fs.promises, "rm").mockImplementationOnce(
+      async (rmPath, options) => {
+        if (rmPath.toString() === targetPath) {
+          throw cleanupFailure;
+        }
+        return realRm(rmPath, options);
+      },
+    );
 
     mockProxyStreamRequest.mockImplementationOnce(
-      async (_request, writer: Writable) => {
-        const response = await writeResponse(writer, CIPHERTEXT, {
+      async (_request, writer: Writable) =>
+        writeResponse(writer, CIPHERTEXT, {
           complete: true,
           bytesWritten: CIPHERTEXT.length,
-        } as ProxyStreamResponse);
-        await fs.promises.chmod(targetDirectory, 0o500);
-        return response;
-      },
+        } as ProxyStreamResponse),
     );
 
     queue.authToken = "test-token";
@@ -283,8 +292,6 @@ describe("TaskQueue ETag ciphertext cleanup", () => {
       await queue.processDownload({ id: itemId }, db);
     } catch (error) {
       cleanupError = error;
-    } finally {
-      await fs.promises.chmod(targetDirectory, 0o700);
     }
 
     expect((cleanupError as NodeJS.ErrnoException).code).toBe("EACCES");

--- a/app/src/main/fetch/queue.etag-cleanup.test.ts
+++ b/app/src/main/fetch/queue.etag-cleanup.test.ts
@@ -1,0 +1,382 @@
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { finished } from "node:stream/promises";
+import type { Writable } from "node:stream";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DB } from "../database";
+import type { Item, ItemMetadata, ProxyStreamResponse } from "../../types";
+import { FetchStatus } from "../../types";
+import { TaskQueue } from "./queue";
+
+const mockProxyStreamRequest = vi.hoisted(() => vi.fn());
+const mockDecryptMessage = vi.hoisted(() => vi.fn());
+
+vi.mock("../proxy", async () => {
+  const actual = await vi.importActual("../proxy");
+  return {
+    ...actual,
+    proxyStreamRequest: mockProxyStreamRequest,
+  };
+});
+
+vi.mock("../crypto", async () => {
+  const actual = await vi.importActual("../crypto");
+  return {
+    ...actual,
+    Crypto: {
+      getInstance: () => ({
+        decryptMessage: mockDecryptMessage,
+      }),
+    },
+  };
+});
+
+const CIPHERTEXT = Buffer.from("downloaded ciphertext");
+const CONTROL_CIPHERTEXT = Buffer.from("unrelated ciphertext");
+
+function etagFor(content: Buffer): string {
+  return `sha256:${createHash("sha256").update(content).digest("hex")}`;
+}
+
+function mockItem(metadata: ItemMetadata, fetchStatus: FetchStatus): Item {
+  return {
+    uuid: metadata.uuid,
+    data: metadata,
+    fetch_status: fetchStatus,
+    fetch_progress: 0,
+    plaintext: null,
+    filename: null,
+    decrypted_size: null,
+  };
+}
+
+function createMockDB(metadata: ItemMetadata): DB {
+  return {
+    getItem: vi.fn(() => mockItem(metadata, FetchStatus.Initial)),
+    getItemsToProcess: vi.fn(() => []),
+    getSource: vi.fn(),
+    completePlaintextItem: vi.fn(),
+    completeFileItem: vi.fn(),
+    startDownloadInProgress: vi.fn(),
+    updateDownloadInProgress: vi.fn(() => true),
+    setDecryptionInProgress: vi.fn(),
+    setSourceMessagePreview: vi.fn(),
+    failDownload: vi.fn(),
+    failDecryption: vi.fn(),
+    terminallyFailItem: vi.fn(),
+  } as unknown as DB;
+}
+
+type QueueErrorCallback = (error: Error | null, result?: unknown) => void;
+
+function captureDownloadErrorCallback(
+  queue: TaskQueue,
+  db: DB,
+  itemId: string,
+): QueueErrorCallback {
+  db.getItemsToProcess = vi.fn(() => [itemId]);
+  let errorCallback: QueueErrorCallback | undefined;
+  vi.spyOn(queue.messageDownloadQueue, "push").mockImplementation(
+    (_task, callback) => {
+      errorCallback = callback as QueueErrorCallback;
+      return undefined as unknown as ReturnType<
+        typeof queue.messageDownloadQueue.push
+      >;
+    },
+  );
+
+  queue.queueFetches({ authToken: "test-token" });
+  expect(errorCallback).toBeDefined();
+  return errorCallback as QueueErrorCallback;
+}
+
+async function writeResponse(
+  writer: Writable,
+  content: Buffer,
+  response: ProxyStreamResponse,
+): Promise<ProxyStreamResponse> {
+  writer.end(content);
+  await finished(writer);
+  return response;
+}
+
+describe("TaskQueue ETag ciphertext cleanup", () => {
+  let sourceId: string;
+  let sourceDownloadDirectory: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sourceId = `etag-cleanup-${randomUUID()}`;
+    sourceDownloadDirectory = path.join(
+      fs.realpathSync(os.tmpdir()),
+      "download",
+      sourceId,
+    );
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(sourceDownloadDirectory, {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  it.each([
+    ["missing", "message", undefined, "Missing ETag checksum"],
+    [
+      "unsupported",
+      "reply",
+      "md5:invalid",
+      "Invalid or unsupported ETag format",
+    ],
+    [
+      "mismatched",
+      "file",
+      `sha256:${"0".repeat(64)}`,
+      "ETag checksum mismatch",
+    ],
+  ])(
+    "removes only the corresponding ciphertext for a %s ETag on a %s",
+    async (_case, kind, etag, expectedError) => {
+      const itemId = "target-item";
+      const metadata = {
+        uuid: itemId,
+        kind,
+        source: sourceId,
+        size: CIPHERTEXT.length,
+      } as ItemMetadata;
+      const db = createMockDB(metadata);
+      const queue = new TaskQueue(db);
+      const targetPath = queue.storage.downloadFilePath(metadata, {
+        id: itemId,
+      });
+      const controlPath = queue.storage.downloadFilePath(metadata, {
+        id: "control-item",
+      });
+      await fs.promises.writeFile(controlPath, CONTROL_CIPHERTEXT);
+
+      mockProxyStreamRequest.mockImplementationOnce(
+        async (_request, writer: Writable) => {
+          const response = {
+            complete: true,
+            bytesWritten: CIPHERTEXT.length,
+            ...(etag === undefined ? {} : { sha256sum: etag }),
+          } as ProxyStreamResponse;
+          return writeResponse(writer, CIPHERTEXT, response);
+        },
+      );
+
+      queue.authToken = "test-token";
+      await expect(queue.processDownload({ id: itemId }, db)).rejects.toThrow(
+        expectedError,
+      );
+
+      expect(db.terminallyFailItem).toHaveBeenCalledWith(itemId);
+      expect(fs.existsSync(targetPath)).toBe(false);
+      await expect(fs.promises.readFile(controlPath)).resolves.toEqual(
+        CONTROL_CIPHERTEXT,
+      );
+    },
+  );
+
+  it("retains ciphertext when a download failure is retryable", async () => {
+    const itemId = "retryable-item";
+    const metadata = {
+      uuid: itemId,
+      kind: "file",
+      source: sourceId,
+      size: CIPHERTEXT.length * 2,
+    } as ItemMetadata;
+    const db = createMockDB(metadata);
+    const queue = new TaskQueue(db);
+    const targetPath = queue.storage.downloadFilePath(metadata, {
+      id: itemId,
+    });
+
+    mockProxyStreamRequest.mockImplementationOnce(
+      async (_request, writer: Writable) =>
+        writeResponse(writer, CIPHERTEXT, {
+          complete: false,
+          bytesWritten: CIPHERTEXT.length,
+          error: new Error("connection closed"),
+        } as ProxyStreamResponse),
+    );
+
+    queue.authToken = "test-token";
+    await expect(queue.processDownload({ id: itemId }, db)).rejects.toThrow(
+      "Unable to complete stream download",
+    );
+
+    expect(db.failDownload).toHaveBeenCalledWith(itemId);
+    expect(db.terminallyFailItem).not.toHaveBeenCalled();
+    await expect(fs.promises.readFile(targetPath)).resolves.toEqual(CIPHERTEXT);
+  });
+
+  it("preserves the ETag error when the ciphertext is already absent", async () => {
+    const itemId = "already-removed-item";
+    const metadata = {
+      uuid: itemId,
+      kind: "message",
+      source: sourceId,
+      size: CIPHERTEXT.length,
+    } as ItemMetadata;
+    const db = createMockDB(metadata);
+    const queue = new TaskQueue(db);
+    const targetPath = queue.storage.downloadFilePath(metadata, {
+      id: itemId,
+    });
+
+    mockProxyStreamRequest.mockImplementationOnce(
+      async (_request, writer: Writable) => {
+        const response = await writeResponse(writer, CIPHERTEXT, {
+          complete: true,
+          bytesWritten: CIPHERTEXT.length,
+        } as ProxyStreamResponse);
+        await fs.promises.unlink(targetPath);
+        return response;
+      },
+    );
+
+    queue.authToken = "test-token";
+    await expect(queue.processDownload({ id: itemId }, db)).rejects.toThrow(
+      "Missing ETag checksum",
+    );
+
+    expect(db.terminallyFailItem).toHaveBeenCalledWith(itemId);
+    expect(fs.existsSync(targetPath)).toBe(false);
+  });
+
+  it("does not write terminal status when ciphertext cleanup gets EACCES", async () => {
+    const itemId = "permission-denied-item";
+    const metadata = {
+      uuid: itemId,
+      kind: "message",
+      source: sourceId,
+      size: CIPHERTEXT.length,
+    } as ItemMetadata;
+    const db = createMockDB(metadata);
+    const queue = new TaskQueue(db);
+    const queueErrorCallback = captureDownloadErrorCallback(queue, db, itemId);
+    const targetPath = queue.storage.downloadFilePath(metadata, {
+      id: itemId,
+    });
+    const targetDirectory = path.dirname(targetPath);
+
+    mockProxyStreamRequest.mockImplementationOnce(
+      async (_request, writer: Writable) => {
+        const response = await writeResponse(writer, CIPHERTEXT, {
+          complete: true,
+          bytesWritten: CIPHERTEXT.length,
+        } as ProxyStreamResponse);
+        await fs.promises.chmod(targetDirectory, 0o500);
+        return response;
+      },
+    );
+
+    queue.authToken = "test-token";
+    let cleanupError: unknown;
+    try {
+      await queue.processDownload({ id: itemId }, db);
+    } catch (error) {
+      cleanupError = error;
+    } finally {
+      await fs.promises.chmod(targetDirectory, 0o700);
+    }
+
+    expect((cleanupError as NodeJS.ErrnoException).code).toBe("EACCES");
+    queueErrorCallback(cleanupError as Error);
+    queue.messageDownloadQueue.emit("task_failed", itemId, cleanupError);
+    expect(db.failDownload).toHaveBeenCalledWith(itemId);
+    expect(db.terminallyFailItem).not.toHaveBeenCalled();
+    expect(db.getItemsToProcess).toHaveBeenCalledTimes(1);
+    expect(fs.existsSync(targetPath)).toBe(true);
+  });
+
+  it("removes ciphertext before writing terminal status", async () => {
+    const itemId = "terminal-write-failure-item";
+    const metadata = {
+      uuid: itemId,
+      kind: "message",
+      source: sourceId,
+      size: CIPHERTEXT.length,
+    } as ItemMetadata;
+    const db = createMockDB(metadata);
+    const queue = new TaskQueue(db);
+    const queueErrorCallback = captureDownloadErrorCallback(queue, db, itemId);
+    const targetPath = queue.storage.downloadFilePath(metadata, {
+      id: itemId,
+    });
+    db.terminallyFailItem = vi.fn(() => {
+      expect(fs.existsSync(targetPath)).toBe(false);
+      throw new Error("terminal DB write failed");
+    });
+
+    mockProxyStreamRequest.mockImplementationOnce(
+      async (_request, writer: Writable) =>
+        writeResponse(writer, CIPHERTEXT, {
+          complete: true,
+          bytesWritten: CIPHERTEXT.length,
+        } as ProxyStreamResponse),
+    );
+
+    queue.authToken = "test-token";
+    let terminalWriteError: unknown;
+    try {
+      await queue.processDownload({ id: itemId }, db);
+    } catch (error) {
+      terminalWriteError = error;
+    }
+
+    expect(terminalWriteError).toEqual(
+      expect.objectContaining({ message: "terminal DB write failed" }),
+    );
+    queueErrorCallback(terminalWriteError as Error);
+    expect(db.failDownload).toHaveBeenCalledWith(itemId);
+    expect(db.terminallyFailItem).toHaveBeenCalledWith(itemId);
+    expect(fs.existsSync(targetPath)).toBe(false);
+  });
+
+  it("retains verified ciphertext until successful decryption", async () => {
+    const itemId = "successful-item";
+    const metadata = {
+      uuid: itemId,
+      kind: "message",
+      source: sourceId,
+      size: CIPHERTEXT.length,
+    } as ItemMetadata;
+    const db = createMockDB(metadata);
+    const queue = new TaskQueue(db);
+    const targetPath = queue.storage.downloadFilePath(metadata, {
+      id: itemId,
+    });
+
+    mockProxyStreamRequest.mockImplementationOnce(
+      async (_request, writer: Writable) =>
+        writeResponse(writer, CIPHERTEXT, {
+          complete: true,
+          bytesWritten: CIPHERTEXT.length,
+          sha256sum: etagFor(CIPHERTEXT),
+        } as ProxyStreamResponse),
+    );
+
+    queue.authToken = "test-token";
+    await queue.processDownload({ id: itemId }, db);
+    await expect(fs.promises.readFile(targetPath)).resolves.toEqual(CIPHERTEXT);
+
+    db.getItem = vi.fn(() =>
+      mockItem(metadata, FetchStatus.DecryptionInProgress),
+    );
+    mockDecryptMessage.mockResolvedValueOnce("decrypted plaintext");
+    await queue.processDecrypt({ id: itemId }, db);
+
+    expect(db.completePlaintextItem).toHaveBeenCalledWith(
+      itemId,
+      "decrypted plaintext",
+    );
+    expect(fs.existsSync(targetPath)).toBe(false);
+  });
+});

--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -52,6 +52,7 @@ vi.mock("fs", () => ({
       writeFile: vi.fn(),
       readFile: vi.fn(),
       unlink: vi.fn(),
+      rm: vi.fn(),
       stat: vi.fn(() => Promise.resolve({ size: 1024 })),
     },
     createWriteStream: vi.fn(() => new PassThrough()),

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -37,6 +37,19 @@ class DownloadCancelledError extends Error {
   }
 }
 
+class DownloadCleanupError extends Error {
+  code: string | undefined;
+
+  constructor(itemId: string, downloadFilePath: string, cause: unknown) {
+    super(
+      `Failed to clean up downloaded ciphertext for ${itemId} at ${downloadFilePath}: ${String(cause)}`,
+      { cause },
+    );
+    this.name = "DownloadCleanupError";
+    this.code = (cause as NodeJS.ErrnoException).code;
+  }
+}
+
 const MESSAGE_QUEUE_BATCH_LIMIT = 25;
 const FILE_QUEUE_BATCH_LIMIT = 2;
 
@@ -112,16 +125,21 @@ export class TaskQueue {
     this.port = port;
     this.storage = new Storage();
 
-    // After each completed or terminally-failed task, try to top up the
-    // queues from the database so large backlogs drain without waiting for
-    // the next sync tick.
+    // After each completed or terminally-failed task, try to top up the queues.
+    // Cleanup failures remain retryable but wait for the next sync tick so a
+    // persistent filesystem error cannot create a tight retry loop.
     const refill = () => this.refillQueues();
+    const refillAfterFailure = (_taskId: string, error: unknown) => {
+      if (!(error instanceof DownloadCleanupError)) {
+        this.refillQueues();
+      }
+    };
     this.messageDownloadQueue.on("task_finish", refill);
-    this.messageDownloadQueue.on("task_failed", refill);
+    this.messageDownloadQueue.on("task_failed", refillAfterFailure);
     this.messageDecryptQueue.on("task_finish", refill);
     this.messageDecryptQueue.on("task_failed", refill);
     this.fileDownloadQueue.on("task_finish", refill);
-    this.fileDownloadQueue.on("task_failed", refill);
+    this.fileDownloadQueue.on("task_failed", refillAfterFailure);
     this.fileDecryptQueue.on("task_finish", refill);
     this.fileDecryptQueue.on("task_failed", refill);
   }
@@ -556,6 +574,21 @@ export class TaskQueue {
     );
   }
 
+  private async terminallyFailEtag(
+    item: ItemFetchTask,
+    db: DB,
+    downloadFilePath: string,
+    errorMessage: string,
+  ): Promise<never> {
+    try {
+      await fs.promises.rm(downloadFilePath, { force: true });
+    } catch (error) {
+      throw new DownloadCleanupError(item.id, downloadFilePath, error);
+    }
+    db.terminallyFailItem(item.id);
+    throw new Error(errorMessage);
+  }
+
   // Verify ETag checksum for transport integrity purposes, otherwise fail terminally.
   // All downloads write to disk, so verification always reads from the file.
   private async verifyEtag(
@@ -566,13 +599,19 @@ export class TaskQueue {
     downloadFilePath: string,
   ): Promise<void> {
     if (!etagRaw) {
-      db.terminallyFailItem(item.id);
-      throw new Error(`Missing ETag checksum for ${metadata.kind} ${item.id}`);
+      return this.terminallyFailEtag(
+        item,
+        db,
+        downloadFilePath,
+        `Missing ETag checksum for ${metadata.kind} ${item.id}`,
+      );
     }
     const colonIdx = etagRaw.indexOf(":");
     if (colonIdx === -1 || etagRaw.slice(0, colonIdx) !== "sha256") {
-      db.terminallyFailItem(item.id);
-      throw new Error(
+      return this.terminallyFailEtag(
+        item,
+        db,
+        downloadFilePath,
         `Invalid or unsupported ETag format for ${metadata.kind} ${item.id}: ${etagRaw}`,
       );
     }
@@ -587,8 +626,10 @@ export class TaskQueue {
     const actualHash = hash.digest("hex");
 
     if (actualHash !== expectedHex) {
-      db.terminallyFailItem(item.id);
-      throw new Error(
+      return this.terminallyFailEtag(
+        item,
+        db,
+        downloadFilePath,
         `ETag checksum mismatch for ${metadata.kind} ${item.id}: expected ${expectedHex}, got ${actualHash}`,
       );
     }
@@ -763,6 +804,15 @@ function createQueue(
   });
 
   q.on("task_failed", (taskId, errorMessage) => {
+    const taskError: unknown = errorMessage;
+    if (taskError instanceof DownloadCleanupError) {
+      console.error(
+        `Task failed because ciphertext cleanup did not complete in ${name}, leaving item retryable: `,
+        taskId,
+        taskError,
+      );
+      return;
+    }
     console.error(
       `Task failed and exceeded retry attempts in ${name}, removing from queue: `,
       taskId,


### PR DESCRIPTION
## Summary

- remove an item's downloaded ciphertext before recording terminal ETag failure
- keep the item retryable when filesystem cleanup cannot complete
- make the cleanup-failure regression test deterministic across CI platforms

## Context

Refs https://github.com/freedomofpress/securedrop-client/issues/3570.

This follows the ETag validation path introduced in #3223 and completes its
temporary-file lifecycle.

## Test plan

```sh
cd app
pnpm exec vitest run --config vitest.config.ts --project=unit \
  src/main/fetch/queue.etag-cleanup.test.ts
```

Observed: 8 tests passed.

```sh
cd app
pnpm exec prettier src/main/fetch/queue.etag-cleanup.test.ts --check
pnpm exec eslint --max-warnings 0 src/main/fetch/queue.etag-cleanup.test.ts
pnpm run typecheck:node
git diff --check
```

Observed: Prettier reported the file uses project style, ESLint exited 0,
`typecheck:node` exited 0, and the diff check passed.

```sh
cd app
pnpm lint
pnpm test
pnpm build:linux
```

Not run locally: this macOS environment is running Node v26.0.0, and
`pnpm install` failed during postinstall while trying to download the
`better-sqlite3` node-v147 darwin-arm64 artifact, which returned 404. The
focused queue test does not need that native binding and was run successfully;
full app CI parity is left for CI.

## Notes

The regression test now injects an `EACCES` error from `fs.promises.rm` instead
of relying on directory permission bits that behave differently across CI
containers and local platforms. Qubes and packaged Linux builds were not run
locally.

## Checklist

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
