### PR TITLE
fix(sync): back off failed pending events

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -41,6 +41,11 @@ import { Search } from "./search";
 export const MESSAGE_PREVIEW_LENGTH = 200;
 const DEFAULT_ITEM_LIMIT = 100;
 export const DEFAULT_PENDING_EVENTS_LIMIT = 20;
+export const PENDING_EVENT_RETRY_BASE_SECONDS = 60;
+export const PENDING_EVENT_RETRY_MAX_SECONDS = 60 * 60;
+const PENDING_EVENT_RETRY_MAX_EXPONENT = Math.ceil(
+  Math.log2(PENDING_EVENT_RETRY_MAX_SECONDS / PENDING_EVENT_RETRY_BASE_SECONDS),
+);
 
 interface KeyObject {
   [key: string]: object;
@@ -189,8 +194,8 @@ export class DB {
     { count: number }
   >;
   private deletePendingEvent: Statement<{ snowflake_id: string }, void>;
-  private incrementPendingEventRetry: Statement<
-    { snowflake_id: string; status: number },
+  private schedulePendingEventRetry: Statement<
+    { snowflake_id: string; status: number | null },
     void
   >;
   private setPendingEventStatus: Statement<
@@ -427,9 +432,15 @@ export class DB {
     this.deletePendingEvent = this.db.prepare(
       `DELETE FROM pending_events WHERE snowflake_id = @snowflake_id`,
     );
-    this.incrementPendingEventRetry = this.db.prepare(`
+    this.schedulePendingEventRetry = this.db.prepare(`
       UPDATE pending_events
-      SET retry_attempts = retry_attempts + 1, last_event_status = @status
+      SET retry_attempts = retry_attempts + 1,
+          last_event_status = COALESCE(@status, last_event_status),
+          next_retry_at = unixepoch() + CASE
+            WHEN retry_attempts >= ${PENDING_EVENT_RETRY_MAX_EXPONENT}
+              THEN ${PENDING_EVENT_RETRY_MAX_SECONDS}
+            ELSE ${PENDING_EVENT_RETRY_BASE_SECONDS} * (1 << retry_attempts)
+          END
       WHERE snowflake_id = @snowflake_id
     `);
     this.setPendingEventStatus = this.db.prepare(`
@@ -437,11 +448,15 @@ export class DB {
       SET last_event_status = @status
       WHERE snowflake_id = @snowflake_id
     `);
-    // Schedule previously-failed events later, and exclude events already reported
-    // and accepted on the server that are just awaiting completion.
+    // Deadlines beyond one maximum backoff window indicate that the wall clock
+    // moved backward. Treat them as due so retries cannot be deferred forever.
     this.selectPendingEvents = this.db.prepare(`
       SELECT snowflake_id, source_uuid, item_uuid, type, data FROM pending_events
       WHERE last_event_status IS NOT ${EventStatus.AlreadyReported}
+        AND (
+          next_retry_at <= unixepoch()
+          OR next_retry_at > unixepoch() + ${PENDING_EVENT_RETRY_MAX_SECONDS}
+        )
       ORDER BY retry_attempts ASC, snowflake_id ASC LIMIT @limit
     `);
     this.deletePendingEventsBySourceScope = this.db.prepare(`
@@ -669,18 +684,23 @@ export class DB {
     })(journalists);
   }
 
-  protected updateBatch(batchResponse: BatchResponse): {
+  protected updateBatch(
+    batchResponse: BatchResponse,
+    submittedEvents: PendingEvent[],
+  ): {
     deleted_items: Item[];
     deleted_sources: string[];
   } {
-    return this.db!.transaction((batch: BatchResponse) => {
-      this.updatePendingEvents(batch.events);
-      const deleted_items = this.updateItems(batch.items);
-      const deleted_sources = this.updateSources(batch.sources);
-      this.updateJournalists(batch.journalists);
-      this.updateVersion();
-      return { deleted_items, deleted_sources };
-    })(batchResponse);
+    return this.db!.transaction(
+      (batch: BatchResponse, submitted: PendingEvent[]) => {
+        this.updatePendingEvents(batch.events, submitted);
+        const deleted_items = this.updateItems(batch.items);
+        const deleted_sources = this.updateSources(batch.sources);
+        this.updateJournalists(batch.journalists);
+        this.updateVersion();
+        return { deleted_items, deleted_sources };
+      },
+    )(batchResponse, submittedEvents);
   }
 
   protected updateSources(sources: {
@@ -1350,15 +1370,23 @@ export class DB {
   // Takes pending events and their statuses from the server and applies
   // pending event updates as needed.
   // Should be run within a transaction that also updates index version.
-  updatePendingEvents(events: {
-    [snowflake_id: string]: [number, string | null];
-  }) {
-    // Remove successfully applied pending events. On failure, retain them in the
-    // pending events table for resubmission on next sync
+  updatePendingEvents(
+    events: { [snowflake_id: string]: [number, string | null] },
+    submittedEvents: PendingEvent[],
+  ) {
+    // Reconcile only the submitted snapshot. Missing statuses are failures, and
+    // response-only IDs are ignored so they cannot mutate unsent local rows.
     const appliedEventIDs: string[] = [];
     const eventIDsToRemove: string[] = [];
-    Object.keys(events).forEach((snowflake_id: string) => {
-      const result = events[snowflake_id][0];
+    for (const submittedEvent of submittedEvents) {
+      const snowflake_id = submittedEvent.id;
+      const response = events[snowflake_id];
+      if (response === undefined) {
+        this.schedulePendingEventRetry.run({ snowflake_id, status: null });
+        continue;
+      }
+
+      const result = response[0];
       if (result === EventStatus.OK) {
         // Event has been accepted by the server: apply + remove from pending_events
         appliedEventIDs.push(snowflake_id);
@@ -1374,9 +1402,9 @@ export class DB {
         // All other statuses indicate event was submitted but not accepted
         // Retain and bump the retry counter, recording the status.
         // This event will be re-scheduled in subsequent batches.
-        this.incrementPendingEventRetry.run({ snowflake_id, status: result });
+        this.schedulePendingEventRetry.run({ snowflake_id, status: result });
       }
-    });
+    }
 
     for (const eventID of eventIDsToRemove) {
       this.deletePendingEvent.run({ snowflake_id: eventID });

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -46,6 +46,11 @@ export const PENDING_EVENT_RETRY_MAX_SECONDS = 60 * 60;
 const PENDING_EVENT_RETRY_MAX_EXPONENT = Math.ceil(
   Math.log2(PENDING_EVENT_RETRY_MAX_SECONDS / PENDING_EVENT_RETRY_BASE_SECONDS),
 );
+const PENDING_EVENT_RETRY_PARAMS = {
+  base_seconds: PENDING_EVENT_RETRY_BASE_SECONDS,
+  max_exponent: PENDING_EVENT_RETRY_MAX_EXPONENT,
+  max_seconds: PENDING_EVENT_RETRY_MAX_SECONDS,
+};
 
 interface KeyObject {
   [key: string]: object;
@@ -195,7 +200,13 @@ export class DB {
   >;
   private deletePendingEvent: Statement<{ snowflake_id: string }, void>;
   private schedulePendingEventRetry: Statement<
-    { snowflake_id: string; status: number | null },
+    {
+      snowflake_id: string;
+      status: number | null;
+      base_seconds: number;
+      max_exponent: number;
+      max_seconds: number;
+    },
     void
   >;
   private setPendingEventStatus: Statement<
@@ -437,9 +448,9 @@ export class DB {
       SET retry_attempts = retry_attempts + 1,
           last_event_status = COALESCE(@status, last_event_status),
           next_retry_at = unixepoch() + CASE
-            WHEN retry_attempts >= ${PENDING_EVENT_RETRY_MAX_EXPONENT}
-              THEN ${PENDING_EVENT_RETRY_MAX_SECONDS}
-            ELSE ${PENDING_EVENT_RETRY_BASE_SECONDS} * (1 << retry_attempts)
+            WHEN retry_attempts >= @max_exponent
+              THEN @max_seconds
+            ELSE @base_seconds * (1 << retry_attempts)
           END
       WHERE snowflake_id = @snowflake_id
     `);
@@ -1367,6 +1378,14 @@ export class DB {
     return pendingEvents;
   }
 
+  private scheduleRetry(snowflake_id: string, status: number | null) {
+    this.schedulePendingEventRetry.run({
+      snowflake_id,
+      status,
+      ...PENDING_EVENT_RETRY_PARAMS,
+    });
+  }
+
   // Takes pending events and their statuses from the server and applies
   // pending event updates as needed.
   // Should be run within a transaction that also updates index version.
@@ -1382,7 +1401,7 @@ export class DB {
       const snowflake_id = submittedEvent.id;
       const response = events[snowflake_id];
       if (response === undefined) {
-        this.schedulePendingEventRetry.run({ snowflake_id, status: null });
+        this.scheduleRetry(snowflake_id, null);
         continue;
       }
 
@@ -1402,7 +1421,7 @@ export class DB {
         // All other statuses indicate event was submitted but not accepted
         // Retain and bump the retry counter, recording the status.
         // This event will be re-scheduled in subsequent batches.
-        this.schedulePendingEventRetry.run({ snowflake_id, status: result });
+        this.scheduleRetry(snowflake_id, result);
       }
     }
 

--- a/app/src/main/database/migrations/20260710000000_pending_event_retry_backoff.sql
+++ b/app/src/main/database/migrations/20260710000000_pending_event_retry_backoff.sql
@@ -1,0 +1,8 @@
+-- migrate:up
+-- Persist when a failed pending event becomes eligible for another attempt.
+ALTER TABLE pending_events
+ADD COLUMN next_retry_at INTEGER NOT NULL DEFAULT 0;
+
+-- migrate:down
+ALTER TABLE pending_events
+DROP COLUMN next_retry_at;

--- a/app/src/main/database/schema.sql
+++ b/app/src/main/database/schema.sql
@@ -38,7 +38,7 @@ CREATE TABLE pending_events (
     source_uuid TEXT REFERENCES sources(uuid) ON DELETE CASCADE,
     item_uuid TEXT REFERENCES items(uuid) ON DELETE CASCADE,
     type TEXT NOT NULL,
-    data JSON, retry_attempts INTEGER NOT NULL DEFAULT 0, last_event_status INTEGER,
+    data JSON, retry_attempts INTEGER NOT NULL DEFAULT 0, last_event_status INTEGER, next_retry_at INTEGER NOT NULL DEFAULT 0,
     CHECK (NOT (source_uuid IS NOT NULL AND item_uuid IS NOT NULL))
 );
 CREATE VIEW state AS
@@ -283,4 +283,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20260416000000'),
   ('20260507000000'),
   ('20260511000000'),
-  ('20260624000000');
+  ('20260624000000'),
+  ('20260710000000');

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -14,7 +14,11 @@ import {
 import { Crypto } from "./crypto";
 import { Datastore } from "./datastore";
 import { Storage } from "./storage";
-import { MESSAGE_PREVIEW_LENGTH } from "./database";
+import {
+  MESSAGE_PREVIEW_LENGTH,
+  PENDING_EVENT_RETRY_BASE_SECONDS,
+  PENDING_EVENT_RETRY_MAX_SECONDS,
+} from "./database";
 import { setUmask } from "./umask";
 
 describe("DB Component Tests", () => {
@@ -1143,20 +1147,23 @@ describe("Datastore Method Tests", () => {
     expect(remainingItemEvent!.target).toHaveProperty("item_uuid", "item3");
   });
 
-  it("updatePendingEvents should remove successful events from pending_events", () => {
+  it("updatePendingEvents should remove successful and gone events", () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),
     });
     db.updateItems({
       item1: mockItemMetadata("item1", "source1"),
+      item2: mockItemMetadata("item2", "source1"),
     });
 
     // Verify source and item exist
     const sourceWithItems = db.getSourceWithItems("source1");
     expect(sourceWithItems).toBeDefined();
     expect(sourceWithItems.uuid).toEqual("source1");
-    expect(sourceWithItems.items.length).toBe(1);
-    expect(sourceWithItems.items[0].uuid).toBe("item1");
+    expect(sourceWithItems.items.map((item) => item.uuid).sort()).toEqual([
+      "item1",
+      "item2",
+    ]);
 
     const snowflakeSource = db.addPendingSourceEvent(
       "source1",
@@ -1166,28 +1173,38 @@ describe("Datastore Method Tests", () => {
       "item1",
       PendingEventType.ItemDeleted,
     )!;
+    const snowflakeGone = db.addPendingItemEvent(
+      "item2",
+      PendingEventType.ItemDeleted,
+    )!;
 
-    // Before update, both events are present
+    // Before update, all events are present
     let events = db.getPendingEvents();
-    expect(events.length).toBe(2);
+    expect(events.length).toBe(3);
 
-    // Simulate server response: both events succeeded (HTTP 200)
-    db.updatePendingEvents({
-      [snowflakeSource.toString()]: [200, ""],
-      [snowflakeItem.toString()]: [200, ""],
-    });
+    // HTTP 200 applies the event; HTTP 410 removes the stale event.
+    db.updatePendingEvents(
+      {
+        [snowflakeSource.toString()]: [200, ""],
+        [snowflakeItem.toString()]: [200, ""],
+        [snowflakeGone.toString()]: [410, "gone"],
+      },
+      events,
+    );
 
     // After update, no pending events should remain
     events = db.getPendingEvents();
     expect(events.length).toBe(0);
   });
 
-  it("updatePendingEvents should retain failed events", () => {
+  it("updatePendingEvents should defer failed events and leave new events due", () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),
     });
     db.updateItems({
       item1: mockItemMetadata("item1", "source1"),
+      item2: mockItemMetadata("item2", "source1"),
+      item3: mockItemMetadata("item3", "source1"),
     });
 
     const snowflakeSource = db.addPendingSourceEvent(
@@ -1198,59 +1215,179 @@ describe("Datastore Method Tests", () => {
       "item1",
       PendingEventType.ItemDeleted,
     )!;
+    const snowflakeItem2 = db.addPendingItemEvent(
+      "item2",
+      PendingEventType.ItemDeleted,
+    )!;
+    const newEvent = db.addPendingItemEvent(
+      "item3",
+      PendingEventType.ItemDeleted,
+    )!;
 
-    // Simulate server response: only one event succeeded
-    db.updatePendingEvents({
-      [snowflakeSource.toString()]: [200, ""],
-      [snowflakeItem.toString()]: [500, "error"], // failed
-    });
+    const submittedEventIds = new Set([
+      snowflakeSource,
+      snowflakeItem,
+      snowflakeItem2,
+    ]);
+    const submittedEvents = db
+      .getPendingEvents()
+      .filter((event) => submittedEventIds.has(event.id));
+    db.updatePendingEvents(
+      {
+        [snowflakeSource.toString()]: [400, "bad request"],
+        [snowflakeItem.toString()]: [409, "conflict"],
+        [snowflakeItem2.toString()]: [500, "server error"],
+      },
+      submittedEvents,
+    );
 
     const events = db.getPendingEvents();
-    expect(events.length).toBe(1);
-    expect(events[0].id).toBe(snowflakeItem);
-    expect(events[0].type).toBe(PendingEventType.ItemDeleted);
+    expect(events.map((event) => event.id)).toEqual([newEvent]);
+
+    const rows = (db as any).db
+      .prepare(
+        `SELECT retry_attempts, last_event_status,
+                next_retry_at - unixepoch() AS retry_delay
+         FROM pending_events
+         WHERE snowflake_id IN (?, ?, ?)
+         ORDER BY last_event_status`,
+      )
+      .all(snowflakeSource, snowflakeItem, snowflakeItem2) as Array<{
+      retry_attempts: number;
+      last_event_status: number;
+      retry_delay: number;
+    }>;
+    expect(rows.map((row) => row.last_event_status)).toEqual([400, 409, 500]);
+    for (const row of rows) {
+      expect(row.retry_attempts).toBe(1);
+      expect(row.retry_delay).toBeGreaterThanOrEqual(
+        PENDING_EVENT_RETRY_BASE_SECONDS - 1,
+      );
+      expect(row.retry_delay).toBeLessThanOrEqual(
+        PENDING_EVENT_RETRY_BASE_SECONDS,
+      );
+    }
   });
 
-  it("updatePendingEvents should bump retry_attempts so failed events are scheduled later", () => {
+  it("updatePendingEvents should exponentially back off retries up to the cap", () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),
     });
-    db.updateItems({
-      item1: mockItemMetadata("item1", "source1"),
-    });
-
-    // snowflakeSource is created first, so it sorts before snowflakeItem by
-    // snowflake_id.
-    const snowflakeSource = db.addPendingSourceEvent(
+    const eventId = db.addPendingSourceEvent(
       "source1",
       PendingEventType.Starred,
     )!;
-    const snowflakeItem = db.addPendingItemEvent(
-      "item1",
-      PendingEventType.ItemDeleted,
+    const expectedDelays = [60, 120, 240, 480, 960, 1920, 3600, 3600];
+
+    for (const [attempt, expectedDelay] of expectedDelays.entries()) {
+      (db as any).db
+        .prepare(
+          "UPDATE pending_events SET next_retry_at = 0 WHERE snowflake_id = ?",
+        )
+        .run(eventId);
+      db.updatePendingEvents(
+        { [eventId]: [500, "error"] },
+        db.getPendingEvents(),
+      );
+
+      const row = (db as any).db
+        .prepare(
+          `SELECT retry_attempts, last_event_status,
+                  next_retry_at - unixepoch() AS retry_delay
+           FROM pending_events WHERE snowflake_id = ?`,
+        )
+        .get(eventId) as {
+        retry_attempts: number;
+        last_event_status: number;
+        retry_delay: number;
+      };
+      expect(row.retry_attempts).toBe(attempt + 1);
+      expect(row.last_event_status).toBe(500);
+      expect(row.retry_delay).toBeGreaterThanOrEqual(expectedDelay - 1);
+      expect(row.retry_delay).toBeLessThanOrEqual(expectedDelay);
+      expect(db.getPendingEvents()).toEqual([]);
+    }
+  });
+
+  it("persists retry scheduling across restart and removes a later success", () => {
+    db.updateSources({ source1: mockSourceMetadata("source1") });
+    const eventId = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.Starred,
     )!;
+    db.updatePendingEvents(
+      { [eventId]: [500, "error"] },
+      db.getPendingEvents(),
+    );
+    expect(db.getPendingEvents()).toEqual([]);
 
-    // With equal retry_attempts, ordering falls back to snowflake_id ascending.
-    let events = db.getPendingEvents();
-    expect(events.map((e) => e.id)).toEqual([snowflakeSource, snowflakeItem]);
+    db.close();
+    db = new Datastore(crypto, new Storage());
+    expect(db.getPendingEvents()).toEqual([]);
 
-    // The earlier (source) event fails to be accepted, bumping its retry count.
-    db.updatePendingEvents({
-      [snowflakeSource.toString()]: [500, "error"],
+    (db as any).db
+      .prepare(
+        "UPDATE pending_events SET next_retry_at = 0 WHERE snowflake_id = ?",
+      )
+      .run(eventId);
+    expect(db.getPendingEvents().map((event) => event.id)).toEqual([eventId]);
+
+    db.updatePendingEvents({ [eventId]: [200, null] }, db.getPendingEvents());
+    expect(
+      (db as any).db
+        .prepare("SELECT 1 FROM pending_events WHERE snowflake_id = ?")
+        .get(eventId),
+    ).toBeUndefined();
+  });
+
+  it("rolls back an omitted-status retry when the batch update fails", () => {
+    db.updateSources({ source1: mockSourceMetadata("source1") });
+    const eventId = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.Starred,
+    )!;
+    const submittedEvents = db.getPendingEvents();
+    vi.spyOn(db, "updateSources").mockImplementationOnce(() => {
+      throw new Error("metadata update failed");
     });
 
-    // Should now be scheduled after the never-failed item event.
-    events = db.getPendingEvents();
-    expect(events.map((e) => e.id)).toEqual([snowflakeItem, snowflakeSource]);
+    expect(() =>
+      db.updateBatch(
+        { sources: {}, items: {}, journalists: {}, events: {} },
+        submittedEvents,
+      ),
+    ).toThrow("metadata update failed");
 
-    // Verify the counter and last status were persisted.
     const row = (db as any).db
       .prepare(
-        "SELECT retry_attempts, last_event_status FROM pending_events WHERE snowflake_id = ?",
+        `SELECT retry_attempts, last_event_status, next_retry_at
+         FROM pending_events WHERE snowflake_id = ?`,
       )
-      .get(snowflakeSource.toString());
-    expect(row.retry_attempts).toBe(1);
-    expect(row.last_event_status).toBe(500);
+      .get(eventId);
+    expect(row).toEqual({
+      retry_attempts: 0,
+      last_event_status: null,
+      next_retry_at: 0,
+    });
+  });
+
+  it("treats a deadline beyond the maximum backoff as due", () => {
+    db.updateSources({ source1: mockSourceMetadata("source1") });
+    const eventId = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.Starred,
+    )!;
+    (db as any).db
+      .prepare(
+        `UPDATE pending_events
+         SET retry_attempts = 1,
+             last_event_status = 500,
+             next_retry_at = unixepoch() + ?
+         WHERE snowflake_id = ?`,
+      )
+      .run(PENDING_EVENT_RETRY_MAX_SECONDS + 60, eventId);
+
+    expect(db.getPendingEvents().map((event) => event.id)).toEqual([eventId]);
   });
 
   it("updatePendingEvents should retain but exclude AlreadyReported events", () => {
@@ -1272,14 +1409,17 @@ describe("Datastore Method Tests", () => {
 
     // The server reports the source event as already reported + accepted (208),
     // and the item event as not yet accepted (500).
-    db.updatePendingEvents({
-      [snowflakeSource.toString()]: [208, null],
-      [snowflakeItem.toString()]: [500, "error"],
-    });
+    db.updatePendingEvents(
+      {
+        [snowflakeSource.toString()]: [208, null],
+        [snowflakeItem.toString()]: [500, "error"],
+      },
+      db.getPendingEvents(),
+    );
 
-    // The AlreadyReported event must be excluded from future sync batches
+    // Both the AlreadyReported and not-yet-due failed event are excluded.
     const events = db.getPendingEvents();
-    expect(events.map((e) => e.id)).toEqual([snowflakeItem]);
+    expect(events).toEqual([]);
 
     // but event should be retained in the table to preserve projection state
     // with the status recorded
@@ -1290,6 +1430,13 @@ describe("Datastore Method Tests", () => {
       .get(snowflakeSource.toString());
     expect(row).toBeDefined();
     expect(row.last_event_status).toBe(208);
+
+    const failedRow = (db as any).db
+      .prepare(
+        "SELECT retry_attempts, last_event_status FROM pending_events WHERE snowflake_id = ?",
+      )
+      .get(snowflakeItem.toString());
+    expect(failedRow).toEqual({ retry_attempts: 1, last_event_status: 500 });
   });
 
   it("updateItems should upsert items with conflicting uuid", () => {

--- a/app/src/main/datastore.ts
+++ b/app/src/main/datastore.ts
@@ -5,6 +5,7 @@ import {
   Item,
   ItemMetadata,
   JournalistMetadata,
+  PendingEvent,
   SourceMetadata,
 } from "../types";
 import { Crypto } from "./crypto";
@@ -71,12 +72,15 @@ export class Datastore extends DB {
     super.updateJournalists(journalists);
   }
 
-  override updateBatch(batchResponse: BatchResponse): {
+  override updateBatch(
+    batchResponse: BatchResponse,
+    submittedEvents: PendingEvent[],
+  ): {
     deleted_items: Item[];
     deleted_sources: string[];
   } {
     // Perform all DB updates
-    const result = super.updateBatch(batchResponse);
+    const result = super.updateBatch(batchResponse, submittedEvents);
     // Perform all filesystem cleanups as necessary
     for (const item of result.deleted_items) {
       void this.storage.deleteItemFs(item);

--- a/app/src/main/sync/index.test.ts
+++ b/app/src/main/sync/index.test.ts
@@ -76,7 +76,7 @@ function mockDB({
       }
     }),
     deleteJournalists: vi.fn(),
-    updateBatch: vi.fn((_metadata) => ({
+    updateBatch: vi.fn((_metadata, _submittedEvents) => ({
       deleted_items: [],
       deleted_sources: [],
     })),
@@ -203,7 +203,7 @@ describe("syncMetadata", () => {
 
     expect(proxyMock).toHaveBeenCalledTimes(2);
     // Should update sources and items with new data
-    expect(db.updateBatch).toHaveBeenCalledWith(batch);
+    expect(db.updateBatch).toHaveBeenCalledWith(batch, []);
   });
 
   it("passes estimated timeouts to proxyJSONRequest", async () => {
@@ -468,7 +468,7 @@ describe("syncMetadata", () => {
 
     expect(proxyMock).toHaveBeenCalledTimes(2);
     expect(db.deleteItemsAsync).toHaveBeenCalledWith([ITEM_UUID_2]);
-    expect(db.updateBatch).toHaveBeenCalledWith(metadata);
+    expect(db.updateBatch).toHaveBeenCalledWith(metadata, []);
     expect(fs.promises.rm).toHaveBeenCalledTimes(1);
     expect(fs.promises.rm).toHaveBeenCalledWith(
       `/mock-home/.config/SecureDrop/files/${SOURCE_UUID_1}/${ITEM_UUID_2}/`,
@@ -550,7 +550,7 @@ describe("syncMetadata", () => {
     await syncModule.syncMetadata(db, "");
 
     expect(proxyMock).toHaveBeenCalledTimes(2);
-    expect(db.updateBatch).toHaveBeenCalledWith(metadata);
+    expect(db.updateBatch).toHaveBeenCalledWith(metadata, []);
   });
 
   it("deletes sources on sync + updates source delta", async () => {
@@ -596,12 +596,15 @@ describe("syncMetadata", () => {
 
     expect(proxyMock).toHaveBeenCalledTimes(2);
     expect(db.deleteSourcesAsync).toHaveBeenCalledWith([SOURCE_UUID_2]);
-    expect(db.updateBatch).toHaveBeenCalledWith({
-      items: {},
-      sources: {},
-      journalists: {},
-      events: {},
-    });
+    expect(db.updateBatch).toHaveBeenCalledWith(
+      {
+        items: {},
+        sources: {},
+        journalists: {},
+        events: {},
+      },
+      [],
+    );
   });
 
   it("deletes source directory from filesystem when source is deleted on server", async () => {
@@ -698,7 +701,7 @@ describe("syncMetadata", () => {
     // The batch request should include the pending events
     const batchRequestArg = proxyMock.mock.calls[1][0];
     expect(JSON.parse(batchRequestArg.body!).events).toEqual(pendingEvents);
-    expect(db.updateBatch).toHaveBeenCalledWith(batch);
+    expect(db.updateBatch).toHaveBeenCalledWith(batch, pendingEvents);
     expect(status).toBe(SyncStatus.UPDATED);
   });
 
@@ -780,7 +783,7 @@ describe("syncMetadata", () => {
     const status = await syncModule.syncMetadata(db, "");
 
     expect(proxyMock).toHaveBeenCalledTimes(2);
-    expect(db.updateBatch).toHaveBeenCalledWith(batch);
+    expect(db.updateBatch).toHaveBeenCalledWith(batch, pendingEvents);
     expect(status).toBe(SyncStatus.UPDATED);
   });
 });

--- a/app/src/main/sync/index.ts
+++ b/app/src/main/sync/index.ts
@@ -287,7 +287,7 @@ export async function syncMetadata(
     return SyncStatus.FORBIDDEN;
   }
 
-  db.updateBatch(batchResponse.data);
+  db.updateBatch(batchResponse.data, pendingEvents);
 
   syncStatus = SyncStatus.UPDATED;
   console.log("[sync] updates complete");

--- a/app/src/main/sync/pending-event-retry.test.ts
+++ b/app/src/main/sync/pending-event-retry.test.ts
@@ -1,0 +1,209 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { Crypto } from "../../../src/main/crypto";
+import { Datastore } from "../../../src/main/datastore";
+import * as proxyModule from "../../../src/main/proxy";
+import { Storage } from "../../../src/main/storage";
+import { syncMetadata } from "../../../src/main/sync";
+import {
+  PendingEvent,
+  PendingEventType,
+  ProxyJSONResponse,
+  SourceMetadata,
+  SyncStatus,
+} from "../../../src/types";
+
+const SOURCE_UUID = "550e8400-e29b-41d4-a716-446655440001";
+type EventResponses = Record<string, [number, string | null]>;
+type RetryRow = {
+  retry_attempts: number;
+  last_event_status: number | null;
+};
+
+function sourceMetadata(): SourceMetadata {
+  return {
+    uuid: SOURCE_UUID,
+    journalist_designation: "amber river",
+    is_starred: false,
+    is_seen: false,
+    has_attachment: false,
+    last_updated: "2026-01-01T00:00:00Z",
+    public_key: "public key",
+    fingerprint: "fingerprint",
+  };
+}
+
+describe("pending event retry scheduling", () => {
+  let crypto: Crypto;
+  let db: Datastore | undefined;
+  let dbDir: string | undefined;
+
+  beforeAll(() => {
+    (Crypto as unknown as { instance?: Crypto }).instance = undefined;
+    crypto = Crypto.initialize({
+      isQubes: false,
+      submissionKeyFingerprint: "",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    db?.close();
+    db = undefined;
+    if (dbDir) {
+      fs.rmSync(dbDir, { recursive: true, force: true });
+      dbDir = undefined;
+    }
+  });
+
+  function createDatastore(): Datastore {
+    dbDir = fs.mkdtempSync(path.join(os.tmpdir(), "pending-event-retry-"));
+    db = new Datastore(crypto, new Storage(), dbDir);
+    db.updateSources({ [SOURCE_UUID]: sourceMetadata() });
+    return db;
+  }
+
+  function addPendingEvent(type: PendingEventType): string {
+    const eventId = db!.addPendingSourceEvent(SOURCE_UUID, type);
+    expect(eventId).not.toBeNull();
+    return eventId!;
+  }
+
+  function getRetryRow(eventId: string): RetryRow | undefined {
+    return db!
+      [
+        "db"
+      ]!.prepare("SELECT retry_attempts, last_event_status FROM pending_events WHERE snowflake_id = ?")
+      .get(eventId) as RetryRow | undefined;
+  }
+
+  async function runMainFlushLoop(eventResponses: EventResponses) {
+    let batchRequests = 0;
+    vi.spyOn(proxyModule, "proxyJSONRequest").mockImplementation(
+      async (request): Promise<ProxyJSONResponse> => {
+        if (request.method === "GET") {
+          return {
+            status: 304,
+            error: false,
+            data: null,
+            headers: new Map(),
+          };
+        }
+        batchRequests += 1;
+        return {
+          status: 200,
+          error: false,
+          data: {
+            sources: {},
+            items: {},
+            journalists: {},
+            events: eventResponses,
+          },
+          headers: new Map(),
+        };
+      },
+    );
+
+    let syncStatus = SyncStatus.NOT_MODIFIED;
+    let syncCycles = 0;
+    do {
+      syncStatus = await syncMetadata(db!, "token");
+      syncCycles += 1;
+    } while (
+      syncStatus === SyncStatus.UPDATED &&
+      db!.getPendingEvents().length > 0 &&
+      syncCycles < 3
+    );
+
+    return { batchRequests, syncCycles, syncStatus };
+  }
+
+  function applySubmittedStatuses(
+    statuses: EventResponses,
+    submittedEvents: PendingEvent[],
+  ): void {
+    db!.updatePendingEvents(statuses, submittedEvents);
+  }
+
+  it("stops the main flush condition after a retained failure", async () => {
+    createDatastore();
+    const eventId = addPendingEvent(PendingEventType.Starred);
+    const result = await runMainFlushLoop({ [eventId]: [500, "retry"] });
+
+    expect(result).toEqual({
+      batchRequests: 1,
+      syncCycles: 1,
+      syncStatus: SyncStatus.UPDATED,
+    });
+    expect(db!.getPendingEvents()).toEqual([]);
+    expect(getRetryRow(eventId)).toEqual({
+      retry_attempts: 1,
+      last_event_status: 500,
+    });
+  });
+
+  it("backs off a submitted event when its status is omitted", async () => {
+    createDatastore();
+    const eventId = addPendingEvent(PendingEventType.Starred);
+    const result = await runMainFlushLoop({});
+
+    expect(result).toEqual({
+      batchRequests: 1,
+      syncCycles: 1,
+      syncStatus: SyncStatus.UPDATED,
+    });
+    expect(db!.getPendingEvents()).toEqual([]);
+    expect(getRetryRow(eventId)).toEqual({
+      retry_attempts: 1,
+      last_event_status: null,
+    });
+  });
+
+  it("ignores an unrelated status and backs off the submitted event", async () => {
+    createDatastore();
+    const eventId = addPendingEvent(PendingEventType.Starred);
+    const result = await runMainFlushLoop({ 999: [500, "unrelated"] });
+
+    expect(result).toEqual({
+      batchRequests: 1,
+      syncCycles: 1,
+      syncStatus: SyncStatus.UPDATED,
+    });
+    expect(getRetryRow(eventId)).toEqual({
+      retry_attempts: 1,
+      last_event_status: null,
+    });
+    expect(getRetryRow("999")).toBeUndefined();
+  });
+
+  it("ignores an unsolicited status targeting an excluded 208 event", async () => {
+    createDatastore();
+    const excludedEventId = addPendingEvent(PendingEventType.Starred);
+    const submitted = db!.getPendingEvents();
+    applySubmittedStatuses({ [excludedEventId]: [208, null] }, submitted);
+    const submittedEventId = addPendingEvent(PendingEventType.Unstarred);
+
+    expect(db!.getPendingEvents().map((event) => event.id)).toEqual([
+      submittedEventId,
+    ]);
+    const result = await runMainFlushLoop({
+      [submittedEventId]: [200, null],
+      [excludedEventId]: [500, "unsolicited"],
+    });
+
+    expect(result).toEqual({
+      batchRequests: 1,
+      syncCycles: 1,
+      syncStatus: SyncStatus.UPDATED,
+    });
+    expect(getRetryRow(excludedEventId)).toEqual({
+      retry_attempts: 0,
+      last_event_status: 208,
+    });
+    expect(getRetryRow(submittedEventId)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- persist a bounded retry deadline when a submitted pending event fails
- back off events omitted from the response and ignore statuses for unsent event IDs
- bind retry constants as SQL parameters so the query satisfies Semgrep policy

## Context

Refs https://github.com/freedomofpress/securedrop-client/issues/3573.

Failed event statuses previously left their rows immediately selectable, so the
pending-event flush loop could resubmit the same event without delay. Retry
state is now updated in the same transaction as the batch response.

## Test plan

```sh
cd app
pnpm exec vitest run --config vitest.config.ts --project=unit src/main/sync/index.test.ts
```

Observed: 23 tests passed.

```sh
cd app
pnpm exec prettier src/main/database/index.ts --check
pnpm exec eslint --max-warnings 0 src/main/database/index.ts
pnpm run typecheck:node
```

Observed: Prettier reported the file uses project style, ESLint exited 0, and
`typecheck:node` exited 0.

```sh
uvx semgrep scan --metrics=off --error --strict --config app/.semgrep app/src/main/database/index.ts
git diff --check
```

Observed: the custom app Semgrep rules scanned `database/index.ts` with 0
findings, and the diff check passed.

```sh
cd app
pnpm exec vitest run --config vitest.config.ts --project=unit \
  src/main/sync/pending-event-retry.test.ts src/main/datastore.test.ts
pnpm run dbmate:check
```

Not completed locally: this macOS environment is running Node v26.0.0, and
`pnpm install` failed during postinstall while trying to download the
`better-sqlite3` node-v147 darwin-arm64 artifact, which returned 404. The
database-backed tests and dbmate check therefore could not load the native
sqlite binding locally.

```sh
make lint
cd app && pnpm lint
cd app && pnpm test
cd app && pnpm build:linux
```

Not run locally: `make lint` requires Poetry, which is not installed here; the
full app lint/test/build commands are left for CI because local dependency
postinstall could not complete under Node v26.

## Notes

The retry delay starts at 60 seconds and doubles to a one-hour cap. Response
statuses are reconciled only against the exact submitted event snapshot, so a
server cannot mutate an unsent local event by returning its ID. Qubes testing
was not run locally.

## Checklist

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
