### PR TITLE
fix(build): use pinned pnpm for Debian app builds

### DIFF
--- a/debian/build-app.sh
+++ b/debian/build-app.sh
@@ -2,10 +2,22 @@
 
 set -euxo pipefail
 
-# Install pnpm v10
-npm install -g pnpm@10
+COREPACK_HOME="$(mktemp -d)"
+COREPACK_SHIMS="$(mktemp -d)"
+export COREPACK_HOME
+export PATH="$COREPACK_SHIMS:$PATH"
+cleanup_corepack_home() {
+    rm -R "$COREPACK_HOME" "$COREPACK_SHIMS"
+}
+trap cleanup_corepack_home EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 cd app
+
+corepack enable --install-directory "$COREPACK_SHIMS"
+corepack install
 
 pnpm install --frozen-lockfile
 pnpm run build:unpack

--- a/debian/build-app.sh
+++ b/debian/build-app.sh
@@ -2,21 +2,9 @@
 
 set -euxo pipefail
 
-COREPACK_HOME="$(mktemp -d)"
-COREPACK_SHIMS="$(mktemp -d)"
-export COREPACK_HOME
-export PATH="$COREPACK_SHIMS:$PATH"
-cleanup_corepack_home() {
-    rm -R "$COREPACK_HOME" "$COREPACK_SHIMS"
-}
-trap cleanup_corepack_home EXIT
-trap 'exit 129' HUP
-trap 'exit 130' INT
-trap 'exit 143' TERM
-
 cd app
 
-corepack enable --install-directory "$COREPACK_SHIMS"
+corepack enable
 corepack install
 
 pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Replace the Debian app build's global `npm install -g pnpm@10` bootstrap with Corepack resolution from `app/package.json`.
- Create fresh Corepack cache and shim directories for each build, and put the shim directory first on `PATH` before running `pnpm`.
- Keep nested package scripts on the pinned package-manager path and clean the temporary Corepack directories on success or failure.

## Context

Fixes #3593.

This uses the existing `packageManager` integrity pin in `app/package.json` for the Debian package build instead of installing a mutable global `pnpm`.

## Test plan

```sh
shellcheck debian/build-app.sh && git diff --check origin/main...HEAD
```

Passed with no output.

```sh
PTP_NOTES=/path/to/ptp-notes
set +e
python3.13 -B "$PTP_NOTES/research/client/pocs/mutable-pnpm-bootstrap-poc.py" "$PWD" > /tmp/sdc34-mutable-poc.out 2>&1
rc=$?
set -e
cat /tmp/sdc34-mutable-poc.out
printf 'exit=%s\n' "$rc"
test "$rc" -eq 2
grep -q 'could not find npm global pnpm bootstrap command' /tmp/sdc34-mutable-poc.out
```

Observed output:

```text
could not find npm global pnpm bootstrap command
exit=2
```

```sh
repo=$PWD
tmp=$(mktemp -d)
mkdir -p "$tmp/debian" "$tmp/app"
cp "$repo/debian/build-app.sh" "$tmp/debian/build-app.sh"
cp "$repo/app/package.json" "$tmp/app/package.json"
PATH=/opt/homebrew/opt/node@24/bin:$PATH node -e 'const fs = require("fs"); const p = process.argv[1]; const j = JSON.parse(fs.readFileSync(p, "utf8")); const pm = j.packageManager; j.packageManager = pm.slice(0, -1) + (pm.endsWith("0") ? "1" : "0"); fs.writeFileSync(p, JSON.stringify(j, null, 2) + "\n");' "$tmp/app/package.json"
set +e
(cd "$tmp" && PATH=/opt/homebrew/opt/node@24/bin:$PATH bash debian/build-app.sh) >"$tmp/out.log" 2>"$tmp/err.log"
rc=$?
set -e
printf 'status=%s\n' "$rc"
cat "$tmp/out.log"
cat "$tmp/err.log"
case "$rc" in
  0) echo 'tampered packageManager unexpectedly succeeded'; exit 1 ;;
  *) grep -E 'Mismatch hashes|hash' "$tmp/err.log" "$tmp/out.log" >/dev/null || { echo 'expected hash verification failure'; exit 1; } ;;
esac
```

Observed output included:

```text
status=1
Adding pnpm@10.14.0+sha512...84740 to the cache...
Internal Error: Mismatch hashes. Expected ...84740, got ...84748
+ cleanup_corepack_home
+ rm -R /var/folders/.../tmp... /var/folders/.../tmp...
```

```sh
PATH=/opt/homebrew/opt/node@24/bin:$PATH bash debian/build-app.sh
```

Observed output included:

```text
Adding pnpm@10.14.0+sha512...84748 to the cache...
Done in 4s using pnpm v10.14.0
> securedrop-app@1.5.0-rc1 build:unpack ...
> pnpm run build && electron-builder --dir
...
+ cleanup_corepack_home
+ rm -R /var/folders/.../tmp... /var/folders/.../tmp...
```

```sh
DOCKER_DEFAULT_PLATFORM=linux/amd64 FAST=1 DEBIAN_VERSION=trixie WHAT=main BUILDER=/private/tmp/securedrop-builder-20260710 ./scripts/build-debs.sh
```

Observed output included:

```text
a716ed32 Use pinned pnpm for Debian app builds
$ git status --short
...
bash ./debian/build-app.sh
+ COREPACK_HOME=/tmp/tmp.KJEVaoWhdB
+ COREPACK_SHIMS=/tmp/tmp.ZdOOXRD7on
+ export PATH=/tmp/tmp.ZdOOXRD7on:...
+ corepack enable --install-directory /tmp/tmp.ZdOOXRD7on
+ corepack install
Adding pnpm@10.14.0+sha512...84748 to the cache...
+ pnpm install --frozen-lockfile
Done in 21.4s using pnpm v10.14.0
+ pnpm run build:unpack
> pnpm run build && electron-builder --dir
...
+ cleanup_corepack_home
+ rm -R /tmp/tmp.KJEVaoWhdB /tmp/tmp.ZdOOXRD7on
...
dpkg-deb: building package 'securedrop-app' in '../securedrop-app_1.5.0~rc1+trixie_amd64.deb'.
...
Build completed successfully. Artifacts and their checksums are:
0358cf4feaa4190b4b1fd421b9bd686127b31539f48cff65a8bf4a5f7ab96316  build/securedrop-app_1.5.0~rc1+trixie_amd64.deb
```

Independent verification also reviewed the diff and cheap gates. The verifier reported `SOUND`, including a fake-global-`pnpm` harness where nested `pnpm run` succeeded through the Corepack shim and the fake global `pnpm` was not invoked.

## Notes

This supersedes #3594 by adding an isolated Corepack shim directory, which keeps package scripts that call bare `pnpm` on the pinned Corepack path.

No Qubes runtime testing was needed for this build-script-only change; the full trixie Debian package build exercises the affected path.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
