### PR TITLE
fix(database): enforce lifecycle count invariants

### DIFF
--- a/app/server_tests/delete-conversation.test.ts
+++ b/app/server_tests/delete-conversation.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, beforeAll, afterAll } from "vitest";
 import { expect } from "@playwright/test";
+import fs from "fs";
+import path from "path";
 
 import { TestContext, createDbHelper, TestHelpers } from "./helper";
 import { Crypto } from "../src/main/crypto";
@@ -13,8 +15,10 @@ const TARGET_SOURCE = {
 describe.sequential("deleting source conversation", () => {
   let context: TestContext;
   let helpers: TestHelpers;
+  let dbHelper: ReturnType<typeof createDbHelper>;
   let initialSourceCount: number;
   let initialItemCount: number;
+  let cleanupFilePath: string;
 
   beforeAll(async () => {
     context = await TestContext.setup();
@@ -22,14 +26,37 @@ describe.sequential("deleting source conversation", () => {
       isQubes: false,
       submissionKeyFingerprint: "",
     });
-    const dbHelper = createDbHelper(crypto, context.dbPath);
+    dbHelper = createDbHelper(crypto, context.dbPath);
     helpers = new TestHelpers(context, dbHelper);
     await context.login();
     await context.runSync();
+    await expect(
+      context.page.locator('[data-testid^="source-checkbox-"]'),
+    ).toHaveCount(3, { timeout: 60000 });
 
     // Store initial counts
     initialSourceCount = await context.getVisibleSourceCount();
     initialItemCount = await helpers.getSourceItemCount(TARGET_SOURCE.uuid);
+    const itemUuid = await dbHelper.withDb((db) => {
+      const item = db.getSourceWithItems(TARGET_SOURCE.uuid).items[0];
+      if (!item) {
+        throw new Error(
+          "Target source has no item for filesystem cleanup test",
+        );
+      }
+      return item.uuid;
+    });
+    cleanupFilePath = path.join(
+      context.tempDir,
+      ".config",
+      "SecureDrop",
+      "files",
+      TARGET_SOURCE.uuid,
+      itemUuid,
+      "plaintext",
+    );
+    fs.mkdirSync(path.dirname(cleanupFilePath), { recursive: true });
+    fs.writeFileSync(cleanupFilePath, "server-backed cleanup secret");
     console.log(`Initial source count: ${initialSourceCount}`);
     console.log(`Initial item count for target source: ${initialItemCount}`);
   }, 180000);
@@ -38,6 +65,44 @@ describe.sequential("deleting source conversation", () => {
     await context.teardown();
     await TestContext.stopServer();
   }, 60000);
+
+  it("round trips a zero truncation bound through preload and API2", async () => {
+    const eventId = await context.page.evaluate(async (sourceUuid) => {
+      const electronWindow = window as unknown as {
+        electronAPI: {
+          addPendingSourceEvent: (
+            sourceUuid: string,
+            type: PendingEventType,
+            data: { upper_bound: number },
+          ) => Promise<string | null>;
+        };
+      };
+      return electronWindow.electronAPI.addPendingSourceEvent(
+        sourceUuid,
+        "source_conversation_truncated" as PendingEventType,
+        { upper_bound: 0 },
+      );
+    }, TARGET_SOURCE.uuid);
+
+    expect(eventId).not.toBeNull();
+    expect(await helpers.getSourceItemCount(TARGET_SOURCE.uuid)).toBe(
+      initialItemCount,
+    );
+    await context.runSync();
+    await helpers.waitForPendingEvents(
+      PendingEventType.SourceConversationTruncated,
+      0,
+      60000,
+    );
+    expect(
+      await helpers.getPendingEventsByType(
+        PendingEventType.SourceConversationTruncated,
+      ),
+    ).toHaveLength(0);
+    expect(await helpers.getSourceItemCount(TARGET_SOURCE.uuid)).toBe(
+      initialItemCount,
+    );
+  });
 
   it("deletes conversation but keeps source account locally", async () => {
     // Verify source exists and has items before deletion
@@ -66,11 +131,20 @@ describe.sequential("deleting source conversation", () => {
     // Verify items are hidden from conversation (projected as deleted)
     const itemCount = await helpers.getSourceItemCount(TARGET_SOURCE.uuid);
     expect(itemCount).toBe(0);
+    expect(fs.existsSync(cleanupFilePath)).toBe(false);
+    expect(
+      await dbHelper.withDb((db) => db.getFilesystemCleanupJobs()),
+    ).toHaveLength(0);
   });
 
   it("syncs the conversation delete event with the server", async () => {
     // Run sync to push the delete event to the server
     await context.runSync();
+    await helpers.waitForPendingEvents(
+      PendingEventType.SourceConversationTruncated,
+      0,
+      60000,
+    );
 
     // Verify pending events are cleared
     const pendingEvents = await helpers.getPendingEventsByType(

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -30,17 +30,30 @@ import {
   EventStatus,
   SearchResult,
   FirstRunStatus,
+  FilesystemCleanupJob,
   PendingEventData,
   SourceItemCounts,
+  IndexDeletionPlan,
 } from "../../types";
 import { Crypto } from "../crypto";
 import { Search } from "./search";
+import {
+  EventUpperBoundSchema,
+  InteractionCountSchema,
+  validatePendingEventData,
+} from "../../schemas";
 
 // Truncate message previews to 200 Unicode code points
 // at the database layer; CSS will handle the rest
 export const MESSAGE_PREVIEW_LENGTH = 200;
 const DEFAULT_ITEM_LIMIT = 100;
 export const DEFAULT_PENDING_EVENTS_LIMIT = 20;
+
+type SourceItemsOptions = {
+  limit?: number;
+  beforeInteractionCount?: number;
+  journalistUuid?: string;
+};
 
 interface KeyObject {
   [key: string]: object;
@@ -75,94 +88,98 @@ export class DB {
   private firstRunStatus: FirstRunStatus = null;
 
   // Prepared statements
-  private selectVersion: Statement<[], { version: string }>;
-  private insertVersion: Statement<[string], void>;
+  private selectVersion!: Statement<[], { version: string }>;
+  private insertVersion!: Statement<[string], void>;
 
-  private selectAllSourceVersion: Statement<
+  private selectAllSourceVersion!: Statement<
     [],
     { uuid: string; version: string }
   >;
-  private selectUnprojectedSourceVersion: Statement<
+  private selectUnprojectedSourceVersion!: Statement<
     { uuid: string },
     { version: string }
   >;
-  private upsertSource: Statement<
+  private upsertSource!: Statement<
     { uuid: string; data: string; version: string },
     void
   >;
-  private deleteSource: Statement<{ uuid: string }, void>;
+  private deleteSource!: Statement<{ uuid: string }, void>;
 
-  private selectAllItemVersion: Statement<
+  private selectAllItemVersion!: Statement<
     [],
     { uuid: string; version: string }
   >;
-  private selectUnprojectedItemVersion: Statement<
+  private selectUnprojectedItemVersion!: Statement<
     { uuid: string },
     { version: string }
   >;
-  private selectMessageItemsProcessable: Statement<
+  private selectMessageItemsProcessable!: Statement<
     { limit: number },
     { uuid: string }
   >;
-  private selectFileItemsProcessable: Statement<
+  private selectFileItemsProcessable!: Statement<
     { limit: number },
     { uuid: string }
   >;
-  private deleteUnprojectedItemsBySource: Statement<
+  private deleteUnprojectedItemsBySource!: Statement<
     { source_uuid: string },
     void
   >;
-  private upsertItem: Statement<
+  private upsertItem!: Statement<
     { uuid: string; data: string; version: string },
     void
   >;
-  private deleteItem: Statement<{ uuid: string }, void>;
-  private deleteItemMany: Statement<{ uuids_json: string }, void>;
-  private updateItemFetchStatus: Statement<{
+  private deleteItem!: Statement<{ uuid: string }, void>;
+  private deleteItemMany!: Statement<{ uuids_json: string }, void>;
+  private updateItemFetchStatus!: Statement<{
     uuid: string;
     fetch_status: number;
   }>;
-  private updateItemFetchStatusWithReset: Statement<{
+  private updateItemFetchStatusWithReset!: Statement<{
     uuid: string;
     fetch_status: number;
   }>;
-  private updateItemsFetchStatusBySource: Statement<{
+  private updateItemsFetchStatusBySource!: Statement<{
     source_uuid: string;
     fetch_status: number;
   }>;
-  private updateItemsFetchStatusBySourceUpTo: Statement<{
+  private updateItemsFetchStatusBySourceUpTo!: Statement<{
     source_uuid: string;
     upper_bound: number;
     fetch_status: number;
   }>;
-  private selectItem: Statement<{ uuid: string }, ItemRow>;
-  private selectItemMany: Statement<{ uuids_json: string }, ItemRow>;
+  private selectItem!: Statement<{ uuid: string }, ItemRow>;
+  private selectItemMany!: Statement<{ uuids_json: string }, ItemRow>;
+  private selectItemsBySourceUpToCleanup!: Statement<
+    { source_uuid: string; upper_bound: number },
+    ItemRow
+  >;
 
-  private selectAllJournalistVersion: Statement<
+  private selectAllJournalistVersion!: Statement<
     [],
     { uuid: string; version: string }
   >;
-  private upsertJournalist: Statement<
+  private upsertJournalist!: Statement<
     { uuid: string; data: string; version: string },
     void
   >;
-  private selectJournalist: Statement<{ uuid: string }, JournalistRow>;
+  private selectJournalist!: Statement<{ uuid: string }, JournalistRow>;
 
-  private deleteJournalist: Statement<{ uuid: string }, void>;
+  private deleteJournalist!: Statement<{ uuid: string }, void>;
 
-  private selectAllSources: Statement<[], SourceRow>;
-  private selectSourceById: Statement<[string], SourceRow>;
-  private selectItemsBySourceId: Statement<[string, number], ItemRow>;
-  private selectItemsBySourceIdBefore: Statement<
+  private selectAllSources!: Statement<[], SourceRow>;
+  private selectSourceById!: Statement<[string], SourceRow>;
+  private selectItemsBySourceId!: Statement<[string, number], ItemRow>;
+  private selectItemsBySourceIdBefore!: Statement<
     [string, number, number],
     ItemRow
   >;
-  private selectItemCountsBySourceUuids: Statement<
+  private selectItemCountsBySourceUuids!: Statement<
     { uuids_json: string },
     { messages: number; files: number; replies: number }
   >;
-  private selectAllJournalists: Statement<[], JournalistRow>;
-  private insertSourcePendingEvent: Statement<
+  private selectAllJournalists!: Statement<[], JournalistRow>;
+  private insertSourcePendingEvent!: Statement<
     {
       snowflake_id: string;
       source_uuid: string;
@@ -171,7 +188,7 @@ export class DB {
     },
     void
   >;
-  private insertItemPendingEvent: Statement<
+  private insertItemPendingEvent!: Statement<
     {
       snowflake_id: string;
       item_uuid?: string;
@@ -180,27 +197,42 @@ export class DB {
     },
     void
   >;
-  private selectSourceConversationSeenEvent: Statement<
+  private selectSourceConversationSeenEvent!: Statement<
     { source_uuid: string },
     { snowflake_id: string; data: string }
   >;
-  private selectUnprojectedUnseenItemsCount: Statement<
+  private selectUnprojectedUnseenItemsCount!: Statement<
     { source_uuid: string; upper_bound: number },
     { count: number }
   >;
-  private deletePendingEvent: Statement<{ snowflake_id: string }, void>;
-  private incrementPendingEventRetry: Statement<
+  private deletePendingEvent!: Statement<{ snowflake_id: string }, void>;
+  private incrementPendingEventRetry!: Statement<
     { snowflake_id: string; status: number },
     void
   >;
-  private setPendingEventStatus: Statement<
+  private setPendingEventStatus!: Statement<
     { snowflake_id: string; status: number },
     void
   >;
-  private selectPendingEvents: Statement<[{ limit: number }], PendingEventRow>;
-  private deletePendingEventsBySourceScope: Statement<
+  private selectPendingEvents!: Statement<[{ limit: number }], PendingEventRow>;
+  private deletePendingEventsBySourceScope!: Statement<
     { source_uuid: string },
     void
+  >;
+  private insertFilesystemCleanupJob!: Statement<FilesystemCleanupJob, void>;
+  private selectPendingFilesystemCleanupJobs!: Statement<
+    [],
+    FilesystemCleanupJob
+  >;
+  private selectFilesystemCleanupJobs!: Statement<[], FilesystemCleanupJob>;
+  private deleteFilesystemCleanupJob!: Statement<{ id: string }, void>;
+  private selectPendingItemCleanup!: Statement<
+    { item_uuid: string },
+    { present: number }
+  >;
+  private selectPendingSourceCleanup!: Statement<
+    { source_uuid: string },
+    { present: number }
   >;
 
   protected constructor(crypto: Crypto, dbDir?: string) {
@@ -265,7 +297,16 @@ export class DB {
     // Initialize search index
     this.searchIndex = new Search(db);
 
-    // Prepare statements
+    this.prepareCoreStatements();
+    this.prepareProjectionStatements();
+    this.preparePendingEventStatements();
+    this.prepareCleanupStatements();
+  }
+
+  private prepareCoreStatements(): void {
+    if (!this.db) {
+      throw new Error("Database is not open");
+    }
     this.selectVersion = this.db.prepare("SELECT version FROM state");
     this.insertVersion = this.db.prepare(
       "INSERT INTO state_history (version) VALUES (?)",
@@ -329,10 +370,17 @@ export class DB {
       "DELETE FROM items WHERE uuid IN (SELECT value FROM json_each(@uuids_json))",
     );
     this.selectItem = this.db.prepare(
-      `SELECT uuid, data, plaintext, filename, fetch_status, fetch_progress, decrypted_size FROM items WHERE uuid = @uuid`,
+      `SELECT uuid, source_uuid, data, plaintext, filename, fetch_status, fetch_progress, decrypted_size FROM items WHERE uuid = @uuid`,
     );
     this.selectItemMany = this.db.prepare(
-      `SELECT uuid, data, plaintext, filename, fetch_status, fetch_progress, decrypted_size FROM items WHERE uuid IN (SELECT value FROM json_each(@uuids_json))`,
+      `SELECT uuid, source_uuid, data, plaintext, filename, fetch_status, fetch_progress, decrypted_size FROM items WHERE uuid IN (SELECT value FROM json_each(@uuids_json))`,
+    );
+    this.selectItemsBySourceUpToCleanup = this.db.prepare(
+      `SELECT uuid, source_uuid, data, plaintext, filename, fetch_status,
+              fetch_progress, decrypted_size
+         FROM items
+        WHERE source_uuid = @source_uuid
+          AND interaction_count <= @upper_bound`,
     );
 
     this.selectAllJournalistVersion = this.db.prepare(
@@ -349,7 +397,12 @@ export class DB {
     this.deleteJournalist = this.db.prepare(
       "DELETE FROM journalists WHERE uuid = @uuid",
     );
+  }
 
+  private prepareProjectionStatements(): void {
+    if (!this.db) {
+      throw new Error("Database is not open");
+    }
     this.selectAllSources = this.db.prepare(`
       SELECT
         s.uuid,
@@ -381,15 +434,29 @@ export class DB {
       WHERE s.uuid = ?
     `);
     this.selectItemsBySourceId = this.db.prepare(`
-      SELECT uuid, data, plaintext, filename, fetch_status, fetch_progress, decrypted_size, is_read FROM items_projected
-      WHERE source_uuid = ?
-      ORDER BY interaction_count DESC
+      SELECT projected.uuid, persisted.source_uuid, projected.data,
+             projected.plaintext, projected.filename, projected.fetch_status,
+             projected.fetch_progress, projected.decrypted_size,
+             projected.is_read
+        FROM items_projected projected
+        LEFT JOIN items persisted
+          ON persisted.uuid = projected.uuid
+         AND projected.version IS NOT NULL
+       WHERE projected.source_uuid = ?
+       ORDER BY projected.interaction_count DESC
       LIMIT ?
     `);
     this.selectItemsBySourceIdBefore = this.db.prepare(`
-      SELECT uuid, data, plaintext, filename, fetch_status, fetch_progress, decrypted_size FROM items_projected
-      WHERE source_uuid = ? AND interaction_count < ?
-      ORDER BY interaction_count DESC
+      SELECT projected.uuid, persisted.source_uuid, projected.data,
+             projected.plaintext, projected.filename, projected.fetch_status,
+             projected.fetch_progress, projected.decrypted_size
+        FROM items_projected projected
+        LEFT JOIN items persisted
+          ON persisted.uuid = projected.uuid
+         AND projected.version IS NOT NULL
+       WHERE projected.source_uuid = ?
+         AND projected.interaction_count < ?
+       ORDER BY projected.interaction_count DESC
       LIMIT ?
     `);
     this.selectItemCountsBySourceUuids = this.db.prepare(`
@@ -403,7 +470,12 @@ export class DB {
     this.selectAllJournalists = this.db.prepare(`
       SELECT uuid, data FROM journalists
     `);
+  }
 
+  private preparePendingEventStatements(): void {
+    if (!this.db) {
+      throw new Error("Database is not open");
+    }
     this.insertSourcePendingEvent = this.db.prepare(`
       INSERT INTO pending_events (snowflake_id, source_uuid, type, data) VALUES (@snowflake_id, @source_uuid, @type, @data)
     `);
@@ -450,6 +522,45 @@ export class DB {
          OR item_uuid IN (
            SELECT uuid FROM items WHERE source_uuid = @source_uuid
          )`);
+  }
+
+  private prepareCleanupStatements(): void {
+    if (!this.db) {
+      throw new Error("Database is not open");
+    }
+    this.insertFilesystemCleanupJob = this.db.prepare(`
+      INSERT INTO filesystem_cleanup_jobs (
+        id, target, source_uuid, item_uuid, metadata_item_uuid, status, reason
+      ) VALUES (
+        @id, @target, @source_uuid, @item_uuid, @metadata_item_uuid, @status, @reason
+      ) ON CONFLICT(id) DO NOTHING
+    `);
+    this.selectPendingFilesystemCleanupJobs = this.db.prepare(`
+      SELECT id, target, source_uuid, item_uuid, metadata_item_uuid, status, reason
+      FROM filesystem_cleanup_jobs
+      WHERE status = 'pending'
+      ORDER BY created_at ASC, id ASC
+    `);
+    this.selectFilesystemCleanupJobs = this.db.prepare(`
+      SELECT id, target, source_uuid, item_uuid, metadata_item_uuid, status, reason
+      FROM filesystem_cleanup_jobs
+      ORDER BY created_at ASC, id ASC
+    `);
+    this.deleteFilesystemCleanupJob = this.db.prepare(
+      "DELETE FROM filesystem_cleanup_jobs WHERE id = @id AND status = 'pending'",
+    );
+    this.selectPendingItemCleanup = this.db.prepare(`
+      SELECT 1 AS present
+      FROM filesystem_cleanup_jobs
+      WHERE target = 'item' AND item_uuid = @item_uuid AND status = 'pending'
+      LIMIT 1
+    `);
+    this.selectPendingSourceCleanup = this.db.prepare(`
+      SELECT 1 AS present
+      FROM filesystem_cleanup_jobs
+      WHERE target = 'source' AND source_uuid = @source_uuid AND status = 'pending'
+      LIMIT 1
+    `);
   }
 
   // Detect runtime environment
@@ -572,6 +683,18 @@ export class DB {
     return stmt.all(...values) as T[];
   }
 
+  getFilesystemCleanupJobs(): FilesystemCleanupJob[] {
+    return this.selectFilesystemCleanupJobs.all();
+  }
+
+  protected getPendingFilesystemCleanupJobs(): FilesystemCleanupJob[] {
+    return this.selectPendingFilesystemCleanupJobs.all();
+  }
+
+  protected completeFilesystemCleanupJob(id: string): void {
+    this.deleteFilesystemCleanupJob.run({ id });
+  }
+
   /// Read the current index version from the DB for sync.
   /// If we are in the initial sync state and there is no
   // source data available, then we return empty.
@@ -606,6 +729,106 @@ export class DB {
     this.insertVersion.run(newVersion);
   }
 
+  private stageSourceCleanup(sourceUuid: string): void {
+    this.insertFilesystemCleanupJob.run({
+      id: `source:${sourceUuid}`,
+      target: "source",
+      source_uuid: sourceUuid,
+      item_uuid: null,
+      metadata_item_uuid: null,
+      status: "pending",
+      reason: null,
+    });
+  }
+
+  private stageItemCleanup(row: ItemRow): void {
+    const identity = this.getItemCleanupIdentity(row);
+    const status = identity.safe ? "pending" : "quarantined";
+    const prefix = identity.safe ? "item" : "quarantine";
+    this.insertFilesystemCleanupJob.run({
+      id: `${prefix}:${row.uuid}`,
+      target: "item",
+      source_uuid: identity.sourceUuid,
+      item_uuid: row.uuid,
+      metadata_item_uuid: identity.metadataItemUuid,
+      status,
+      reason: identity.reason,
+    });
+  }
+
+  private getItemCleanupIdentity(row: ItemRow): {
+    safe: boolean;
+    sourceUuid: string | null;
+    metadataItemUuid: string | null;
+    reason: string | null;
+  } {
+    let metadata: Record<string, unknown>;
+    try {
+      metadata = JSON.parse(row.data) as Record<string, unknown>;
+    } catch {
+      return this.quarantinedIdentity(row, null, "malformed_metadata");
+    }
+    const metadataItemUuid =
+      typeof metadata.uuid === "string" ? metadata.uuid : null;
+    if (!row.source_uuid || metadataItemUuid !== row.uuid) {
+      return this.quarantinedIdentity(
+        row,
+        metadataItemUuid,
+        "metadata_uuid_mismatch",
+      );
+    }
+    return {
+      safe: true,
+      sourceUuid: row.source_uuid,
+      metadataItemUuid,
+      reason: null,
+    };
+  }
+
+  private quarantinedIdentity(
+    row: ItemRow,
+    metadataItemUuid: string | null,
+    reason: string,
+  ) {
+    return {
+      safe: false,
+      sourceUuid: row.source_uuid,
+      metadataItemUuid,
+      reason,
+    };
+  }
+
+  private stageItemCleanupRows(rows: ItemRow[]): void {
+    for (const row of rows) {
+      this.stageItemCleanup(row);
+    }
+  }
+
+  private assertNoPendingCleanupForItem(
+    itemUuid: string,
+    sourceUuid: string,
+  ): void {
+    const itemPending = this.selectPendingItemCleanup.get({
+      item_uuid: itemUuid,
+    });
+    const sourcePending = this.selectPendingSourceCleanup.get({
+      source_uuid: sourceUuid,
+    });
+    if (itemPending || sourcePending) {
+      throw new Error(
+        `Cannot update item ${itemUuid} before pending filesystem cleanup completes`,
+      );
+    }
+  }
+
+  private assertNoPendingCleanupForSource(sourceUuid: string): void {
+    if (this.selectPendingSourceCleanup.get({ source_uuid: sourceUuid })) {
+      throw new Error(
+        `Cannot update source ${sourceUuid} before pending filesystem cleanup completes`,
+      );
+    }
+  }
+
   protected deleteItems(items: string[]): Item[] {
     if (items.length === 0) {
       return [];
@@ -618,9 +841,11 @@ export class DB {
         const uuids_json = JSON.stringify(batch);
         // Batch fetch before delete so callers can act on deleted items
         const rows = this.selectItemMany.all({ uuids_json }) as ItemRow[];
+        this.stageItemCleanupRows(rows);
         rows.forEach((row) => {
           deletedItems.push({
             uuid: row.uuid,
+            source_uuid: row.source_uuid ?? undefined,
             data: JSON.parse(row.data) as ItemMetadata,
             plaintext: row.plaintext,
             filename: row.filename,
@@ -642,6 +867,10 @@ export class DB {
   // Delete source and any source items from the DB and search index
   private deleteSourceAndItems(sourceUuid: string): void {
     return this.db!.transaction((sourceUuid: string) => {
+      if (!this.selectUnprojectedSourceVersion.get({ uuid: sourceUuid })) {
+        return;
+      }
+      this.stageSourceCleanup(sourceUuid);
       // First, remove all search index entries for this source
       this.searchIndex.removeSource(sourceUuid);
       // Delete all source items
@@ -669,15 +898,141 @@ export class DB {
     })(journalists);
   }
 
-  protected updateBatch(batchResponse: BatchResponse): {
+  private nextLocalInteractionCount(sourceUuid: string): number {
+    const row = this.db!.prepare(
+      `SELECT MAX(value) AS maximum
+         FROM (
+           SELECT interaction_count AS value
+             FROM items
+            WHERE source_uuid = @source_uuid
+           UNION ALL
+           SELECT json_extract(data, '$.metadata.interaction_count') AS value
+             FROM pending_events
+            WHERE source_uuid = @source_uuid
+              AND type = 'reply_sent'
+              AND json_valid(data) = 1
+         )
+        WHERE typeof(value) = 'integer'
+          AND value >= 1
+          AND value <= ${Number.MAX_SAFE_INTEGER}`,
+    ).get({ source_uuid: sourceUuid }) as { maximum: number | null };
+    if (row.maximum === null) {
+      return 1;
+    }
+    return Math.min(row.maximum + 1, Number.MAX_SAFE_INTEGER);
+  }
+
+  private repairInvalidPendingReplyCounts(): void {
+    const rows = this.db!.prepare(
+      `SELECT snowflake_id, source_uuid, data
+         FROM pending_events
+        WHERE type = 'reply_sent'
+          AND source_uuid IS NOT NULL`,
+    ).all() as Array<{
+      snowflake_id: string;
+      source_uuid: string;
+      data: string;
+    }>;
+    const update = this.db!.prepare(
+      `UPDATE pending_events SET data = @data WHERE snowflake_id = @snowflake_id`,
+    );
+
+    for (const row of rows) {
+      let data: Record<string, unknown>;
+      try {
+        data = JSON.parse(row.data) as Record<string, unknown>;
+      } catch {
+        console.warn("Skipping malformed pending reply count repair", {
+          event: row.snowflake_id,
+        });
+        continue;
+      }
+      if (
+        !data.metadata ||
+        typeof data.metadata !== "object" ||
+        Array.isArray(data.metadata)
+      ) {
+        continue;
+      }
+      const metadata = data.metadata as Record<string, unknown>;
+      if (
+        InteractionCountSchema.safeParse(metadata.interaction_count).success
+      ) {
+        continue;
+      }
+      metadata.interaction_count = this.nextLocalInteractionCount(
+        row.source_uuid,
+      );
+      update.run({
+        snowflake_id: row.snowflake_id,
+        data: JSON.stringify(data, sortKeys),
+      });
+    }
+  }
+
+  protected removeInvalidLifecycleData(): Item[] {
+    return this.db!.transaction(() => {
+      // Replies retain unsent plaintext and ciphertext; only repair their local
+      // optimistic count. Invalid server item cache rows can be safely refetched.
+      this.repairInvalidPendingReplyCounts();
+      const invalidItems = this.db!.prepare(
+        `SELECT uuid FROM items
+           WHERE typeof(interaction_count) != 'integer'
+              OR interaction_count < 1
+              OR interaction_count > ${Number.MAX_SAFE_INTEGER}
+              OR CASE
+                   WHEN json_valid(data) = 0 THEN 1
+                   ELSE COALESCE(
+                     json_type(data, '$.uuid') != 'text'
+                     OR uuid IS NOT json_extract(data, '$.uuid'),
+                     1
+                   )
+                 END = 1`,
+      ).all() as { uuid: string }[];
+      const invalidEvents = this.db!.prepare(
+        `SELECT snowflake_id FROM pending_events
+           WHERE CASE
+             WHEN type IN (
+               'source_conversation_seen',
+               'source_conversation_truncated'
+             ) THEN CASE
+               WHEN data IS NULL OR json_valid(data) = 0 THEN 1
+               ELSE COALESCE(
+                 json_type(data, '$.upper_bound') != 'integer'
+                 OR json_extract(data, '$.upper_bound') < 0
+                 OR json_extract(data, '$.upper_bound') > ${Number.MAX_SAFE_INTEGER},
+                 1
+               )
+             END
+             ELSE 0
+           END = 1`,
+      ).all() as { snowflake_id: string }[];
+
+      for (const { snowflake_id } of invalidEvents) {
+        this.deletePendingEvent.run({ snowflake_id });
+      }
+      return this.deleteItems(invalidItems.map(({ uuid }) => uuid));
+    })();
+  }
+
+  protected updateBatch(
+    batchResponse: BatchResponse,
+    deletions: IndexDeletionPlan,
+  ): {
     deleted_items: Item[];
     deleted_sources: string[];
   } {
     return this.db!.transaction((batch: BatchResponse) => {
+      const deleted_items = this.deleteItems(deletions.items);
+      this.deleteSources(deletions.sources);
+      this.deleteJournalists(deletions.journalists);
       this.updatePendingEvents(batch.events);
-      const deleted_items = this.updateItems(batch.items);
-      const deleted_sources = this.updateSources(batch.sources);
-      this.updateJournalists(batch.journalists);
+      deleted_items.push(...this.updateItemRows(batch.items));
+      const deleted_sources = [
+        ...deletions.sources,
+        ...this.updateSourceRows(batch.sources),
+      ];
+      this.updateJournalistRows(batch.journalists);
       this.updateVersion();
       return { deleted_items, deleted_sources };
     })(batchResponse);
@@ -686,47 +1041,65 @@ export class DB {
   protected updateSources(sources: {
     [uuid: string]: SourceMetadata | null;
   }): string[] {
+    return this.db!.transaction(() => this.updateSourceRows(sources))();
+  }
+
+  private updateSourceRows(sources: {
+    [uuid: string]: SourceMetadata | null;
+  }): string[] {
     const deletedSourceUuids: string[] = [];
-    this.db!.transaction(
-      (sources: { [uuid: string]: SourceMetadata | null }) => {
-        Object.keys(sources).forEach((sourceid: string) => {
-          const metadata = sources[sourceid];
-          if (metadata) {
-            const info = JSON.stringify(metadata, sortKeys);
-            const version = computeVersion(info);
-            this.upsertSource.run({ uuid: sourceid, data: info, version });
-            this.searchIndex.indexSource(sourceid);
-          } else {
-            deletedSourceUuids.push(sourceid);
-            this.deleteSourceAndItems(sourceid);
-          }
-        });
-      },
-    )(sources);
+    Object.keys(sources).forEach((sourceid: string) => {
+      const metadata = sources[sourceid];
+      if (metadata) {
+        this.assertNoPendingCleanupForSource(sourceid);
+        const info = JSON.stringify(metadata, sortKeys);
+        const version = computeVersion(info);
+        this.upsertSource.run({ uuid: sourceid, data: info, version });
+        this.searchIndex.indexSource(sourceid);
+      } else {
+        deletedSourceUuids.push(sourceid);
+        this.deleteSourceAndItems(sourceid);
+      }
+    });
     return deletedSourceUuids;
   }
 
   protected updateItems(items: {
     [uuid: string]: ItemMetadata | null;
   }): Item[] {
+    return this.db!.transaction(() => this.updateItemRows(items))();
+  }
+
+  private updateItemRows(items: {
+    [uuid: string]: ItemMetadata | null;
+  }): Item[] {
     const deletedItems: Item[] = [];
-    this.db!.transaction((items: { [uuid: string]: ItemMetadata | null }) => {
-      Object.keys(items).forEach((itemid: string) => {
-        const metadata = items[itemid];
-        if (metadata) {
-          const blob = JSON.stringify(metadata, sortKeys);
-          const version = computeVersion(blob);
-          this.upsertItem.run({ uuid: itemid, data: blob, version });
-        } else {
-          const item = this.getItem(itemid);
-          if (item) {
-            deletedItems.push(item);
-          }
-          this.deleteItem.run({ uuid: itemid });
-          this.searchIndex.removeItem(itemid);
+    Object.keys(items).forEach((itemid: string) => {
+      const metadata = items[itemid];
+      if (metadata) {
+        if (metadata.uuid !== itemid) {
+          throw new Error(
+            `Item metadata UUID ${metadata.uuid} does not match map key ${itemid}`,
+          );
         }
-      });
-    })(items);
+        InteractionCountSchema.parse(metadata.interaction_count);
+        this.assertNoPendingCleanupForItem(itemid, metadata.source);
+        const blob = JSON.stringify(metadata, sortKeys);
+        const version = computeVersion(blob);
+        this.upsertItem.run({ uuid: itemid, data: blob, version });
+      } else {
+        const item = this.getItem(itemid);
+        if (item) {
+          deletedItems.push(item);
+          const row = this.selectItem.get({ uuid: itemid });
+          if (row) {
+            this.stageItemCleanup(row);
+          }
+        }
+        this.deleteItem.run({ uuid: itemid });
+        this.searchIndex.removeItem(itemid);
+      }
+    });
     return deletedItems;
   }
 
@@ -750,24 +1123,22 @@ export class DB {
   protected updateJournalists(journalists: {
     [uuid: string]: JournalistMetadata | null;
   }) {
-    this.db!.transaction(
-      (journalists: { [uuid: string]: JournalistMetadata | null }) => {
-        Object.keys(journalists).forEach((id: string) => {
-          const metadata = journalists[id];
-          if (metadata) {
-            const blob = JSON.stringify(metadata, sortKeys);
-            const version = computeVersion(blob);
-            this.upsertJournalist.run({
-              uuid: id,
-              data: blob,
-              version: version,
-            });
-          } else {
-            this.deleteJournalist.run({ uuid: id });
-          }
-        });
-      },
-    )(journalists);
+    this.db!.transaction(() => this.updateJournalistRows(journalists))();
+  }
+
+  private updateJournalistRows(journalists: {
+    [uuid: string]: JournalistMetadata | null;
+  }) {
+    Object.keys(journalists).forEach((id: string) => {
+      const metadata = journalists[id];
+      if (metadata) {
+        const blob = JSON.stringify(metadata, sortKeys);
+        const version = computeVersion(blob);
+        this.upsertJournalist.run({ uuid: id, data: blob, version });
+      } else {
+        this.deleteJournalist.run({ uuid: id });
+      }
+    });
   }
 
   // Helper function for truthy values
@@ -825,11 +1196,7 @@ export class DB {
 
   getSourceWithItems(
     sourceUuid: string,
-    options?: {
-      limit?: number;
-      beforeInteractionCount?: number;
-      journalistUuid?: string;
-    },
+    options?: SourceItemsOptions,
   ): SourceWithItems {
     if (!this.db) {
       throw new Error("Database is not open");
@@ -845,69 +1212,18 @@ export class DB {
 
     const sourceData = JSON.parse(sourceRow.data);
 
-    let limit = DEFAULT_ITEM_LIMIT;
-    if (options?.limit) {
-      limit = options?.limit;
-    }
-    // Fetch limit+1 rows to detect if there are more historical items
+    const limit = options?.limit || DEFAULT_ITEM_LIMIT;
     const fetchLimit = limit + 1;
-    let rows: ItemRow[];
-    if (options?.beforeInteractionCount) {
-      rows = this.selectItemsBySourceIdBefore.all(
-        sourceUuid,
-        options.beforeInteractionCount,
-        fetchLimit,
-      );
-    } else {
-      rows = this.selectItemsBySourceId.all(sourceUuid, fetchLimit);
-    }
+    const rows = this.getSourceItemRows(sourceUuid, options, fetchLimit);
     const hasMoreHistoricalItems = rows.length > limit;
-    // Take at most `limit` rows (DESC order), then reverse to ASC for display
-    const itemRows = rows.slice(0, limit).reverse();
-
-    const items = itemRows.map((row) => {
-      const data = JSON.parse(row.data) as ItemMetadata;
-      if (row.is_read !== undefined && "is_read" in data) {
-        (data as { is_read: boolean }).is_read = this.isTruthy(row.is_read);
-      }
-      return {
-        uuid: row.uuid,
-        data,
-        plaintext: row.plaintext,
-        filename: row.filename,
-        fetch_status: row.fetch_status,
-        fetch_progress: row.fetch_progress,
-        decrypted_size: row.decrypted_size,
-      };
-    });
-
-    // Return most recently seen message: all replies are seen, if journalistUuid is specified
-    // use seen_by field, otherwise fallback to the is_read field
-    const journalistUuid = options?.journalistUuid;
-    let maxSeenInteractionCount: number | null = null;
-    for (const item of items) {
-      const interaction = item.data.interaction_count ?? null;
-      if (interaction === null) {
-        continue;
-      }
-      let hasBeenSeen: boolean;
-      if (journalistUuid) {
-        hasBeenSeen = item.data.seen_by.includes(journalistUuid);
-      } else if (item.data.kind !== "reply") {
-        hasBeenSeen = item.data.is_read;
-      } else {
-        hasBeenSeen = true;
-      }
-      if (
-        hasBeenSeen &&
-        (maxSeenInteractionCount === null ||
-          interaction > maxSeenInteractionCount)
-      ) {
-        maxSeenInteractionCount = interaction;
-      }
-    }
-    // If nothing has been seen, return null
-    const lastSeenInteractionCount = maxSeenInteractionCount ?? null;
+    const items = rows
+      .slice(0, limit)
+      .reverse()
+      .map((row) => this.toItem(row));
+    const lastSeenInteractionCount = this.getLastSeenInteractionCount(
+      items,
+      options?.journalistUuid,
+    );
 
     return {
       uuid: sourceRow.uuid,
@@ -916,6 +1232,60 @@ export class DB {
       hasMoreHistoricalItems,
       lastSeenInteractionCount,
     };
+  }
+
+  private getSourceItemRows(
+    sourceUuid: string,
+    options: SourceItemsOptions | undefined,
+    fetchLimit: number,
+  ): ItemRow[] {
+    if (options?.beforeInteractionCount) {
+      return this.selectItemsBySourceIdBefore.all(
+        sourceUuid,
+        options.beforeInteractionCount,
+        fetchLimit,
+      );
+    }
+    return this.selectItemsBySourceId.all(sourceUuid, fetchLimit);
+  }
+
+  private toItem(row: ItemRow): Item {
+    const data = JSON.parse(row.data) as ItemMetadata;
+    if (row.is_read !== undefined && "is_read" in data) {
+      data.is_read = this.isTruthy(row.is_read);
+    }
+    return {
+      uuid: row.uuid,
+      source_uuid: row.source_uuid ?? undefined,
+      data,
+      plaintext: row.plaintext,
+      filename: row.filename,
+      fetch_status: row.fetch_status as FetchStatus | null,
+      fetch_progress: row.fetch_progress,
+      decrypted_size: row.decrypted_size,
+    };
+  }
+
+  private getLastSeenInteractionCount(
+    items: Item[],
+    journalistUuid?: string,
+  ): number | null {
+    let maximum: number | null = null;
+    for (const item of items) {
+      const interaction = item.data.interaction_count;
+      if (this.wasItemSeen(item, journalistUuid)) {
+        maximum =
+          maximum === null ? interaction : Math.max(maximum, interaction);
+      }
+    }
+    return maximum;
+  }
+
+  private wasItemSeen(item: Item, journalistUuid?: string): boolean {
+    if (journalistUuid) {
+      return item.data.seen_by.includes(journalistUuid);
+    }
+    return item.data.kind === "reply" || item.data.is_read;
   }
 
   getSourceItemCounts(sourceUuids: string[]): SourceItemCounts {
@@ -998,6 +1368,7 @@ export class DB {
     }
     return {
       uuid: row.uuid,
+      source_uuid: row.source_uuid ?? undefined,
       data: JSON.parse(row.data) as ItemMetadata,
       plaintext: row.plaintext,
       filename: row.filename,
@@ -1121,45 +1492,74 @@ export class DB {
     });
   }
 
+  private stageTruncationCleanup(
+    sourceUuid: string,
+    data: PendingEventData | undefined,
+  ): void {
+    const upperBound = EventUpperBoundSchema.parse(data?.upper_bound);
+    const rows = this.selectItemsBySourceUpToCleanup.all({
+      source_uuid: sourceUuid,
+      upper_bound: upperBound,
+    });
+    this.stageItemCleanupRows(rows);
+  }
+
+  private stagePendingEventCleanup(event: PendingEventRow): void {
+    if (event.type === PendingEventType.SourceDeleted && event.source_uuid) {
+      this.stageSourceCleanup(event.source_uuid);
+      return;
+    }
+    if (
+      event.type === PendingEventType.SourceConversationTruncated &&
+      event.source_uuid
+    ) {
+      this.stageTruncationCleanup(
+        event.source_uuid,
+        JSON.parse(event.data) as PendingEventData,
+      );
+      return;
+    }
+    if (event.type === PendingEventType.ItemDeleted && event.item_uuid) {
+      const row = this.selectItem.get({ uuid: event.item_uuid });
+      if (row) {
+        this.stageItemCleanup(row);
+      }
+    }
+  }
+
   addPendingSourceEvent(
     sourceUuid: string,
     type: PendingEventType,
     data?: PendingEventData,
   ): string | null {
+    validatePendingEventData(type, data);
     return this.db!.transaction(() => {
+      if (!this.selectUnprojectedSourceVersion.get({ uuid: sourceUuid })) {
+        return null;
+      }
       const snowflakeID = this.snowflake
         .generate({ timestamp: Date.now() })
         .toString();
 
       if (type === PendingEventType.SourceDeleted) {
+        this.stageSourceCleanup(sourceUuid);
         this.purgePendingEventsForSource(sourceUuid);
         this.markSourceItemsScheduledDeletion(sourceUuid);
       } else if (type === PendingEventType.SourceConversationTruncated) {
+        this.stageTruncationCleanup(sourceUuid, data);
         this.purgePendingEventsForSource(sourceUuid);
-        if (data?.upper_bound !== undefined) {
-          this.markSourceItemsScheduledDeletionUpTo(
-            sourceUuid,
-            data.upper_bound,
-          );
-        }
+        this.markSourceItemsScheduledDeletionUpTo(
+          sourceUuid,
+          EventUpperBoundSchema.parse(data?.upper_bound),
+        );
       }
 
-      try {
-        this.insertSourcePendingEvent.run({
-          snowflake_id: snowflakeID,
-          source_uuid: sourceUuid,
-          type: type,
-          data: data ? JSON.stringify(data) : null,
-        });
-      } catch (err) {
-        if (err instanceof Error && "code" in err) {
-          if (err.code === "SQLITE_CONSTRAINT_FOREIGNKEY") {
-            return null;
-          } else {
-            throw err;
-          }
-        }
-      }
+      this.insertSourcePendingEvent.run({
+        snowflake_id: snowflakeID,
+        source_uuid: sourceUuid,
+        type: type,
+        data: data ? JSON.stringify(data) : null,
+      });
 
       return snowflakeID;
     })();
@@ -1184,6 +1584,7 @@ export class DB {
     sourceUuid: string,
     interactionCount: number,
   ): Promise<string> {
+    InteractionCountSchema.parse(interactionCount);
     const itemUuid = crypto.randomUUID();
     const snowflakeID = this.snowflake
       .generate({ timestamp: Date.now() })
@@ -1225,36 +1626,36 @@ export class DB {
   }
 
   addPendingItemEvent(itemUuid: string, type: PendingEventType): string | null {
-    const snowflakeID = this.snowflake
-      .generate({ timestamp: Date.now() })
-      .toString();
-    try {
+    return this.db!.transaction(() => {
+      const row = this.selectItem.get({ uuid: itemUuid });
+      if (!row) {
+        return null;
+      }
+      if (type === PendingEventType.ItemDeleted) {
+        this.stageItemCleanup(row);
+      }
+      const snowflakeID = this.snowflake
+        .generate({ timestamp: Date.now() })
+        .toString();
       this.insertItemPendingEvent.run({
         snowflake_id: snowflakeID,
         item_uuid: itemUuid,
         type: type,
         data: null,
       });
-    } catch (err) {
-      if (err instanceof Error && "code" in err) {
-        if (err.code === "SQLITE_CONSTRAINT_FOREIGNKEY") {
-          return null;
-        } else {
-          throw err;
-        }
-      }
-    }
-    return snowflakeID;
+      return snowflakeID;
+    })();
   }
 
   addPendingSourceConversationSeen(
     sourceUuid: string,
     upperBound: number,
   ): string | null {
+    const validatedUpperBound = EventUpperBoundSchema.parse(upperBound);
     return this.db!.transaction(() => {
       const unseen = this.selectUnprojectedUnseenItemsCount.get({
         source_uuid: sourceUuid,
-        upper_bound: upperBound,
+        upper_bound: validatedUpperBound,
       })!;
       if (unseen.count == 0) {
         return null;
@@ -1268,7 +1669,7 @@ export class DB {
         const existingUpperBound = (
           JSON.parse(existing.data) as { upper_bound: number }
         ).upper_bound;
-        if (existingUpperBound >= upperBound) {
+        if (existingUpperBound >= validatedUpperBound) {
           return null;
         }
         this.deletePendingEvent.run({ snowflake_id: existing.snowflake_id });
@@ -1282,7 +1683,7 @@ export class DB {
           snowflake_id: snowflakeId,
           source_uuid: sourceUuid,
           type: PendingEventType.SourceConversationSeen,
-          data: JSON.stringify({ upper_bound: upperBound }),
+          data: JSON.stringify({ upper_bound: validatedUpperBound }),
         });
       } catch (err) {
         if (err instanceof Error && "code" in err) {
@@ -1378,20 +1779,25 @@ export class DB {
       }
     });
 
-    for (const eventID of eventIDsToRemove) {
-      this.deletePendingEvent.run({ snowflake_id: eventID });
-    }
-
-    const eventsToApply: PendingEventRow[] = this.selectWhereIn(
+    const appliedEventSet = new Set(appliedEventIDs);
+    const eventsToFinalize: PendingEventRow[] = this.selectWhereIn(
       "pending_events",
       "snowflake_id",
-      appliedEventIDs,
+      [...appliedEventIDs, ...eventIDsToRemove],
     );
-    for (const event of eventsToApply) {
+    for (const event of eventsToFinalize) {
+      this.stagePendingEventCleanup(event);
       // For reply_sent events, upsert the item into the items table manually
       // to avoid doing a duplicate fetch from the server
-      if (event.type === PendingEventType.ReplySent) {
+      if (
+        appliedEventSet.has(event.snowflake_id) &&
+        event.type === PendingEventType.ReplySent
+      ) {
         const replyData = JSON.parse(event.data) as ReplySentData;
+        this.assertNoPendingCleanupForItem(
+          replyData.uuid,
+          replyData.metadata.source,
+        );
         const metadataBlob = JSON.stringify(replyData.metadata, sortKeys);
         const version = computeVersion(metadataBlob);
         this.upsertItem.run({

--- a/app/src/main/database/migrations/20260710200000_filesystem_cleanup_jobs.sql
+++ b/app/src/main/database/migrations/20260710200000_filesystem_cleanup_jobs.sql
@@ -1,0 +1,37 @@
+-- migrate:up
+-- Retain safe filesystem cleanup identities after item and event rows disappear.
+CREATE TABLE filesystem_cleanup_jobs (
+    id TEXT PRIMARY KEY,
+    target TEXT NOT NULL CHECK (target IN ('item', 'source')),
+    source_uuid TEXT,
+    item_uuid TEXT,
+    metadata_item_uuid TEXT,
+    status TEXT NOT NULL CHECK (status IN ('pending', 'quarantined')),
+    reason TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (
+        (
+            target = 'source'
+            AND source_uuid IS NOT NULL
+            AND item_uuid IS NULL
+            AND metadata_item_uuid IS NULL
+            AND status = 'pending'
+        )
+        OR
+        (
+            target = 'item'
+            AND item_uuid IS NOT NULL
+            AND (
+                (status = 'pending' AND source_uuid IS NOT NULL)
+                OR status = 'quarantined'
+            )
+        )
+    )
+);
+
+CREATE INDEX idx_filesystem_cleanup_jobs_status
+ON filesystem_cleanup_jobs(status, created_at, id);
+
+-- migrate:down
+DROP INDEX IF EXISTS idx_filesystem_cleanup_jobs_status;
+DROP TABLE IF EXISTS filesystem_cleanup_jobs;

--- a/app/src/main/database/schema.sql
+++ b/app/src/main/database/schema.sql
@@ -273,6 +273,36 @@ WHERE
             pending_events.type = 'source_deleted'
     )
 /* sources_projected(uuid,data,version,has_attachment,is_seen) */;
+CREATE TABLE filesystem_cleanup_jobs (
+    id TEXT PRIMARY KEY,
+    target TEXT NOT NULL CHECK (target IN ('item', 'source')),
+    source_uuid TEXT,
+    item_uuid TEXT,
+    metadata_item_uuid TEXT,
+    status TEXT NOT NULL CHECK (status IN ('pending', 'quarantined')),
+    reason TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (
+        (
+            target = 'source'
+            AND source_uuid IS NOT NULL
+            AND item_uuid IS NULL
+            AND metadata_item_uuid IS NULL
+            AND status = 'pending'
+        )
+        OR
+        (
+            target = 'item'
+            AND item_uuid IS NOT NULL
+            AND (
+                (status = 'pending' AND source_uuid IS NOT NULL)
+                OR status = 'quarantined'
+            )
+        )
+    )
+);
+CREATE INDEX idx_filesystem_cleanup_jobs_status
+ON filesystem_cleanup_jobs(status, created_at, id);
 -- Dbmate schema migrations
 INSERT INTO "schema_migrations" (version) VALUES
   ('20260203225412'),
@@ -283,4 +313,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20260416000000'),
   ('20260507000000'),
   ('20260511000000'),
-  ('20260624000000');
+  ('20260624000000'),
+  ('20260710200000');

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -337,9 +337,9 @@ describe("Datastore Method Tests", () => {
     });
 
     db.updateItems({
-      item1: mockItemMetadata("item1", "source2", "message", 1),
-      item2: mockItemMetadata("item2", "source2", "message", 2),
-      item3: mockItemMetadata("item3", "source2", "message", 3),
+      source2Item1: mockItemMetadata("source2Item1", "source2", "message", 1),
+      source2Item2: mockItemMetadata("source2Item2", "source2", "message", 2),
+      source2Item3: mockItemMetadata("source2Item3", "source2", "message", 3),
     });
     sourceWithItems = db.getSourceWithItems("source2");
     expect(sourceWithItems.items.length).toEqual(3);
@@ -1088,7 +1088,7 @@ describe("Datastore Method Tests", () => {
     expect(unrelatedEvent!.target).toHaveProperty("source_uuid", "source2");
   });
 
-  it("pending SourceConversationTruncated should purge all pending events for that source scope", async () => {
+  it("rejects SourceConversationTruncated without data without mutation", async () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),
       source2: mockSourceMetadata("source2"),
@@ -1112,35 +1112,20 @@ describe("Datastore Method Tests", () => {
       PendingEventType.ItemDeleted,
     );
 
-    const deleteEventId = db.addPendingSourceEvent(
-      "source1",
-      PendingEventType.SourceConversationTruncated,
-    );
+    const eventsBefore = db.getPendingEvents();
 
-    const events = db.getPendingEvents();
-    expect(events.length).toBe(3);
+    expect(() =>
+      db.addPendingSourceEvent(
+        "source1",
+        PendingEventType.SourceConversationTruncated,
+      ),
+    ).toThrow();
 
-    const deleteEvent = events.find((e) => e.id === deleteEventId);
-    expect(deleteEvent).toBeDefined();
-    expect(deleteEvent!.type).toBe(
-      PendingEventType.SourceConversationTruncated,
-    );
-    expect(deleteEvent!.target).toHaveProperty("source_uuid", "source1");
-
-    const remainingSourceEvent = events.find(
-      (e) => e.id === unrelatedSourceEvent,
-    );
-    expect(remainingSourceEvent).toBeDefined();
-    expect(remainingSourceEvent!.type).toBe(PendingEventType.Starred);
-    expect(remainingSourceEvent!.target).toHaveProperty(
-      "source_uuid",
-      "source2",
-    );
-
-    const remainingItemEvent = events.find((e) => e.id === unrelatedItemEvent);
-    expect(remainingItemEvent).toBeDefined();
-    expect(remainingItemEvent!.type).toBe(PendingEventType.ItemDeleted);
-    expect(remainingItemEvent!.target).toHaveProperty("item_uuid", "item3");
+    expect(db.getPendingEvents()).toEqual(eventsBefore);
+    expect(db.getItem("item1")?.fetch_status).toBe(FetchStatus.Initial);
+    expect(db.getItem("item2")?.fetch_status).toBe(FetchStatus.Initial);
+    expect(unrelatedSourceEvent).not.toBeNull();
+    expect(unrelatedItemEvent).not.toBeNull();
   });
 
   it("updatePendingEvents should remove successful events from pending_events", () => {

--- a/app/src/main/datastore.ts
+++ b/app/src/main/datastore.ts
@@ -2,12 +2,15 @@ import { DB } from "./database";
 import { Storage } from "./storage";
 import {
   BatchResponse,
+  FilesystemCleanupJob,
   Item,
   ItemMetadata,
   JournalistMetadata,
   SourceMetadata,
+  IndexDeletionPlan,
 } from "../types";
 import { Crypto } from "./crypto";
+import { BatchResponseSchema } from "../schemas";
 
 /**
  * Datastore wraps DB and Storage to ensure that deletion operations remove both
@@ -16,6 +19,7 @@ import { Crypto } from "./crypto";
 export class Datastore extends DB {
   private readonly storage: Storage;
   private readonly DELETE_BATCH_SIZE = 8;
+  private cleanupPromise: Promise<void> | null = null;
 
   constructor(crypto: Crypto, storage: Storage, dbDir?: string) {
     super(crypto, dbDir);
@@ -24,45 +28,32 @@ export class Datastore extends DB {
 
   async deleteItemsAsync(items: string[]): Promise<Item[]> {
     const deletedItems = super.deleteItems(items);
-    // TODO: Consider routing FS deletions to the fetch worker so that FS I/O
-    // never runs on the main process event loop.
-    for (let i = 0; i < deletedItems.length; i += this.DELETE_BATCH_SIZE) {
-      const batch = deletedItems.slice(i, i + this.DELETE_BATCH_SIZE);
-      await Promise.all(batch.map((item) => this.storage.deleteItemFs(item)));
-    }
+    await this.runFilesystemCleanupJobs();
     return deletedItems;
   }
 
   async deleteSourcesAsync(sources: string[]): Promise<void> {
     super.deleteSources(sources);
-    for (let i = 0; i < sources.length; i += this.DELETE_BATCH_SIZE) {
-      const batch = sources.slice(i, i + this.DELETE_BATCH_SIZE);
-      await Promise.all(
-        batch.map((source) => this.storage.deleteSourceFs(source)),
-      );
-    }
+    await this.runFilesystemCleanupJobs();
   }
 
   override deleteJournalists(journalists: string[]): void {
     super.deleteJournalists(journalists);
   }
 
+  async cleanupInvalidLifecycleData(): Promise<void> {
+    super.removeInvalidLifecycleData();
+    await this.runFilesystemCleanupJobs();
+  }
+
   override updateItems(items: { [uuid: string]: ItemMetadata | null }): Item[] {
-    const deletedItems = super.updateItems(items);
-    for (const item of deletedItems) {
-      void this.storage.deleteItemFs(item);
-    }
-    return deletedItems;
+    return super.updateItems(items);
   }
 
   override updateSources(sources: {
     [uuid: string]: SourceMetadata | null;
   }): string[] {
-    const deletedSourceUuids = super.updateSources(sources);
-    for (const uuid of deletedSourceUuids) {
-      void this.storage.deleteSourceFs(uuid);
-    }
-    return deletedSourceUuids;
+    return super.updateSources(sources);
   }
 
   override updateJournalists(journalists: {
@@ -71,27 +62,57 @@ export class Datastore extends DB {
     super.updateJournalists(journalists);
   }
 
-  override updateBatch(batchResponse: BatchResponse): {
+  override updateBatch(
+    batchResponse: BatchResponse,
+    deletions: IndexDeletionPlan,
+  ): {
     deleted_items: Item[];
     deleted_sources: string[];
   } {
-    // Perform all DB updates
-    const result = super.updateBatch(batchResponse);
-    // Perform all filesystem cleanups as necessary
-    for (const item of result.deleted_items) {
-      void this.storage.deleteItemFs(item);
-    }
-    for (const uuid of result.deleted_sources) {
-      void this.storage.deleteSourceFs(uuid);
-    }
+    const validatedBatch = BatchResponseSchema.parse(batchResponse);
+    const result = super.updateBatch(validatedBatch, deletions);
+    void this.runFilesystemCleanupJobs();
     return result;
   }
 
-  async deleteSourceFs(sourceID: string): Promise<void> {
-    return this.storage.deleteSourceFs(sourceID);
+  runFilesystemCleanupJobs(): Promise<void> {
+    const previousCleanup = this.cleanupPromise ?? Promise.resolve();
+    const cleanup = previousCleanup.then(() =>
+      this.drainFilesystemCleanupJobs(),
+    );
+    this.cleanupPromise = cleanup;
+    void cleanup.then(
+      () => this.clearCleanupPromise(cleanup),
+      () => this.clearCleanupPromise(cleanup),
+    );
+    return cleanup;
   }
 
-  async deleteItemFs(item: Item): Promise<void> {
-    return this.storage.deleteItemFs(item);
+  private clearCleanupPromise(cleanup: Promise<void>): void {
+    if (this.cleanupPromise === cleanup) {
+      this.cleanupPromise = null;
+    }
+  }
+
+  private async drainFilesystemCleanupJobs(): Promise<void> {
+    const jobs = super.getPendingFilesystemCleanupJobs();
+    for (let i = 0; i < jobs.length; i += this.DELETE_BATCH_SIZE) {
+      const batch = jobs.slice(i, i + this.DELETE_BATCH_SIZE);
+      await Promise.all(batch.map((job) => this.runFilesystemCleanupJob(job)));
+    }
+  }
+
+  private async runFilesystemCleanupJob(
+    job: FilesystemCleanupJob,
+  ): Promise<void> {
+    try {
+      await this.storage.runFilesystemCleanupJob(job);
+      super.completeFilesystemCleanupJob(job.id);
+    } catch (error) {
+      console.error("Failed to run filesystem cleanup job", {
+        job: job.id,
+        error,
+      });
+    }
   }
 }

--- a/app/src/main/index.test.ts
+++ b/app/src/main/index.test.ts
@@ -1,10 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { SyncStatus } from "../types";
+import { PendingEventType, SyncStatus } from "../types";
 
 const testState = vi.hoisted(() => {
   const registeredHandlers = new Map<string, (...args: unknown[]) => unknown>();
   const workerInstances: MockWorker[] = [];
+  const datastore = {
+    addPendingSourceConversationSeen: vi.fn(),
+    addPendingSourceEvent: vi.fn(),
+    addPendingSourceEventBatch: vi.fn(),
+    cleanupInvalidLifecycleData: vi.fn(() => Promise.resolve()),
+    close: vi.fn(),
+    deleteItemFs: vi.fn(),
+    getPendingEvents: vi.fn(() => []),
+    getSourceWithItems: vi.fn(() => ({ items: [] })),
+    runFilesystemCleanupJobs: vi.fn(() => Promise.resolve()),
+  };
 
   class MockWorker {
     on = vi.fn();
@@ -81,7 +92,7 @@ const testState = vi.hoisted(() => {
       qubes_gpg_domain: undefined,
     })),
     cryptoInitialize: vi.fn(() => ({ mock: "crypto" })),
-    datastoreClose: vi.fn(),
+    datastore,
     setUmask: vi.fn(),
   };
 });
@@ -131,8 +142,17 @@ vi.mock("./crypto", () => ({
 
 vi.mock("./datastore", () => ({
   Datastore: class {
-    getPendingEvents = vi.fn(() => []);
-    close = testState.datastoreClose;
+    addPendingSourceConversationSeen =
+      testState.datastore.addPendingSourceConversationSeen;
+    addPendingSourceEvent = testState.datastore.addPendingSourceEvent;
+    addPendingSourceEventBatch = testState.datastore.addPendingSourceEventBatch;
+    cleanupInvalidLifecycleData =
+      testState.datastore.cleanupInvalidLifecycleData;
+    close = testState.datastore.close;
+    deleteItemFs = testState.datastore.deleteItemFs;
+    getPendingEvents = testState.datastore.getPendingEvents;
+    getSourceWithItems = testState.datastore.getSourceWithItems;
+    runFilesystemCleanupJobs = testState.datastore.runFilesystemCleanupJobs;
   },
 }));
 
@@ -230,12 +250,26 @@ describe("syncMetadata IPC handler", () => {
     testState.mockSleep.mockResolvedValue(undefined);
     testState.configLoad.mockClear();
     testState.cryptoInitialize.mockClear();
-    testState.datastoreClose.mockClear();
+    for (const mock of Object.values(testState.datastore)) {
+      mock.mockClear();
+    }
     testState.setUmask.mockClear();
   });
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("repairs invalid lifecycle data before registering IPC handlers", async () => {
+    await loadMainProcessModule();
+
+    expect(
+      testState.datastore.cleanupInvalidLifecycleData,
+    ).toHaveBeenCalledOnce();
+    expect(
+      testState.datastore.cleanupInvalidLifecycleData.mock
+        .invocationCallOrder[0],
+    ).toBeLessThan(testState.ipcMain.handle.mock.invocationCallOrder[0]!);
   });
 
   it("re-wakes the fetch worker when sync returns NOT_MODIFIED", async () => {
@@ -316,5 +350,119 @@ describe("syncMetadata IPC handler", () => {
     expect(testState.mockSleep).toHaveBeenNthCalledWith(1, 2000);
     expect(testState.mockSleep).toHaveBeenNthCalledWith(2, 4000);
     expect(testState.mockSleep).toHaveBeenNthCalledWith(3, 8000);
+  });
+});
+
+describe("lifecycle event IPC handlers", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    testState.registeredHandlers.clear();
+    for (const mock of Object.values(testState.datastore)) {
+      mock.mockClear();
+    }
+    await loadMainProcessModule();
+  });
+
+  it("rejects an invalid truncation bound before cleanup", async () => {
+    const handler = testState.registeredHandlers.get("addPendingSourceEvent");
+    expect(handler).toBeDefined();
+
+    await expect(
+      handler!({}, "source-1", PendingEventType.SourceConversationTruncated, {
+        upper_bound: 1.5,
+      }),
+    ).rejects.toThrow();
+
+    expect(testState.datastore.getSourceWithItems).not.toHaveBeenCalled();
+    expect(testState.datastore.deleteItemFs).not.toHaveBeenCalled();
+    expect(testState.datastore.addPendingSourceEvent).not.toHaveBeenCalled();
+  });
+
+  it("handles a zero truncation bound without skipping cleanup", async () => {
+    const handler = testState.registeredHandlers.get("addPendingSourceEvent");
+    expect(handler).toBeDefined();
+
+    await handler!(
+      {},
+      "source-1",
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 0 },
+    );
+
+    expect(testState.datastore.getSourceWithItems).not.toHaveBeenCalled();
+    expect(testState.datastore.deleteItemFs).not.toHaveBeenCalled();
+    expect(testState.datastore.addPendingSourceEvent).toHaveBeenCalledWith(
+      "source-1",
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 0 },
+    );
+    expect(testState.datastore.runFilesystemCleanupJobs).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    PendingEventType.SourceConversationSeen,
+    PendingEventType.SourceConversationTruncated,
+  ])("rejects %s without data before cleanup", async (type) => {
+    const handler = testState.registeredHandlers.get("addPendingSourceEvent");
+    expect(handler).toBeDefined();
+
+    await expect(handler!({}, "source-1", type)).rejects.toThrow();
+
+    expect(testState.datastore.getSourceWithItems).not.toHaveBeenCalled();
+    expect(testState.datastore.deleteItemFs).not.toHaveBeenCalled();
+    expect(testState.datastore.addPendingSourceEvent).not.toHaveBeenCalled();
+  });
+
+  it("validates a source event batch before any cleanup", async () => {
+    const handler = testState.registeredHandlers.get(
+      "addPendingSourceEventBatch",
+    );
+    expect(handler).toBeDefined();
+
+    await expect(
+      handler!({}, [
+        {
+          sourceUuid: "source-1",
+          type: PendingEventType.SourceConversationTruncated,
+          data: { upper_bound: 1 },
+        },
+        {
+          sourceUuid: "source-2",
+          type: PendingEventType.SourceConversationTruncated,
+        },
+      ]),
+    ).rejects.toThrow();
+
+    expect(testState.datastore.getSourceWithItems).not.toHaveBeenCalled();
+    expect(testState.datastore.deleteItemFs).not.toHaveBeenCalled();
+    expect(
+      testState.datastore.addPendingSourceEventBatch,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid seen bound before the datastore call", async () => {
+    const handler = testState.registeredHandlers.get(
+      "addPendingSourceConversationSeen",
+    );
+    expect(handler).toBeDefined();
+
+    await expect(handler!({}, "source-1", Number.NaN)).rejects.toThrow();
+
+    expect(
+      testState.datastore.addPendingSourceConversationSeen,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("passes a zero seen bound to the datastore", async () => {
+    const handler = testState.registeredHandlers.get(
+      "addPendingSourceConversationSeen",
+    );
+    expect(handler).toBeDefined();
+
+    await handler!({}, "source-1", 0);
+
+    expect(
+      testState.datastore.addPendingSourceConversationSeen,
+    ).toHaveBeenCalledWith("source-1", 0);
   });
 });

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -38,7 +38,12 @@ import {
   PendingEventData,
   type ms,
 } from "../types";
-import { TokenResponseSchema, API_MINOR_VERSION } from "../schemas";
+import {
+  TokenResponseSchema,
+  API_MINOR_VERSION,
+  EventUpperBoundSchema,
+  validatePendingEventData,
+} from "../schemas";
 import { syncMetadata, shouldSkipSync } from "./sync";
 import workerPath from "./fetch/worker?modulePath";
 import { Lock, LockTimeoutError } from "./sync/lock";
@@ -163,6 +168,7 @@ if (!gotTheLock) {
   }
 
   const { db, cryptoConfig } = initializeMainDependencies();
+  const startupCleanup = db.cleanupInvalidLifecycleData();
 
   // Generate a CSP nonce for this session (used by Ant Design)
   const cspNonce = randomBytes(32).toString("base64");
@@ -276,6 +282,7 @@ if (!gotTheLock) {
   // Some APIs can only be used after this event occurs.
   app
     .whenReady()
+    .then(() => startupCleanup)
     .then(() => {
       // Set strict Content Security Policy via HTTP header with nonce
       session.defaultSession.webRequest.onHeadersReceived(
@@ -493,43 +500,15 @@ if (!gotTheLock) {
         return systemLanguage;
       });
 
-      // Handle cleanup from source event: in cases of deletion or truncation,
-      // we should abort fetches and delete from the fs
-      async function sourceEventCleanup(
+      function abortSourceFetch(
         sourceUuid: string,
         type: PendingEventType,
-        data?: PendingEventData,
-      ) {
-        // Immediately delete any source files from the fs on pending deletion
-        if (type === PendingEventType.SourceDeleted) {
-          await db.deleteSourceFs(sourceUuid);
-          // Abort any in-flight downloads for this source in the fetch worker
-          if (fetchWorker) {
-            fetchWorker.postMessage({
-              type: "abortSourceFetch",
-              sourceUuid,
-            });
-          }
-        }
-        // For truncation, abort in-flight downloads and delete truncated item files from the fs
-        if (type === PendingEventType.SourceConversationTruncated) {
-          // Abort any in-flight downloads for this source in the fetch worker
-          if (fetchWorker) {
-            fetchWorker.postMessage({
-              type: "abortSourceFetch",
-              sourceUuid,
-            });
-          }
-          if (data?.upper_bound) {
-            const items = db.getSourceWithItems(sourceUuid, {
-              beforeInteractionCount: data?.upper_bound + 1,
-            }).items;
-            const DELETE_BATCH_SIZE = 8;
-            for (let i = 0; i < items.length; i += DELETE_BATCH_SIZE) {
-              const batch = items.slice(i, i + DELETE_BATCH_SIZE);
-              await Promise.all(batch.map((item) => db.deleteItemFs(item)));
-            }
-          }
+      ): void {
+        const deletesSourceData =
+          type === PendingEventType.SourceDeleted ||
+          type === PendingEventType.SourceConversationTruncated;
+        if (deletesSourceData && fetchWorker) {
+          fetchWorker.postMessage({ type: "abortSourceFetch", sourceUuid });
         }
       }
 
@@ -541,8 +520,11 @@ if (!gotTheLock) {
           type: PendingEventType,
           data?: PendingEventData,
         ): Promise<string | null> => {
-          await sourceEventCleanup(sourceUuid, type, data);
-          return db.addPendingSourceEvent(sourceUuid, type, data);
+          validatePendingEventData(type, data);
+          const eventId = db.addPendingSourceEvent(sourceUuid, type, data);
+          abortSourceFetch(sourceUuid, type);
+          await db.runFilesystemCleanupJobs();
+          return eventId;
         },
       );
 
@@ -556,16 +538,15 @@ if (!gotTheLock) {
             data?: PendingEventData;
           }>,
         ): Promise<(string | null)[]> => {
-          const EVENT_BATCH_SIZE = 8;
-          for (let i = 0; i < events.length; i += EVENT_BATCH_SIZE) {
-            const batch = events.slice(i, i + EVENT_BATCH_SIZE);
-            await Promise.all(
-              batch.map(({ sourceUuid, type, data }) =>
-                sourceEventCleanup(sourceUuid, type, data),
-              ),
-            );
+          for (const { type, data } of events) {
+            validatePendingEventData(type, data);
           }
-          return db.addPendingSourceEventBatch(events);
+          const eventIds = db.addPendingSourceEventBatch(events);
+          for (const { sourceUuid, type } of events) {
+            abortSourceFetch(sourceUuid, type);
+          }
+          await db.runFilesystemCleanupJobs();
+          return eventIds;
         },
       );
 
@@ -592,13 +573,9 @@ if (!gotTheLock) {
           itemUuid: string,
           type: PendingEventType,
         ): Promise<string | null> => {
-          if (type === PendingEventType.ItemDeleted) {
-            const item = db.getItem(itemUuid);
-            if (item) {
-              db.deleteItemFs(item);
-            }
-          }
-          return db.addPendingItemEvent(itemUuid, type);
+          const eventId = db.addPendingItemEvent(itemUuid, type);
+          await db.runFilesystemCleanupJobs();
+          return eventId;
         },
       );
 
@@ -609,7 +586,10 @@ if (!gotTheLock) {
           sourceUuid: string,
           upperBound: number,
         ): Promise<string | null> => {
-          return db.addPendingSourceConversationSeen(sourceUuid, upperBound);
+          return db.addPendingSourceConversationSeen(
+            sourceUuid,
+            EventUpperBoundSchema.parse(upperBound),
+          );
         },
       );
 

--- a/app/src/main/lifecycle-counts.test.ts
+++ b/app/src/main/lifecycle-counts.test.ts
@@ -1,0 +1,933 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import {
+  BatchResponseSchema,
+  PendingEventSchema,
+  PendingEventType,
+} from "../schemas";
+import {
+  EventStatus,
+  FetchStatus,
+  ItemMetadata,
+  SourceMetadata,
+} from "../types";
+import { Crypto } from "./crypto";
+import { Datastore } from "./datastore";
+import * as proxyModule from "./proxy";
+import { Storage } from "./storage";
+import { syncMetadata } from "./sync";
+
+const SOURCE_UUID = "11111111-1111-4111-8111-111111111111";
+const SECOND_SOURCE_UUID = "22222222-2222-4222-8222-222222222222";
+const ITEM_UUID = "33333333-3333-4333-8333-333333333333";
+const SECOND_ITEM_UUID = "44444444-4444-4444-8444-444444444444";
+const THIRD_ITEM_UUID = "66666666-6666-4666-8666-666666666666";
+const FOURTH_ITEM_UUID = "77777777-7777-4777-8777-777777777777";
+const FIFTH_ITEM_UUID = "88888888-8888-4888-8888-888888888888";
+const JOURNALIST_UUID = "55555555-5555-4555-8555-555555555555";
+
+const BOUNDARY_CASES = [
+  {
+    label: "below the safe integer minimum",
+    value: Number.MIN_SAFE_INTEGER - 1,
+    itemValid: false,
+    eventValid: false,
+  },
+  {
+    label: "safe integer minimum",
+    value: Number.MIN_SAFE_INTEGER,
+    itemValid: false,
+    eventValid: false,
+  },
+  { label: "negative integer", value: -1, itemValid: false, eventValid: false },
+  {
+    label: "negative fraction",
+    value: -0.5,
+    itemValid: false,
+    eventValid: false,
+  },
+  { label: "zero", value: 0, itemValid: false, eventValid: true },
+  {
+    label: "smallest positive fraction",
+    value: Number.MIN_VALUE,
+    itemValid: false,
+    eventValid: false,
+  },
+  {
+    label: "positive fraction below one",
+    value: 0.5,
+    itemValid: false,
+    eventValid: false,
+  },
+  { label: "one", value: 1, itemValid: true, eventValid: true },
+  {
+    label: "positive fraction above one",
+    value: 1.5,
+    itemValid: false,
+    eventValid: false,
+  },
+  {
+    label: "below the safe integer maximum",
+    value: Number.MAX_SAFE_INTEGER - 1,
+    itemValid: true,
+    eventValid: true,
+  },
+  {
+    label: "safe integer maximum",
+    value: Number.MAX_SAFE_INTEGER,
+    itemValid: true,
+    eventValid: true,
+  },
+  {
+    label: "above the safe integer maximum",
+    value: Number.MAX_SAFE_INTEGER + 1,
+    itemValid: false,
+    eventValid: false,
+  },
+  { label: "NaN", value: Number.NaN, itemValid: false, eventValid: false },
+  {
+    label: "positive infinity",
+    value: Number.POSITIVE_INFINITY,
+    itemValid: false,
+    eventValid: false,
+  },
+  {
+    label: "negative infinity",
+    value: Number.NEGATIVE_INFINITY,
+    itemValid: false,
+    eventValid: false,
+  },
+];
+
+function batchResponse(kind: "message" | "reply", interactionCount: number) {
+  const metadata =
+    kind === "reply"
+      ? {
+          kind,
+          uuid: ITEM_UUID,
+          source: SOURCE_UUID,
+          size: 22,
+          journalist_uuid: JOURNALIST_UUID,
+          is_deleted_by_source: false,
+          seen_by: [],
+          interaction_count: interactionCount,
+        }
+      : {
+          kind,
+          uuid: ITEM_UUID,
+          source: SOURCE_UUID,
+          size: 22,
+          is_read: false,
+          seen_by: [],
+          interaction_count: interactionCount,
+        };
+  return {
+    sources: {},
+    items: { [ITEM_UUID]: metadata },
+    journalists: {},
+    events: {},
+  };
+}
+
+function pendingEvent(type: PendingEventType, upperBound: number) {
+  return {
+    id: "123",
+    type,
+    target: { source_uuid: SOURCE_UUID, version: "source-version" },
+    data: { upper_bound: upperBound },
+  };
+}
+
+describe.each([
+  {
+    domain: "message interaction_count",
+    expected: "itemValid" as const,
+    value: (count: number) => batchResponse("message", count),
+  },
+  {
+    domain: "reply interaction_count",
+    expected: "itemValid" as const,
+    value: (count: number) => batchResponse("reply", count),
+  },
+  {
+    domain: "seen upper_bound",
+    expected: "eventValid" as const,
+    value: (count: number) =>
+      pendingEvent(PendingEventType.SourceConversationSeen, count),
+  },
+  {
+    domain: "truncation upper_bound",
+    expected: "eventValid" as const,
+    value: (count: number) =>
+      pendingEvent(PendingEventType.SourceConversationTruncated, count),
+  },
+])("$domain boundary matrix", ({ expected, value }) => {
+  it.each(BOUNDARY_CASES)("handles $label", (boundary) => {
+    const schema =
+      expected === "itemValid" ? BatchResponseSchema : PendingEventSchema;
+    expect(schema.safeParse(value(boundary.value)).success).toBe(
+      boundary[expected],
+    );
+  });
+});
+
+it("leaves duplicate positive interaction counts for global validation", () => {
+  const singleItemBatch = batchResponse("message", 1);
+  const batch = {
+    ...singleItemBatch,
+    items: {
+      ...singleItemBatch.items,
+      [SECOND_ITEM_UUID]: itemMetadata(SECOND_ITEM_UUID, SOURCE_UUID, 1),
+    },
+  };
+
+  expect(BatchResponseSchema.safeParse(batch).success).toBe(true);
+});
+
+it("rejects an item whose metadata UUID differs from its map key", () => {
+  const validBatch = batchResponse("message", 1);
+  const mismatchedBatch = {
+    ...validBatch,
+    items: {
+      [SECOND_ITEM_UUID]: itemMetadata(ITEM_UUID, SOURCE_UUID, 1),
+    },
+  };
+
+  expect(BatchResponseSchema.safeParse(mismatchedBatch).success).toBe(false);
+});
+
+describe.each([
+  PendingEventType.SourceConversationSeen,
+  PendingEventType.SourceConversationTruncated,
+])("PendingEventSchema %s upper_bound", (type) => {
+  it("rejects missing data", () => {
+    expect(
+      PendingEventSchema.safeParse({
+        id: "123",
+        type,
+        target: { source_uuid: SOURCE_UUID, version: "source-version" },
+      }).success,
+    ).toBe(false);
+  });
+});
+
+function sourceMetadata(uuid: string): SourceMetadata {
+  return {
+    uuid,
+    journalist_designation: "able baker",
+    is_starred: false,
+    is_seen: false,
+    has_attachment: false,
+    last_updated: "2026-07-10T00:00:00Z",
+    public_key: "fake-public-key",
+    fingerprint: "fake-fingerprint",
+  };
+}
+
+function itemMetadata(
+  uuid: string,
+  sourceUuid: string,
+  interactionCount: number,
+): ItemMetadata {
+  return {
+    kind: "message",
+    uuid,
+    source: sourceUuid,
+    size: 22,
+    is_read: false,
+    seen_by: [],
+    interaction_count: interactionCount,
+  };
+}
+
+describe("lifecycle count datastore boundaries", () => {
+  const originalHomedir = os.homedir;
+  let crypto: Crypto;
+  let db: Datastore;
+  let storage: Storage;
+  let tmpDir: string;
+
+  beforeAll(() => {
+    (Crypto as unknown as { instance: Crypto | undefined }).instance =
+      undefined;
+    crypto = Crypto.initialize({
+      isQubes: false,
+      submissionKeyFingerprint: "",
+    });
+  });
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sd-lifecycle-counts-"));
+    os.homedir = () => tmpDir;
+    storage = new Storage();
+    db = new Datastore(crypto, storage, tmpDir);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    db.close();
+    os.homedir = originalHomedir;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rejects an invalid sync batch before applying planned deletions", async () => {
+    const existingItem = itemMetadata(ITEM_UUID, SOURCE_UUID, 1);
+    db.updateSources({ [SOURCE_UUID]: sourceMetadata(SOURCE_UUID) });
+    db.updateItems({ [ITEM_UUID]: existingItem });
+    db.completePlaintextItem(ITEM_UUID, "existing searchable secret");
+    const itemDirectory = storage.itemDirectory(existingItem).path;
+    fs.writeFileSync(path.join(itemDirectory, "plaintext"), "secret");
+
+    const clientIndex = db.getIndex();
+    const batch = {
+      sources: {},
+      items: {
+        [SECOND_ITEM_UUID]: itemMetadata(SECOND_ITEM_UUID, SOURCE_UUID, 1.5),
+      },
+      journalists: {},
+      events: {},
+    };
+    vi.spyOn(proxyModule, "proxyJSONRequest")
+      .mockResolvedValueOnce({
+        status: 200,
+        error: false,
+        data: {
+          sources: clientIndex.sources,
+          items: { [SECOND_ITEM_UUID]: "second-item-version" },
+          journalists: {},
+        },
+        headers: new Map(),
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        error: false,
+        data: batch,
+        headers: new Map(),
+      });
+
+    await expect(syncMetadata(db, "token")).rejects.toThrow();
+
+    expect(db.getItem(ITEM_UUID)).not.toBeNull();
+    expect(db.getItem(SECOND_ITEM_UUID)).toBeNull();
+    expect(db.search("existing searchable")).toHaveLength(1);
+    expect(fs.existsSync(itemDirectory)).toBe(true);
+  });
+
+  it("rejects zero and negative cursors through the real sync path", async () => {
+    const existingItem = itemMetadata(ITEM_UUID, SOURCE_UUID, 1);
+    db.updateSources({ [SOURCE_UUID]: sourceMetadata(SOURCE_UUID) });
+    db.updateItems({ [ITEM_UUID]: existingItem });
+    db.completePlaintextItem(ITEM_UUID, "zero cursor rollback secret");
+    const itemDirectory = storage.itemDirectory(existingItem).path;
+    fs.writeFileSync(path.join(itemDirectory, "plaintext"), "secret");
+
+    const clientIndex = db.getIndex();
+    vi.spyOn(proxyModule, "proxyJSONRequest")
+      .mockResolvedValueOnce({
+        status: 200,
+        error: false,
+        data: {
+          sources: clientIndex.sources,
+          items: {
+            [SECOND_ITEM_UUID]: "zero-item-version",
+            [THIRD_ITEM_UUID]: "negative-item-version",
+          },
+          journalists: {},
+        },
+        headers: new Map(),
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        error: false,
+        data: {
+          sources: {},
+          items: {
+            [SECOND_ITEM_UUID]: itemMetadata(SECOND_ITEM_UUID, SOURCE_UUID, 0),
+            [THIRD_ITEM_UUID]: itemMetadata(THIRD_ITEM_UUID, SOURCE_UUID, -1),
+          },
+          journalists: {},
+          events: {},
+        },
+        headers: new Map(),
+      });
+
+    await expect(syncMetadata(db, "token")).rejects.toThrow();
+
+    expect(db.getItem(ITEM_UUID)).not.toBeNull();
+    expect(db.getItem(SECOND_ITEM_UUID)).toBeNull();
+    expect(db.getItem(THIRD_ITEM_UUID)).toBeNull();
+    expect(db.search("zero cursor rollback")).toHaveLength(1);
+    expect(fs.existsSync(itemDirectory)).toBe(true);
+  });
+
+  it("rolls back planned deletions when the batch transaction fails", () => {
+    const deletedItem = itemMetadata(ITEM_UUID, SOURCE_UUID, 1);
+    const updatedItem = itemMetadata(SECOND_ITEM_UUID, SOURCE_UUID, 2);
+    db.updateSources({ [SOURCE_UUID]: sourceMetadata(SOURCE_UUID) });
+    db.updateItems({
+      [ITEM_UUID]: deletedItem,
+      [SECOND_ITEM_UUID]: updatedItem,
+    });
+    db.completePlaintextItem(ITEM_UUID, "rollback searchable secret");
+    const itemDirectory = storage.itemDirectory(deletedItem).path;
+    fs.writeFileSync(path.join(itemDirectory, "plaintext"), "secret");
+
+    expect(() =>
+      db.updateBatch(
+        {
+          sources: {},
+          items: {
+            [SECOND_ITEM_UUID]: {
+              kind: "file",
+              uuid: SECOND_ITEM_UUID,
+              source: SOURCE_UUID,
+              size: 22,
+              is_read: false,
+              seen_by: [],
+              interaction_count: 2,
+            },
+          },
+          journalists: {},
+          events: {},
+        },
+        { sources: [], items: [ITEM_UUID], journalists: [] },
+      ),
+    ).toThrow("items.kind is immutable");
+
+    expect(db.getItem(ITEM_UUID)).not.toBeNull();
+    expect(db.getItem(SECOND_ITEM_UUID)?.data.kind).toBe("message");
+    expect(db.search("rollback searchable")).toHaveLength(1);
+    expect(fs.existsSync(itemDirectory)).toBe(true);
+  });
+
+  it("rolls back direct item writes when one interaction count is invalid", () => {
+    db.updateSources({ [SOURCE_UUID]: sourceMetadata(SOURCE_UUID) });
+
+    expect(() =>
+      db.updateItems({
+        [ITEM_UUID]: itemMetadata(ITEM_UUID, SOURCE_UUID, 1),
+        [SECOND_ITEM_UUID]: itemMetadata(SECOND_ITEM_UUID, SOURCE_UUID, 1.5),
+      }),
+    ).toThrow();
+
+    expect(db.getItem(ITEM_UUID)).toBeNull();
+    expect(db.getItem(SECOND_ITEM_UUID)).toBeNull();
+  });
+
+  it("rolls back source event batches when one upper bound is invalid", () => {
+    db.updateSources({
+      [SOURCE_UUID]: sourceMetadata(SOURCE_UUID),
+      [SECOND_SOURCE_UUID]: sourceMetadata(SECOND_SOURCE_UUID),
+    });
+    db.updateItems({
+      [ITEM_UUID]: itemMetadata(ITEM_UUID, SOURCE_UUID, 1),
+      [SECOND_ITEM_UUID]: itemMetadata(SECOND_ITEM_UUID, SECOND_SOURCE_UUID, 1),
+    });
+
+    expect(() =>
+      db.addPendingSourceEventBatch([
+        {
+          sourceUuid: SOURCE_UUID,
+          type: PendingEventType.SourceConversationTruncated,
+          data: { upper_bound: 1 },
+        },
+        {
+          sourceUuid: SECOND_SOURCE_UUID,
+          type: PendingEventType.SourceConversationTruncated,
+          data: { upper_bound: 1.5 },
+        },
+      ]),
+    ).toThrow();
+
+    expect(db.getPendingEvents()).toHaveLength(0);
+    expect(db.getItem(ITEM_UUID)?.fetch_status).toBe(FetchStatus.Initial);
+    expect(db.getItem(SECOND_ITEM_UUID)?.fetch_status).toBe(
+      FetchStatus.Initial,
+    );
+    expect(db.getSourceWithItems(SOURCE_UUID).items).toHaveLength(1);
+    expect(db.getSourceWithItems(SECOND_SOURCE_UUID).items).toHaveLength(1);
+  });
+
+  it("rejects unexpected source event data before mutation", () => {
+    db.updateSources({ [SOURCE_UUID]: sourceMetadata(SOURCE_UUID) });
+
+    expect(() =>
+      db.addPendingSourceEvent(SOURCE_UUID, PendingEventType.SourceDeleted, {
+        upper_bound: 1,
+      }),
+    ).toThrow();
+
+    expect(db.getPendingEvents()).toHaveLength(0);
+    expect(db.getSourceWithItems(SOURCE_UUID).uuid).toBe(SOURCE_UUID);
+    expect(db.getFilesystemCleanupJobs()).toHaveLength(0);
+  });
+
+  it("accepts zero seen bounds but rejects invalid item counts", async () => {
+    db.updateSources({ [SOURCE_UUID]: sourceMetadata(SOURCE_UUID) });
+    db.updateItems({
+      [ITEM_UUID]: itemMetadata(ITEM_UUID, SOURCE_UUID, 1),
+    });
+
+    expect(() =>
+      db.addPendingSourceConversationSeen(SOURCE_UUID, Number.NaN),
+    ).toThrow();
+    expect(db.addPendingSourceConversationSeen(SOURCE_UUID, 0)).toBeNull();
+    await expect(
+      db.addPendingReplySentEvent("reply", SOURCE_UUID, 1.5),
+    ).rejects.toThrow();
+
+    expect(db.getPendingEvents()).toHaveLength(0);
+    expect(db.getSourceWithItems(SOURCE_UUID).items).toHaveLength(1);
+  });
+
+  it("cleans pre-existing invalid lifecycle state on startup", async () => {
+    const fractionalItem = itemMetadata(ITEM_UUID, SOURCE_UUID, 1.5);
+    const zeroItem: ItemMetadata = {
+      kind: "file",
+      uuid: SECOND_ITEM_UUID,
+      source: SOURCE_UUID,
+      size: 22,
+      is_read: false,
+      seen_by: [],
+      interaction_count: 0,
+    };
+    const validItem = itemMetadata(
+      THIRD_ITEM_UUID,
+      SOURCE_UUID,
+      Number.MAX_SAFE_INTEGER,
+    );
+    db.updateSources({ [SOURCE_UUID]: sourceMetadata(SOURCE_UUID) });
+    db.updateItems({ [THIRD_ITEM_UUID]: validItem });
+    db.completePlaintextItem(THIRD_ITEM_UUID, "valid maximum secret");
+    const zeroEventId = db.addPendingSourceEvent(
+      SOURCE_UUID,
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 0 },
+    );
+    const validEventId = db.addPendingSourceEvent(
+      SOURCE_UUID,
+      PendingEventType.Starred,
+    );
+    const replyEventId = "fractional-reply";
+    const rawDb = db["db"]!;
+    rawDb
+      .prepare(
+        `INSERT INTO items (uuid, data, plaintext, version, fetch_status)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(
+        ITEM_UUID,
+        JSON.stringify(fractionalItem),
+        "pre-existing fractional secret",
+        "fractional-version",
+        FetchStatus.Complete,
+      );
+    rawDb
+      .prepare(
+        `INSERT INTO items (uuid, data, plaintext, version, fetch_status)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(
+        SECOND_ITEM_UUID,
+        JSON.stringify(zeroItem),
+        "pre-existing zero secret",
+        "zero-version",
+        FetchStatus.Complete,
+      );
+    rawDb
+      .prepare(
+        `INSERT INTO search_index(source_uuid, item_uuid, type, content)
+         VALUES (?, ?, 'message', ?)`,
+      )
+      .run(SOURCE_UUID, ITEM_UUID, "pre-existing fractional secret");
+    rawDb
+      .prepare(
+        `INSERT INTO search_index(source_uuid, item_uuid, type, content)
+         VALUES (?, ?, 'message', ?)`,
+      )
+      .run(SOURCE_UUID, SECOND_ITEM_UUID, "pre-existing zero secret");
+    rawDb
+      .prepare(
+        `INSERT INTO pending_events (snowflake_id, source_uuid, type, data)
+         VALUES (?, ?, ?, ?)`,
+      )
+      .run(
+        "fractional-truncation",
+        SOURCE_UUID,
+        PendingEventType.SourceConversationTruncated,
+        JSON.stringify({ upper_bound: 1.5 }),
+      );
+    rawDb
+      .prepare(
+        `INSERT INTO pending_events (snowflake_id, source_uuid, type, data)
+         VALUES (?, ?, ?, ?)`,
+      )
+      .run(
+        replyEventId,
+        SOURCE_UUID,
+        PendingEventType.ReplySent,
+        JSON.stringify({
+          uuid: FOURTH_ITEM_UUID,
+          metadata: {
+            kind: "reply",
+            uuid: FOURTH_ITEM_UUID,
+            source: SOURCE_UUID,
+            size: 27,
+            journalist_uuid: "",
+            is_deleted_by_source: false,
+            seen_by: [],
+            interaction_count: 1.5,
+          },
+          plaintext: "unsent journalist plaintext",
+          reply: "encrypted reply payload",
+        }),
+      );
+    const itemDirectory = storage.itemDirectory(fractionalItem).path;
+    const zeroItemDirectory = storage.itemDirectory(zeroItem).path;
+    const validItemDirectory = storage.itemDirectory(validItem).path;
+    fs.writeFileSync(path.join(itemDirectory, "plaintext"), "secret");
+    fs.writeFileSync(path.join(zeroItemDirectory, "plaintext"), "secret");
+    fs.writeFileSync(path.join(validItemDirectory, "plaintext"), "secret");
+
+    expect(db.search("pre-existing fractional")).toHaveLength(1);
+    expect(
+      rawDb
+        .prepare(
+          "SELECT COUNT(*) AS count FROM search_index WHERE item_uuid = ?",
+        )
+        .get(SECOND_ITEM_UUID),
+    ).toEqual({ count: 1 });
+    expect(db.search("valid maximum")).toHaveLength(1);
+    expect(fs.existsSync(itemDirectory)).toBe(true);
+    expect(fs.existsSync(zeroItemDirectory)).toBe(true);
+    expect(fs.existsSync(validItemDirectory)).toBe(true);
+
+    await db.cleanupInvalidLifecycleData();
+
+    expect(db.getItem(ITEM_UUID)).toBeNull();
+    expect(db.getItem(SECOND_ITEM_UUID)).toBeNull();
+    expect(db.getItem(THIRD_ITEM_UUID)).not.toBeNull();
+    expect(db.search("pre-existing fractional")).toHaveLength(0);
+    expect(
+      rawDb
+        .prepare(
+          "SELECT COUNT(*) AS count FROM search_index WHERE item_uuid = ?",
+        )
+        .get(SECOND_ITEM_UUID),
+    ).toEqual({ count: 0 });
+    expect(db.search("valid maximum")).toHaveLength(1);
+    expect(fs.existsSync(itemDirectory)).toBe(false);
+    expect(fs.existsSync(zeroItemDirectory)).toBe(false);
+    expect(fs.existsSync(validItemDirectory)).toBe(true);
+    expect(db.getFilesystemCleanupJobs()).toHaveLength(0);
+    const remainingEvents = db.getPendingEvents();
+    expect(remainingEvents.map(({ id }) => id)).toEqual(
+      expect.arrayContaining([zeroEventId, validEventId, replyEventId]),
+    );
+    expect(remainingEvents).toHaveLength(3);
+    expect(remainingEvents.find(({ id }) => id === replyEventId)?.data).toEqual(
+      expect.objectContaining({
+        plaintext: "unsent journalist plaintext",
+        reply: "encrypted reply payload",
+        metadata: expect.objectContaining({
+          interaction_count: Number.MAX_SAFE_INTEGER,
+        }),
+      }),
+    );
+  });
+
+  it("discards a malformed legacy truncation without deleting valid data", async () => {
+    const validItem = itemMetadata(FIFTH_ITEM_UUID, SOURCE_UUID, 1);
+    db.updateSources({ [SOURCE_UUID]: sourceMetadata(SOURCE_UUID) });
+    db.updateItems({ [FIFTH_ITEM_UUID]: validItem });
+    const itemDirectory = storage.itemDirectory(validItem).path;
+    fs.writeFileSync(path.join(itemDirectory, "plaintext"), "valid secret");
+    db["db"]!.prepare(
+      `INSERT INTO pending_events (snowflake_id, source_uuid, type, data)
+       VALUES (?, ?, ?, ?)`,
+    ).run(
+      "fractional-truncation",
+      SOURCE_UUID,
+      PendingEventType.SourceConversationTruncated,
+      JSON.stringify({ upper_bound: 1.5 }),
+    );
+
+    expect(db.getSourceWithItems(SOURCE_UUID).items).toHaveLength(0);
+    await db.cleanupInvalidLifecycleData();
+
+    expect(db.getSourceWithItems(SOURCE_UUID).items).toHaveLength(1);
+    expect(fs.existsSync(itemDirectory)).toBe(true);
+    expect(db.getFilesystemCleanupJobs()).toHaveLength(0);
+  });
+
+  it("quarantines an aliased legacy item without deleting a shared path", async () => {
+    const victimItem = itemMetadata(ITEM_UUID, SOURCE_UUID, 1);
+    const aliasedMetadata = itemMetadata(ITEM_UUID, SOURCE_UUID, 1.5);
+    db.updateSources({ [SOURCE_UUID]: sourceMetadata(SOURCE_UUID) });
+    db.updateItems({ [ITEM_UUID]: victimItem });
+    db.completePlaintextItem(ITEM_UUID, "valid victim secret");
+    const victimDirectory = storage.itemDirectory(victimItem).path;
+    const rowIdentityDirectory = storage.itemDirectoryByIdentity(
+      SOURCE_UUID,
+      SECOND_ITEM_UUID,
+      true,
+    ).path;
+    fs.writeFileSync(path.join(victimDirectory, "plaintext"), "victim");
+    const historicalAliasFile = path.join(victimDirectory, "alias-ciphertext");
+    const rowIdentityFile = path.join(rowIdentityDirectory, "row-ciphertext");
+    fs.writeFileSync(historicalAliasFile, "alias");
+    fs.writeFileSync(rowIdentityFile, "row");
+    const rawDb = db["db"]!;
+    rawDb
+      .prepare(
+        `INSERT INTO items (uuid, data, plaintext, version, fetch_status)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(
+        SECOND_ITEM_UUID,
+        JSON.stringify(aliasedMetadata),
+        "invalid alias secret",
+        "alias-version",
+        FetchStatus.Complete,
+      );
+    rawDb
+      .prepare(
+        `INSERT INTO search_index(source_uuid, item_uuid, type, content)
+         VALUES (?, ?, 'message', ?)`,
+      )
+      .run(SOURCE_UUID, SECOND_ITEM_UUID, "invalid alias secret");
+    await db.cleanupInvalidLifecycleData();
+
+    expect(db.getItem(ITEM_UUID)).not.toBeNull();
+    expect(db.getItem(SECOND_ITEM_UUID)).toBeNull();
+    expect(db.search("valid victim")).toHaveLength(1);
+    expect(db.search("invalid alias")).toHaveLength(0);
+    expect(fs.existsSync(victimDirectory)).toBe(true);
+    expect(fs.readFileSync(historicalAliasFile, "utf8")).toBe("alias");
+    expect(fs.readFileSync(rowIdentityFile, "utf8")).toBe("row");
+    expect(db.getFilesystemCleanupJobs()).toEqual([
+      expect.objectContaining({
+        target: "item",
+        source_uuid: SOURCE_UUID,
+        item_uuid: SECOND_ITEM_UUID,
+        metadata_item_uuid: ITEM_UUID,
+        status: "quarantined",
+        reason: "metadata_uuid_mismatch",
+      }),
+    ]);
+  });
+
+  it("does not give a projected reply alias filesystem identity", () => {
+    const victimItem = itemMetadata(ITEM_UUID, SOURCE_UUID, 2);
+    db.updateSources({ [SOURCE_UUID]: sourceMetadata(SOURCE_UUID) });
+    db.updateItems({ [ITEM_UUID]: victimItem });
+    const victimDirectory = storage.itemDirectory(victimItem).path;
+    fs.writeFileSync(path.join(victimDirectory, "plaintext"), "victim");
+    db["db"]!.prepare(
+      `INSERT INTO pending_events (snowflake_id, source_uuid, type, data)
+         VALUES (?, ?, ?, ?)`,
+    ).run(
+      "reply-alias",
+      SOURCE_UUID,
+      PendingEventType.ReplySent,
+      JSON.stringify({
+        uuid: ITEM_UUID,
+        metadata: {
+          kind: "reply",
+          uuid: ITEM_UUID,
+          source: SOURCE_UUID,
+          size: 5,
+          journalist_uuid: "",
+          is_deleted_by_source: false,
+          seen_by: [],
+          interaction_count: 1,
+        },
+        plaintext: "alias",
+        reply: "encrypted reply payload",
+      }),
+    );
+
+    const projectedAlias = db
+      .getSourceWithItems(SOURCE_UUID)
+      .items.find(({ plaintext }) => plaintext === "alias");
+
+    expect(projectedAlias).toBeDefined();
+    expect(projectedAlias?.source_uuid).toBeUndefined();
+    expect(fs.existsSync(victimDirectory)).toBe(true);
+  });
+
+  it("retries a failed cleanup job after restart", async () => {
+    const zeroItem = itemMetadata(ITEM_UUID, SOURCE_UUID, 0);
+    db.updateSources({ [SOURCE_UUID]: sourceMetadata(SOURCE_UUID) });
+    const rawDb = db["db"]!;
+    rawDb
+      .prepare(
+        `INSERT INTO items (uuid, data, plaintext, version, fetch_status)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(
+        ITEM_UUID,
+        JSON.stringify(zeroItem),
+        "retryable cleanup secret",
+        "zero-version",
+        FetchStatus.Complete,
+      );
+    rawDb
+      .prepare(
+        `INSERT INTO search_index(source_uuid, item_uuid, type, content)
+         VALUES (?, ?, 'message', ?)`,
+      )
+      .run(SOURCE_UUID, ITEM_UUID, "retryable cleanup secret");
+    const itemDirectory = storage.itemDirectory(zeroItem).path;
+    fs.writeFileSync(path.join(itemDirectory, "plaintext"), "secret");
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(fs.promises, "rm").mockRejectedValue(
+      new Error("permission denied"),
+    );
+
+    await db.cleanupInvalidLifecycleData();
+
+    expect(db.getItem(ITEM_UUID)).toBeNull();
+    expect(db.search("retryable cleanup")).toHaveLength(0);
+    expect(fs.existsSync(itemDirectory)).toBe(true);
+    expect(db.getFilesystemCleanupJobs()).toEqual([
+      expect.objectContaining({
+        item_uuid: ITEM_UUID,
+        status: "pending",
+      }),
+    ]);
+    expect(() =>
+      db.updateItems({
+        [ITEM_UUID]: itemMetadata(ITEM_UUID, SOURCE_UUID, 1),
+      }),
+    ).toThrow("before pending filesystem cleanup completes");
+
+    vi.mocked(fs.promises.rm).mockRestore();
+    db.close();
+    db = new Datastore(crypto, storage, tmpDir);
+    await db.cleanupInvalidLifecycleData();
+
+    expect(db.getItem(ITEM_UUID)).toBeNull();
+    expect(db.search("retryable cleanup")).toHaveLength(0);
+    expect(fs.existsSync(itemDirectory)).toBe(false);
+    expect(db.getFilesystemCleanupJobs()).toHaveLength(0);
+  });
+
+  it("rolls back event mutation when cleanup job insertion fails", () => {
+    const item = itemMetadata(ITEM_UUID, SOURCE_UUID, 1);
+    db.updateSources({ [SOURCE_UUID]: sourceMetadata(SOURCE_UUID) });
+    db.updateItems({ [ITEM_UUID]: item });
+    const itemDirectory = storage.itemDirectory(item).path;
+    const plaintext = path.join(itemDirectory, "plaintext");
+    fs.writeFileSync(plaintext, "secret");
+    const rawDb = db["db"]!;
+    rawDb.exec(`
+      CREATE TRIGGER fail_cleanup_job_insert
+      BEFORE INSERT ON filesystem_cleanup_jobs
+      BEGIN
+        SELECT RAISE(ABORT, 'injected cleanup insertion failure');
+      END;
+    `);
+
+    expect(() =>
+      db.addPendingSourceEvent(
+        SOURCE_UUID,
+        PendingEventType.SourceConversationTruncated,
+        { upper_bound: 1 },
+      ),
+    ).toThrow("injected cleanup insertion failure");
+
+    expect(db.getPendingEvents()).toHaveLength(0);
+    expect(db.getFilesystemCleanupJobs()).toHaveLength(0);
+    expect(db.getItem(ITEM_UUID)?.fetch_status).toBe(FetchStatus.Initial);
+    expect(fs.readFileSync(plaintext, "utf8")).toBe("secret");
+  });
+
+  it("retains an acknowledged truncation cleanup across restart", async () => {
+    const item = itemMetadata(ITEM_UUID, SOURCE_UUID, 1);
+    db.updateSources({ [SOURCE_UUID]: sourceMetadata(SOURCE_UUID) });
+    db.updateItems({ [ITEM_UUID]: item });
+    const itemDirectory = storage.itemDirectory(item).path;
+    const plaintext = path.join(itemDirectory, "plaintext");
+    fs.writeFileSync(plaintext, "orphan prevention secret");
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(fs.promises, "rm").mockRejectedValue(
+      new Error("persistent permission failure"),
+    );
+    const eventId = db.addPendingSourceEvent(
+      SOURCE_UUID,
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 1 },
+    )!;
+    await db.runFilesystemCleanupJobs();
+
+    db.updateBatch(
+      {
+        sources: {},
+        items: {},
+        journalists: {},
+        events: { [eventId]: [EventStatus.OK, null] },
+      },
+      { sources: [], items: [ITEM_UUID], journalists: [] },
+    );
+    await db.runFilesystemCleanupJobs();
+
+    expect(db.getItem(ITEM_UUID)).toBeNull();
+    expect(db.getPendingEvents()).toHaveLength(0);
+    expect(fs.readFileSync(plaintext, "utf8")).toBe("orphan prevention secret");
+    expect(db.getFilesystemCleanupJobs()).toEqual([
+      expect.objectContaining({ item_uuid: ITEM_UUID, status: "pending" }),
+    ]);
+
+    vi.mocked(fs.promises.rm).mockRestore();
+    db.close();
+    db = new Datastore(crypto, storage, tmpDir);
+    await db.cleanupInvalidLifecycleData();
+
+    expect(fs.existsSync(plaintext)).toBe(false);
+    expect(db.getFilesystemCleanupJobs()).toHaveLength(0);
+  });
+
+  it("preserves coherent zero-bound truncation behavior", () => {
+    db.updateSources({ [SOURCE_UUID]: sourceMetadata(SOURCE_UUID) });
+    db.updateItems({
+      [ITEM_UUID]: itemMetadata(ITEM_UUID, SOURCE_UUID, 1),
+      [SECOND_ITEM_UUID]: itemMetadata(SECOND_ITEM_UUID, SOURCE_UUID, 2),
+    });
+    db.completePlaintextItem(ITEM_UUID, "zero-bound secret");
+    db.completePlaintextItem(SECOND_ITEM_UUID, "positive-count secret");
+
+    const eventId = db.addPendingSourceEvent(
+      SOURCE_UUID,
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 0 },
+    );
+
+    expect(eventId).not.toBeNull();
+    expect(db.getPendingEvents()).toEqual([
+      expect.objectContaining({
+        id: eventId,
+        type: PendingEventType.SourceConversationTruncated,
+        data: { upper_bound: 0 },
+      }),
+    ]);
+    expect(db.getItem(ITEM_UUID)?.fetch_status).toBe(FetchStatus.Complete);
+    expect(db.getItem(SECOND_ITEM_UUID)?.fetch_status).toBe(
+      FetchStatus.Complete,
+    );
+    expect(db.getSourceWithItems(SOURCE_UUID).items).toHaveLength(2);
+    expect(db.search("zero-bound")).toHaveLength(1);
+    expect(db.search("positive-count")).toHaveLength(1);
+  });
+});

--- a/app/src/main/storage.test.ts
+++ b/app/src/main/storage.test.ts
@@ -144,6 +144,14 @@ describe("PathBuilder", () => {
       expect(result2).toBe(`${tempDir}/foo/bar/file.txt`);
     });
 
+    it("should allow existing directories within root", () => {
+      fs.mkdirSync(path.join(tempDir, "existing"));
+
+      const result = builder.getSubBuilder("existing");
+
+      expect(result.path).toBe(`${tempDir}/existing/`);
+    });
+
     it("should reject bad input", () => {
       expect(() => builder.join("..")).toThrow("Invalid path component: ..");
       expect(() => builder.join("foo/bar")).toThrow(

--- a/app/src/main/storage.ts
+++ b/app/src/main/storage.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import os from "os";
-import { Item, ItemMetadata } from "../types";
+import pathModule from "path";
+import { FilesystemCleanupJob, ItemMetadata } from "../types";
 import { ItemFetchTask } from "./fetch/queue";
 
 /// Newtype for when we know a path component is potentially unsafe,
@@ -53,8 +54,14 @@ export class PathBuilder {
   doesntEscape(path: string) {
     // Don't allow escape via symlinks
     if (fs.existsSync(path)) {
+      const root = fs.realpathSync(this.path);
       const absolute = fs.realpathSync(path);
-      if (!absolute.startsWith(this.path)) {
+      const relative = pathModule.relative(root, absolute);
+      if (
+        relative === ".." ||
+        relative.startsWith(`..${pathModule.sep}`) ||
+        pathModule.isAbsolute(relative)
+      ) {
         throw new Error(`Path ${path} escapes root ${this.path}`);
       }
     }
@@ -116,9 +123,15 @@ export class Storage {
   }
 
   itemDirectory(item: ItemMetadata, mkdir: boolean = true): PathBuilder {
-    const dir = this.sourceDirectory(item.source, mkdir).getSubBuilder(
-      item.uuid,
-    );
+    return this.itemDirectoryByIdentity(item.source, item.uuid, mkdir);
+  }
+
+  itemDirectoryByIdentity(
+    sourceUuid: string,
+    itemUuid: string,
+    mkdir: boolean = true,
+  ): PathBuilder {
+    const dir = this.sourceDirectory(sourceUuid, mkdir).getSubBuilder(itemUuid);
     if (mkdir) {
       fs.mkdirSync(dir.path, { recursive: true });
     }
@@ -133,30 +146,25 @@ export class Storage {
     return new PathBuilder(tempDir + "/");
   }
 
-  async deleteSourceFs(sourceID: string): Promise<void> {
-    try {
-      const sourceDirectory = this.sourceDirectory(sourceID, false).path;
-      await fs.promises.rm(sourceDirectory, { recursive: true, force: true });
-    } catch (err) {
-      console.error("Failed to delete source from filesystem: ", {
-        sourceID,
-        error: err,
-      });
+  async runFilesystemCleanupJob(job: FilesystemCleanupJob): Promise<void> {
+    if (job.status !== "pending" || !job.source_uuid) {
+      throw new Error(`Cleanup job ${job.id} is not executable`);
     }
+    const directory =
+      job.target === "source"
+        ? this.sourceDirectory(job.source_uuid, false)
+        : this.itemDirectoryByIdentity(
+            job.source_uuid,
+            this.requireItemUuid(job),
+            false,
+          );
+    await fs.promises.rm(directory.path, { recursive: true, force: true });
   }
 
-  async deleteItemFs(item: Item): Promise<void> {
-    try {
-      const itemDirectory = this.itemDirectory(item.data, false);
-      await fs.promises.rm(itemDirectory.path, {
-        recursive: true,
-        force: true,
-      });
-    } catch (err) {
-      console.error("Failed to delete item from filesystem", {
-        item: item.uuid,
-        error: err,
-      });
+  private requireItemUuid(job: FilesystemCleanupJob): string {
+    if (!job.item_uuid) {
+      throw new Error(`Item cleanup job ${job.id} has no item identity`);
     }
+    return job.item_uuid;
   }
 }

--- a/app/src/main/sync/index.test.ts
+++ b/app/src/main/sync/index.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, MockInstance } from "vitest";
 import * as syncModule from "../../../src/main/sync";
-import { Storage } from "../../../src/main/storage";
 import { Lock, LockTimeoutError } from "../../../src/main/sync/lock";
 import { Datastore } from "../../../src/main/datastore";
 import {
@@ -17,23 +16,6 @@ import {
 import * as proxyModule from "../../../src/main/proxy";
 import { estimateTimeout } from "../../../src/main/timeouts";
 import { IndexSized, BatchResponseSized } from "../../../src/schemas";
-import * as fs from "fs";
-
-vi.mock("fs", () => ({
-  promises: {
-    rm: vi.fn(),
-  },
-  existsSync: vi.fn(() => true),
-  realpathSync: vi.fn((path) => path),
-  mkdirSync: vi.fn(),
-}));
-
-vi.mock("os", () => ({
-  default: {
-    homedir: vi.fn(() => "/mock-home"),
-    tmpdir: vi.fn(() => "/tmp"),
-  },
-}));
 
 // Valid UUIDs for testing
 const SOURCE_UUID_1 = "550e8400-e29b-41d4-a716-446655440001";
@@ -41,40 +23,24 @@ const SOURCE_UUID_2 = "550e8400-e29b-41d4-a716-446655440002";
 const ITEM_UUID_1 = "660e8400-e29b-41d4-a716-446655440001";
 const ITEM_UUID_2 = "660e8400-e29b-41d4-a716-446655440002";
 const JOURNALIST_UUID_1 = "770e8400-e29b-41d4-a716-446655440001";
+const EMPTY_DELETIONS = { sources: [], items: [], journalists: [] };
 
 function mockDB({
   index = { sources: {}, items: {}, journalists: {} },
   itemFileData = {},
   pendingEvents = [],
-  storage,
 }: {
   index?: Index;
   itemFileData?: object;
   pendingEvents?: PendingEvent[];
-  storage?: Storage;
 } = {}) {
   const db = {
     getVersion: vi.fn(() => "v1"),
     getIndex: vi.fn(() => index),
     getItem: vi.fn((_itemID) => null),
     getItemsToProcess: vi.fn(() => []),
-    deleteItemsAsync: vi.fn((itemIDs: string[]) => {
-      if (storage) {
-        for (const itemID of itemIDs) {
-          const item = db.getItem(itemID);
-          if (item) {
-            storage.deleteItemFs(item);
-          }
-        }
-      }
-    }),
-    deleteSourcesAsync: vi.fn(async (sourceIDs: string[]) => {
-      if (storage) {
-        for (const sourceID of sourceIDs) {
-          await storage.deleteSourceFs(sourceID);
-        }
-      }
-    }),
+    deleteItemsAsync: vi.fn(),
+    deleteSourcesAsync: vi.fn(),
     deleteJournalists: vi.fn(),
     updateBatch: vi.fn((_metadata) => ({
       deleted_items: [],
@@ -82,6 +48,7 @@ function mockDB({
     })),
     getItemFileData: vi.fn(() => itemFileData),
     getPendingEvents: vi.fn(() => pendingEvents),
+    runFilesystemCleanupJobs: vi.fn(() => Promise.resolve()),
   } as unknown as Datastore;
   return db;
 }
@@ -162,7 +129,7 @@ describe("syncMetadata", () => {
         [SOURCE_UUID_1]: "abc",
       },
       items: {
-        [SOURCE_UUID_2]: "def",
+        [ITEM_UUID_1]: "def",
       },
       journalists: {
         [JOURNALIST_UUID_1]: "ghi",
@@ -173,7 +140,7 @@ describe("syncMetadata", () => {
         [SOURCE_UUID_1]: mockSourceMetadata(SOURCE_UUID_1),
       },
       items: {
-        [SOURCE_UUID_2]: mockItemMetadata(ITEM_UUID_1, SOURCE_UUID_1),
+        [ITEM_UUID_1]: mockItemMetadata(ITEM_UUID_1, SOURCE_UUID_1),
       },
       journalists: {
         [JOURNALIST_UUID_1]: mockJournalistMetadata(JOURNALIST_UUID_1),
@@ -203,7 +170,7 @@ describe("syncMetadata", () => {
 
     expect(proxyMock).toHaveBeenCalledTimes(2);
     // Should update sources and items with new data
-    expect(db.updateBatch).toHaveBeenCalledWith(batch);
+    expect(db.updateBatch).toHaveBeenCalledWith(batch, EMPTY_DELETIONS);
   });
 
   it("passes estimated timeouts to proxyJSONRequest", async () => {
@@ -374,16 +341,19 @@ describe("syncMetadata", () => {
     db = mockDB({
       index: clientIndex,
     });
-    const metadataToUpdate = await syncModule.reconcileIndex(
-      db,
-      serverIndex,
-      clientIndex,
-    );
-    expect(metadataToUpdate).toEqual({
-      sources: [SOURCE_UUID_1],
-      items: [ITEM_UUID_1],
-      journalists: [JOURNALIST_UUID_1],
-      events: [],
+    const reconciliation = syncModule.reconcileIndex(serverIndex, clientIndex);
+    expect(reconciliation).toEqual({
+      request: {
+        sources: [SOURCE_UUID_1],
+        items: [ITEM_UUID_1],
+        journalists: [JOURNALIST_UUID_1],
+        events: [],
+      },
+      deletions: {
+        sources: [],
+        items: [ITEM_UUID_2],
+        journalists: [],
+      },
     });
   });
 
@@ -427,10 +397,7 @@ describe("syncMetadata", () => {
       events: {},
     };
 
-    db = mockDB({
-      index: clientIndex,
-      storage: new Storage(),
-    });
+    db = mockDB({ index: clientIndex });
 
     // Mock getItem to return data for ITEM_UUID_2 so cleanup can happen
     db.getItem = vi.fn((itemID: string) => {
@@ -467,16 +434,12 @@ describe("syncMetadata", () => {
     await syncModule.syncMetadata(db, "");
 
     expect(proxyMock).toHaveBeenCalledTimes(2);
-    expect(db.deleteItemsAsync).toHaveBeenCalledWith([ITEM_UUID_2]);
-    expect(db.updateBatch).toHaveBeenCalledWith(metadata);
-    expect(fs.promises.rm).toHaveBeenCalledTimes(1);
-    expect(fs.promises.rm).toHaveBeenCalledWith(
-      `/mock-home/.config/SecureDrop/files/${SOURCE_UUID_1}/${ITEM_UUID_2}/`,
-      {
-        recursive: true,
-        force: true,
-      },
-    );
+    expect(db.deleteItemsAsync).not.toHaveBeenCalled();
+    expect(db.updateBatch).toHaveBeenCalledWith(metadata, {
+      sources: [],
+      items: [ITEM_UUID_2],
+      journalists: [],
+    });
   });
 
   it("reconciles partial sources", async () => {
@@ -511,16 +474,15 @@ describe("syncMetadata", () => {
       index: clientIndex,
     });
 
-    const metadataToUpdate = await syncModule.reconcileIndex(
-      db,
-      serverIndex,
-      clientIndex,
-    );
-    expect(metadataToUpdate).toEqual({
-      items: [ITEM_UUID_1],
-      sources: [],
-      journalists: [],
-      events: [],
+    const reconciliation = syncModule.reconcileIndex(serverIndex, clientIndex);
+    expect(reconciliation).toEqual({
+      request: {
+        items: [ITEM_UUID_1],
+        sources: [],
+        journalists: [],
+        events: [],
+      },
+      deletions: EMPTY_DELETIONS,
     });
 
     const metadata: BatchResponse = {
@@ -550,7 +512,7 @@ describe("syncMetadata", () => {
     await syncModule.syncMetadata(db, "");
 
     expect(proxyMock).toHaveBeenCalledTimes(2);
-    expect(db.updateBatch).toHaveBeenCalledWith(metadata);
+    expect(db.updateBatch).toHaveBeenCalledWith(metadata, EMPTY_DELETIONS);
   });
 
   it("deletes sources on sync + updates source delta", async () => {
@@ -595,16 +557,23 @@ describe("syncMetadata", () => {
     await syncModule.syncMetadata(db, "");
 
     expect(proxyMock).toHaveBeenCalledTimes(2);
-    expect(db.deleteSourcesAsync).toHaveBeenCalledWith([SOURCE_UUID_2]);
-    expect(db.updateBatch).toHaveBeenCalledWith({
-      items: {},
-      sources: {},
-      journalists: {},
-      events: {},
-    });
+    expect(db.deleteSourcesAsync).not.toHaveBeenCalled();
+    expect(db.updateBatch).toHaveBeenCalledWith(
+      {
+        items: {},
+        sources: {},
+        journalists: {},
+        events: {},
+      },
+      {
+        sources: [SOURCE_UUID_2],
+        items: [],
+        journalists: [],
+      },
+    );
   });
 
-  it("deletes source directory from filesystem when source is deleted on server", async () => {
+  it("defers source deletion until the validated batch is applied", async () => {
     // Client index has both sources
     const clientIndex: Index = {
       sources: {
@@ -624,7 +593,7 @@ describe("syncMetadata", () => {
       journalists: {},
     };
 
-    db = mockDB({ index: clientIndex, storage: new Storage() });
+    db = mockDB({ index: clientIndex });
 
     mockProxyResponses([
       {
@@ -643,9 +612,14 @@ describe("syncMetadata", () => {
 
     await syncModule.syncMetadata(db, "");
 
-    expect(fs.promises.rm).toHaveBeenCalledWith(
-      `/mock-home/.config/SecureDrop/files/${SOURCE_UUID_2}/`,
-      { recursive: true, force: true },
+    expect(db.deleteSourcesAsync).not.toHaveBeenCalled();
+    expect(db.updateBatch).toHaveBeenCalledWith(
+      { sources: {}, items: {}, journalists: {}, events: {} },
+      {
+        sources: [SOURCE_UUID_2],
+        items: [],
+        journalists: [],
+      },
     );
   });
 
@@ -698,7 +672,7 @@ describe("syncMetadata", () => {
     // The batch request should include the pending events
     const batchRequestArg = proxyMock.mock.calls[1][0];
     expect(JSON.parse(batchRequestArg.body!).events).toEqual(pendingEvents);
-    expect(db.updateBatch).toHaveBeenCalledWith(batch);
+    expect(db.updateBatch).toHaveBeenCalledWith(batch, EMPTY_DELETIONS);
     expect(status).toBe(SyncStatus.UPDATED);
   });
 
@@ -780,7 +754,7 @@ describe("syncMetadata", () => {
     const status = await syncModule.syncMetadata(db, "");
 
     expect(proxyMock).toHaveBeenCalledTimes(2);
-    expect(db.updateBatch).toHaveBeenCalledWith(batch);
+    expect(db.updateBatch).toHaveBeenCalledWith(batch, EMPTY_DELETIONS);
     expect(status).toBe(SyncStatus.UPDATED);
   });
 });
@@ -815,24 +789,6 @@ describe("shouldSkipSync", () => {
     const db = mockDB();
     db.getVersion = vi.fn(() => ""); // initial state
     expect(syncModule.shouldSkipSync(db, "v1")).toBe(false);
-  });
-});
-
-describe("Storage.deleteSourceFs", () => {
-  beforeEach(() => {
-    vi.resetAllMocks();
-  });
-
-  it("deletes source directory when it exists", async () => {
-    vi.mocked(fs.existsSync).mockReturnValue(true);
-    const storage = new Storage();
-
-    await storage.deleteSourceFs(SOURCE_UUID_1);
-
-    expect(fs.promises.rm).toHaveBeenCalledWith(
-      `/mock-home/.config/SecureDrop/files/${SOURCE_UUID_1}/`,
-      { recursive: true, force: true },
-    );
   });
 });
 

--- a/app/src/main/sync/index.ts
+++ b/app/src/main/sync/index.ts
@@ -5,6 +5,8 @@ import {
   BatchRequest,
   BatchResponse,
   SyncStatus,
+  IndexDeletionPlan,
+  PendingEvent,
 } from "../../types";
 import { DB, DEFAULT_PENDING_EVENTS_LIMIT } from "../database";
 import { Datastore } from "../datastore";
@@ -119,13 +121,10 @@ async function submitBatch(
   );
 }
 
-// Given the server index and the client's index, return the sources and items
-// that need to be synced. Also deletes items that are not in the server index.
-export async function reconcileIndex(
-  db: Datastore,
+export function reconcileIndex(
   serverIndex: Index,
   clientIndex: Index,
-): Promise<BatchRequest> {
+): { request: BatchRequest; deletions: IndexDeletionPlan } {
   const sourcesToUpdate: string[] = [];
   Object.keys(serverIndex.sources).forEach((sourceID) => {
     if (
@@ -141,10 +140,6 @@ export async function reconcileIndex(
   const sourcesToDelete = Object.keys(clientIndex.sources).filter(
     (source) => !serverSourceSet.has(source),
   );
-  if (sourcesToDelete.length > 0) {
-    await db.deleteSourcesAsync(sourcesToDelete);
-  }
-
   const itemsToUpdate: string[] = [];
   Object.keys(serverIndex.items).forEach((itemID) => {
     if (
@@ -159,10 +154,6 @@ export async function reconcileIndex(
   const itemsToDelete = Object.keys(clientIndex.items).filter(
     (item) => !serverItemSet.has(item),
   );
-  if (itemsToDelete.length > 0) {
-    await db.deleteItemsAsync(itemsToDelete);
-  }
-
   const journalistsToUpdate: string[] = [];
   Object.keys(serverIndex.journalists).forEach((journalistID) => {
     if (
@@ -178,15 +169,18 @@ export async function reconcileIndex(
   const journalistsToDelete = Object.keys(clientIndex.journalists).filter(
     (journalist) => !serverJournalistSet.has(journalist),
   );
-  if (journalistsToDelete.length > 0) {
-    db.deleteJournalists(journalistsToDelete);
-  }
-
   return {
-    sources: sourcesToUpdate,
-    items: itemsToUpdate,
-    journalists: journalistsToUpdate,
-    events: [],
+    request: {
+      sources: sourcesToUpdate,
+      items: itemsToUpdate,
+      journalists: journalistsToUpdate,
+      events: [],
+    },
+    deletions: {
+      sources: sourcesToDelete,
+      items: itemsToDelete,
+      journalists: journalistsToDelete,
+    },
   };
 }
 
@@ -201,6 +195,43 @@ export function shouldSkipSync(db: DB, hintedVersion?: string): boolean {
   return nothingIncoming && nothingOutgoing;
 }
 
+function getPendingEventsForAttempt(
+  db: Datastore,
+  attempt?: number,
+): PendingEvent[] {
+  if (attempt === undefined || attempt <= 0) {
+    return db.getPendingEvents();
+  }
+  const limit = Math.max(
+    1,
+    Math.ceil(DEFAULT_PENDING_EVENTS_LIMIT / (attempt + 1)),
+  );
+  return db.getPendingEvents(limit);
+}
+
+function buildBatchPlan(
+  db: Datastore,
+  indexResponse: IndexResponse,
+  pendingEvents: PendingEvent[],
+): { request: BatchRequest; deletions: IndexDeletionPlan } {
+  const emptyDeletions = { sources: [], items: [], journalists: [] };
+  if (indexResponse.status !== 200) {
+    return {
+      request: {
+        sources: [],
+        items: [],
+        journalists: [],
+        events: pendingEvents,
+      },
+      deletions: emptyDeletions,
+    };
+  }
+
+  const reconciliation = reconcileIndex(indexResponse.index, db.getIndex());
+  reconciliation.request.events = pendingEvents;
+  return reconciliation;
+}
+
 // Executes metadata sync with SecureDrop server, updating
 // the current version and persisting updated source, reply,
 // and submission metadata to the DB.
@@ -213,16 +244,11 @@ export async function syncMetadata(
   attempt?: number,
 ): Promise<SyncStatus> {
   console.log("[sync] syncing ", { hintedRecords, attempt });
+  await db.runFilesystemCleanupJobs();
 
   const currentVersion = db.getVersion();
 
-  // Decrease event batch size on retry attempts
-  const pendingEvents =
-    attempt && attempt > 0
-      ? db.getPendingEvents(
-          Math.max(1, Math.ceil(DEFAULT_PENDING_EVENTS_LIMIT / (attempt + 1))),
-        )
-      : db.getPendingEvents();
+  const pendingEvents = getPendingEventsForAttempt(db, attempt);
 
   const indexResponse = await getServerIndex(
     authToken,
@@ -238,25 +264,11 @@ export async function syncMetadata(
 
   let syncStatus = SyncStatus.NOT_MODIFIED;
 
-  const request: BatchRequest = {
-    sources: [],
-    items: [],
-    journalists: [],
-    events: pendingEvents,
-  };
-
-  if (indexResponse.status === 200) {
-    // Reconcile with client's index to get metadata to update
-    const clientIndex = db.getIndex();
-    const { sources, items, journalists } = await reconcileIndex(
-      db,
-      indexResponse.index,
-      clientIndex,
-    );
-    request.sources = sources;
-    request.items = items;
-    request.journalists = journalists;
-  }
+  const { request, deletions } = buildBatchPlan(
+    db,
+    indexResponse,
+    pendingEvents,
+  );
 
   // No pending events and no server updates, nothing to sync
   if (
@@ -287,7 +299,8 @@ export async function syncMetadata(
     return SyncStatus.FORBIDDEN;
   }
 
-  db.updateBatch(batchResponse.data);
+  db.updateBatch(batchResponse.data, deletions);
+  await db.runFilesystemCleanupJobs();
 
   syncStatus = SyncStatus.UPDATED;
   console.log("[sync] updates complete");

--- a/app/src/renderer/features/conversation/conversationSlice.ts
+++ b/app/src/renderer/features/conversation/conversationSlice.ts
@@ -38,7 +38,7 @@ export const fetchConversation = createAsyncThunk(
 
     // Mark all items in this conversation as seen
     const maxInteractionCount = sourceWithItems.items.reduce(
-      (max, item) => Math.max(max, item.data.interaction_count ?? 0),
+      (max, item) => Math.max(max, item.data.interaction_count),
       0,
     );
     if (maxInteractionCount > 0) {
@@ -74,7 +74,7 @@ export const fetchOlderConversationItems = createAsyncThunk(
 
     // Mark all older items in this conversation as seen
     const maxInteractionCount = sourceWithItems.items.reduce(
-      (max, item) => Math.max(max, item.data.interaction_count ?? 0),
+      (max, item) => Math.max(max, item.data.interaction_count),
       0,
     );
     if (maxInteractionCount > 0) {

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
@@ -255,6 +255,11 @@ describe("Sources Component", () => {
     // Mock electronAPI with partial implementation for these tests
     window.electronAPI = {
       getSources: vi.fn().mockResolvedValue(mockSources),
+      getSourceItemCounts: vi.fn().mockResolvedValue({
+        messages: 0,
+        files: 0,
+        replies: 0,
+      }),
       search: vi
         .fn()
         .mockImplementation((query: string) =>
@@ -1251,7 +1256,7 @@ describe("Sources Component", () => {
 
       // Focus the search input and fire keydown on it
       const searchInput = screen.getByTestId("source-search-input");
-      searchInput.focus();
+      await userEvent.click(searchInput);
 
       // Press Ctrl+Delete while focused on input
       fireEvent.keyDown(searchInput, {

--- a/app/src/schemas.ts
+++ b/app/src/schemas.ts
@@ -18,6 +18,20 @@ export const API_MINOR_VERSION = 4; // 2.x
 
 export const UUIDSchema = z.uuid({ version: "v4" });
 
+export const InteractionCountSchema = z
+  .number()
+  .finite()
+  .int()
+  .positive()
+  .safe();
+
+export const EventUpperBoundSchema = z
+  .number()
+  .finite()
+  .int()
+  .nonnegative()
+  .safe();
+
 export interface SizedSchema {
   recordSize: number;
   description: string;
@@ -61,7 +75,7 @@ export const ReplyMetadataSchema = z.object({
   journalist_uuid: UUIDSchema,
   is_deleted_by_source: z.boolean(),
   seen_by: z.array(UUIDSchema),
-  interaction_count: z.number(),
+  interaction_count: InteractionCountSchema,
 });
 
 export const SubmissionMetadataSchema = z.object({
@@ -71,7 +85,7 @@ export const SubmissionMetadataSchema = z.object({
   size: z.number(),
   is_read: z.boolean(),
   seen_by: z.array(UUIDSchema),
-  interaction_count: z.number(),
+  interaction_count: InteractionCountSchema,
 });
 
 // Item metadata is either a reply or submission
@@ -101,12 +115,24 @@ export const IndexSized: SizedSchema = {
 };
 
 // Metadata, maps UUIDs to full metadata objects
-export const BatchResponseSchema = z.object({
-  sources: z.record(UUIDSchema, SourceMetadataSchema.nullable()),
-  items: z.record(UUIDSchema, ItemMetadataSchema.nullable()),
-  journalists: z.record(UUIDSchema, JournalistMetadataSchema.nullable()),
-  events: z.record(z.string(), z.tuple([z.number(), z.string().nullable()])),
-});
+export const BatchResponseSchema = z
+  .object({
+    sources: z.record(UUIDSchema, SourceMetadataSchema.nullable()),
+    items: z.record(UUIDSchema, ItemMetadataSchema.nullable()),
+    journalists: z.record(UUIDSchema, JournalistMetadataSchema.nullable()),
+    events: z.record(z.string(), z.tuple([z.number(), z.string().nullable()])),
+  })
+  .superRefine(({ items }, context) => {
+    for (const [itemUuid, metadata] of Object.entries(items)) {
+      if (metadata !== null && metadata.uuid !== itemUuid) {
+        context.addIssue({
+          code: "custom",
+          message: "Item metadata UUID must match its batch map key",
+          path: ["items", itemUuid, "uuid"],
+        });
+      }
+    }
+  });
 
 // Interface for size calculations
 export const BatchResponseSized: SizedSchema = {
@@ -151,16 +177,40 @@ const BasePendingEvent = {
   target: z.union([SourceTargetSchema, ItemTargetSchema]),
 };
 
-const SourceConversationSeenDataSchema = z.object({ upper_bound: z.number() });
+const SourceConversationSeenDataSchema = z.object({
+  upper_bound: EventUpperBoundSchema,
+});
 
 const SourceConversationTruncatedDataSchema = z.object({
-  upper_bound: z.number(),
+  upper_bound: EventUpperBoundSchema,
 });
 
 export const PendingEventDataSchema = z.union([
   SourceConversationSeenDataSchema,
   SourceConversationTruncatedDataSchema,
 ]);
+
+const SourcePendingEventDataSchemas: Partial<
+  Record<PendingEventType, z.ZodType<unknown>>
+> = {
+  [PendingEventType.SourceDeleted]: z.undefined(),
+  [PendingEventType.SourceConversationTruncated]:
+    SourceConversationTruncatedDataSchema,
+  [PendingEventType.Starred]: z.undefined(),
+  [PendingEventType.Unstarred]: z.undefined(),
+  [PendingEventType.SourceConversationSeen]: SourceConversationSeenDataSchema,
+};
+
+export function validatePendingEventData(
+  type: PendingEventType,
+  data?: PendingEventData,
+): void {
+  const schema = SourcePendingEventDataSchemas[type];
+  if (!schema) {
+    throw new Error(`Unsupported source event type: ${type}`);
+  }
+  schema.parse(data);
+}
 
 export const PendingEventSchema = z.discriminatedUnion("type", [
   z.object({

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -164,6 +164,22 @@ export type MetadataRequest = {
   journalists: string[];
 };
 
+export type IndexDeletionPlan = {
+  sources: string[];
+  items: string[];
+  journalists: string[];
+};
+
+export type FilesystemCleanupJob = {
+  id: string;
+  target: "item" | "source";
+  source_uuid: string | null;
+  item_uuid: string | null;
+  metadata_item_uuid: string | null;
+  status: "pending" | "quarantined";
+  reason: string | null;
+};
+
 /** UI Types */
 
 export type Source = {
@@ -226,6 +242,7 @@ export type SourceRow = {
 
 export type Item = {
   uuid: string;
+  source_uuid?: string;
   data: ItemMetadata;
   plaintext: string | null;
   filename: string | null;
@@ -237,6 +254,7 @@ export type Item = {
 // Database representation
 export type ItemRow = {
   uuid: string;
+  source_uuid: string | null;
   data: string; // JSON stringified ItemMetadata
   plaintext: string | null;
   filename: string | null;


### PR DESCRIPTION
## Summary

- Enforces safe integer lifecycle counts at IPC, schema, and database write boundaries so invalid server-provided values cannot drive deletion, seen, or pagination state.
- Repairs invalid released rows during startup and queues filesystem cleanup work before destructive state mutation so plaintext cleanup survives restart and rollback edges.
- Adds focused lifecycle-count coverage for zero, fractional, duplicate, and legacy pending-event states across sync, storage, datastore, and renderer selection paths.

## Context

Fixes #3572.
Fixes #3574.
Fixes #3578.
Fixes #3579.

This follows the existing pending-event projection and startup database maintenance patterns, while adding a durable cleanup job table for file cleanup that must outlive a single process run.

## Test plan

```sh
cd app
PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec vitest run --config vitest.config.ts --project=unit --coverage=false src/main/lifecycle-counts.test.ts src/main/datastore.test.ts src/main/database/search.test.ts
```

Passed: 3 test files, 190 tests.

```sh
cd app
PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec vitest run --config vitest.config.ts --project=unit --coverage=false src/main/storage.test.ts src/main/sync/index.test.ts src/main/index.test.ts
```

Passed: 3 test files, 63 tests.

```sh
cd app
PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec vitest run --config vitest.config.ts --project=component --coverage=false src/renderer/features/conversation/conversationSlice.test.ts src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
```

Passed: 2 test files, 64 tests. The run emitted existing React `act(...)` and test i18n stderr warnings.

```sh
cd app
PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm lint
```

Passed: Prettier, ESLint with `--max-warnings 0`, `typecheck:node`, and `typecheck:web`.

```sh
cd app
PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm dbmate:check
```

Passed: migrations applied, schema dumped, and no schema diff remained.

```sh
PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec vitest run --config vitest.config.ts --project=component --coverage=false src/renderer/views/Inbox.test.tsx src/renderer/views/SignIn.a11y.test.tsx src/renderer/views/SignIn.test.tsx src/renderer/views/Inbox/MainContent/Header.test.tsx src/renderer/views/Inbox/Sidebar/SourceList/Toolbar.test.tsx
```

Passed: 5 test files, 22 tests. This reran the untouched component tests that timed out only during the full local coverage run.

```sh
cd app
PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm build:linux
```

Passed. Electron Builder emitted existing packaging warnings about Linux desktop metadata, optional dbmate platform binaries, and default icon/category settings.

```sh
git diff --check origin/main...HEAD
```

Passed.

```sh
cd app
PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm test
```

Run locally for CI parity. Result: 970 tests passed and 5 untouched renderer accessibility/memoization tests timed out under coverage (`Inbox.test.tsx`, `SignIn.a11y.test.tsx`, `SignIn.test.tsx`, `Header.test.tsx`, and `Toolbar.test.tsx`). The same timed-out files passed when rerun directly without coverage, as shown above.

```sh
cd app
pnpm server-test -- server_tests/delete-conversation.test.ts
```

Not run locally. The shared local SecureDrop server-test slot was reserved for another acceptance run; CI server-tests should cover this server test change.

## Notes

The patch intentionally combines the zero/fractional/duplicate lifecycle-count issues because they share the same database and IPC invariants. A schema-only validation change was rejected because it would not repair invalid rows or preserve filesystem cleanup across restart.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
