### PR TITLE
fix(sync): retry destructive events after AlreadyReported

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -41,6 +41,16 @@ import { Search } from "./search";
 export const MESSAGE_PREVIEW_LENGTH = 200;
 const DEFAULT_ITEM_LIMIT = 100;
 export const DEFAULT_PENDING_EVENTS_LIMIT = 20;
+// API2 retains completed idempotence keys for 24 hours. These bounds reach
+// 24h15 after 13 responses while limiting failure recovery latency to 4 hours.
+const ALREADY_REPORTED_INITIAL_RETRY_SECONDS = 60;
+const ALREADY_REPORTED_MAX_RETRY_SECONDS = 4 * 60 * 60;
+const ALREADY_REPORTED_MAX_BACKOFF_EXPONENT = 8;
+const RETRYABLE_ALREADY_REPORTED_EVENT_TYPES = new Set<PendingEventType>([
+  PendingEventType.ItemDeleted,
+  PendingEventType.SourceDeleted,
+  PendingEventType.SourceConversationTruncated,
+]);
 
 interface KeyObject {
   [key: string]: object;
@@ -189,12 +199,20 @@ export class DB {
     { count: number }
   >;
   private deletePendingEvent: Statement<{ snowflake_id: string }, void>;
+  private selectPendingEventRetryState: Statement<
+    { snowflake_id: string },
+    { type: string; retry_attempts: number }
+  >;
   private incrementPendingEventRetry: Statement<
     { snowflake_id: string; status: number },
     void
   >;
   private setPendingEventStatus: Statement<
     { snowflake_id: string; status: number },
+    void
+  >;
+  private deferPendingEventRetry: Statement<
+    { snowflake_id: string; status: number; retry_delay_seconds: number },
     void
   >;
   private selectPendingEvents: Statement<[{ limit: number }], PendingEventRow>;
@@ -427,21 +445,44 @@ export class DB {
     this.deletePendingEvent = this.db.prepare(
       `DELETE FROM pending_events WHERE snowflake_id = @snowflake_id`,
     );
+    this.selectPendingEventRetryState = this.db.prepare(`
+      SELECT type, retry_attempts FROM pending_events
+      WHERE snowflake_id = @snowflake_id
+    `);
     this.incrementPendingEventRetry = this.db.prepare(`
       UPDATE pending_events
-      SET retry_attempts = retry_attempts + 1, last_event_status = @status
+      SET retry_attempts = retry_attempts + 1,
+          last_event_status = @status,
+          next_retry_at = NULL,
+          retry_delay_seconds = NULL
       WHERE snowflake_id = @snowflake_id
     `);
     this.setPendingEventStatus = this.db.prepare(`
       UPDATE pending_events
-      SET last_event_status = @status
+      SET last_event_status = @status,
+          next_retry_at = NULL,
+          retry_delay_seconds = NULL
       WHERE snowflake_id = @snowflake_id
     `);
-    // Schedule previously-failed events later, and exclude events already reported
-    // and accepted on the server that are just awaiting completion.
+    this.deferPendingEventRetry = this.db.prepare(`
+      UPDATE pending_events
+      SET retry_attempts = retry_attempts + 1,
+          last_event_status = @status,
+          next_retry_at = datetime(
+            'now', printf('+%d seconds', @retry_delay_seconds)
+          ),
+          retry_delay_seconds = @retry_delay_seconds
+      WHERE snowflake_id = @snowflake_id
+    `);
+    // A retry timestamp beyond its recorded delay means the wall clock moved
+    // backward after scheduling. Treat it as due instead of stranding the row.
     this.selectPendingEvents = this.db.prepare(`
       SELECT snowflake_id, source_uuid, item_uuid, type, data FROM pending_events
       WHERE last_event_status IS NOT ${EventStatus.AlreadyReported}
+         OR next_retry_at <= CURRENT_TIMESTAMP
+         OR next_retry_at > datetime(
+           'now', printf('+%d seconds', retry_delay_seconds)
+         )
       ORDER BY retry_attempts ASC, snowflake_id ASC LIMIT @limit
     `);
     this.deletePendingEventsBySourceScope = this.db.prepare(`
@@ -1347,6 +1388,29 @@ export class DB {
     return pendingEvents;
   }
 
+  private getAlreadyReportedRetryDelay(snowflakeId: string): number | null {
+    const event = this.selectPendingEventRetryState.get({
+      snowflake_id: snowflakeId,
+    });
+    if (
+      !event ||
+      !RETRYABLE_ALREADY_REPORTED_EVENT_TYPES.has(
+        event.type as PendingEventType,
+      )
+    ) {
+      return null;
+    }
+
+    const exponent = Math.min(
+      event.retry_attempts,
+      ALREADY_REPORTED_MAX_BACKOFF_EXPONENT,
+    );
+    return Math.min(
+      ALREADY_REPORTED_INITIAL_RETRY_SECONDS * 2 ** exponent,
+      ALREADY_REPORTED_MAX_RETRY_SECONDS,
+    );
+  }
+
   // Takes pending events and their statuses from the server and applies
   // pending event updates as needed.
   // Should be run within a transaction that also updates index version.
@@ -1366,10 +1430,20 @@ export class DB {
         // Target no longer exists on the server: remove pending_event.
         eventIDsToRemove.push(snowflake_id);
       } else if (result === EventStatus.AlreadyReported) {
-        // Already reported to the server but awaiting completion.
-        // Retain the event but record the status so it's excluded from future
-        // sync batches and not re-sent.
-        this.setPendingEventStatus.run({ snowflake_id, status: result });
+        // API2 returns 208 for both Processing and completed idempotence keys,
+        // so the client cannot infer a final outcome. Destructive handlers are
+        // idempotent when retried with the same event ID after the server's
+        // 24-hour key expires. Other event types remain suppressed.
+        const retryDelay = this.getAlreadyReportedRetryDelay(snowflake_id);
+        if (retryDelay === null) {
+          this.setPendingEventStatus.run({ snowflake_id, status: result });
+        } else {
+          this.deferPendingEventRetry.run({
+            snowflake_id,
+            status: result,
+            retry_delay_seconds: retryDelay,
+          });
+        }
       } else {
         // All other statuses indicate event was submitted but not accepted
         // Retain and bump the retry counter, recording the status.

--- a/app/src/main/database/migrations/20260710194500_retry_already_reported_events.sql
+++ b/app/src/main/database/migrations/20260710194500_retry_already_reported_events.sql
@@ -1,0 +1,24 @@
+-- migrate:up
+-- Delay retries for destructive events that may still be processing on the
+-- server. The recorded delay lets selection detect a backward wall-clock jump.
+ALTER TABLE pending_events
+ADD COLUMN next_retry_at TIMESTAMP;
+ALTER TABLE pending_events
+ADD COLUMN retry_delay_seconds INTEGER;
+
+-- Release destructive events stranded by the previous permanent 208 filter.
+UPDATE pending_events
+SET next_retry_at = CURRENT_TIMESTAMP,
+    retry_delay_seconds = 0
+WHERE last_event_status = 208
+  AND type IN (
+    'item_deleted',
+    'source_deleted',
+    'source_conversation_truncated'
+  );
+
+-- migrate:down
+ALTER TABLE pending_events
+DROP COLUMN retry_delay_seconds;
+ALTER TABLE pending_events
+DROP COLUMN next_retry_at;

--- a/app/src/main/database/schema.sql
+++ b/app/src/main/database/schema.sql
@@ -38,7 +38,7 @@ CREATE TABLE pending_events (
     source_uuid TEXT REFERENCES sources(uuid) ON DELETE CASCADE,
     item_uuid TEXT REFERENCES items(uuid) ON DELETE CASCADE,
     type TEXT NOT NULL,
-    data JSON, retry_attempts INTEGER NOT NULL DEFAULT 0, last_event_status INTEGER,
+    data JSON, retry_attempts INTEGER NOT NULL DEFAULT 0, last_event_status INTEGER, next_retry_at TIMESTAMP, retry_delay_seconds INTEGER,
     CHECK (NOT (source_uuid IS NOT NULL AND item_uuid IS NOT NULL))
 );
 CREATE VIEW state AS
@@ -283,4 +283,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20260416000000'),
   ('20260507000000'),
   ('20260511000000'),
-  ('20260624000000');
+  ('20260624000000'),
+  ('20260710194500');

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -246,6 +246,31 @@ describe("Datastore Method Tests", () => {
     };
   }
 
+  type PendingEventRetryState = {
+    retry_attempts: number;
+    last_event_status: number | null;
+    next_retry_at: string | null;
+    retry_delay_seconds: number | null;
+  };
+
+  function pendingEventRetryState(eventId: string): PendingEventRetryState {
+    const row = db["db"]!.prepare(
+      `SELECT retry_attempts, last_event_status, next_retry_at,
+                retry_delay_seconds
+         FROM pending_events WHERE snowflake_id = ?`,
+    ).get(eventId) as PendingEventRetryState | undefined;
+    if (!row) {
+      throw new Error(`missing pending event ${eventId}`);
+    }
+    return row;
+  }
+
+  function makePendingEventDue(eventId: string): void {
+    db["db"]!.prepare(
+      "UPDATE pending_events SET next_retry_at = CURRENT_TIMESTAMP WHERE snowflake_id = ?",
+    ).run(eventId);
+  }
+
   it("getJournalistbyID should return the first matching journalist", () => {
     // Insert two Journalists
     db.updateJournalists({
@@ -1253,43 +1278,180 @@ describe("Datastore Method Tests", () => {
     expect(row.last_event_status).toBe(500);
   });
 
-  it("updatePendingEvents should retain but exclude AlreadyReported events", () => {
+  it("backs off repeated destructive AlreadyReported responses beyond 24 hours", () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),
     });
-    db.updateItems({
-      item1: mockItemMetadata("item1", "source1"),
+    const eventId = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.SourceDeleted,
+    )!;
+    const expectedDelays = [
+      60, 120, 240, 480, 960, 1_920, 3_840, 7_680, 14_400, 14_400, 14_400,
+      14_400, 14_400,
+    ];
+    let elapsedSeconds = 0;
+
+    for (const expectedDelay of expectedDelays) {
+      db.updatePendingEvents({ [eventId]: [208, null] });
+      const state = pendingEventRetryState(eventId);
+      expect(state.retry_delay_seconds).toBe(expectedDelay);
+      expect(db.getPendingEvents()).toEqual([]);
+      elapsedSeconds += expectedDelay;
+      makePendingEventDue(eventId);
+      expect(db.getPendingEvents().map((event) => event.id)).toEqual([eventId]);
+    }
+
+    expect(elapsedSeconds).toBe(87_300);
+    expect(pendingEventRetryState(eventId).retry_attempts).toBe(13);
+  });
+
+  it("releases an implausibly future retry after a backward clock jump", () => {
+    db.updateSources({
+      source1: mockSourceMetadata("source1"),
+    });
+    const eventId = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.SourceDeleted,
+    )!;
+    db.updatePendingEvents({ [eventId]: [208, null] });
+    expect(db.getPendingEvents()).toEqual([]);
+
+    db["db"]!.prepare(
+      "UPDATE pending_events SET next_retry_at = datetime('now', '+1 day') WHERE snowflake_id = ?",
+    ).run(eventId);
+
+    expect(db.getPendingEvents().map((event) => event.id)).toEqual([eventId]);
+  });
+
+  it("migrates stranded events and preserves deferred retries across restart", () => {
+    db.updateSources({ source1: mockSourceMetadata("source1") });
+    const eventId = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.SourceDeleted,
+    )!;
+    const rawDb = db["db"]!;
+    rawDb
+      .prepare(
+        "UPDATE pending_events SET last_event_status = 208 WHERE snowflake_id = ?",
+      )
+      .run(eventId);
+    rawDb
+      .prepare("DELETE FROM schema_migrations WHERE version = ?")
+      .run("20260710194500");
+    rawDb.exec("ALTER TABLE pending_events DROP COLUMN retry_delay_seconds");
+    rawDb.exec("ALTER TABLE pending_events DROP COLUMN next_retry_at");
+
+    db.close();
+    db = new Datastore(crypto, new Storage());
+
+    expect(pendingEventRetryState(eventId).retry_delay_seconds).toBe(0);
+    expect(db.getPendingEvents().map((event) => event.id)).toEqual([eventId]);
+    db.updatePendingEvents({ [eventId]: [208, null] });
+    const deferredState = pendingEventRetryState(eventId);
+    expect(deferredState.retry_delay_seconds).toBe(60);
+    expect(db.getPendingEvents()).toEqual([]);
+
+    db.close();
+    db = new Datastore(crypto, new Storage());
+
+    expect(pendingEventRetryState(eventId)).toEqual(deferredState);
+    expect(db.getPendingEvents()).toEqual([]);
+  });
+
+  it("clears deferral through 500 to 200 and removes Gone events", () => {
+    db.updateSources({
+      source1: mockSourceMetadata("source1"),
+      source2: mockSourceMetadata("source2"),
+    });
+    const successEventId = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.SourceDeleted,
+    )!;
+    const goneEventId = db.addPendingSourceEvent(
+      "source2",
+      PendingEventType.SourceDeleted,
+    )!;
+
+    db.updatePendingEvents({
+      [successEventId]: [208, null],
+      [goneEventId]: [208, null],
+    });
+    makePendingEventDue(successEventId);
+    makePendingEventDue(goneEventId);
+    db.updatePendingEvents({
+      [successEventId]: [500, "failed to process event"],
+      [goneEventId]: [410, null],
     });
 
-    const snowflakeSource = db.addPendingSourceEvent(
-      "source1",
+    expect(pendingEventRetryState(successEventId)).toMatchObject({
+      retry_attempts: 2,
+      last_event_status: 500,
+      next_retry_at: null,
+      retry_delay_seconds: null,
+    });
+    expect(db.getPendingEvents().map((event) => event.id)).toEqual([
+      successEventId,
+    ]);
+    expect(() => pendingEventRetryState(goneEventId)).toThrow(
+      `missing pending event ${goneEventId}`,
+    );
+
+    db.updateBatch({
+      sources: { source1: null },
+      items: {},
+      journalists: {},
+      events: { [successEventId]: [200, null] },
+    });
+    expect(db.getPendingEvents()).toEqual([]);
+  });
+
+  it("selects fresh and failed events around deferred 208 responses", () => {
+    db.updateSources({
+      failed: mockSourceMetadata("failed"),
+      destructive: mockSourceMetadata("destructive"),
+      suppressed: mockSourceMetadata("suppressed"),
+      fresh: mockSourceMetadata("fresh"),
+    });
+    const failedId = db.addPendingSourceEvent(
+      "failed",
       PendingEventType.Starred,
     )!;
-    const snowflakeItem = db.addPendingItemEvent(
-      "item1",
-      PendingEventType.ItemDeleted,
+    const destructiveId = db.addPendingSourceEvent(
+      "destructive",
+      PendingEventType.SourceDeleted,
+    )!;
+    const suppressedId = db.addPendingSourceEvent(
+      "suppressed",
+      PendingEventType.Starred,
+    )!;
+    const freshId = db.addPendingSourceEvent(
+      "fresh",
+      PendingEventType.Unstarred,
     )!;
 
-    // The server reports the source event as already reported + accepted (208),
-    // and the item event as not yet accepted (500).
     db.updatePendingEvents({
-      [snowflakeSource.toString()]: [208, null],
-      [snowflakeItem.toString()]: [500, "error"],
+      [failedId]: [500, "failed"],
+      [destructiveId]: [208, null],
+      [suppressedId]: [208, null],
     });
 
-    // The AlreadyReported event must be excluded from future sync batches
-    const events = db.getPendingEvents();
-    expect(events.map((e) => e.id)).toEqual([snowflakeItem]);
-
-    // but event should be retained in the table to preserve projection state
-    // with the status recorded
-    const row = (db as any).db
-      .prepare(
-        "SELECT last_event_status FROM pending_events WHERE snowflake_id = ?",
-      )
-      .get(snowflakeSource.toString());
-    expect(row).toBeDefined();
-    expect(row.last_event_status).toBe(208);
+    expect(db.getPendingEvents().map((event) => event.id)).toEqual([
+      freshId,
+      failedId,
+    ]);
+    makePendingEventDue(destructiveId);
+    expect(db.getPendingEvents().map((event) => event.id)).toEqual([
+      freshId,
+      failedId,
+      destructiveId,
+    ]);
+    expect(pendingEventRetryState(suppressedId)).toMatchObject({
+      retry_attempts: 0,
+      last_event_status: 208,
+      next_retry_at: null,
+      retry_delay_seconds: null,
+    });
   });
 
   it("updateItems should upsert items with conflicting uuid", () => {

--- a/app/src/main/sync/alreadyReported.test.ts
+++ b/app/src/main/sync/alreadyReported.test.ts
@@ -1,0 +1,189 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  MockInstance,
+  vi,
+} from "vitest";
+
+import { Crypto } from "../crypto";
+import { Datastore } from "../datastore";
+import * as proxyModule from "../proxy";
+import { Storage } from "../storage";
+import { syncMetadata } from ".";
+import {
+  BatchResponse,
+  ItemMetadata,
+  PendingEventType,
+  SourceMetadata,
+} from "../../types";
+
+const SOURCE_UUID = "550e8400-e29b-41d4-a716-446655440001";
+const ITEM_UUID = "660e8400-e29b-41d4-a716-446655440001";
+const IDEMPOTENCE_PERIOD_SECONDS = 24 * 60 * 60;
+
+type PendingEventRetryState = {
+  retry_attempts: number;
+  retry_delay_seconds: number;
+};
+
+function sourceMetadata(): SourceMetadata {
+  return {
+    uuid: SOURCE_UUID,
+    journalist_designation: "source alpha",
+    is_starred: false,
+    is_seen: false,
+    has_attachment: true,
+    last_updated: "2026-07-07T00:00:00Z",
+    public_key: "fake-key",
+    fingerprint: "fake-fingerprint",
+  };
+}
+
+function itemMetadata(): ItemMetadata {
+  return {
+    uuid: ITEM_UUID,
+    source: SOURCE_UUID,
+    kind: "message",
+    size: 42,
+    is_read: false,
+    seen_by: [],
+    interaction_count: 1,
+  };
+}
+
+function responseWithStatus(eventId: string, status: number): BatchResponse {
+  return {
+    sources: {},
+    items: {},
+    journalists: {},
+    events: { [eventId]: [status, null] },
+  };
+}
+
+function queueSyncResponse(
+  proxyMock: MockInstance,
+  batchResponse: BatchResponse,
+): void {
+  proxyMock
+    .mockResolvedValueOnce({
+      status: 304,
+      error: false,
+      data: null,
+      headers: new Map(),
+    })
+    .mockResolvedValueOnce({
+      status: 200,
+      error: false,
+      data: batchResponse,
+      headers: new Map(),
+    });
+}
+
+describe("AlreadyReported sync retry", () => {
+  let crypto: Crypto;
+  let db: Datastore;
+  let testHome: string;
+
+  beforeAll(() => {
+    (Crypto as any).instance = undefined;
+    crypto = Crypto.initialize({
+      isQubes: false,
+      submissionKeyFingerprint: "",
+    });
+  });
+
+  beforeEach(() => {
+    testHome = fs.mkdtempSync(path.join(os.tmpdir(), "already-reported-sync-"));
+    vi.spyOn(os, "homedir").mockReturnValue(testHome);
+    db = new Datastore(crypto, new Storage(), path.join(testHome, "database"));
+    db.updateSources({ [SOURCE_UUID]: sourceMetadata() });
+    db.updateItems({ [ITEM_UUID]: itemMetadata() });
+  });
+
+  afterEach(() => {
+    db.close();
+    vi.restoreAllMocks();
+    fs.rmSync(testHome, { recursive: true, force: true });
+  });
+
+  it("reuses the event ID through the completed-key retention period", async () => {
+    const eventId = db.addPendingSourceEvent(
+      SOURCE_UUID,
+      PendingEventType.SourceDeleted,
+    )!;
+    const proxyMock = vi.spyOn(proxyModule, "proxyJSONRequest");
+    const observedDelays: number[] = [];
+    let elapsedSeconds = 0;
+
+    while (elapsedSeconds <= IDEMPOTENCE_PERIOD_SECONDS) {
+      queueSyncResponse(proxyMock, responseWithStatus(eventId, 208));
+      await syncMetadata(db, "token");
+
+      const state = db["db"]!.prepare(
+        `SELECT retry_attempts, retry_delay_seconds
+           FROM pending_events WHERE snowflake_id = ?`,
+      ).get(eventId) as PendingEventRetryState;
+      observedDelays.push(state.retry_delay_seconds);
+      elapsedSeconds += state.retry_delay_seconds;
+      expect(db.getPendingEvents()).toEqual([]);
+      db["db"]!.prepare(
+        "UPDATE pending_events SET next_retry_at = CURRENT_TIMESTAMP WHERE snowflake_id = ?",
+      ).run(eventId);
+    }
+
+    expect(observedDelays).toEqual([
+      60, 120, 240, 480, 960, 1_920, 3_840, 7_680, 14_400, 14_400, 14_400,
+      14_400, 14_400,
+    ]);
+    expect(elapsedSeconds).toBe(87_300);
+
+    queueSyncResponse(proxyMock, responseWithStatus(eventId, 410));
+    await syncMetadata(db, "token");
+
+    const submittedIds = proxyMock.mock.calls
+      .filter(([request]) => request.path_query === "/api/v2/data")
+      .map(([request]) => JSON.parse(request.body!).events[0]?.id)
+      .filter((id) => id !== undefined);
+    expect(submittedIds).toHaveLength(14);
+    expect(new Set(submittedIds)).toEqual(new Set([eventId]));
+    expect(db.getPendingEvents()).toEqual([]);
+    expect(db.getSources().size).toBe(1);
+
+    proxyMock
+      .mockResolvedValueOnce({
+        status: 200,
+        error: false,
+        data: { sources: {}, items: {}, journalists: {} },
+        headers: new Map(),
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        error: false,
+        data: { sources: {}, items: {}, journalists: {}, events: {} },
+        headers: new Map(),
+      });
+    await syncMetadata(db, "token");
+
+    expect(
+      (
+        db["db"]!.prepare("SELECT COUNT(*) AS count FROM sources").get() as {
+          count: number;
+        }
+      ).count,
+    ).toBe(0);
+    expect(
+      (
+        db["db"]!.prepare("SELECT COUNT(*) AS count FROM items").get() as {
+          count: number;
+        }
+      ).count,
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- retry destructive events that receive `208 AlreadyReported` with the same ID
- persist bounded exponential backoff and recover from backward clock changes
- migrate destructive events stranded by the previous permanent suppression

## Context

Refs https://github.com/freedomofpress/securedrop-client/issues/3568.

This builds on the pending-event status handling introduced in #3540 while
preserving suppression for non-destructive event types.

## Test plan

```sh
cd app
pnpm exec vitest run --config vitest.config.ts --project=unit \
  src/main/sync/alreadyReported.test.ts src/main/sync/index.test.ts \
  src/main/datastore.test.ts
```

Observed: 95 tests passed.

```sh
cd app
tmp_home=$(mktemp -d)
HOME="$tmp_home" pnpm run dbmate:check
```

Observed: all migrations applied and the generated schema matched.

```sh
cd app
pnpm lint
git diff --check origin/main...HEAD
```

Observed: formatting, ESLint, both TypeScript checks, and the diff check passed.

## Notes

API2 returns `208` for both processing and completed idempotence keys and keeps
successful keys for 24 hours. The backoff schedule spans that window with 13
requests, capped at four hours, and retries only destructive handlers whose
same-ID replay was verified as idempotent. Qubes testing was not run locally.

## Checklist

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
