### PR TITLE
fix(build): use pinned pnpm for Debian app builds

### DIFF
--- a/debian/build-app.sh
+++ b/debian/build-app.sh
@@ -2,10 +2,10 @@
 
 set -euxo pipefail
 
-# Install pnpm v10
-npm install -g pnpm@10
-
 cd app
+
+corepack enable pnpm
+corepack install
 
 pnpm install --frozen-lockfile
 pnpm run build:unpack


### PR DESCRIPTION
## Summary

- remove the mutable `npm install -g pnpm@10` bootstrap from Debian app packaging
- resolve pnpm through Corepack from the committed `app/package.json` package-manager pin
- keep `pnpm install --frozen-lockfile` and `pnpm run build:unpack` on the same Debian build path

## Context

Fixes #3593.

This applies the package-manager pinning direction discussed in #2555 to the
Debian app package build path, where the package manager runs before app
dependency installation.

## Test plan

```sh
python3 -B /path/to/mutable-pnpm-bootstrap-poc.py /path/to/unpatched-securedrop-client
```

Observed on unpatched `origin/main` `cf01cebc`: `bootstrap_spec: pnpm@10`,
`npm_install_hook_ran: true`, `mutable_tool_reached_build_step: true`,
`packaged_output_mutated: true`, and `vulnerable: true`.

```sh
python3 -B /path/to/mutable-pnpm-bootstrap-poc.py /path/to/patched-securedrop-client
```

Observed on this branch after rebasing onto `origin/main` `6e0d25ab`: the PoC
exited `2` with `could not find npm global pnpm bootstrap command`.

```sh
PATH="/opt/homebrew/opt/node@24/bin:$PATH" \
  COREPACK_HOME="$(mktemp -d)" \
  corepack install
```

Observed from `app/`: Corepack 0.35.0 added
`pnpm@10.14.0+sha512.ad27...4748` to the cache as `pnpm/10.14.0`.

```sh
# same packageManager value with the final SHA-512 nibble changed
PATH="/opt/homebrew/opt/node@24/bin:$PATH" \
  COREPACK_HOME="$(mktemp -d)" \
  corepack install
```

Observed: Corepack exited `1` with `Mismatch hashes`, expecting the tampered
hash and reporting the committed `ad27...4748` hash from the fetched pnpm
artifact.

```sh
shellcheck debian/build-app.sh
git diff --check origin/main...HEAD
```

Observed: both passed with no output.

```sh
DEBIAN_VERSION=trixie WHAT=main FAST=1 \
  BUILDER=/path/to/securedrop-builder \
  ./scripts/build-debs.sh
```

Observed in a local amd64 trixie builder: the pinned NodeSource package installed
`node v24.15.0` with `/usr/bin/corepack` (`corepack 0.34.6`), the package build
completed, and `securedrop-app_1.5.0~rc1+trixie_amd64.deb` had SHA-256
`0358cf4feaa4190b4b1fd421b9bd686127b31539f48cff65a8bf4a5f7ab96316`.

## Notes

This change does not attempt to remove network access from Corepack package-manager
resolution; it binds the selected pnpm artifact to the committed version and
SHA-512 integrity value before app dependency installation starts.

## Checklist

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
