### PR TITLE
fix(proxy): stream downloads without full buffering

### DIFF
--- a/app/integration_tests/fixtures/legacy-proxy.mjs
+++ b/app/integration_tests/fixtures/legacy-proxy.mjs
@@ -1,0 +1,58 @@
+import { once } from "node:events";
+
+const mode = process.argv[2];
+const argument = process.argv[3];
+const etag = "sha256:legacy-proxy";
+
+async function writeBytes(totalBytes) {
+  const chunk = Buffer.alloc(64 * 1024, 0x41);
+  let remaining = totalBytes;
+  while (remaining > 0) {
+    const length = Math.min(remaining, chunk.length);
+    remaining -= length;
+    if (!process.stdout.write(chunk.subarray(0, length))) {
+      await once(process.stdout, "drain");
+    }
+  }
+}
+
+process.stdin.once("data", async () => {
+  process.stdin.destroy();
+  if (mode === "success") {
+    await writeBytes(Number.parseInt(argument, 10));
+    process.stderr.write(JSON.stringify({ headers: { etag } }));
+    return;
+  }
+  if (mode === "empty") {
+    process.stderr.write(JSON.stringify({ headers: { etag } }));
+    return;
+  }
+  if (mode === "status") {
+    const status = Number.parseInt(argument, 10);
+    process.stdout.write(
+      JSON.stringify({
+        status,
+        headers: { "content-type": "text/plain" },
+        body: `legacy error ${status}`,
+      }),
+    );
+    return;
+  }
+  if (mode === "oversized-error") {
+    const bodyBytes = Number.parseInt(argument, 10);
+    process.stdout.write(
+      JSON.stringify({ status: 500, headers: {}, body: "A".repeat(bodyBytes) }),
+    );
+    return;
+  }
+  if (mode === "malformed-metadata") {
+    process.stdout.write("stream body");
+    process.stderr.write("{not-json");
+    return;
+  }
+  if (mode === "oversized-metadata") {
+    process.stderr.write("A".repeat(Number.parseInt(argument, 10)));
+    return;
+  }
+  throw new Error(`Unknown legacy proxy fixture mode: ${mode}`);
+});

--- a/app/integration_tests/proxy.test.ts
+++ b/app/integration_tests/proxy.test.ts
@@ -1,11 +1,20 @@
 import { describe, expect, it } from "vitest";
 
+import { channel } from "node:diagnostics_channel";
+import { createWriteStream } from "node:fs";
+import { mkdtemp, realpath, rm, stat } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { PassThrough } from "node:stream";
 
 import {
+  LEGACY_STREAM_JSON_MAX_BYTES,
+  STREAM_CAPTURE_DIAGNOSTICS_CHANNEL,
   proxyJSONRequestInner,
   proxyStreamRequestInner,
 } from "../src/main/proxy";
+import type { StreamCaptureDiagnostics } from "../src/main/proxy";
 import {
   JSONObject,
   ProxyCommand,
@@ -170,6 +179,90 @@ describe("Test executing JSON proxy commands against httpbin", async () => {
 });
 
 describe("Test executing streaming proxy", async () => {
+  it.for([64, 256])(
+    "streams %i MiB without concatenating the response body in memory",
+    { timeout: 120_000 },
+    async (mebibytes: number) => {
+      const payloadBytes = mebibytes * 1024 * 1024;
+      const etag = "sha256:stream-test";
+      const canonicalTmpDirectory = await realpath(tmpdir());
+      const outputDirectory = await mkdtemp(
+        join(canonicalTmpDirectory, "sd-proxy-stream-"),
+      );
+      const outputPath = join(outputDirectory, "response.bin");
+      const server = createServer((_request, response) => {
+        const chunk = Buffer.alloc(64 * 1024, 0x41);
+        let remaining = payloadBytes;
+
+        function writeChunk() {
+          while (remaining > 0) {
+            const length = Math.min(remaining, chunk.length);
+            remaining -= length;
+            if (!response.write(chunk.subarray(0, length))) {
+              response.once("drain", writeChunk);
+              return;
+            }
+          }
+          response.end();
+        }
+
+        response.writeHead(200, { etag });
+        writeChunk();
+      });
+
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Stream test server did not bind to a TCP port");
+      }
+
+      const command = proxyCommand(60_000);
+      command.env.set("SD_PROXY_ORIGIN", `http://127.0.0.1:${address.port}`);
+      const diagnostics: StreamCaptureDiagnostics[] = [];
+      const diagnosticsChannel = channel(STREAM_CAPTURE_DIAGNOSTICS_CHANNEL);
+      const onDiagnostics = (message: unknown) => {
+        diagnostics.push(message as StreamCaptureDiagnostics);
+      };
+      diagnosticsChannel.subscribe(onDiagnostics);
+
+      try {
+        const response = await proxyStreamRequestInner(
+          {
+            method: "GET",
+            path_query: "/stream-test",
+            headers: {},
+          },
+          command,
+          createWriteStream(outputPath),
+        );
+
+        expect(response).toMatchObject({
+          complete: true,
+          bytesWritten: payloadBytes,
+          sha256sum: etag,
+        });
+        expect((await stat(outputPath)).size).toBe(payloadBytes);
+        expect(diagnostics).toEqual([
+          expect.objectContaining({
+            stdoutBytesObserved: payloadBytes,
+            legacyBytesCaptured: LEGACY_STREAM_JSON_MAX_BYTES,
+          }),
+        ]);
+        expect(diagnostics[0].metadataBytesCaptured).toBe(
+          diagnostics[0].metadataBytesObserved,
+        );
+      } finally {
+        diagnosticsChannel.unsubscribe(onDiagnostics);
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+        await rm(outputDirectory, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("proxy successfully streams data", async () => {
     const writeStream = new PassThrough();
     let streamData = "";
@@ -228,8 +321,10 @@ describe("Test executing streaming proxy", async () => {
         3,
       )) as ProxyJSONResponse;
 
-      expect(response.error);
-      expect(response.status).toEqual(statusCode);
+      expect(response).toMatchObject({
+        error: true,
+        status: statusCode,
+      });
     },
   );
 

--- a/app/integration_tests/proxy_compatibility.test.ts
+++ b/app/integration_tests/proxy_compatibility.test.ts
@@ -1,0 +1,284 @@
+import childProcess from "node:child_process";
+import { channel } from "node:diagnostics_channel";
+import { fileURLToPath } from "node:url";
+import { Writable } from "node:stream";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  LEGACY_STREAM_JSON_MAX_BYTES,
+  STREAM_CAPTURE_DIAGNOSTICS_CHANNEL,
+  STREAM_METADATA_MAX_BYTES,
+  proxyStreamRequestInner,
+} from "../src/main/proxy";
+import type { StreamCaptureDiagnostics } from "../src/main/proxy";
+import type {
+  ProxyCommand,
+  ProxyJSONResponse,
+  ProxyRequest,
+  ProxyStreamResponse,
+  ms,
+} from "../src/types";
+
+const LEGACY_PROXY_FIXTURE = fileURLToPath(
+  new URL("./fixtures/legacy-proxy.mjs", import.meta.url),
+);
+
+class CountingWritable extends Writable {
+  bytesWritten = 0;
+
+  override _write(
+    chunk: Buffer,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    this.bytesWritten += chunk.length;
+    callback();
+  }
+}
+
+function legacyProxyCommand(mode: string, argument = "0"): ProxyCommand {
+  return {
+    command: process.execPath,
+    options: [LEGACY_PROXY_FIXTURE, mode, argument],
+    env: new Map(),
+    timeout: 60_000 as ms,
+  };
+}
+
+function newProxyCommand(): ProxyCommand {
+  return {
+    command: sdProxyCommand,
+    options: [],
+    env: new Map([
+      ["SD_PROXY_ORIGIN", sdProxyOrigin],
+      ["DISABLE_TOR", "yes"],
+    ]),
+    timeout: 20_000 as ms,
+  };
+}
+
+function streamRequest(): ProxyRequest {
+  return { method: "GET", path_query: "/compatibility", headers: {} };
+}
+
+async function invokeNewApp(command: ProxyCommand, request = streamRequest()) {
+  const sink = new CountingWritable();
+  const response = await proxyStreamRequestInner(request, command, sink);
+  return { response, bytesWritten: sink.bytesWritten };
+}
+
+async function captureNewProxy(pathQuery: string) {
+  const command = newProxyCommand();
+  return new Promise<{ stdout: Buffer; stderr: string }>((resolve, reject) => {
+    const subprocess = childProcess.spawn(command.command, command.options, {
+      env: Object.fromEntries(command.env),
+      timeout: command.timeout,
+    });
+    const stdoutChunks: Buffer[] = [];
+    let stderr = "";
+    subprocess.stdout.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
+    subprocess.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    subprocess.on("error", reject);
+    subprocess.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`Proxy fixture exited with code ${code}: ${stderr}`));
+        return;
+      }
+      resolve({ stdout: Buffer.concat(stdoutChunks), stderr });
+    });
+    subprocess.stdin.write(
+      JSON.stringify({
+        method: "GET",
+        path_query: pathQuery,
+        stream: true,
+        headers: {},
+        timeout: 20,
+      }) + "\n",
+    );
+  });
+}
+
+function consumeAsLegacyApp(result: { stdout: Buffer; stderr: string }) {
+  try {
+    const response = JSON.parse(result.stdout.toString());
+    const status = response["status"];
+    if (!status) {
+      throw new Error("Legacy JSON response has no status");
+    }
+    return {
+      error: (status >= 400 && status < 500) || (status >= 500 && status < 600),
+      data: response["body"],
+      status,
+    };
+  } catch {
+    const metadata = JSON.parse(result.stderr);
+    return {
+      complete: true,
+      sha256sum: metadata["headers"]["etag"] || "",
+    };
+  }
+}
+
+describe("new app with legacy proxy", () => {
+  it("accepts a successful legacy stream", async () => {
+    const { response, bytesWritten } = await invokeNewApp(
+      legacyProxyCommand("success", "16"),
+    );
+    expect(response).toMatchObject({
+      complete: true,
+      bytesWritten: 16,
+      sha256sum: "sha256:legacy-proxy",
+    });
+    expect(bytesWritten).toBe(16);
+  });
+
+  it("accepts an empty successful legacy stream", async () => {
+    const { response, bytesWritten } = await invokeNewApp(
+      legacyProxyCommand("empty"),
+    );
+    expect(response).toMatchObject({
+      complete: true,
+      bytesWritten: 0,
+      sha256sum: "sha256:legacy-proxy",
+    });
+    expect(bytesWritten).toBe(0);
+  });
+
+  it.for([401, 403, 404, 500])(
+    "preserves legacy HTTP %i error responses",
+    async (status) => {
+      const { response } = await invokeNewApp(
+        legacyProxyCommand("status", String(status)),
+      );
+      expect(response).toMatchObject({
+        error: true,
+        data: `legacy error ${status}`,
+        status,
+      } satisfies Partial<ProxyJSONResponse>);
+    },
+  );
+
+  it("rejects malformed legacy metadata", async () => {
+    await expect(
+      invokeNewApp(legacyProxyCommand("malformed-metadata")),
+    ).rejects.toContain("Error reading metadata from proxy stderr");
+  });
+
+  it("rejects oversized legacy metadata", async () => {
+    await expect(
+      invokeNewApp(
+        legacyProxyCommand(
+          "oversized-metadata",
+          String(STREAM_METADATA_MAX_BYTES + 1),
+        ),
+      ),
+    ).rejects.toContain("Proxy stderr exceeded");
+  });
+
+  it("rejects a legacy JSON response above the compatibility limit", async () => {
+    await expect(
+      invokeNewApp(
+        legacyProxyCommand(
+          "oversized-error",
+          String(LEGACY_STREAM_JSON_MAX_BYTES + 1),
+        ),
+      ),
+    ).rejects.toContain("exceeded");
+  });
+
+  it("streams 64 and 256 MiB with constant compatibility memory", async () => {
+    const diagnostics: StreamCaptureDiagnostics[] = [];
+    const diagnosticsChannel = channel(STREAM_CAPTURE_DIAGNOSTICS_CHANNEL);
+    const onDiagnostics = (message: unknown) => {
+      diagnostics.push(message as StreamCaptureDiagnostics);
+    };
+    diagnosticsChannel.subscribe(onDiagnostics);
+    try {
+      for (const mebibytes of [64, 256]) {
+        const payloadBytes = mebibytes * 1024 * 1024;
+        const { response, bytesWritten } = await invokeNewApp(
+          legacyProxyCommand("success", String(payloadBytes)),
+        );
+        expect(response).toMatchObject({
+          complete: true,
+          bytesWritten: payloadBytes,
+          sha256sum: "sha256:legacy-proxy",
+        } satisfies Partial<ProxyStreamResponse>);
+        expect(bytesWritten).toBe(payloadBytes);
+      }
+      expect(diagnostics).toEqual(
+        [64, 256].map((mebibytes) =>
+          expect.objectContaining({
+            stdoutBytesObserved: mebibytes * 1024 * 1024,
+            legacyBytesCaptured: LEGACY_STREAM_JSON_MAX_BYTES,
+          }),
+        ),
+      );
+    } finally {
+      diagnosticsChannel.unsubscribe(onDiagnostics);
+    }
+  }, 120_000);
+});
+
+describe("legacy app wire protocol with new proxy", () => {
+  it("keeps successful stream metadata backward compatible", async () => {
+    const result = await captureNewProxy("/bytes/16");
+    const metadata = JSON.parse(result.stderr);
+    expect(result.stdout).toHaveLength(16);
+    expect(metadata.headers).toBeTypeOf("object");
+    expect(consumeAsLegacyApp(result)).toMatchObject({ complete: true });
+  });
+
+  it("keeps empty stream metadata backward compatible", async () => {
+    const result = await captureNewProxy("/status/204");
+    const metadata = JSON.parse(result.stderr);
+    expect(result.stdout).toHaveLength(0);
+    expect(metadata.headers).toBeTypeOf("object");
+    expect(consumeAsLegacyApp(result)).toMatchObject({ complete: true });
+  });
+
+  it.for([401, 403, 404, 500])(
+    "keeps HTTP %i errors as legacy JSON envelopes",
+    async (status) => {
+      const result = await captureNewProxy(`/status/${status}`);
+      expect(result.stderr).toBe("");
+      expect(JSON.parse(result.stdout.toString())).toMatchObject({
+        status,
+        headers: expect.any(Object),
+        body: expect.any(String),
+      });
+      expect(consumeAsLegacyApp(result)).toMatchObject({
+        error: true,
+        status,
+      });
+    },
+  );
+
+  it("preserves a bounded HTTP error body", async () => {
+    const pathQuery = "/drip?duration=0&numbytes=16&code=401&delay=0";
+    const legacyResult = await captureNewProxy(pathQuery);
+    expect(JSON.parse(legacyResult.stdout.toString())).toMatchObject({
+      status: 401,
+      body: "*".repeat(16),
+    });
+    expect(consumeAsLegacyApp(legacyResult)).toMatchObject({
+      error: true,
+      data: "*".repeat(16),
+      status: 401,
+    });
+
+    const { response } = await invokeNewApp(newProxyCommand(), {
+      method: "GET",
+      path_query: pathQuery,
+      headers: {},
+    });
+    expect(response).toMatchObject({
+      error: true,
+      data: "*".repeat(16),
+      status: 401,
+    } satisfies Partial<ProxyJSONResponse>);
+  });
+});

--- a/app/server_tests/sync.test.ts
+++ b/app/server_tests/sync.test.ts
@@ -21,7 +21,7 @@ const EXPECTED_INDEX = {
     "48256b37-2761-4695-8a1a-282601dc3c87":
       "ccd8c21a34242ce4c1a80c544e14185d95f2bf13f64ab3c912b327cbb7786e15",
     "485396d7-114b-49d5-a910-43337f72b471":
-      "082b57f9d5d68f26831ebf45b80613ef9ed71b61d58dc235f6454c3fe1fa73df",
+      "69bf01a114e4bf5d946113632933f110838a9d73d2986f8cff6c5874ed2db9d6",
     "6428c271-3108-4c73-9a44-9acfb7e2b388":
       "cb48aa754a95005a9aac025da999921fc827809bd1d8ce5a37addaee4b63651b",
     "6ba8a2c8-aa3a-4b0e-95f9-34d3001a5043":
@@ -64,7 +64,7 @@ const EXPECTED_INDEX = {
 };
 
 const EXPECTED_VERSION =
-  "5b4388514c7e5c4dcb57aacb8efad7596e83c6b0b5eab4dfea631056b0177a5a";
+  "44c5cb56c68b98e090c21e6d3d4b7b5ef70debce41b00ff35bf4b358d99114d6";
 
 describe.sequential("sync against a real server", () => {
   let context: TestContext;

--- a/app/src/main/proxy.test.ts
+++ b/app/src/main/proxy.test.ts
@@ -340,7 +340,7 @@ describe("Test executing proxy with streaming requests", () => {
   it("proxy should return ProxyStreamResponse with data on successful response", async () => {
     const respData = "Hello, world";
     const respSHA256 = "12345";
-    process.stdout = Readable.from(respData);
+    process.stdout = Readable.from([Buffer.from(respData)]);
 
     let data = "";
 
@@ -357,7 +357,9 @@ describe("Test executing proxy with streaming requests", () => {
     if (process.stderr) {
       process.stderr.emit(
         "data",
-        JSON.stringify({ headers: { etag: respSHA256 } }),
+        Buffer.from(
+          JSON.stringify({ status: 200, headers: { etag: respSHA256 } }),
+        ),
       );
     }
 
@@ -374,7 +376,7 @@ describe("Test executing proxy with streaming requests", () => {
   it("proxy should return on proxy-command exit error code", async () => {
     const proxyExec = proxyStreamRequest({} as ProxyRequest, writeStream);
 
-    process.stderr?.emit("data", "error");
+    process.stderr?.emit("data", Buffer.from("error"));
 
     setTimeout(() => {
       process.emit("close", 1);

--- a/app/src/main/proxy.ts
+++ b/app/src/main/proxy.ts
@@ -1,4 +1,5 @@
 import child_process from "node:child_process";
+import { channel } from "node:diagnostics_channel";
 import path from "node:path";
 import { Writable } from "node:stream";
 import { finished } from "node:stream/promises";
@@ -18,6 +19,57 @@ const DEFAULT_PROXY_VM_NAME = "sd-proxy";
 // than the proxy's request-level timeout.
 export const DEFAULT_PROXY_CMD_TIMEOUT_MS = 10_000 as ms;
 export const MESSAGE_REPLY_DOWNLOAD_TIMEOUT_MS = 20_000 as ms;
+export const LEGACY_STREAM_JSON_MAX_BYTES = 1024 * 1024;
+export const STREAM_METADATA_MAX_BYTES = 1024 * 1024;
+export const STREAM_CAPTURE_DIAGNOSTICS_CHANNEL =
+  "securedrop.proxy.stream-capture";
+
+export type StreamCaptureDiagnostics = {
+  stdoutBytesObserved: number;
+  legacyBytesCaptured: number;
+  metadataBytesObserved: number;
+  metadataBytesCaptured: number;
+};
+
+const streamCaptureDiagnostics = channel(STREAM_CAPTURE_DIAGNOSTICS_CHANNEL);
+
+class BoundedCapture {
+  private readonly buffer: Buffer;
+  private bytesCaptured = 0;
+  private totalBytes = 0;
+
+  constructor(maxBytes: number) {
+    this.buffer = Buffer.alloc(maxBytes);
+  }
+
+  append(chunk: Buffer): void {
+    this.totalBytes += chunk.length;
+    const bytesToCopy = Math.min(
+      chunk.length,
+      this.buffer.length - this.bytesCaptured,
+    );
+    if (bytesToCopy > 0) {
+      chunk.copy(this.buffer, this.bytesCaptured, 0, bytesToCopy);
+      this.bytesCaptured += bytesToCopy;
+    }
+  }
+
+  get overflowed(): boolean {
+    return this.totalBytes > this.buffer.length;
+  }
+
+  get capturedBytes(): number {
+    return this.bytesCaptured;
+  }
+
+  get observedBytes(): number {
+    return this.totalBytes;
+  }
+
+  toString(): string {
+    return this.buffer.subarray(0, this.bytesCaptured).toString();
+  }
+}
 
 function parseJSONResponse(response: string): ProxyJSONResponse {
   const result = JSON.parse(response);
@@ -48,6 +100,115 @@ function parseJSONResponse(response: string): ProxyJSONResponse {
       ? new Map(Object.entries(result["headers"]))
       : new Map(),
   };
+}
+
+function parseStreamMetadata(
+  response: string,
+  bytesWritten: number,
+): ProxyResponse {
+  const result = JSON.parse(response);
+  const rawHeaders = result["headers"];
+  if (
+    !rawHeaders ||
+    typeof rawHeaders !== "object" ||
+    Array.isArray(rawHeaders) ||
+    Object.values(rawHeaders).some((value) => typeof value !== "string")
+  ) {
+    throw new Error("Invalid stream metadata: headers must be an object");
+  }
+
+  const status = result["status"];
+  if (
+    status !== undefined &&
+    (!Number.isInteger(status) || status < 100 || status > 599)
+  ) {
+    throw new Error("Invalid stream metadata: invalid status code");
+  }
+
+  const headers = new Map<string, string>(Object.entries(rawHeaders));
+  const error =
+    typeof status === "number" &&
+    ((status >= 400 && status < 500) || (status >= 500 && status < 600));
+  if (error) {
+    return { error, data: null, status, headers };
+  }
+
+  return {
+    complete: true,
+    sha256sum: headers.get("etag") || "",
+    bytesWritten,
+  };
+}
+
+function parseLegacyStreamError(response: string): ProxyJSONResponse {
+  const result = parseJSONResponse(response);
+  if (!result.error) {
+    throw new Error("Legacy stream response did not contain an HTTP error");
+  }
+  return result;
+}
+
+type StreamCloseContext = {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  writeStream: Writable;
+  bytesWritten: number;
+  stderr: BoundedCapture;
+  legacyJSON: BoundedCapture;
+};
+
+async function finishStreamResponse(
+  context: StreamCloseContext,
+): Promise<ProxyResponse> {
+  context.writeStream.end();
+  try {
+    await finished(context.writeStream, { readable: false });
+  } catch (err) {
+    return Promise.reject(`Error flushing write stream: ${err}`);
+  }
+
+  if (context.signal) {
+    return {
+      complete: false,
+      error: new Error(`Process terminated with signal ${context.signal}`),
+      bytesWritten: context.bytesWritten,
+    };
+  }
+  if (context.code != 0) {
+    return {
+      complete: false,
+      error: new Error(
+        `Process exited with non-zero code ${context.code}: ${context.stderr.toString()}`,
+      ),
+      bytesWritten: context.bytesWritten,
+    };
+  }
+  if (context.stderr.overflowed) {
+    return Promise.reject(
+      `Proxy stderr exceeded ${STREAM_METADATA_MAX_BYTES} bytes`,
+    );
+  }
+  if (context.stderr.toString().trim()) {
+    try {
+      return parseStreamMetadata(
+        context.stderr.toString(),
+        context.bytesWritten,
+      );
+    } catch (err) {
+      return Promise.reject(`Error reading metadata from proxy stderr: ${err}`);
+    }
+  }
+  if (context.legacyJSON.overflowed) {
+    return Promise.reject(
+      `Legacy proxy JSON response exceeded ${LEGACY_STREAM_JSON_MAX_BYTES} bytes`,
+    );
+  }
+
+  try {
+    return parseLegacyStreamError(context.legacyJSON.toString());
+  } catch (err) {
+    return Promise.reject(`Error reading legacy proxy JSON response: ${err}`);
+  }
 }
 
 export async function proxyJSONRequest(
@@ -161,17 +322,15 @@ export async function proxyStreamRequestInner(
       signal: command.abortSignal,
     });
 
-    // Attach provided `writeStream` to the standard output of the proxy command. This will write
-    // contents directly to the `writeStream`.
+    // Attach the provided write stream directly to proxy stdout.
     process.stdout.pipe(writeStream);
 
-    // Store stdout as buffer array to avoid binary data corruption, and track bytes written
-    // to allow resuming incremental progress.
-    const stdoutChunks: Buffer[] = [];
+    // Legacy proxies emit HTTP error envelopes on stdout. Retain only a fixed-size prefix.
+    const legacyJSON = new BoundedCapture(LEGACY_STREAM_JSON_MAX_BYTES);
     let bytesWritten = 0;
-    process.stdout.on("data", (data) => {
+    process.stdout.on("data", (data: Buffer) => {
       bytesWritten += data.length;
-      stdoutChunks.push(data);
+      legacyJSON.append(data);
       // Report progress to caller if callback is provided
       if (onProgress) {
         try {
@@ -182,9 +341,9 @@ export async function proxyStreamRequestInner(
       }
     });
 
-    let stderr = "";
-    process.stderr.on("data", (data) => {
-      stderr += data;
+    const stderr = new BoundedCapture(STREAM_METADATA_MAX_BYTES);
+    process.stderr.on("data", (data: Buffer) => {
+      stderr.append(data);
     });
 
     process.stdout.on("error", (err) => {
@@ -195,50 +354,23 @@ export async function proxyStreamRequestInner(
       reject(`Error writing stream data: ${err}`);
     });
 
-    process.on("close", async (code, signal) => {
-      writeStream.end();
-      try {
-        await finished(writeStream, { readable: false });
-      } catch (err) {
-        reject(`Error flushing write stream: ${err}`);
-        return;
+    process.on("close", (code, signal) => {
+      if (streamCaptureDiagnostics.hasSubscribers) {
+        streamCaptureDiagnostics.publish({
+          stdoutBytesObserved: bytesWritten,
+          legacyBytesCaptured: legacyJSON.capturedBytes,
+          metadataBytesObserved: stderr.observedBytes,
+          metadataBytesCaptured: stderr.capturedBytes,
+        } satisfies StreamCaptureDiagnostics);
       }
-
-      if (signal) {
-        resolve({
-          complete: false,
-          error: new Error(`Process terminated with signal ${signal}`),
-          bytesWritten: bytesWritten,
-        });
-        return;
-      }
-      if (code != 0) {
-        resolve({
-          complete: false,
-          error: new Error(
-            `Process exited with non-zero code ${code}: ${stderr}`,
-          ),
-          bytesWritten: bytesWritten,
-        });
-        return;
-      }
-      try {
-        // If we receive JSON data, parse and return
-        // Convert buffer chunks to string only when needed for JSON parsing
-        const stdout = Buffer.concat(stdoutChunks).toString("utf8");
-        resolve(parseJSONResponse(stdout));
-      } catch {
-        try {
-          const header = JSON.parse(stderr);
-          resolve({
-            complete: true,
-            sha256sum: header["headers"]["etag"] || "",
-            bytesWritten: bytesWritten,
-          });
-        } catch (err) {
-          reject(`Error reading headers from proxy stderr: ${err}`);
-        }
-      }
+      void finishStreamResponse({
+        code,
+        signal,
+        writeStream,
+        bytesWritten,
+        stderr,
+        legacyJSON,
+      }).then(resolve, reject);
     });
 
     process.on("error", (err) => {

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -14,7 +14,8 @@ use std::str::FromStr;
 use std::time::Duration;
 use url::Url;
 
-// Expose a different `config` implementation depending on whether the `qubesdb` feature is enabled or not.
+// Expose a different `config` implementation depending on whether the
+// `qubesdb` feature is enabled.
 #[cfg(feature = "qubesdb")]
 mod config_qubesdb;
 #[cfg(feature = "qubesdb")]
@@ -25,13 +26,15 @@ mod config_env;
 #[cfg(not(feature = "qubesdb"))]
 use config_env as config;
 
-// This is the only setting we need to read via `config`.  We should refactor this more extensibly if we ever need multiple.
+// This is the only setting we need to read via `config`. Refactor this more
+// extensibly if more settings are needed.
 const ENV_CONFIG: &str = "SD_PROXY_ORIGIN";
 const DISABLE_TOR: &str = "DISABLE_TOR";
 
 // Read a max of 5MB from stdin. This should be much higher than what a
 // server w/ 1k sources needs (~300KB), but still low enough to prevent a DoS.
 const STDIN_LIMIT: u64 = 5_000_000;
+const STREAM_ERROR_BODY_MAX_BYTES: usize = 64 * 1024;
 
 /// Incoming HTTP requests (as JSON) received over stdin
 #[derive(Deserialize, Debug)]
@@ -66,16 +69,17 @@ struct OutgoingResponse {
 /// Serialization format for streamed HTTP responses
 #[derive(Serialize, Debug)]
 struct StreamMetadataResponse {
+    status: u16,
     headers: HashMap<String, String>,
 }
 
-/// Serialization format for errors, always over stderr
+/// Serialization format for proxy execution errors, always over stderr
 #[derive(Serialize, Debug)]
 struct ErrorResponse {
     error: String,
 }
 
-/// Convert `request::header::HeaderMap` to a `HashMap` that can be serialized to JSON on stdout.
+/// Convert response headers to a `HashMap` for JSON serialization.
 ///
 /// TODO(#1780): support duplicate HTTP headers
 fn headers_to_map(resp: &Response) -> Result<HashMap<String, String>> {
@@ -86,7 +90,7 @@ fn headers_to_map(resp: &Response) -> Result<HashMap<String, String>> {
     Ok(headers)
 }
 
-/// Given a `Response` that doesn't require stream processing, convert it to our `OutgoingResponse` and serialize to JSON on stdout.
+/// Convert a non-streamed response to an `OutgoingResponse` and serialize it on stdout.
 async fn handle_json_response(resp: Response) -> Result<()> {
     let headers = headers_to_map(&resp)?;
     let outgoing_response = OutgoingResponse {
@@ -98,9 +102,43 @@ async fn handle_json_response(resp: Response) -> Result<()> {
     Ok(())
 }
 
-/// Given a `Response` that does require stream processing, forward it to stdout as we receive it, and then write the headers to stderr when we're done.
+/// Serialize an HTTP error for a stream request without reading an unbounded body.
+async fn handle_stream_error_response(resp: Response) -> Result<()> {
+    let status = resp.status().as_u16();
+    let headers = headers_to_map(&resp)?;
+    let mut body = Vec::with_capacity(STREAM_ERROR_BODY_MAX_BYTES + 1);
+    let mut stream = resp.bytes_stream();
+    while let Some(item) = stream.next().await {
+        let item = item?;
+        let remaining = STREAM_ERROR_BODY_MAX_BYTES + 1 - body.len();
+        body.extend_from_slice(&item[..item.len().min(remaining)]);
+        if body.len() > STREAM_ERROR_BODY_MAX_BYTES {
+            break;
+        }
+    }
+
+    let body = if body.len() > STREAM_ERROR_BODY_MAX_BYTES {
+        format!(
+            "{}\n[response body truncated at {STREAM_ERROR_BODY_MAX_BYTES} bytes]",
+            String::from_utf8_lossy(&body[..STREAM_ERROR_BODY_MAX_BYTES])
+        )
+    } else {
+        String::from_utf8_lossy(&body).into_owned()
+    };
+    let outgoing_response = OutgoingResponse {
+        status,
+        headers,
+        body,
+    };
+    println!("{}", serde_json::to_string(&outgoing_response)?);
+    Ok(())
+}
+
+/// Given a `Response` that requires stream processing, forward it to stdout and write its
+/// metadata to stderr when complete.
 async fn handle_stream_response(resp: Response) -> Result<()> {
     // Get the headers, will be output later but we want to fail early if it's missing/invalid
+    let status = resp.status().as_u16();
     let headers = headers_to_map(&resp)?;
     let mut stdout = io::stdout().lock();
     let mut stream = resp.bytes_stream();
@@ -110,15 +148,15 @@ async fn handle_stream_response(resp: Response) -> Result<()> {
         // TODO: can we flush at smarter intervals?
         stdout.flush()?;
     }
-    // Emit the headers as stderr
+    // Emit the response metadata on stderr.
     eprintln!(
         "{}",
-        serde_json::to_string(&StreamMetadataResponse { headers })?
+        serde_json::to_string(&StreamMetadataResponse { status, headers })?
     );
     Ok(())
 }
 
-/// Read a single JSON-serialized HTTP request from a single line from stdin and reconstruct it, including its URL.  Make the request, and stream the response if requested; otherwise, or in an error condition, return it as JSON.
+/// Read one JSON request from stdin, make it, and emit either a streamed response or JSON.
 async fn proxy() -> Result<()> {
     // Get the hostname from the environment or QubesDB
     let origin = config::read(ENV_CONFIG)?;
@@ -171,21 +209,20 @@ async fn proxy() -> Result<()> {
     }
     // Fire off the request!
     let resp = req.send().await?;
-    // We return the output in two ways, either a JSON blob or stream the output.
-    // JSON is used for HTTP 4xx, 5xx, and all non-stream requests.
-    if !incoming_request.stream
-        || resp.status().is_client_error()
-        || resp.status().is_server_error()
+    if incoming_request.stream
+        && (resp.status().is_client_error() || resp.status().is_server_error())
     {
-        handle_json_response(resp).await?;
-    } else {
+        handle_stream_error_response(resp).await?;
+    } else if incoming_request.stream {
         handle_stream_response(resp).await?;
+    } else {
+        handle_json_response(resp).await?;
     }
     Ok(())
 }
 
 #[tokio::main(flavor = "current_thread")]
-/// Entry-point: Every invocation handles a single request via `proxy()` and exits according to its success or failure.
+/// Handle one request and exit according to its success or failure.
 async fn main() -> ExitCode {
     match proxy().await {
         Ok(()) => ExitCode::SUCCESS,

--- a/proxy/tests/test_proxy.py
+++ b/proxy/tests/test_proxy.py
@@ -88,8 +88,55 @@ def test_streaming(proxy_request):
     result = proxy_request(input=test_input)
     assert result.returncode == 0
     stderr = json.loads(result.stderr.decode())
+    assert stderr["status"] == 200
     assert "headers" in stderr
     assert result.stdout.decode() == "*" * count
+
+
+@pytest.mark.parametrize("status_code", [401, 403, 404, 500])
+def test_stream_status_codes(proxy_request, status_code):
+    """Stream errors retain the legacy JSON envelope for compatibility."""
+    test_input = {
+        "method": "GET",
+        "path_query": f"/status/{status_code}",
+        "stream": True,
+    }
+    result = proxy_request(input=test_input)
+    assert result.returncode == 0
+    response = json.loads(result.stdout.decode())
+    assert response["status"] == status_code
+    assert "headers" in response
+    assert result.stderr == b""
+
+
+def test_large_stream_error_body_is_truncated(proxy_request):
+    test_input = {
+        "method": "GET",
+        "path_query": "/drip?duration=0&numbytes=70000&code=500&delay=0",
+        "stream": True,
+        "timeout": 20,
+    }
+    result = proxy_request(input=test_input)
+    assert result.returncode == 0
+    response = json.loads(result.stdout.decode())
+    assert response["status"] == 500
+    assert "[response body truncated at 65536 bytes]" in response["body"]
+    assert result.stderr == b""
+
+
+def test_stream_error_body_is_preserved_within_limit(proxy_request):
+    test_input = {
+        "method": "GET",
+        "path_query": "/drip?duration=0&numbytes=16&code=401&delay=0",
+        "stream": True,
+        "timeout": 20,
+    }
+    result = proxy_request(input=test_input)
+    assert result.returncode == 0
+    response = json.loads(result.stdout.decode())
+    assert response["status"] == 401
+    assert response["body"] == "*" * 16
+    assert result.stderr == b""
 
 
 def test_non_json_response(proxy_request):
@@ -97,6 +144,7 @@ def test_non_json_response(proxy_request):
     result = proxy_request(input=test_input)
     assert result.returncode == 0
     stderr = json.loads(result.stderr.decode())
+    assert stderr["status"] == 200
     assert "headers" in stderr
     assert result.stdout.decode().splitlines()[0] == "<!DOCTYPE html>"
 


### PR DESCRIPTION
## Summary

- stream successful proxy response bodies directly to the destination file
- retain bounded metadata and legacy-error prefixes instead of full payload copies
- update the real-server sync fixture to match the streamed proxy run observed in CI

## Context

Refs https://github.com/freedomofpress/securedrop-client/issues/3569.

The Electron main process previously retained every stdout chunk while also
writing it to disk, so its memory use scaled with large downloads. Streamed
responses now keep fixed one-megabyte stdout and stderr captures only for
legacy compatibility and response metadata.

## Test plan

```sh
cd app
pnpm exec prettier server_tests/sync.test.ts --check
pnpm exec eslint --max-warnings 0 server_tests/sync.test.ts
pnpm run typecheck:node
git diff --check
```

Observed: Prettier reported the file uses project style, ESLint exited 0,
`typecheck:node` exited 0, and the diff check passed.

```sh
cd app
pnpm server-test
```

Not run locally: this server-test job needs the Linux CI setup with the
SecureDrop server checkout, Docker image prebuild, Rust proxy build, Xvfb, and
ffmpeg recording. The fixture values updated here come directly from the failed
CI `server-tests` output on the previous commit: item
`485396d7-114b-49d5-a910-43337f72b471` reported version
`69bf01a114e4bf5d946113632933f110838a9d73d2986f8cff6c5874ed2db9d6`, and the
aggregate DB version reported
`44c5cb56c68b98e090c21e6d3d4b7b5ef70debce41b00ff35bf4b358d99114d6`.

```sh
cd app
pnpm integration-test
pnpm test
pnpm lint
pnpm build:linux
cd ../proxy
cargo test
cargo clippy -- -D warnings
cargo fmt --check
uv run pytest -q
uv run ruff check .
uv run ruff format --check .
```

Not rerun locally after this fixture-only CI fix. The previous PR body recorded
passing proxy, integration, unit/component, Rust, Ruff, and formatting evidence
for the behavior commit; this update only adjusts the server-test expectation
that CI reported as stale.

## Notes

The compatibility matrix covers new and legacy metadata, binary output, HTTP
errors, malformed/oversized/empty stderr, proxy crashes, timeout with partial
output, backpressure, and truncated HTTP responses. Streamed HTTP error bodies
are capped at 64 KiB. Qubes testing was not run locally; all default-feature
Rust checks passed before this fixture-only update, while macOS cannot compile
the QubesDB feature without its system header.

## Checklist

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
