### PR TITLE
fix(export): include complete source history

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -153,6 +153,7 @@ export class DB {
   private selectAllSources: Statement<[], SourceRow>;
   private selectSourceById: Statement<[string], SourceRow>;
   private selectItemsBySourceId: Statement<[string, number], ItemRow>;
+  private selectAllItemsBySourceId: Statement<[string, number], ItemRow>;
   private selectItemsBySourceIdBefore: Statement<
     [string, number, number],
     ItemRow
@@ -385,6 +386,12 @@ export class DB {
       WHERE source_uuid = ?
       ORDER BY interaction_count DESC
       LIMIT ?
+    `);
+    this.selectAllItemsBySourceId = this.db.prepare(`
+      SELECT uuid, data, plaintext, filename, fetch_status, fetch_progress, decrypted_size, is_read FROM items_projected
+      WHERE source_uuid = ?
+        AND (fetch_status IS NULL OR fetch_status != ?)
+      ORDER BY interaction_count ASC, uuid ASC
     `);
     this.selectItemsBySourceIdBefore = this.db.prepare(`
       SELECT uuid, data, plaintext, filename, fetch_status, fetch_progress, decrypted_size FROM items_projected
@@ -915,6 +922,46 @@ export class DB {
       items,
       hasMoreHistoricalItems,
       lastSeenInteractionCount,
+    };
+  }
+
+  getSourceWithAllItems(sourceUuid: string): SourceWithItems {
+    if (!this.db) {
+      throw new Error("Database is not open");
+    }
+
+    const sourceRow = this.selectSourceById.get(sourceUuid) as
+      | SourceRow
+      | undefined;
+    if (!sourceRow) {
+      throw new Error(`Source with UUID ${sourceUuid} not found`);
+    }
+
+    const rows = this.selectAllItemsBySourceId.all(
+      sourceUuid,
+      FetchStatus.ScheduledDeletion,
+    );
+    const items = rows.map((row) => {
+      const data = JSON.parse(row.data) as ItemMetadata;
+      if (row.is_read !== undefined && "is_read" in data) {
+        (data as { is_read: boolean }).is_read = this.isTruthy(row.is_read);
+      }
+      return {
+        uuid: row.uuid,
+        data,
+        plaintext: row.plaintext,
+        filename: row.filename,
+        fetch_status: row.fetch_status,
+        fetch_progress: row.fetch_progress,
+        decrypted_size: row.decrypted_size,
+      };
+    });
+
+    return {
+      uuid: sourceRow.uuid,
+      data: JSON.parse(sourceRow.data) as SourceMetadata,
+      items,
+      hasMoreHistoricalItems: false,
     };
   }
 

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -689,6 +689,87 @@ describe("Datastore Method Tests", () => {
     expect(items).toEqual(sortedItems);
   });
 
+  it.each([0, 1, 100, 101, 201])(
+    "getSourceWithAllItems returns all %i projected items",
+    (itemCount) => {
+      db.updateSources({
+        source1: mockSourceMetadata("source1"),
+      });
+
+      const items = Object.fromEntries(
+        Array.from({ length: itemCount }, (_, index) => {
+          const interactionCount = index + 1;
+          const uuid = `item-${interactionCount.toString().padStart(3, "0")}`;
+          return [
+            uuid,
+            mockItemMetadata(uuid, "source1", "message", interactionCount),
+          ];
+        }),
+      );
+      db.updateItems(items);
+
+      const sourceWithItems = db.getSourceWithAllItems("source1");
+      expect(sourceWithItems.items).toHaveLength(itemCount);
+      expect(sourceWithItems.hasMoreHistoricalItems).toBe(false);
+      expect(
+        sourceWithItems.items.map((item) => item.data.interaction_count),
+      ).toEqual(Array.from({ length: itemCount }, (_, index) => index + 1));
+    },
+  );
+
+  it("getSourceWithAllItems orders duplicate counts by UUID", () => {
+    db.updateSources({
+      source1: mockSourceMetadata("source1"),
+    });
+    db.updateItems({
+      "item-z": mockItemMetadata("item-z", "source1", "message", 7),
+      "item-a": mockItemMetadata("item-a", "source1", "reply", 7),
+      "item-m": mockItemMetadata("item-m", "source1", "file", 6),
+    });
+
+    expect(
+      db.getSourceWithAllItems("source1").items.map((item) => item.uuid),
+    ).toEqual(["item-m", "item-a", "item-z"]);
+  });
+
+  it("getSourceWithAllItems excludes hidden and scheduled-deletion rows", () => {
+    db.updateSources({
+      source1: mockSourceMetadata("source1"),
+    });
+    db.updateItems({
+      truncated: mockItemMetadata("truncated", "source1", "message", 1),
+      visible: mockItemMetadata("visible", "source1", "message", 10),
+      deleted: mockItemMetadata("deleted", "source1", "message", 11),
+      scheduled: mockItemMetadata("scheduled", "source1", "file", 12),
+    });
+    db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 1 },
+    );
+    db.addPendingItemEvent("deleted", PendingEventType.ItemDeleted);
+    db.updateFetchStatus("scheduled", FetchStatus.ScheduledDeletion);
+
+    expect(
+      db.getSourceWithAllItems("source1").items.map((item) => item.uuid),
+    ).toEqual(["visible"]);
+  });
+
+  it("getSourceWithAllItems rejects missing and pending-deleted sources", () => {
+    expect(() => db.getSourceWithAllItems("missing")).toThrow(
+      "Source with UUID missing not found",
+    );
+
+    db.updateSources({
+      source1: mockSourceMetadata("source1"),
+    });
+    db.addPendingSourceEvent("source1", PendingEventType.SourceDeleted);
+
+    expect(() => db.getSourceWithAllItems("source1")).toThrow(
+      "Source with UUID source1 not found",
+    );
+  });
+
   it("pending ItemDeleted event should delete reply", () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -48,6 +48,7 @@ import { setUmask } from "./umask";
 import { Exporter, Printer } from "./export";
 import { Storage } from "./storage";
 import { writeTranscript } from "./transcriber";
+import { prepareSourceExport } from "./source-export";
 import { initLogging } from "./log";
 
 // Set umask so any files written are owner-only read/write (600).
@@ -682,12 +683,14 @@ if (!gotTheLock) {
           whistleflow?: boolean,
         ): Promise<DeviceStatus> => {
           try {
-            const filePath: string = await writeTranscript(sourceUuid, db);
+            const { filePath, sourceWithItems } = await writeTranscript(
+              sourceUuid,
+              db,
+            );
 
             if (!fs.existsSync(filePath)) {
               throw new Error(`Transcript file not found: ${filePath}`);
             }
-            const sourceWithItems = db.getSourceWithItems(sourceUuid);
             const sourceName = sourceWithItems.data.journalist_designation;
             return await exporter.export(
               [filePath],
@@ -751,30 +754,16 @@ if (!gotTheLock) {
           whistleflow?: boolean,
         ): Promise<DeviceStatus> => {
           try {
-            const transcriptPath: string = await writeTranscript(
+            const { filepaths, sourceName } = await prepareSourceExport(
               sourceUuid,
               db,
             );
 
-            if (!fs.existsSync(transcriptPath)) {
-              throw new Error(`Transcript file not found: ${transcriptPath}`);
+            if (!fs.existsSync(filepaths[0])) {
+              throw new Error(`Transcript file not found: ${filepaths[0]}`);
             }
-
-            const sourceWithItems = db.getSourceWithItems(sourceUuid);
-            const filenames: string[] = [transcriptPath];
-            for (const item of sourceWithItems.items) {
-              if (
-                item.data.kind === "file" &&
-                item.fetch_status === FetchStatus.Complete &&
-                item.filename &&
-                fs.existsSync(item.filename)
-              ) {
-                filenames.push(item.filename);
-              }
-            }
-            const sourceName = sourceWithItems.data.journalist_designation;
             return await exporter.export(
-              filenames,
+              filepaths,
               passphrase,
               sourceName,
               whistleflow,
@@ -794,7 +783,7 @@ if (!gotTheLock) {
         "printTranscript",
         async (_event, sourceUuid: string): Promise<DeviceStatus> => {
           try {
-            const filePath: string = await writeTranscript(sourceUuid, db);
+            const { filePath } = await writeTranscript(sourceUuid, db);
 
             if (!fs.existsSync(filePath)) {
               throw new Error(`Transcript file not found: ${filePath}`);

--- a/app/src/main/source-export.test.ts
+++ b/app/src/main/source-export.test.ts
@@ -1,0 +1,305 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+import * as tar from "tar";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DeviceErrorStatus,
+  ItemMetadata,
+  PrintStatus,
+  SourceMetadata,
+} from "../types";
+import { Crypto } from "./crypto";
+import { Datastore } from "./datastore";
+import { ArchiveExporter, Exporter, EXPORT_QUBE, Printer } from "./export";
+import { prepareSourceExport } from "./source-export";
+import { Storage } from "./storage";
+
+const OLD_MESSAGE = "SENTINEL_OLD_MESSAGE_IN_ALL_HISTORY_TRANSCRIPT";
+const OLD_FILE = "SENTINEL_OLD_FILE_IN_ALL_HISTORY_EXPORT";
+const NEW_DURING_EXPORT = "SENTINEL_NEW_FILE_AFTER_TRANSCRIPT_SNAPSHOT";
+
+function sourceMetadata(uuid: string): SourceMetadata {
+  return {
+    uuid,
+    journalist_designation: "export source",
+    is_starred: false,
+    is_seen: false,
+    has_attachment: true,
+    last_updated: "2026-07-08T00:00:00Z",
+    public_key: "unused",
+    fingerprint: "unused",
+  };
+}
+
+function itemMetadata(
+  uuid: string,
+  interactionCount: number,
+  kind: "message" | "reply" | "file",
+): ItemMetadata {
+  if (kind === "reply") {
+    return {
+      uuid,
+      source: "source-1",
+      kind,
+      size: 1,
+      journalist_uuid: "journalist-1",
+      is_deleted_by_source: false,
+      seen_by: [],
+      interaction_count: interactionCount,
+    };
+  }
+  return {
+    uuid,
+    source: "source-1",
+    kind,
+    size: 1,
+    is_read: false,
+    seen_by: [],
+    interaction_count: interactionCount,
+  };
+}
+
+function seedItems(db: Datastore, storage: Storage, itemCount: number): void {
+  const items: Record<string, ItemMetadata> = {};
+  for (
+    let interactionCount = 1;
+    interactionCount <= itemCount;
+    interactionCount += 1
+  ) {
+    const uuid = `item-${interactionCount.toString().padStart(3, "0")}`;
+    let kind: "message" | "reply" | "file" = "message";
+    if ([2, 60, 120, 121].includes(interactionCount)) {
+      kind = "file";
+    } else if (interactionCount % 5 === 0) {
+      kind = "reply";
+    }
+    items[uuid] = itemMetadata(uuid, interactionCount, kind);
+  }
+  db.updateItems(items);
+
+  for (const item of Object.values(items)) {
+    if (item.kind === "file") {
+      continue;
+    }
+    const plaintext =
+      item.interaction_count === 1
+        ? OLD_MESSAGE
+        : `item ${item.interaction_count}`;
+    db.completePlaintextItem(item.uuid, plaintext);
+  }
+
+  const oldFile = items["item-002"];
+  if (oldFile) {
+    completeFile(db, storage, oldFile, OLD_FILE);
+  }
+  const newerFile = items["item-060"];
+  if (newerFile) {
+    completeFile(db, storage, newerFile, "newer file");
+  }
+  if (items["item-121"]) {
+    db.completeFileItem("item-121", "/missing/item-121/payload.txt", 1);
+  }
+}
+
+function completeFile(
+  db: Datastore,
+  storage: Storage,
+  metadata: ItemMetadata,
+  content: string,
+): string {
+  const filename = storage.itemDirectory(metadata).join("payload.txt");
+  fs.writeFileSync(filename, content, "utf8");
+  db.completeFileItem(metadata.uuid, filename, Buffer.byteLength(content));
+  return filename;
+}
+
+async function extractArchive(
+  archivePath: string,
+  root: string,
+): Promise<string> {
+  const extractDir = path.join(root, `extract-${path.basename(archivePath)}`);
+  fs.mkdirSync(extractDir, { recursive: true });
+  await tar.x({ file: archivePath, cwd: extractDir });
+  return extractDir;
+}
+
+describe("source-wide archival workflows", () => {
+  const originalHomedir = os.homedir;
+  let homeDir: string;
+  let db: Datastore;
+  let storage: Storage;
+
+  beforeEach(() => {
+    homeDir = fs.mkdtempSync(
+      path.join(fs.realpathSync(os.tmpdir()), "source-export-"),
+    );
+    os.homedir = () => homeDir;
+    storage = new Storage();
+    db = new Datastore({} as Crypto, storage);
+    db.updateSources({ "source-1": sourceMetadata("source-1") });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (db) {
+      db.close();
+    }
+    os.homedir = originalHomedir;
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("exports all 201 projected items from one snapshot", async () => {
+    seedItems(db, storage, 201);
+
+    const getJournalists = db.getJournalists.bind(db);
+    vi.spyOn(db, "getJournalists").mockImplementation(() => {
+      const metadata = itemMetadata("item-202", 202, "file");
+      db.updateItems({ "item-202": metadata });
+      completeFile(db, storage, metadata, NEW_DURING_EXPORT);
+      return getJournalists();
+    });
+
+    const prepared = await prepareSourceExport("source-1", db);
+    expect(prepared.filepaths).toHaveLength(3);
+    expect(prepared.sourceName).toBe("export source");
+    expect(fs.readFileSync(prepared.filepaths[0]!, "utf8")).toContain(
+      OLD_MESSAGE,
+    );
+    expect(prepared.filepaths.some((file) => file.includes("item-202"))).toBe(
+      false,
+    );
+    expect(db.getItem("item-202")).not.toBeNull();
+
+    const archiveDir = path.join(homeDir, "archive");
+    fs.mkdirSync(archiveDir);
+    const archivePath = await new ArchiveExporter(EXPORT_QUBE).createArchive({
+      archiveDir,
+      archiveFilename: "source-export.sd-export",
+      metadata: { device: "disk" },
+      filepaths: prepared.filepaths,
+      sourceName: prepared.sourceName,
+    });
+    const extracted = await extractArchive(archivePath, homeDir);
+    const exportRoot = path.join(extracted, "export_data", "export source");
+
+    expect(fs.readdirSync(exportRoot).sort()).toEqual([
+      "item-002-payload.txt",
+      "item-060-payload.txt",
+      "source-1-transcript.txt",
+    ]);
+    expect(
+      fs.readFileSync(path.join(exportRoot, "item-002-payload.txt"), "utf8"),
+    ).toBe(OLD_FILE);
+    expect(
+      fs.readFileSync(path.join(exportRoot, "source-1-transcript.txt"), "utf8"),
+    ).toContain(OLD_MESSAGE);
+    expect(
+      fs.readdirSync(exportRoot).some((name) => name.includes("item-202")),
+    ).toBe(false);
+    expect(
+      fs.readdirSync(exportRoot).some((name) => name.includes("item-120")),
+    ).toBe(false);
+    expect(
+      fs.readdirSync(exportRoot).some((name) => name.includes("item-121")),
+    ).toBe(false);
+  });
+
+  it("keeps the normal 100-item transcript complete", async () => {
+    seedItems(db, storage, 100);
+    const prepared = await prepareSourceExport("source-1", db);
+    const transcript = fs.readFileSync(prepared.filepaths[0]!, "utf8");
+
+    expect(transcript).toContain(OLD_MESSAGE);
+    expect(transcript).toContain("item 100");
+    expect(db.getSourceWithItems("source-1").hasMoreHistoricalItems).toBe(
+      false,
+    );
+  });
+
+  it("prints the all-history transcript through the production archive workflow", async () => {
+    seedItems(db, storage, 101);
+    const prepared = await prepareSourceExport("source-1", db);
+
+    class CapturingPrinter extends Printer {
+      printedTranscript = "";
+
+      override async runQrexecExport(archivePath: string): Promise<void> {
+        const extracted = await extractArchive(archivePath, homeDir);
+        if (archivePath.includes("printer-preflight")) {
+          this.processStderr = PrintStatus.PRINT_PREFLIGHT_SUCCESS;
+          return;
+        }
+        const transcriptPath = path.join(
+          extracted,
+          "export_data",
+          "source-1-transcript.txt",
+        );
+        this.printedTranscript = fs.readFileSync(transcriptPath, "utf8");
+        this.processStderr = PrintStatus.PRINT_SUCCESS;
+      }
+    }
+
+    const printer = new CapturingPrinter();
+    expect(await printer.initiatePrint()).toBe(
+      PrintStatus.PRINT_PREFLIGHT_SUCCESS,
+    );
+    expect(await printer.print([prepared.filepaths[0]!])).toBe(
+      PrintStatus.PRINT_SUCCESS,
+    );
+    expect(printer.printedTranscript).toContain(OLD_MESSAGE);
+    expect(printer.tmpdir).toBeNull();
+  });
+
+  it("cleans export and print temporary archives after transfer failures", async () => {
+    seedItems(db, storage, 1);
+    const prepared = await prepareSourceExport("source-1", db);
+
+    class FailingExporter extends Exporter {
+      failedArchiveDir: string | null = null;
+
+      override async runQrexecExport(archivePath: string): Promise<void> {
+        this.failedArchiveDir = path.dirname(archivePath);
+        throw new Error("export transfer failed");
+      }
+    }
+    const exporter = new FailingExporter();
+    await expect(
+      exporter.export(prepared.filepaths, null, prepared.sourceName, true),
+    ).rejects.toThrow("export transfer failed");
+    expect(exporter.tmpdir).toBeNull();
+    if (!exporter.failedArchiveDir) {
+      throw new Error("export did not reach the transfer boundary");
+    }
+    expect(fs.existsSync(exporter.failedArchiveDir)).toBe(false);
+
+    class FailingPrinter extends Printer {
+      calls = 0;
+      failedArchiveDir: string | null = null;
+
+      override async runQrexecExport(archivePath: string): Promise<void> {
+        this.calls += 1;
+        if (this.calls === 1) {
+          this.processStderr = PrintStatus.PRINT_PREFLIGHT_SUCCESS;
+          return;
+        }
+        this.failedArchiveDir = path.dirname(archivePath);
+        throw new Error("print transfer failed");
+      }
+    }
+    const printer = new FailingPrinter();
+    expect(await printer.initiatePrint()).toBe(
+      PrintStatus.PRINT_PREFLIGHT_SUCCESS,
+    );
+    expect(await printer.print([prepared.filepaths[0]!])).toBe(
+      DeviceErrorStatus.UNEXPECTED_RETURN_STATUS,
+    );
+    expect(printer.tmpdir).toBeNull();
+    if (!printer.failedArchiveDir) {
+      throw new Error("print did not reach the transfer boundary");
+    }
+    expect(fs.existsSync(printer.failedArchiveDir)).toBe(false);
+  });
+});

--- a/app/src/main/source-export.ts
+++ b/app/src/main/source-export.ts
@@ -1,0 +1,34 @@
+import fs from "fs";
+
+import { FetchStatus } from "../types";
+import { DB } from "./database";
+import { writeTranscript } from "./transcriber";
+
+export type PreparedSourceExport = {
+  filepaths: [string, ...string[]];
+  sourceName: string;
+};
+
+export async function prepareSourceExport(
+  sourceUuid: string,
+  db: DB,
+): Promise<PreparedSourceExport> {
+  const { filePath, sourceWithItems } = await writeTranscript(sourceUuid, db);
+  const filepaths: [string, ...string[]] = [filePath];
+
+  for (const item of sourceWithItems.items) {
+    if (
+      item.data.kind === "file" &&
+      item.fetch_status === FetchStatus.Complete &&
+      item.filename &&
+      fs.existsSync(item.filename)
+    ) {
+      filepaths.push(item.filename);
+    }
+  }
+
+  return {
+    filepaths,
+    sourceName: sourceWithItems.data.journalist_designation,
+  };
+}

--- a/app/src/main/transcriber.test.ts
+++ b/app/src/main/transcriber.test.ts
@@ -131,7 +131,7 @@ describe("Transcriber Component Tests", () => {
   function createMockDB() {
     return {
       getJournalists: vi.fn(),
-      getSourceWithItems: vi.fn(),
+      getSourceWithAllItems: vi.fn(),
     } as unknown as DB;
   }
 
@@ -242,7 +242,7 @@ Interesting message there
     const db = createMockDB();
 
     db.getJournalists = vi.fn(() => [mockJournalist]);
-    db.getSourceWithItems = vi.fn(() => mockSourceWithItems);
+    db.getSourceWithAllItems = vi.fn(() => mockSourceWithItems);
 
     const expectedSource: string = "Source: palpable disquiet";
     const expectedTranscript: string = `Transcript:
@@ -258,11 +258,11 @@ notsuperman replied:
 Interesting message there
 `;
 
-    const output: string = await writeTranscript(mockSourceWithItems.uuid, db);
-    expect(output).toContain("transcript.txt");
-    expect(fs.existsSync(output)).toBe(true);
-    console.log(`BANANA: ${output}`);
-    const fileContents = fs.readFileSync(output, "utf-8");
+    const output = await writeTranscript(mockSourceWithItems.uuid, db);
+    expect(output.filePath).toContain("transcript.txt");
+    expect(output.sourceWithItems).toBe(mockSourceWithItems);
+    expect(fs.existsSync(output.filePath)).toBe(true);
+    const fileContents = fs.readFileSync(output.filePath, "utf-8");
     expect(fileContents).toContain(expectedSource);
     expect(fileContents).toContain(expectedTranscript);
   });

--- a/app/src/main/transcriber.ts
+++ b/app/src/main/transcriber.ts
@@ -7,6 +7,11 @@ import { type SourceWithItems } from "../types";
 import { Liquid } from "liquidjs";
 import transcriptTemplateContent from "../../resources/templates/transcript.txt.liquid?raw";
 
+export type TranscriptArtifact = {
+  filePath: string;
+  sourceWithItems: SourceWithItems;
+};
+
 export async function renderTranscript(data: SourceWithItems, db: DB) {
   const transcriptTemplateName = "transcript.txt.liquid";
 
@@ -59,11 +64,11 @@ export async function renderTranscript(data: SourceWithItems, db: DB) {
 export async function writeTranscript(
   sourceUuid: string,
   db: DB,
-): Promise<string> {
+): Promise<TranscriptArtifact> {
   const storage = new Storage();
 
   try {
-    const sourceWithItems = db.getSourceWithItems(sourceUuid);
+    const sourceWithItems = db.getSourceWithAllItems(sourceUuid);
     const filePath: string = join(
       storage.sourceDirectory(sourceUuid).path,
       "transcript.txt",
@@ -71,7 +76,7 @@ export async function writeTranscript(
 
     const fileContent = await renderTranscript(sourceWithItems, db);
     fs.writeFileSync(filePath, fileContent, "utf-8");
-    return filePath;
+    return { filePath, sourceWithItems };
   } catch (error) {
     console.error(
       `Failed to write transcript for source: ${sourceUuid}:`,


### PR DESCRIPTION
## Summary

- include every projected source item in source-wide transcripts and print artifacts
- include every completed, existing source file in source-wide export archives
- use one deterministic database snapshot for transcript rendering and file selection

## Context

Fixes #3581.

The renderer remains page-bounded; source-wide artifact generation now uses a
dedicated all-history query over the same projected rows.

## Test plan

```sh
cd app
TMPDIR=/private/tmp/sdc3581-tests pnpm exec vitest run \
  --config vitest.config.ts --project=unit --no-file-parallelism \
  src/main/source-export.test.ts \
  src/main/transcriber.test.ts \
  src/main/datastore.test.ts
pnpm exec vitest run --config vitest.config.ts --project=unit \
  src/main/export.test.ts
pnpm lint
pnpm dbmate:check
pnpm build
cd ..
TMPDIR=/private/tmp python3 -m pytest export/tests/test_directory.py -q
git diff --check
```

Observed: 83 focused source/export tests, 16 existing export tests, and 13
Python archive extraction tests passed locally. Formatting, ESLint, both
TypeScript checks, database schema verification, the app build, and the diff
check passed.

The original 151-item reproducer returned only items 52 through 151 on `main`.
The patched production-path proof returned complete 0, 1, 100, 101, 151, and
201-item histories. Archive tests confirmed that the oldest message and
completed file are included, while incomplete, missing, failed, cancelled,
pending-deleted, pending-truncated, and post-snapshot files remain excluded.

## Notes

This does not change conversation UI pagination. Archive member-name collisions
remain tracked separately and are outside this change.

Qubes export and print hardware integration was not available locally. The
production exporter and printer classes exercised archive creation, transfer
boundaries, and cleanup after transfer failures.

## Checklist

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
