### PR TITLE
fix(crypto): cap decrypted file expansion

### DIFF
--- a/app/src/main/__tests__/crypto.gpg.test.ts
+++ b/app/src/main/__tests__/crypto.gpg.test.ts
@@ -9,12 +9,22 @@ import {
 } from "vitest";
 import * as path from "path";
 import * as fs from "fs";
+import * as os from "os";
 import * as openpgp from "openpgp";
 import { execFileSync, execSync, spawn } from "child_process";
 import { EventEmitter } from "events";
-import { PassThrough } from "stream";
-import { gzipSync } from "zlib";
-import { Crypto, CryptoError, encryptMessage } from "../crypto";
+import { PassThrough, Readable, Writable } from "stream";
+import { pipeline } from "stream/promises";
+import { createGzip, gzipSync } from "zlib";
+import {
+  createDecryptedByteLimit,
+  Crypto,
+  CryptoError,
+  encryptMessage,
+  MAX_DECRYPTED_BYTES,
+  MAX_DECRYPTED_GZIP_BYTES,
+  MAX_GPG_STDERR_BYTES,
+} from "../crypto";
 import {
   createGpgTestEnvironment,
   createTestEncryptedFile,
@@ -28,6 +38,144 @@ vi.mock("child_process", { spy: true });
 
 // Verify GPG is available - fail tests if not
 const isGpgAvailable = verifyGpgAvailable();
+
+interface EncryptedFileFixture {
+  cleanup: () => void;
+  filePath: string;
+}
+
+function* largeByteChunks(
+  plaintextBytes: number,
+  fillByte = 0x41,
+): Generator<Buffer> {
+  const chunk = Buffer.alloc(1024 * 1024, fillByte);
+  for (let bytes = 0; bytes < plaintextBytes; bytes += chunk.length) {
+    yield chunk.subarray(0, Math.min(chunk.length, plaintextBytes - bytes));
+  }
+}
+
+async function createLargeEncryptedFile(
+  plaintextBytes: number,
+  recipientKeyId: string,
+  gpgHomedir: string,
+): Promise<EncryptedFileFixture> {
+  const tempDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "crypto-large-file-test-"),
+  );
+  const gzipPath = path.join(tempDirectory, "large-fixture.gz");
+  const encryptedPath = path.join(tempDirectory, "large-fixture.gpg");
+
+  await pipeline(
+    Readable.from(largeByteChunks(plaintextBytes)),
+    createGzip({ level: 9 }),
+    fs.createWriteStream(gzipPath),
+  );
+  execFileSync("gpg", [
+    "--homedir",
+    gpgHomedir,
+    "--batch",
+    "--trust-model",
+    "always",
+    "--encrypt",
+    "-r",
+    recipientKeyId,
+    "--output",
+    encryptedPath,
+    gzipPath,
+  ]);
+  return {
+    cleanup: () => fs.rmSync(tempDirectory, { force: true, recursive: true }),
+    filePath: encryptedPath,
+  };
+}
+
+async function createStoredOpenPgpFile(
+  plaintextBytes: number,
+  gpgHomedir: string,
+): Promise<EncryptedFileFixture> {
+  const tempDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "crypto-openpgp-file-test-"),
+  );
+  const plainPath = path.join(tempDirectory, "stored-packet-plain.bin");
+  const packetPath = path.join(tempDirectory, "stored-packet.asc");
+
+  await pipeline(
+    Readable.from(largeByteChunks(plaintextBytes, 0x45)),
+    fs.createWriteStream(plainPath),
+  );
+  execFileSync("gpg", [
+    "--batch",
+    "--yes",
+    "--no-options",
+    "--homedir",
+    gpgHomedir,
+    "--compress-algo",
+    "zlib",
+    "--store",
+    "--armor",
+    "--output",
+    packetPath,
+    plainPath,
+  ]);
+  return {
+    cleanup: () => fs.rmSync(tempDirectory, { force: true, recursive: true }),
+    filePath: packetPath,
+  };
+}
+
+function abortPlaintextAtSize(
+  controller: AbortController,
+  targetBytes: number,
+): { maxBytes: () => number; stop: () => void } {
+  let maxBytes = 0;
+  const recordWrite = (
+    stream: fs.WriteStream,
+    bytes: number,
+    error?: Error | null,
+  ) => {
+    if (!error && path.basename(String(stream.path)) === "plaintext") {
+      maxBytes += bytes;
+    }
+    if (maxBytes >= targetBytes && !controller.signal.aborted) {
+      controller.abort();
+    }
+  };
+  const prototype = fs.WriteStream.prototype as any;
+  const write = prototype._write;
+  prototype._write = function (
+    this: fs.WriteStream,
+    chunk: Buffer,
+    encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    write.call(this, chunk, encoding, (error?: Error | null) => {
+      recordWrite(this, chunk.length, error);
+      callback(error);
+    });
+  };
+  const writev = prototype._writev;
+  prototype._writev = function (
+    this: fs.WriteStream,
+    chunks: Array<{ chunk: Buffer; encoding: BufferEncoding }>,
+    callback: (error?: Error | null) => void,
+  ): void {
+    writev.call(this, chunks, (error?: Error | null) => {
+      const bytes = chunks.reduce(
+        (total, entry) => total + entry.chunk.length,
+        0,
+      );
+      recordWrite(this, bytes, error);
+      callback(error);
+    });
+  };
+  return {
+    maxBytes: () => maxBytes,
+    stop: () => {
+      prototype._write = write;
+      prototype._writev = writev;
+    },
+  };
+}
 
 describe("Crypto with Real GPG", () => {
   let gpgEnv: GpgTestEnvironment;
@@ -165,6 +313,15 @@ and symbols: !@#$%^&*()_+-={}[]|\\:";'<>?,./`;
         testKeyId,
         gpgEnv.homedir,
       );
+      const operationDirectories: string[] = [];
+      const createTempDir = storage.createTempDir.bind(storage);
+      const createTempDirSpy = vi
+        .spyOn(storage, "createTempDir")
+        .mockImplementation((prefix) => {
+          const directory = createTempDir(prefix);
+          operationDirectories.push(directory.path);
+          return directory;
+        });
 
       try {
         // Decrypt using our crypto class
@@ -180,7 +337,10 @@ and symbols: !@#$%^&*()_+-={}[]|\\:";'<>?,./`;
         const fs = await import("fs");
         const decryptedContent = fs.readFileSync(result, "utf8");
         expect(decryptedContent).toBe(originalContent);
+        expect(operationDirectories).toHaveLength(1);
+        expect(fs.existsSync(operationDirectories[0])).toBe(false);
       } finally {
+        createTempDirSpy.mockRestore();
         cleanup();
       }
     });
@@ -400,6 +560,55 @@ and symbols: !@#$%^&*()_+-={}[]|\\:";'<>?,./`;
 
       expect(results).toEqual(messages);
     });
+
+    it("removes temp dirs after sequential and concurrent file decryptions", async () => {
+      const { filePath, cleanup } = createTestEncryptedFile(
+        "cleanup stress content",
+        "cleanup-stress.txt",
+        testKeyId,
+        gpgEnv.homedir,
+      );
+      const destinations = Array.from({ length: 4 }, () =>
+        storage.createTempDir("securedrop-cleanup-target-"),
+      );
+      const operationDirectories: string[] = [];
+      const createTempDir = storage.createTempDir.bind(storage);
+      const createTempDirSpy = vi
+        .spyOn(storage, "createTempDir")
+        .mockImplementation((prefix) => {
+          const directory = createTempDir(prefix);
+          operationDirectories.push(directory.path);
+          return directory;
+        });
+
+      try {
+        const results = [
+          await crypto.decryptFile(storage, destinations[0], filePath),
+          await crypto.decryptFile(storage, destinations[1], filePath),
+          ...(await Promise.all(
+            destinations
+              .slice(2)
+              .map((destination) =>
+                crypto.decryptFile(storage, destination, filePath),
+              ),
+          )),
+        ];
+
+        expect(
+          results.map((result) => fs.readFileSync(result, "utf8")),
+        ).toEqual(Array(4).fill("cleanup stress content"));
+        expect(operationDirectories).toHaveLength(4);
+        expect(
+          operationDirectories.every((directory) => !fs.existsSync(directory)),
+        ).toBe(true);
+      } finally {
+        createTempDirSpy.mockRestore();
+        cleanup();
+        for (const destination of destinations) {
+          fs.rmSync(destination.path, { force: true, recursive: true });
+        }
+      }
+    });
   });
 
   describe("encryptMessage", () => {
@@ -556,7 +765,7 @@ and symbols: !@#$%^&*()_+-={}[]|\\:";'<>?,./`;
     });
   });
 
-  describe("GPG stderr failure modes (mocked spawn)", () => {
+  describe("GPG stream failure modes (mocked spawn)", () => {
     afterEach(() => {
       vi.restoreAllMocks();
     });
@@ -564,10 +773,413 @@ and symbols: !@#$%^&*()_+-={}[]|\\:";'<>?,./`;
     function makeMockProcess() {
       const proc = new EventEmitter() as any;
       proc.stdout = new PassThrough();
-      proc.stderr = new EventEmitter();
-      proc.stdin = { write: vi.fn(), end: vi.fn() };
+      proc.stderr = new PassThrough();
+      proc.stdin = new PassThrough();
+      proc.kill = vi.fn();
       return proc;
     }
+
+    async function emitErrorOnNextTurn(
+      stream: PassThrough,
+      error: Error,
+    ): Promise<void> {
+      await new Promise<void>((resolve, reject) => {
+        setImmediate(() => {
+          try {
+            stream.emit("error", error);
+            resolve();
+          } catch (emissionError) {
+            reject(emissionError);
+          }
+        });
+      });
+    }
+
+    function trackOperationDirectories(): string[] {
+      const directories: string[] = [];
+      const createTempDir = storage.createTempDir.bind(storage);
+      vi.spyOn(storage, "createTempDir").mockImplementation((prefix) => {
+        const directory = createTempDir(prefix);
+        directories.push(directory.path);
+        return directory;
+      });
+      return directories;
+    }
+
+    function expectOperationDirectoriesRemoved(directories: string[]): void {
+      expect(directories).toHaveLength(1);
+      expect(directories.every((entry) => !fs.existsSync(entry))).toBe(true);
+    }
+
+    it.each([
+      ["stdout", "Failed to read GPG message output"],
+      ["stderr", "Failed to read GPG diagnostics"],
+    ])("handles a %s stream error before close", async (stream, message) => {
+      const proc = makeMockProcess();
+      vi.mocked(spawn).mockReturnValueOnce(proc);
+
+      const decryption = crypto.decryptMessage(Buffer.from("encrypted"));
+      const streamError = new Error(`${stream} read failed`);
+      proc[stream].emit("error", streamError);
+      proc.emit("close", 1, null);
+
+      await expect(decryption).rejects.toThrow(message);
+      expect(proc.kill).toHaveBeenCalledOnce();
+      expect(() => proc[stream].emit("error", streamError)).not.toThrow();
+    });
+
+    it("absorbs stdout and stderr errors after successful close", async () => {
+      const proc = makeMockProcess();
+      vi.mocked(spawn).mockReturnValueOnce(proc);
+
+      const decryption = crypto.decryptMessage(Buffer.from("encrypted"));
+      proc.stdout.end(Buffer.from("plaintext"));
+      proc.emit("close", 0, null);
+
+      await expect(decryption).resolves.toBe("plaintext");
+      expect(() =>
+        proc.stdout.emit("error", new Error("late stdout")),
+      ).not.toThrow();
+      expect(() =>
+        proc.stderr.emit("error", new Error("late stderr")),
+      ).not.toThrow();
+    });
+
+    it("allows an exact GPG lockfile diagnostic before expected key stderr", async () => {
+      const proc = makeMockProcess();
+      vi.mocked(spawn).mockReturnValueOnce(proc);
+
+      const decryption = crypto.decryptMessage(Buffer.from("encrypted"));
+      proc.stdout.end(Buffer.from("plaintext"));
+      proc.stderr.emit(
+        "data",
+        Buffer.from(
+          "gpg: lockfile disappeared\n" +
+            "gpg: encrypted with rsa4096 key, ID C3E7C4C0A2201B2A, created 2013-10-12\n" +
+            '      "SecureDrop Test/Development (DO NOT USE IN PRODUCTION)"\n',
+        ),
+      );
+      proc.emit("close", 0, null);
+
+      await expect(decryption).resolves.toBe("plaintext");
+    });
+
+    it("settles once when stream errors race abort and process exit", async () => {
+      const proc = makeMockProcess();
+      const controller = new AbortController();
+      vi.mocked(spawn).mockReturnValueOnce(proc);
+
+      const decryption = crypto.decryptMessage(
+        Buffer.from("encrypted"),
+        controller.signal,
+      );
+      controller.abort();
+
+      expect(() =>
+        proc.stdout.emit("error", new Error("stdout read failed")),
+      ).not.toThrow();
+      expect(() =>
+        proc.stderr.emit("error", new Error("stderr read failed")),
+      ).not.toThrow();
+      expect(() =>
+        proc.emit("error", new Error("process failed")),
+      ).not.toThrow();
+      proc.emit("close", null, "SIGTERM");
+
+      await expect(decryption).rejects.toMatchObject({ name: "AbortError" });
+      expect(proc.kill).toHaveBeenCalledOnce();
+    });
+
+    it("stops collecting a message after the decrypted byte limit", async () => {
+      const proc = makeMockProcess();
+      vi.mocked(spawn).mockReturnValueOnce(proc);
+
+      const promise = crypto.decryptMessage(Buffer.from("encrypted"));
+      const chunk = Buffer.alloc(1024 * 1024);
+      for (
+        let index = 0;
+        index <= MAX_DECRYPTED_BYTES / chunk.length;
+        index += 1
+      ) {
+        proc.stdout.emit("data", chunk);
+      }
+      proc.emit("close", null, "SIGTERM");
+
+      await expect(promise).rejects.toThrow(
+        `Decrypted message exceeds the ${MAX_DECRYPTED_BYTES}-byte limit`,
+      );
+      expect(proc.kill).toHaveBeenCalledOnce();
+      const epipe = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+      expect(() => proc.stdin.emit("error", epipe)).not.toThrow();
+    });
+
+    it("rejects invalid UTF-8 instead of expanding replacement characters", async () => {
+      const proc = makeMockProcess();
+      vi.mocked(spawn).mockReturnValueOnce(proc);
+
+      const promise = crypto.decryptMessage(Buffer.from("encrypted"));
+      proc.stdout.emit("data", Buffer.from([0xff, 0xff, 0xff]));
+
+      await expect(promise).rejects.toThrow(
+        "Decrypted message is not valid UTF-8",
+      );
+      expect(proc.kill).toHaveBeenCalledOnce();
+    });
+
+    it("bounds hostile GPG stderr for messages", async () => {
+      const proc = makeMockProcess();
+      vi.mocked(spawn).mockReturnValueOnce(proc);
+
+      const promise = crypto.decryptMessage(Buffer.from("encrypted"));
+      proc.stderr.emit("data", Buffer.alloc(MAX_GPG_STDERR_BYTES + 1, 0x41));
+
+      await expect(promise).rejects.toThrow(
+        `GPG stderr exceeds the ${MAX_GPG_STDERR_BYTES}-byte limit`,
+      );
+      expect(proc.kill).toHaveBeenCalledOnce();
+    });
+
+    it("bounds hostile GPG stderr for files and removes operation state", async () => {
+      const proc = makeMockProcess();
+      const operationDirectories: string[] = [];
+      const createTempDir = storage.createTempDir.bind(storage);
+      vi.spyOn(storage, "createTempDir").mockImplementation((prefix) => {
+        const directory = createTempDir(prefix);
+        operationDirectories.push(directory.path);
+        return directory;
+      });
+      vi.mocked(spawn).mockReturnValueOnce(proc);
+
+      const promise = crypto.decryptFile(
+        storage,
+        itemDirectory,
+        "/fake/path.gpg",
+      );
+      proc.stderr.emit("data", Buffer.alloc(MAX_GPG_STDERR_BYTES + 1, 0x41));
+
+      await expect(promise).rejects.toThrow(
+        `GPG stderr exceeds the ${MAX_GPG_STDERR_BYTES}-byte limit`,
+      );
+      expect(operationDirectories).toHaveLength(1);
+      expect(fs.existsSync(operationDirectories[0])).toBe(false);
+    });
+
+    it("rejects a pre-aborted file signal without creating operation state", async () => {
+      const controller = new AbortController();
+      const createTempDir = vi.spyOn(storage, "createTempDir");
+      controller.abort();
+
+      await expect(
+        crypto.decryptFile(
+          storage,
+          itemDirectory,
+          "/fake/path.gpg",
+          controller.signal,
+        ),
+      ).rejects.toMatchObject({ name: "AbortError" });
+      expect(createTempDir).not.toHaveBeenCalled();
+    });
+
+    it("settles once when file output errors race cancellation", async () => {
+      const proc = makeMockProcess();
+      const controller = new AbortController();
+      const operationDirectories: string[] = [];
+      const createTempDir = storage.createTempDir.bind(storage);
+      vi.spyOn(storage, "createTempDir").mockImplementation((prefix) => {
+        const directory = createTempDir(prefix);
+        operationDirectories.push(directory.path);
+        return directory;
+      });
+      vi.mocked(spawn).mockReturnValueOnce(proc);
+
+      const decryption = crypto.decryptFile(
+        storage,
+        itemDirectory,
+        "/fake/path.gpg",
+        controller.signal,
+      );
+      controller.abort();
+      expect(() =>
+        proc.stdout.emit("error", new Error("late stdout")),
+      ).not.toThrow();
+      expect(() =>
+        proc.stderr.emit("error", new Error("late stderr")),
+      ).not.toThrow();
+      proc.emit("close", null, "SIGTERM");
+
+      await expect(decryption).rejects.toMatchObject({ name: "AbortError" });
+      expect(proc.kill).toHaveBeenCalledOnce();
+      expect(operationDirectories).toHaveLength(1);
+      expect(fs.existsSync(operationDirectories[0])).toBe(false);
+    });
+
+    it("handles a file stderr stream error and removes operation state", async () => {
+      const proc = makeMockProcess();
+      const operationDirectories: string[] = [];
+      const createTempDir = storage.createTempDir.bind(storage);
+      vi.spyOn(storage, "createTempDir").mockImplementation((prefix) => {
+        const directory = createTempDir(prefix);
+        operationDirectories.push(directory.path);
+        return directory;
+      });
+      vi.mocked(spawn).mockReturnValueOnce(proc);
+
+      const decryption = crypto.decryptFile(
+        storage,
+        itemDirectory,
+        "/fake/path.gpg",
+      );
+      proc.stderr.emit("error", new Error("stderr read failed"));
+      proc.emit("close", 1, null);
+
+      await expect(decryption).rejects.toThrow(
+        "Failed to read GPG diagnostics",
+      );
+      expect(proc.kill).toHaveBeenCalledOnce();
+      expect(operationDirectories).toHaveLength(1);
+      expect(fs.existsSync(operationDirectories[0])).toBe(false);
+      expect(() =>
+        proc.stderr.emit("error", new Error("late stderr")),
+      ).not.toThrow();
+    });
+
+    it("preserves a file stdout error when child exit races cleanup", async () => {
+      const proc = makeMockProcess();
+      const operationDirectories: string[] = [];
+      const createTempDir = storage.createTempDir.bind(storage);
+      vi.spyOn(storage, "createTempDir").mockImplementation((prefix) => {
+        const directory = createTempDir(prefix);
+        operationDirectories.push(directory.path);
+        return directory;
+      });
+      proc.kill.mockImplementation(() => {
+        queueMicrotask(() => proc.emit("close", null, "SIGTERM"));
+      });
+      vi.mocked(spawn).mockReturnValueOnce(proc);
+
+      const decryption = crypto
+        .decryptFile(storage, itemDirectory, "/fake/path.gpg")
+        .catch((error: unknown) => error);
+      proc.stdout.emit("error", new Error("stdout read failed"));
+
+      const error = await decryption;
+      expect(error).toMatchObject({
+        message: "Failed to write decrypted GPG output",
+        cause: { message: "stdout read failed" },
+      });
+      expect(proc.kill).toHaveBeenCalledOnce();
+      expect(operationDirectories).toHaveLength(1);
+      expect(fs.existsSync(operationDirectories[0])).toBe(false);
+      expect(() =>
+        proc.stdout.emit("error", new Error("late stdout")),
+      ).not.toThrow();
+    });
+
+    it("handles file stdin failure before close and consumes later errors", async () => {
+      const proc = makeMockProcess();
+      const operationDirectories = trackOperationDirectories();
+      vi.mocked(spawn).mockReturnValueOnce(proc);
+
+      const rejection = vi.fn();
+      const decryption = crypto
+        .decryptFile(storage, itemDirectory, "/fake/path.gpg")
+        .catch((error: unknown) => {
+          rejection(error);
+          return error;
+        });
+      proc.stdin.emit("error", new Error("file stdin failed"));
+      proc.emit("close", null, "SIGTERM");
+
+      await expect(decryption).resolves.toMatchObject({
+        message: "GPG file input stream failed",
+        cause: { message: "file stdin failed" },
+      });
+      await emitErrorOnNextTurn(
+        proc.stdin,
+        new Error("later file stdin failed"),
+      );
+      expect(rejection).toHaveBeenCalledOnce();
+      expect(proc.kill).toHaveBeenCalledOnce();
+      expectOperationDirectoriesRemoved(operationDirectories);
+    });
+
+    it("handles file stdin failure after successful process close", async () => {
+      const proc = makeMockProcess();
+      const operationDirectories = trackOperationDirectories();
+      vi.mocked(spawn).mockReturnValueOnce(proc);
+
+      const decryption = crypto.decryptFile(
+        storage,
+        itemDirectory,
+        "/fake/path.gpg",
+      );
+      proc.emit("close", 0, null);
+      proc.stdin.emit("error", new Error("file stdin failed after close"));
+
+      await expect(decryption).rejects.toMatchObject({
+        message: "GPG file input stream failed",
+        cause: { message: "file stdin failed after close" },
+      });
+      expect(proc.kill).toHaveBeenCalledOnce();
+      expectOperationDirectoriesRemoved(operationDirectories);
+    });
+
+    it("consumes file stdin failure after decryptFile succeeds", async () => {
+      const proc = makeMockProcess();
+      const plaintext = Buffer.from("successful file plaintext");
+      const operationDirectories = trackOperationDirectories();
+      vi.mocked(spawn).mockReturnValueOnce(proc);
+
+      const decryption = crypto.decryptFile(
+        storage,
+        itemDirectory,
+        "/fake/path.gpg",
+      );
+      proc.stdout.end(gzipSync(plaintext));
+      proc.emit("close", 0, null);
+
+      const outputPath = await decryption;
+      expect(fs.readFileSync(outputPath)).toEqual(plaintext);
+      await emitErrorOnNextTurn(
+        proc.stdin,
+        new Error("late file stdin failed"),
+      );
+      expect(proc.kill).not.toHaveBeenCalled();
+      expectOperationDirectoriesRemoved(operationDirectories);
+    });
+
+    it("settles once when file stdin failure races abort and exit", async () => {
+      const proc = makeMockProcess();
+      const controller = new AbortController();
+      const operationDirectories = trackOperationDirectories();
+      vi.mocked(spawn).mockReturnValueOnce(proc);
+
+      const rejection = vi.fn();
+      const decryption = crypto
+        .decryptFile(
+          storage,
+          itemDirectory,
+          "/fake/path.gpg",
+          controller.signal,
+        )
+        .catch((error: unknown) => {
+          rejection(error);
+          return error;
+        });
+      controller.abort();
+      proc.stdin.emit("error", new Error("concurrent file stdin failed"));
+      proc.emit("error", new Error("concurrent process failed"));
+      proc.emit("close", null, "SIGTERM");
+
+      await expect(decryption).resolves.toMatchObject({ name: "AbortError" });
+      await emitErrorOnNextTurn(
+        proc.stdin,
+        new Error("post-race file stdin failed"),
+      );
+      expect(rejection).toHaveBeenCalledOnce();
+      expect(proc.kill).toHaveBeenCalledOnce();
+      expectOperationDirectoriesRemoved(operationDirectories);
+    });
 
     it("throws CryptoError when GPG exits 0 with unexpected stderr (decryptMessage)", async () => {
       const proc = makeMockProcess();
@@ -579,6 +1191,7 @@ and symbols: !@#$%^&*()_+-={}[]|\\:";'<>?,./`;
         "data",
         Buffer.from("gpg: WARNING: unexpected warning\n"),
       );
+      proc.stdout.end();
       proc.emit("close", 0, null);
 
       await expect(promise).rejects.toBeInstanceOf(CryptoError);
@@ -599,12 +1212,604 @@ and symbols: !@#$%^&*()_+-={}[]|\\:";'<>?,./`;
         "data",
         Buffer.from("gpg: WARNING: unexpected warning\n"),
       );
+      proc.stdout.end();
       proc.emit("close", 0, null);
 
       await expect(promise).rejects.toBeInstanceOf(CryptoError);
       await expect(promise).rejects.toThrow(
         /GPG file decryption emitted stderr/,
       );
+    });
+  });
+
+  describe("file cancellation after GPG completion", () => {
+    let largeFixture: EncryptedFileFixture;
+
+    beforeAll(async () => {
+      largeFixture = await createLargeEncryptedFile(
+        MAX_DECRYPTED_BYTES,
+        testKeyId,
+        gpgEnv.homedir,
+      );
+    }, 60_000);
+
+    afterAll(() => {
+      largeFixture.cleanup();
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    function trackOperationDirectories(): string[] {
+      const directories: string[] = [];
+      const createTempDir = storage.createTempDir.bind(storage);
+      vi.spyOn(storage, "createTempDir").mockImplementation((prefix) => {
+        const directory = createTempDir(prefix);
+        directories.push(directory.path);
+        return directory;
+      });
+      return directories;
+    }
+
+    function expectNoDecryptResidue(operationDirectories: string[]): void {
+      expect(operationDirectories).toHaveLength(1);
+      expect(operationDirectories.every((entry) => !fs.existsSync(entry))).toBe(
+        true,
+      );
+      expect(fs.readdirSync(itemDirectory.path)).toEqual([]);
+    }
+
+    async function expectBoundaryCancellation(
+      configure: (controller: AbortController) => void,
+    ): Promise<void> {
+      const fixture = createTestEncryptedFile(
+        Buffer.alloc(4 * 1024 * 1024, 0x42),
+        "boundary-fixture.bin",
+        testKeyId,
+        gpgEnv.homedir,
+      );
+      const controller = new AbortController();
+      const operationDirectories = trackOperationDirectories();
+      configure(controller);
+      try {
+        await expect(
+          crypto.decryptFile(
+            storage,
+            itemDirectory,
+            fixture.filePath,
+            controller.signal,
+          ),
+        ).rejects.toMatchObject({ name: "AbortError" });
+        expectNoDecryptResidue(operationDirectories);
+      } finally {
+        fixture.cleanup();
+      }
+    }
+
+    async function expectBoundaryCompletion(
+      configure: (controller: AbortController) => void,
+    ): Promise<void> {
+      const plaintext = Buffer.from("published plaintext");
+      const fixture = createTestEncryptedFile(
+        plaintext,
+        "published-fixture.bin",
+        testKeyId,
+        gpgEnv.homedir,
+      );
+      const controller = new AbortController();
+      const operationDirectories = trackOperationDirectories();
+      configure(controller);
+      try {
+        const outputPath = await crypto.decryptFile(
+          storage,
+          itemDirectory,
+          fixture.filePath,
+          controller.signal,
+        );
+        expect(controller.signal.aborted).toBe(true);
+        expect(outputPath).toBe(itemDirectory.join("published-fixture.bin"));
+        expect(fs.readFileSync(outputPath)).toEqual(plaintext);
+        expect(operationDirectories).toHaveLength(1);
+        expect(
+          operationDirectories.every((entry) => !fs.existsSync(entry)),
+        ).toBe(true);
+      } finally {
+        fixture.cleanup();
+      }
+    }
+
+    it.each([
+      ["first", 1],
+      ["middle", MAX_DECRYPTED_BYTES / 2],
+      ["last", MAX_DECRYPTED_BYTES],
+    ])(
+      "cancels a 500 MiB real-GPG file on the %s gunzip plaintext chunk",
+      async (_position, targetBytes) => {
+        const controller = new AbortController();
+        const operationDirectories = trackOperationDirectories();
+        const writes = abortPlaintextAtSize(controller, targetBytes);
+
+        try {
+          await expect(
+            crypto.decryptFile(
+              storage,
+              itemDirectory,
+              largeFixture.filePath,
+              controller.signal,
+            ),
+          ).rejects.toMatchObject({ name: "AbortError" });
+        } finally {
+          writes.stop();
+        }
+
+        expect(controller.signal.aborted).toBe(true);
+        expect(writes.maxBytes()).toBeGreaterThanOrEqual(targetBytes);
+        expect(writes.maxBytes()).toBeLessThan(targetBytes + 64 * 1024 * 1024);
+        expectNoDecryptResidue(operationDirectories);
+      },
+      180_000,
+    );
+
+    it("cancels gzip header validation", async () => {
+      await expectBoundaryCancellation((controller) => {
+        const open = fs.promises.open.bind(fs.promises);
+        vi.spyOn(fs.promises, "open").mockImplementation(async (...args) => {
+          const file = await open(...args);
+          if (path.basename(String(args[0])) === "decrypted.gz") {
+            const read = file.read.bind(file);
+            vi.spyOn(file, "read").mockImplementation(async (...readArgs) => {
+              const result = await read(...readArgs);
+              controller.abort();
+              return result;
+            });
+          }
+          return file;
+        });
+      });
+    });
+
+    it("prefers header cancellation to a concurrent read error", async () => {
+      await expectBoundaryCancellation((controller) => {
+        const open = fs.promises.open.bind(fs.promises);
+        vi.spyOn(fs.promises, "open").mockImplementation(async (...args) => {
+          const file = await open(...args);
+          if (path.basename(String(args[0])) === "decrypted.gz") {
+            vi.spyOn(file, "read").mockImplementation(async () => {
+              controller.abort();
+              throw new Error("header read failed");
+            });
+          }
+          return file;
+        });
+      });
+    });
+
+    it.each(["before", "after"] as const)(
+      "cancels %s final-file fsync completion",
+      async (timing) => {
+        await expectBoundaryCancellation((controller) => {
+          const open = fs.promises.open.bind(fs.promises);
+          vi.spyOn(fs.promises, "open").mockImplementation(async (...args) => {
+            const file = await open(...args);
+            if (path.basename(String(args[0])) !== "plaintext") {
+              return file;
+            }
+            const sync = file.sync.bind(file);
+            vi.spyOn(file, "sync").mockImplementation(async () => {
+              if (timing === "before") {
+                controller.abort();
+              }
+              await sync();
+              if (timing === "after") {
+                controller.abort();
+              }
+            });
+            return file;
+          });
+        });
+      },
+    );
+
+    it("prefers fsync cancellation to a concurrent sync error", async () => {
+      await expectBoundaryCancellation((controller) => {
+        const open = fs.promises.open.bind(fs.promises);
+        vi.spyOn(fs.promises, "open").mockImplementation(async (...args) => {
+          const file = await open(...args);
+          if (path.basename(String(args[0])) === "plaintext") {
+            vi.spyOn(file, "sync").mockImplementation(async () => {
+              controller.abort();
+              throw new Error("fsync failed");
+            });
+          }
+          return file;
+        });
+      });
+    });
+
+    it("does not publish when cancellation happens before final link", async () => {
+      let linkCalls = 0;
+      await expectBoundaryCancellation((controller) => {
+        const open = fs.promises.open.bind(fs.promises);
+        vi.spyOn(fs.promises, "open").mockImplementation(async (...args) => {
+          const file = await open(...args);
+          if (path.basename(String(args[0])) === "plaintext") {
+            const sync = file.sync.bind(file);
+            vi.spyOn(file, "sync").mockImplementation(async () => {
+              await sync();
+              controller.abort();
+            });
+          }
+          return file;
+        });
+        const link = fs.promises.link.bind(fs.promises);
+        vi.spyOn(fs.promises, "link").mockImplementation(async (...args) => {
+          linkCalls += 1;
+          await link(...args);
+        });
+      });
+      expect(linkCalls).toBe(0);
+    });
+
+    it("keeps the committed file when cancellation happens after final link", async () => {
+      await expectBoundaryCompletion((controller) => {
+        const link = fs.promises.link.bind(fs.promises);
+        vi.spyOn(fs.promises, "link").mockImplementation(async (...args) => {
+          await link(...args);
+          controller.abort();
+        });
+      });
+    });
+
+    it("prefers publication cancellation to a concurrent link error", async () => {
+      await expectBoundaryCancellation((controller) => {
+        vi.spyOn(fs.promises, "link").mockImplementation(async () => {
+          controller.abort();
+          throw new Error("link failed");
+        });
+      });
+    });
+
+    it("falls back to rmSync when async temp cleanup fails", async () => {
+      await expectBoundaryCancellation((controller) => {
+        const open = fs.promises.open.bind(fs.promises);
+        vi.spyOn(fs.promises, "open").mockImplementation(async (...args) => {
+          const file = await open(...args);
+          if (path.basename(String(args[0])) === "plaintext") {
+            const sync = file.sync.bind(file);
+            vi.spyOn(file, "sync").mockImplementation(async () => {
+              controller.abort();
+              await sync();
+            });
+          }
+          return file;
+        });
+
+        const rm = fs.promises.rm.bind(fs.promises);
+        vi.spyOn(fs.promises, "rm").mockImplementation(async (...args) => {
+          if (
+            path.basename(String(args[0])).startsWith(".securedrop-decrypt-")
+          ) {
+            throw new Error("temp async rm failed");
+          }
+          return rm(...args);
+        });
+      });
+    });
+
+    it("does not replace an existing final file after cancellation", async () => {
+      const fixture = createTestEncryptedFile(
+        Buffer.from("replacement"),
+        "boundary-fixture.bin",
+        testKeyId,
+        gpgEnv.homedir,
+      );
+      const finalOutputPath = itemDirectory.join("boundary-fixture.bin");
+      const originalContent = Buffer.from("original");
+      const controller = new AbortController();
+      const operationDirectories = trackOperationDirectories();
+      const link = fs.promises.link.bind(fs.promises);
+      vi.spyOn(fs.promises, "link").mockImplementation(async (...args) => {
+        controller.abort();
+        await link(...args);
+      });
+      fs.writeFileSync(finalOutputPath, originalContent);
+
+      try {
+        await expect(
+          crypto.decryptFile(
+            storage,
+            itemDirectory,
+            fixture.filePath,
+            controller.signal,
+          ),
+        ).rejects.toMatchObject({ name: "AbortError" });
+        expect(operationDirectories).toHaveLength(1);
+        expect(
+          operationDirectories.every((entry) => !fs.existsSync(entry)),
+        ).toBe(true);
+        expect(fs.readFileSync(finalOutputPath)).toEqual(originalContent);
+      } finally {
+        fixture.cleanup();
+      }
+    });
+
+    it("keeps the committed file when cancellation crosses helper completion", async () => {
+      await expectBoundaryCompletion((controller) => {
+        const link = fs.promises.link.bind(fs.promises);
+        vi.spyOn(fs.promises, "link").mockImplementation(async (...args) => {
+          await link(...args);
+          let checkpoints = 4;
+          const abortAfterCheckpoints = () => {
+            if (checkpoints === 0) {
+              controller.abort();
+              return;
+            }
+            checkpoints -= 1;
+            queueMicrotask(abortAfterCheckpoints);
+          };
+          queueMicrotask(abortAfterCheckpoints);
+        });
+      });
+    });
+
+    it("propagates cancellation through a qubes-gpg-client shim", async () => {
+      const fixture = createTestEncryptedFile(
+        Buffer.alloc(4 * 1024 * 1024, 0x43),
+        "qubes-shim-fixture.bin",
+        testKeyId,
+        gpgEnv.homedir,
+      );
+      const shimDirectory = fs.mkdtempSync(
+        path.join(os.tmpdir(), "qubes-gpg-client-test-"),
+      );
+      const shimPath = path.join(shimDirectory, "qubes-gpg-client");
+      fs.writeFileSync(
+        shimPath,
+        '#!/bin/sh\nexec gpg --homedir "$SD_TEST_GPG_HOME" "$@"\n',
+        { mode: 0o755 },
+      );
+      const originalPath = process.env.PATH;
+      const controller = new AbortController();
+      const operationDirectories = trackOperationDirectories();
+      const open = fs.promises.open.bind(fs.promises);
+      vi.spyOn(fs.promises, "open").mockImplementation(async (...args) => {
+        const file = await open(...args);
+        if (path.basename(String(args[0])) === "plaintext") {
+          const sync = file.sync.bind(file);
+          vi.spyOn(file, "sync").mockImplementation(async () => {
+            controller.abort();
+            await sync();
+          });
+        }
+        return file;
+      });
+
+      try {
+        process.env.PATH = `${shimDirectory}:${originalPath}`;
+        process.env.SD_TEST_GPG_HOME = gpgEnv.homedir;
+        (Crypto as any).instance = undefined;
+        const qubesCrypto = Crypto.initialize({
+          isQubes: true,
+          submissionKeyFingerprint: "",
+        });
+        await expect(
+          qubesCrypto.decryptFile(
+            storage,
+            itemDirectory,
+            fixture.filePath,
+            controller.signal,
+          ),
+        ).rejects.toMatchObject({ name: "AbortError" });
+        expectNoDecryptResidue(operationDirectories);
+      } finally {
+        process.env.PATH = originalPath;
+        delete process.env.SD_TEST_GPG_HOME;
+        fixture.cleanup();
+        fs.rmSync(shimDirectory, { force: true, recursive: true });
+      }
+    });
+
+    it("prefers an observed gunzip cancellation over a later stream error", async () => {
+      const fixtureDirectory = fs.mkdtempSync(
+        path.join(os.tmpdir(), "crypto-cancel-error-race-"),
+      );
+      const malformedPath = path.join(fixtureDirectory, "malformed.gz");
+      const encryptedPath = `${malformedPath}.gpg`;
+      const gzipPayload = gzipSync(Buffer.alloc(64 * 1024 * 1024, 0x44));
+      fs.writeFileSync(
+        malformedPath,
+        gzipPayload.subarray(0, gzipPayload.length - 8),
+      );
+      execFileSync("gpg", [
+        "--homedir",
+        gpgEnv.homedir,
+        "--batch",
+        "--trust-model",
+        "always",
+        "--encrypt",
+        "-r",
+        testKeyId,
+        "--output",
+        encryptedPath,
+        malformedPath,
+      ]);
+      const controller = new AbortController();
+      const operationDirectories = trackOperationDirectories();
+      const writes = abortPlaintextAtSize(controller, 1);
+
+      try {
+        await expect(
+          crypto.decryptFile(
+            storage,
+            itemDirectory,
+            encryptedPath,
+            controller.signal,
+          ),
+        ).rejects.toMatchObject({ name: "AbortError" });
+        expectNoDecryptResidue(operationDirectories);
+      } finally {
+        writes.stop();
+        fs.rmSync(fixtureDirectory, { force: true, recursive: true });
+      }
+    });
+  });
+
+  describe("decrypted byte limit", () => {
+    async function streamBytes(chunks: Buffer[], maxBytes: number) {
+      const output: Buffer[] = [];
+      await pipeline(
+        Readable.from(chunks),
+        createDecryptedByteLimit("Test output", maxBytes),
+        new Writable({
+          write(chunk: Buffer, _encoding, callback) {
+            output.push(chunk);
+            callback();
+          },
+        }),
+      );
+      return Buffer.concat(output);
+    }
+
+    async function discardBytes(byteCount: number, maxBytes: number) {
+      const chunk = Buffer.alloc(64 * 1024 * 1024);
+      function* chunks() {
+        let remaining = byteCount;
+        while (remaining > 0) {
+          const bytes = Math.min(remaining, chunk.length);
+          yield chunk.subarray(0, bytes);
+          remaining -= bytes;
+        }
+      }
+      await pipeline(
+        Readable.from(chunks()),
+        createDecryptedByteLimit("Test output", maxBytes),
+        new Writable({
+          write(_chunk, _encoding, callback) {
+            callback();
+          },
+        }),
+      );
+    }
+
+    it("rejects a real OpenPGP packet one byte over the intermediate limit", async () => {
+      const fixture = await createStoredOpenPgpFile(
+        MAX_DECRYPTED_GZIP_BYTES + 1,
+        gpgEnv.homedir,
+      );
+      const operationDirectories: string[] = [];
+      const createTempDir = storage.createTempDir.bind(storage);
+      const createTempDirSpy = vi
+        .spyOn(storage, "createTempDir")
+        .mockImplementation((prefix) => {
+          const directory = createTempDir(prefix);
+          operationDirectories.push(directory.path);
+          return directory;
+        });
+
+      try {
+        await expect(
+          crypto.decryptFile(storage, itemDirectory, fixture.filePath),
+        ).rejects.toMatchObject({
+          message: "Failed to write decrypted GPG output",
+          cause: {
+            message: `GPG-decrypted file exceeds the ${MAX_DECRYPTED_GZIP_BYTES}-byte limit`,
+          },
+        });
+        expect(operationDirectories).toHaveLength(1);
+        expect(
+          operationDirectories.every((entry) => !fs.existsSync(entry)),
+        ).toBe(true);
+        expect(fs.readdirSync(itemDirectory.path)).toEqual([]);
+      } finally {
+        createTempDirSpy.mockRestore();
+        fixture.cleanup();
+      }
+    }, 180_000);
+
+    it("rejects a real-GPG gzip member one byte over the production limit", async () => {
+      const fixture = await createLargeEncryptedFile(
+        MAX_DECRYPTED_BYTES + 1,
+        testKeyId,
+        gpgEnv.homedir,
+      );
+      const operationDirectories: string[] = [];
+      const createTempDir = storage.createTempDir.bind(storage);
+      const createTempDirSpy = vi
+        .spyOn(storage, "createTempDir")
+        .mockImplementation((prefix) => {
+          const directory = createTempDir(prefix);
+          operationDirectories.push(directory.path);
+          return directory;
+        });
+
+      try {
+        await expect(
+          crypto.decryptFile(storage, itemDirectory, fixture.filePath),
+        ).rejects.toMatchObject({
+          message: "Failed to decompress decrypted file",
+          cause: {
+            message: `Decompressed file exceeds the ${MAX_DECRYPTED_BYTES}-byte limit`,
+          },
+        });
+        expect(operationDirectories).toHaveLength(1);
+        expect(
+          operationDirectories.every((entry) => !fs.existsSync(entry)),
+        ).toBe(true);
+        expect(fs.readdirSync(itemDirectory.path)).toEqual([]);
+      } finally {
+        createTempDirSpy.mockRestore();
+        fixture.cleanup();
+      }
+    }, 180_000);
+
+    it("allows output exactly at the limit", async () => {
+      const output = await streamBytes([Buffer.alloc(4), Buffer.alloc(4)], 8);
+      expect(output).toHaveLength(8);
+    });
+
+    it("rejects the first byte over the limit", async () => {
+      await expect(
+        streamBytes([Buffer.alloc(8), Buffer.alloc(1)], 8),
+      ).rejects.toThrow("Test output exceeds the 8-byte limit");
+    });
+
+    it("allows plaintext exactly at the production limit", async () => {
+      await expect(
+        discardBytes(MAX_DECRYPTED_BYTES, MAX_DECRYPTED_BYTES),
+      ).resolves.toBeUndefined();
+    });
+
+    it("rejects plaintext one byte over the production limit", async () => {
+      await expect(
+        discardBytes(MAX_DECRYPTED_BYTES + 1, MAX_DECRYPTED_BYTES),
+      ).rejects.toThrow(
+        `Test output exceeds the ${MAX_DECRYPTED_BYTES}-byte limit`,
+      );
+    });
+
+    it("allows intermediate gzip exactly at its production limit", async () => {
+      await expect(
+        discardBytes(MAX_DECRYPTED_GZIP_BYTES, MAX_DECRYPTED_GZIP_BYTES),
+      ).resolves.toBeUndefined();
+    });
+
+    it("rejects intermediate gzip one byte over its production limit", async () => {
+      await expect(
+        discardBytes(MAX_DECRYPTED_GZIP_BYTES + 1, MAX_DECRYPTED_GZIP_BYTES),
+      ).rejects.toThrow(
+        `Test output exceeds the ${MAX_DECRYPTED_GZIP_BYTES}-byte limit`,
+      );
+    });
+
+    it("derives the gzip allowance from compression and framing", () => {
+      const compressBound =
+        MAX_DECRYPTED_BYTES +
+        Math.floor(MAX_DECRYPTED_BYTES / 4096) +
+        Math.floor(MAX_DECRYPTED_BYTES / 16384) +
+        Math.floor(MAX_DECRYPTED_BYTES / 33554432) +
+        13;
+      expect(MAX_DECRYPTED_GZIP_BYTES).toBe(compressBound + 1024 + 8);
     });
   });
 

--- a/app/src/main/__tests__/crypto.gpg.test.ts
+++ b/app/src/main/__tests__/crypto.gpg.test.ts
@@ -10,9 +10,10 @@ import {
 import * as path from "path";
 import * as fs from "fs";
 import * as openpgp from "openpgp";
-import { execSync, spawn } from "child_process";
+import { execFileSync, execSync, spawn } from "child_process";
 import { EventEmitter } from "events";
 import { PassThrough } from "stream";
+import { gzipSync } from "zlib";
 import { Crypto, CryptoError, encryptMessage } from "../crypto";
 import {
   createGpgTestEnvironment,
@@ -254,6 +255,57 @@ and symbols: !@#$%^&*()_+-={}[]|\\:";'<>?,./`;
         expect(decryptedContent).toBe(originalContent);
       } finally {
         cleanup();
+      }
+    });
+
+    it("should not leave plaintext when malformed gzip decompression fails", async () => {
+      const fixtureDirectory = fs.mkdtempSync(
+        path.join(itemDirectory.path, "encrypted-fixture-"),
+      );
+      const malformedGzipPath = path.join(fixtureDirectory, "malformed-output");
+      const encryptedPath = `${malformedGzipPath}.gpg`;
+      const plaintext = Buffer.alloc(4 * 1024 * 1024, 0x41);
+      const gzipPayload = gzipSync(plaintext, { level: 9 });
+      fs.writeFileSync(
+        malformedGzipPath,
+        gzipPayload.subarray(0, gzipPayload.length - 8),
+      );
+      execFileSync("gpg", [
+        "--homedir",
+        gpgEnv.homedir,
+        "--batch",
+        "--trust-model",
+        "always",
+        "--encrypt",
+        "-r",
+        testKeyId,
+        "--output",
+        encryptedPath,
+        malformedGzipPath,
+      ]);
+
+      const finalOutputPath = itemDirectory.join("malformed-output");
+      try {
+        await expect(
+          crypto.decryptFile(storage, itemDirectory, encryptedPath),
+        ).rejects.toThrow("Failed to decompress decrypted file");
+
+        const finalOutputExists = fs.existsSync(finalOutputPath);
+        expect({
+          finalOutputExists,
+          finalOutputBytes: finalOutputExists
+            ? fs.statSync(finalOutputPath).size
+            : 0,
+          itemDirectoryEntries: fs
+            .readdirSync(itemDirectory.path)
+            .filter((entry) => entry !== path.basename(fixtureDirectory)),
+        }).toEqual({
+          finalOutputExists: false,
+          finalOutputBytes: 0,
+          itemDirectoryEntries: [],
+        });
+      } finally {
+        fs.rmSync(fixtureDirectory, { recursive: true, force: true });
       }
     });
 

--- a/app/src/main/__tests__/crypto.integration.test.ts
+++ b/app/src/main/__tests__/crypto.integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { spawn } from "child_process";
-import { EventEmitter } from "events";
+import { PassThrough } from "stream";
 import * as fs from "fs";
 import { Crypto, CryptoError } from "../crypto";
 import { Storage, PathBuilder, UnsafePathComponent } from "../storage";
@@ -32,10 +32,11 @@ type CryptoWithPrivateMethods = {
 
 describe("Crypto Integration Tests", () => {
   let mockProcess: {
-    stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
-    stdout: { on: ReturnType<typeof vi.fn>; pipe: ReturnType<typeof vi.fn> };
-    stderr: { on: ReturnType<typeof vi.fn> };
+    stdin: PassThrough;
+    stdout: PassThrough;
+    stderr: PassThrough;
     on: ReturnType<typeof vi.fn>;
+    kill: ReturnType<typeof vi.fn>;
   };
   let storage: Storage;
   let itemDirectory: PathBuilder;
@@ -50,21 +51,25 @@ describe("Crypto Integration Tests", () => {
     (mockFs.realpathSync as any) = vi.fn((path) => path);
     (mockFs.existsSync as any) = vi.fn(() => false);
     (mockFs.mkdirSync as any) = vi.fn();
+    vi.mocked(mockFs.promises.open).mockResolvedValue({
+      close: vi.fn().mockResolvedValue(undefined),
+      sync: vi.fn().mockResolvedValue(undefined),
+    } as never);
+    vi.mocked(mockFs.promises.link).mockResolvedValue();
+    vi.mocked(mockFs.promises.rm).mockResolvedValue();
 
     // Mock process object for spawn
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    vi.spyOn(stdin, "write");
+    vi.spyOn(stdin, "end");
     mockProcess = {
-      stdin: {
-        write: vi.fn(),
-        end: vi.fn(),
-      },
-      stdout: {
-        on: vi.fn(),
-        pipe: vi.fn(),
-      },
-      stderr: {
-        on: vi.fn(),
-      },
+      stdin,
+      stdout,
+      stderr,
       on: vi.fn(),
+      kill: vi.fn(),
     };
 
     // Create real Storage and PathBuilder instances
@@ -89,25 +94,11 @@ describe("Crypto Integration Tests", () => {
       mockProcess.on.mockImplementation(
         (event: string, callback: (code: number) => void) => {
           if (event === "close") {
-            // Simulate successful GPG exit
-            setTimeout(() => callback(0), 10);
+            setTimeout(() => {
+              mockProcess.stdout.end(Buffer.from(testMessage));
+              callback(0);
+            }, 10);
           }
-          return mockProcess;
-        },
-      );
-
-      mockProcess.stdout.on.mockImplementation(
-        (event: string, callback: (data: Buffer) => void) => {
-          if (event === "data") {
-            // Simulate GPG output (decrypted content - no gzip decompression for messages)
-            setTimeout(() => callback(Buffer.from(testMessage)), 5);
-          }
-          return mockProcess;
-        },
-      );
-
-      mockProcess.stderr.on.mockImplementation(
-        (_event: string, _callback: (data: Buffer) => void) => {
           return mockProcess;
         },
       );
@@ -138,17 +129,11 @@ describe("Crypto Integration Tests", () => {
       mockProcess.on.mockImplementation(
         (event: string, callback: (code: number) => void) => {
           if (event === "close") {
-            // Simulate GPG failure
-            setTimeout(() => callback(1), 10);
-          }
-          return mockProcess;
-        },
-      );
-
-      mockProcess.stderr.on.mockImplementation(
-        (event: string, callback: (data: Buffer) => void) => {
-          if (event === "data") {
-            setTimeout(() => callback(Buffer.from("GPG decryption error")), 5);
+            setTimeout(() => {
+              mockProcess.stderr.end(Buffer.from("GPG decryption error"));
+              mockProcess.stdout.end();
+              callback(1);
+            }, 10);
           }
           return mockProcess;
         },
@@ -156,10 +141,9 @@ describe("Crypto Integration Tests", () => {
 
       mockSpawn.mockReturnValue(mockProcess as never);
 
-      await expect(crypto.decryptMessage(encryptedContent)).rejects.toThrow(
-        CryptoError,
-      );
-      await expect(crypto.decryptMessage(encryptedContent)).rejects.toThrow(
+      const decryption = crypto.decryptMessage(encryptedContent);
+      await expect(decryption).rejects.toThrow(CryptoError);
+      await expect(decryption).rejects.toThrow(
         "GPG decryption failed (exit code 1): GPG decryption error",
       );
     });
@@ -184,10 +168,9 @@ describe("Crypto Integration Tests", () => {
 
       mockSpawn.mockReturnValue(mockProcess as never);
 
-      await expect(crypto.decryptMessage(encryptedContent)).rejects.toThrow(
-        CryptoError,
-      );
-      await expect(crypto.decryptMessage(encryptedContent)).rejects.toThrow(
+      const decryption = crypto.decryptMessage(encryptedContent);
+      await expect(decryption).rejects.toThrow(CryptoError);
+      await expect(decryption).rejects.toThrow(
         "Failed to start GPG process: Process spawn failed",
       );
     });
@@ -196,13 +179,7 @@ describe("Crypto Integration Tests", () => {
   describe("File Decryption", () => {
     beforeEach(() => {
       // Mock filesystem operations
-      const mockWriteStream = Object.assign(new EventEmitter(), {
-        end: vi.fn(),
-        destroy: vi.fn(function (this: EventEmitter) {
-          setImmediate(() => this.emit("close"));
-        }),
-        writable: true,
-      });
+      const mockWriteStream = new PassThrough();
       mockFs.createWriteStream.mockReturnValue(mockWriteStream as never);
 
       mockFs.createReadStream.mockReturnValue({
@@ -233,13 +210,14 @@ describe("Crypto Integration Tests", () => {
       mockProcess.on.mockImplementation(
         (event: string, callback: (code: number) => void) => {
           if (event === "close") {
-            setTimeout(() => callback(0), 10);
+            setTimeout(() => {
+              mockProcess.stdout.end();
+              callback(0);
+            }, 10);
           }
           return mockProcess;
         },
       );
-
-      mockProcess.stderr.on.mockImplementation(() => mockProcess);
 
       // Mock the private methods that would handle gzip
       const cryptoWithPrivate = crypto as unknown as CryptoWithPrivateMethods;
@@ -280,19 +258,11 @@ describe("Crypto Integration Tests", () => {
       mockProcess.on.mockImplementation(
         (event: string, callback: (code: number) => void) => {
           if (event === "close") {
-            setTimeout(() => callback(2), 10);
-          }
-          return mockProcess;
-        },
-      );
-
-      mockProcess.stderr.on.mockImplementation(
-        (event: string, callback: (data: Buffer) => void) => {
-          if (event === "data") {
-            setTimeout(
-              () => callback(Buffer.from("GPG file decryption error")),
-              5,
-            );
+            setTimeout(() => {
+              mockProcess.stderr.end(Buffer.from("GPG file decryption error"));
+              mockProcess.stdout.end();
+              callback(2);
+            }, 10);
           }
           return mockProcess;
         },
@@ -300,12 +270,13 @@ describe("Crypto Integration Tests", () => {
 
       mockSpawn.mockReturnValue(mockProcess as never);
 
-      await expect(
-        crypto.decryptFile(storage, itemDirectory, testFilePath),
-      ).rejects.toThrow(CryptoError);
-      await expect(
-        crypto.decryptFile(storage, itemDirectory, testFilePath),
-      ).rejects.toThrow(
+      const decryption = crypto.decryptFile(
+        storage,
+        itemDirectory,
+        testFilePath,
+      );
+      await expect(decryption).rejects.toThrow(CryptoError);
+      await expect(decryption).rejects.toThrow(
         "GPG file decryption failed (exit code 2): GPG file decryption error",
       );
     });
@@ -322,13 +293,14 @@ describe("Crypto Integration Tests", () => {
       mockProcess.on.mockImplementation(
         (event: string, callback: (code: number) => void) => {
           if (event === "close") {
-            setTimeout(() => callback(0), 10);
+            setTimeout(() => {
+              mockProcess.stdout.end();
+              callback(0);
+            }, 10);
           }
           return mockProcess;
         },
       );
-
-      mockProcess.stderr.on.mockImplementation(() => mockProcess);
 
       // Mock no filename in gzip header
       const cryptoWithPrivate = crypto as unknown as CryptoWithPrivateMethods;
@@ -365,7 +337,10 @@ describe("Crypto Integration Tests", () => {
       mockProcess.on.mockImplementation(
         (event: string, callback: (code: number) => void) => {
           if (event === "close") {
-            setTimeout(() => callback(0), 10);
+            setTimeout(() => {
+              mockProcess.stdout.end();
+              callback(0);
+            }, 10);
           }
           return mockProcess;
         },
@@ -382,12 +357,15 @@ describe("Crypto Integration Tests", () => {
 
       mockSpawn.mockReturnValue(mockProcess as never);
 
-      await expect(
-        crypto.decryptFile(storage, itemDirectory, testFilePath),
-      ).rejects.toThrow(CryptoError);
-      await expect(
-        crypto.decryptFile(storage, itemDirectory, testFilePath),
-      ).rejects.toThrow("Failed to decompress decrypted file");
+      const decryption = crypto.decryptFile(
+        storage,
+        itemDirectory,
+        testFilePath,
+      );
+      await expect(decryption).rejects.toThrow(CryptoError);
+      await expect(decryption).rejects.toThrow(
+        "Failed to decompress decrypted file",
+      );
     });
   });
 
@@ -403,16 +381,10 @@ describe("Crypto Integration Tests", () => {
       mockProcess.on.mockImplementation(
         (event: string, callback: (code: number) => void) => {
           if (event === "close") {
-            setTimeout(() => callback(0), 10);
-          }
-          return mockProcess;
-        },
-      );
-
-      mockProcess.stdout.on.mockImplementation(
-        (event: string, callback: (data: Buffer) => void) => {
-          if (event === "data") {
-            setTimeout(() => callback(Buffer.from("decrypted")), 5);
+            setTimeout(() => {
+              mockProcess.stdout.end(Buffer.from("decrypted"));
+              callback(0);
+            }, 10);
           }
           return mockProcess;
         },
@@ -441,16 +413,10 @@ describe("Crypto Integration Tests", () => {
       mockProcess.on.mockImplementation(
         (event: string, callback: (code: number) => void) => {
           if (event === "close") {
-            setTimeout(() => callback(0), 10);
-          }
-          return mockProcess;
-        },
-      );
-
-      mockProcess.stdout.on.mockImplementation(
-        (event: string, callback: (data: Buffer) => void) => {
-          if (event === "data") {
-            setTimeout(() => callback(Buffer.from("decrypted")), 5);
+            setTimeout(() => {
+              mockProcess.stdout.end(Buffer.from("decrypted"));
+              callback(0);
+            }, 10);
           }
           return mockProcess;
         },

--- a/app/src/main/crypto.ts
+++ b/app/src/main/crypto.ts
@@ -1,6 +1,11 @@
-import { spawn } from "child_process";
+import {
+  spawn,
+  type ChildProcessWithoutNullStreams,
+  type SpawnOptionsWithoutStdio,
+} from "child_process";
 import { createGunzip } from "zlib";
-import { pipeline, finished } from "stream/promises";
+import { Transform, TransformCallback } from "stream";
+import { pipeline } from "stream/promises";
 
 import * as openpgp from "openpgp";
 import * as fs from "fs";
@@ -10,6 +15,116 @@ import { ms } from "../types";
 
 // Allow 3 minutes for decryption, which might need to wait for sd-gpg to start
 const SHELL_TIMEOUT = 180_000 as ms;
+export const MAX_DECRYPTED_BYTES = 500 * 1024 * 1024;
+export const MAX_GPG_STDERR_BYTES = 64 * 1024;
+const GZIP_HEADER_READ_BYTES = 1024;
+const GZIP_TRAILER_BYTES = 8;
+const GZIP_FIXED_HEADER_BYTES = 10;
+const GZIP_EXTRA_FLAG = 4;
+const GZIP_FILENAME_FLAG = 8;
+const GZIP_MAGIC = Buffer.from([0x1f, 0x8b]);
+
+// The server's 500 MiB Apache/Flask cap covers the entire source request, so
+// the uploaded stream is smaller than this plaintext limit. It stores that
+// stream in one gzip member. Bound its deflate representation with zlib's
+// compressBound formula, then allow the header bytes this client can parse and
+// the fixed gzip trailer without assuming a separate filename limit.
+export const MAX_DECRYPTED_GZIP_BYTES =
+  MAX_DECRYPTED_BYTES +
+  Math.floor(MAX_DECRYPTED_BYTES / 4096) +
+  Math.floor(MAX_DECRYPTED_BYTES / 16384) +
+  Math.floor(MAX_DECRYPTED_BYTES / 33554432) +
+  13 +
+  GZIP_HEADER_READ_BYTES +
+  GZIP_TRAILER_BYTES;
+
+class DecryptedSizeLimitError extends Error {
+  constructor(stage: string, maxBytes = MAX_DECRYPTED_BYTES) {
+    super(`${stage} exceeds the ${maxBytes}-byte limit`);
+    this.name = "DecryptedSizeLimitError";
+  }
+}
+
+class BoundedBufferCollector {
+  private readonly chunks: Buffer[] = [];
+  private bytesSeen = 0;
+
+  constructor(private readonly maxBytes: number) {}
+
+  append(chunk: Buffer): boolean {
+    const remaining = this.maxBytes - this.bytesSeen;
+    if (remaining > 0) {
+      this.chunks.push(Buffer.from(chunk.subarray(0, remaining)));
+      this.bytesSeen += Math.min(chunk.length, remaining);
+    }
+    return chunk.length <= remaining;
+  }
+
+  toString(): string {
+    return Buffer.concat(this.chunks, this.bytesSeen).toString("utf8");
+  }
+}
+
+class Utf8MessageCollector {
+  private readonly decoder = new TextDecoder("utf-8", {
+    fatal: true,
+    ignoreBOM: true,
+  });
+  private readonly chunks: string[] = [];
+  private bytesSeen = 0;
+
+  append(chunk: Buffer): void {
+    this.bytesSeen += chunk.length;
+    if (this.bytesSeen > MAX_DECRYPTED_BYTES) {
+      throw new DecryptedSizeLimitError("Decrypted message");
+    }
+    const decoded = this.decoder.decode(chunk, { stream: true });
+    if (decoded) {
+      this.chunks.push(decoded);
+    }
+  }
+
+  finish(): string {
+    const decoded = this.decoder.decode();
+    if (decoded) {
+      this.chunks.push(decoded);
+    }
+    return this.chunks.join("");
+  }
+}
+
+class ByteLimitTransform extends Transform {
+  private bytesSeen = 0;
+
+  constructor(
+    private readonly stage: string,
+    private readonly maxBytes: number,
+  ) {
+    super();
+  }
+
+  override _transform(
+    chunk: Buffer,
+    _encoding: BufferEncoding,
+    callback: TransformCallback,
+  ): void {
+    this.bytesSeen += chunk.length;
+    if (this.bytesSeen > this.maxBytes) {
+      callback(
+        new Error(`${this.stage} exceeds the ${this.maxBytes}-byte limit`),
+      );
+      return;
+    }
+    callback(null, chunk);
+  }
+}
+
+export function createDecryptedByteLimit(
+  stage: string,
+  maxBytes = MAX_DECRYPTED_BYTES,
+): Transform {
+  return new ByteLimitTransform(stage, maxBytes);
+}
 
 export interface CryptoConfig {
   isQubes: boolean;
@@ -36,13 +151,18 @@ const GPG_STDERR_ANONYMOUS_THEN_KNOWN =
   /^(gpg: encrypted with RSA key, ID [0-9A-Fa-f]+\n)(gpg: encrypted with (?:4096-bit RSA|rsa4096) key, ID [0-9A-Fa-f]+, created \d{4}-\d{2}-\d{2}\n\s+"[^"]*"\n)$/;
 const GPG_STDERR_KNOWN_THEN_ANONYMOUS =
   /^(gpg: encrypted with (?:4096-bit RSA|rsa4096) key, ID [0-9A-Fa-f]+, created \d{4}-\d{2}-\d{2}\n\s+"[^"]*"\n)(gpg: encrypted with RSA key, ID [0-9A-Fa-f]+\n)$/;
+const GPG_STDERR_LOCKFILE_DISAPPEARED = /^(?:gpg: lockfile disappeared\n)+/;
 
 function isExpectedGpgStderr(stderr: string): boolean {
   const normalized = stderr.trimEnd() + "\n";
+  const withoutLockfileDiagnostic = normalized.replace(
+    GPG_STDERR_LOCKFILE_DISAPPEARED,
+    "",
+  );
   return (
-    GPG_STDERR_KNOWN_KEY.test(normalized) ||
-    GPG_STDERR_ANONYMOUS_THEN_KNOWN.test(normalized) ||
-    GPG_STDERR_KNOWN_THEN_ANONYMOUS.test(normalized)
+    GPG_STDERR_KNOWN_KEY.test(withoutLockfileDiagnostic) ||
+    GPG_STDERR_ANONYMOUS_THEN_KNOWN.test(withoutLockfileDiagnostic) ||
+    GPG_STDERR_KNOWN_THEN_ANONYMOUS.test(withoutLockfileDiagnostic)
   );
 }
 
@@ -54,6 +174,582 @@ export class CryptoError extends Error {
     super(message);
     this.name = "CryptoError";
   }
+}
+
+type GpgScope = "message" | "file";
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function createAbortError(): Error {
+  const error = new Error("Decryption was cancelled");
+  error.name = "AbortError";
+  return error;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw createAbortError();
+  }
+}
+
+function isCancellation(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+async function settleAbortable<T>(
+  operation: Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  try {
+    const result = await operation;
+    throwIfAborted(signal);
+    return result;
+  } catch (error) {
+    if (signal?.aborted) {
+      throw createAbortError();
+    }
+    throw error;
+  }
+}
+
+function cleanupFailure(message: string, error: unknown): CryptoError {
+  return new CryptoError(message, asError(error));
+}
+
+async function syncFile(filePath: string, signal?: AbortSignal): Promise<void> {
+  throwIfAborted(signal);
+  const file = await fs.promises.open(filePath, "r");
+  try {
+    throwIfAborted(signal);
+    await settleAbortable(file.sync(), signal);
+  } finally {
+    await file.close();
+  }
+  throwIfAborted(signal);
+}
+
+async function removeDirectoryIfExists(directoryPath: string): Promise<void> {
+  try {
+    await fs.promises.rm(directoryPath, { force: true, recursive: true });
+  } catch {
+    try {
+      fs.rmSync(directoryPath, { force: true, recursive: true });
+    } catch (syncError) {
+      throw cleanupFailure(
+        "Failed to remove temporary decrypted files",
+        syncError,
+      );
+    }
+  }
+}
+
+async function publishFileWithoutReplace(
+  temporaryOutputPath: string,
+  finalOutputPath: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  throwIfAborted(signal);
+  try {
+    await fs.promises.link(temporaryOutputPath, finalOutputPath);
+  } catch (error) {
+    if (signal?.aborted) {
+      throw createAbortError();
+    }
+    throw error;
+  }
+}
+
+function startGpgTimeout(callback: () => void): NodeJS.Timeout {
+  const timeout = setTimeout(callback, SHELL_TIMEOUT);
+  timeout.unref();
+  return timeout;
+}
+
+function clearGpgTimeout(timeout: NodeJS.Timeout | null): void {
+  if (timeout) {
+    clearTimeout(timeout);
+  }
+}
+
+function stopGpgProcess(
+  process: ChildProcessWithoutNullStreams,
+  terminate: boolean,
+): void {
+  if (terminate) {
+    process.kill();
+  }
+  process.stdin.destroy?.();
+  process.stdout.destroy?.();
+  process.stderr.destroy?.();
+}
+
+function messageOutputError(error: unknown): CryptoError {
+  const cause = asError(error);
+  const message =
+    cause instanceof DecryptedSizeLimitError
+      ? cause.message
+      : "Decrypted message is not valid UTF-8";
+  return new CryptoError(message, cause);
+}
+
+function gpgStderrLimitError(): CryptoError {
+  return new CryptoError(
+    `GPG stderr exceeds the ${MAX_GPG_STDERR_BYTES}-byte limit`,
+  );
+}
+
+function gpgInputError(error: Error): CryptoError {
+  return new CryptoError("Failed to write encrypted content to GPG", error);
+}
+
+function gpgFileInputError(error: Error): CryptoError {
+  return new CryptoError("GPG file input stream failed", error);
+}
+
+function gpgOutputWriteError(error: unknown): CryptoError {
+  return new CryptoError(
+    "Failed to write decrypted GPG output",
+    asError(error),
+  );
+}
+
+function writeGpgInput(
+  process: ChildProcessWithoutNullStreams,
+  encryptedContent: Buffer,
+  fail: (error: Error) => void,
+): void {
+  try {
+    process.stdin.write(encryptedContent);
+    process.stdin.end();
+  } catch (error) {
+    fail(gpgInputError(asError(error)));
+  }
+}
+
+function gpgCompletionError(
+  scope: GpgScope,
+  code: number | null,
+  signal: NodeJS.Signals | null,
+  stderr: string,
+): Error | null {
+  if (signal) {
+    return new Error(`Process terminated with signal ${signal}`);
+  }
+  const prefix = scope === "file" ? "GPG file decryption" : "GPG decryption";
+  if (code !== 0) {
+    return new CryptoError(`${prefix} failed (exit code ${code}): ${stderr}`);
+  }
+  if (stderr.trim() && !isExpectedGpgStderr(stderr)) {
+    const label = scope === "file" ? "GPG file decryption" : "GPG decryption";
+    return new CryptoError(
+      `${label} emitted stderr: ${JSON.stringify(stderr.trim())}`,
+    );
+  }
+  return null;
+}
+
+function gpgSpawnError(scope: GpgScope, error: Error): CryptoError {
+  const context = scope === "file" ? " for file decryption" : "";
+  return new CryptoError(
+    `Failed to start GPG process${context}: ${error.message}`,
+    error,
+  );
+}
+
+function spawnGpgProcess(
+  command: string[],
+  options: SpawnOptionsWithoutStdio,
+  scope: GpgScope,
+): ChildProcessWithoutNullStreams {
+  try {
+    return spawn(command[0], command.slice(1), options);
+  } catch (error) {
+    throw gpgSpawnError(scope, asError(error));
+  }
+}
+
+function fileCloseError(
+  code: number | null,
+  signal: NodeJS.Signals | null,
+  stderr: string,
+): Error | null {
+  if (code === 0 && !signal) {
+    return null;
+  }
+  return (
+    gpgCompletionError("file", code, signal, stderr) ??
+    new CryptoError("GPG file decryption failed")
+  );
+}
+
+interface MessageProcessHandlers {
+  abort: () => void;
+  close: (code: number | null, signal: NodeJS.Signals | null) => void;
+  processError: (error: Error) => void;
+  stderr: (chunk: Buffer) => void;
+  stderrError: (error: Error) => void;
+  stdinError: (error: Error) => void;
+  stdout: (chunk: Buffer) => void;
+  stdoutError: (error: Error) => void;
+}
+
+function registerMessageProcessHandlers(
+  process: ChildProcessWithoutNullStreams,
+  signal: AbortSignal | undefined,
+  handlers: MessageProcessHandlers,
+): void {
+  process.stdin.on?.("error", handlers.stdinError);
+  process.stdout.on("error", handlers.stdoutError);
+  process.stderr.on("error", handlers.stderrError);
+  process.stdout.on("data", handlers.stdout);
+  process.stderr.on("data", handlers.stderr);
+  process.on("error", handlers.processError);
+  process.on("close", handlers.close);
+  signal?.addEventListener("abort", handlers.abort, { once: true });
+}
+
+interface FileProcessHandlers {
+  abort: () => void;
+  close: (code: number | null, signal: NodeJS.Signals | null) => void;
+  pipelineError: (error: unknown) => void;
+  pipelineSuccess: () => void;
+  processError: (error: Error) => void;
+  stderr: (chunk: Buffer) => void;
+  stderrError: (error: Error) => void;
+  stdinError: (error: Error) => void;
+}
+
+function registerFileProcessHandlers(
+  process: ChildProcessWithoutNullStreams,
+  outputPipeline: Promise<void>,
+  signal: AbortSignal | undefined,
+  handlers: FileProcessHandlers,
+): void {
+  process.stdin.on("error", handlers.stdinError);
+  process.stderr.on("error", handlers.stderrError);
+  process.stderr.on("data", handlers.stderr);
+  process.on("error", handlers.processError);
+  process.on("close", handlers.close);
+  signal?.addEventListener("abort", handlers.abort, { once: true });
+  outputPipeline.then(handlers.pipelineSuccess, handlers.pipelineError);
+}
+
+class GpgMessageCollectorRunner {
+  private readonly diagnostics = new BoundedBufferCollector(
+    MAX_GPG_STDERR_BYTES,
+  );
+  private readonly plaintext = new Utf8MessageCollector();
+  private reject!: (reason?: unknown) => void;
+  private resolve!: (value: string) => void;
+  private settled = false;
+  private timeout: NodeJS.Timeout | null = null;
+
+  constructor(
+    private readonly process: ChildProcessWithoutNullStreams,
+    private readonly encryptedContent: Buffer,
+    private readonly signal?: AbortSignal,
+  ) {}
+
+  run(): Promise<string> {
+    return new Promise((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+      this.registerHandlers();
+      this.timeout = startGpgTimeout(() => this.onTimeout());
+      this.startInput();
+    });
+  }
+
+  private finish(
+    error: Error | null,
+    result?: string,
+    terminate = false,
+  ): void {
+    if (this.settled) {
+      return;
+    }
+    this.settled = true;
+    clearGpgTimeout(this.timeout);
+    this.signal?.removeEventListener("abort", this.onAbort);
+    stopGpgProcess(this.process, terminate);
+    if (error) {
+      this.reject(error);
+      return;
+    }
+    this.resolve(result ?? "");
+  }
+
+  private failStreamRead(description: string, error: Error): void {
+    this.finish(
+      new CryptoError(`Failed to read GPG ${description}`, error),
+      undefined,
+      true,
+    );
+  }
+
+  private finishPlaintext(): void {
+    try {
+      this.finish(null, this.plaintext.finish());
+    } catch (decodeError) {
+      this.finish(messageOutputError(decodeError));
+    }
+  }
+
+  private onAbort = (): void => {
+    this.finish(createAbortError(), undefined, true);
+  };
+
+  private onClose = (
+    code: number | null,
+    exitSignal: NodeJS.Signals | null,
+  ): void => {
+    if (this.settled) {
+      return;
+    }
+    const error = gpgCompletionError(
+      "message",
+      code,
+      exitSignal,
+      this.diagnostics.toString(),
+    );
+    if (error) {
+      this.finish(error);
+      return;
+    }
+    this.finishPlaintext();
+  };
+
+  private onStderr = (chunk: Buffer): void => {
+    if (!this.diagnostics.append(chunk)) {
+      this.finish(gpgStderrLimitError(), undefined, true);
+    }
+  };
+
+  private onStdout = (chunk: Buffer): void => {
+    try {
+      this.plaintext.append(chunk);
+    } catch (error) {
+      this.finish(messageOutputError(error), undefined, true);
+    }
+  };
+
+  private onTimeout(): void {
+    this.finish(
+      new CryptoError("GPG message decryption timed out"),
+      undefined,
+      true,
+    );
+  }
+
+  private registerHandlers(): void {
+    registerMessageProcessHandlers(this.process, this.signal, {
+      abort: this.onAbort,
+      close: this.onClose,
+      processError: (error) =>
+        this.finish(gpgSpawnError("message", error), undefined, true),
+      stderr: this.onStderr,
+      stderrError: (error) => this.failStreamRead("diagnostics", error),
+      stdinError: (error) => this.finish(gpgInputError(error), undefined, true),
+      stdout: this.onStdout,
+      stdoutError: (error) => this.failStreamRead("message output", error),
+    });
+  }
+
+  private startInput(): void {
+    if (this.signal?.aborted) {
+      this.onAbort();
+      return;
+    }
+    writeGpgInput(this.process, this.encryptedContent, (error) =>
+      this.finish(error, undefined, true),
+    );
+  }
+}
+
+function collectGpgMessage(
+  process: ChildProcessWithoutNullStreams,
+  encryptedContent: Buffer,
+  signal?: AbortSignal,
+): Promise<string> {
+  return new GpgMessageCollectorRunner(process, encryptedContent, signal).run();
+}
+
+class GpgFileOutputWriter {
+  private closeResult: [number | null, NodeJS.Signals | null] | null = null;
+  private readonly diagnostics = new BoundedBufferCollector(
+    MAX_GPG_STDERR_BYTES,
+  );
+  private readonly output: fs.WriteStream;
+  private outputPipeline!: Promise<void>;
+  private pipelineDone = false;
+  private pipelineError: Error | null = null;
+  private reject!: (reason?: unknown) => void;
+  private resolve!: () => void;
+  private settled = false;
+  private timeout: NodeJS.Timeout | null = null;
+
+  constructor(
+    private readonly process: ChildProcessWithoutNullStreams,
+    outputPath: string,
+    private readonly signal?: AbortSignal,
+  ) {
+    this.output = fs.createWriteStream(outputPath, { flags: "wx" });
+  }
+
+  run(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+      this.startPipeline();
+      this.registerHandlers();
+      this.timeout = startGpgTimeout(() => this.onTimeout());
+      if (this.signal?.aborted) {
+        this.onAbort();
+      }
+    });
+  }
+
+  private complete(): void {
+    if (this.settled || !this.pipelineDone || !this.closeResult) {
+      return;
+    }
+    const error = gpgCompletionError(
+      "file",
+      this.closeResult[0],
+      this.closeResult[1],
+      this.diagnostics.toString(),
+    );
+    if (error) {
+      this.fail(error, false);
+      return;
+    }
+    this.settled = true;
+    clearGpgTimeout(this.timeout);
+    this.signal?.removeEventListener("abort", this.onAbort);
+    stopGpgProcess(this.process, false);
+    this.resolve();
+  }
+
+  private fail(error: Error, terminate = true): void {
+    if (this.settled) {
+      return;
+    }
+    this.settled = true;
+    clearGpgTimeout(this.timeout);
+    this.signal?.removeEventListener("abort", this.onAbort);
+    stopGpgProcess(this.process, terminate);
+    this.output.destroy();
+    void this.outputPipeline
+      .catch(() => undefined)
+      .then(() => this.reject(error));
+  }
+
+  private onAbort = (): void => {
+    this.fail(createAbortError());
+  };
+
+  private onClose = (
+    code: number | null,
+    exitSignal: NodeJS.Signals | null,
+  ): void => {
+    if (this.pipelineError) {
+      this.fail(this.pipelineError, false);
+      return;
+    }
+    const error = fileCloseError(code, exitSignal, this.diagnostics.toString());
+    if (error) {
+      this.fail(error, false);
+      return;
+    }
+    this.closeResult = [code, exitSignal];
+    this.complete();
+  };
+
+  private onPipelineError = (error: unknown): void => {
+    if (this.settled) {
+      return;
+    }
+    this.pipelineError = gpgOutputWriteError(error);
+    stopGpgProcess(this.process, true);
+    if (this.closeResult) {
+      this.fail(this.pipelineError, false);
+    }
+  };
+
+  private onStderr = (chunk: Buffer): void => {
+    if (!this.diagnostics.append(chunk)) {
+      this.fail(gpgStderrLimitError());
+    }
+  };
+
+  private onTimeout(): void {
+    this.fail(new CryptoError("GPG file decryption timed out"));
+  }
+
+  private registerHandlers(): void {
+    registerFileProcessHandlers(
+      this.process,
+      this.outputPipeline,
+      this.signal,
+      {
+        abort: this.onAbort,
+        close: this.onClose,
+        pipelineError: this.onPipelineError,
+        pipelineSuccess: () => {
+          this.pipelineDone = true;
+          this.complete();
+        },
+        processError: (error) => this.fail(gpgSpawnError("file", error)),
+        stderr: this.onStderr,
+        stderrError: (error) =>
+          this.fail(new CryptoError("Failed to read GPG diagnostics", error)),
+        stdinError: (error) => this.fail(gpgFileInputError(error)),
+      },
+    );
+  }
+
+  private startPipeline(): void {
+    this.outputPipeline = pipeline(
+      this.process.stdout,
+      createDecryptedByteLimit("GPG-decrypted file", MAX_DECRYPTED_GZIP_BYTES),
+      this.output,
+      { signal: this.signal },
+    );
+  }
+}
+
+function writeGpgOutputToFile(
+  process: ChildProcessWithoutNullStreams,
+  outputPath: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  return new GpgFileOutputWriter(process, outputPath, signal).run();
+}
+
+function gzipFilenameOffset(data: Buffer): number {
+  if ((data[3] & GZIP_EXTRA_FLAG) === 0) {
+    return GZIP_FIXED_HEADER_BYTES;
+  }
+  if (GZIP_FIXED_HEADER_BYTES + 2 > data.length) {
+    throw new Error("Incomplete gzip header");
+  }
+  return (
+    GZIP_FIXED_HEADER_BYTES + 2 + data.readUInt16LE(GZIP_FIXED_HEADER_BYTES)
+  );
+}
+
+function decodeGzipFilename(
+  data: Buffer,
+  filenameStart: number,
+): UnsafePathComponent | null {
+  const filenameEnd = data.indexOf(0, filenameStart);
+  if (filenameEnd < 0) {
+    throw new Error("Filename in gzip header not null-terminated");
+  }
+  const filename = data.subarray(filenameStart, filenameEnd).toString("utf8");
+  return filename.trim() ? new UnsafePathComponent(filename) : null;
 }
 
 export class Crypto {
@@ -110,7 +806,7 @@ export class Crypto {
     }
   }
 
-  private getSpawnOptions() {
+  private getSpawnOptions(): SpawnOptionsWithoutStdio {
     let env: NodeJS.ProcessEnv;
     if (this.isQubes && this.qubesGpgDomain) {
       env = { ...process.env, QUBES_GPG_DOMAIN: this.qubesGpgDomain };
@@ -119,7 +815,6 @@ export class Crypto {
     }
     return {
       env: env,
-      timeout: SHELL_TIMEOUT,
     };
   }
 
@@ -145,6 +840,8 @@ export class Crypto {
       const process = spawn(cmd[0], cmd.slice(1), this.getSpawnOptions());
       let stdout = "";
       let stderr = "";
+      const timeout = setTimeout(() => process.kill(), SHELL_TIMEOUT);
+      timeout.unref();
 
       process.stdout.on("data", (data) => {
         stdout += data.toString();
@@ -155,10 +852,12 @@ export class Crypto {
       });
 
       process.on("error", (err) => {
+        clearTimeout(timeout);
         reject(err);
       });
 
       process.on("close", (code, signal) => {
+        clearTimeout(timeout);
         if (signal) {
           reject(new Error(`Process terminated with signal ${signal}`));
         } else if (code !== 0) {
@@ -196,88 +895,14 @@ export class Crypto {
     encryptedContent: Buffer,
     signal?: AbortSignal,
   ): Promise<string> {
+    if (signal?.aborted) {
+      throw createAbortError();
+    }
     const cmd = this.getGpgCommand();
     cmd.push("--decrypt");
 
-    return new Promise((resolve, reject) => {
-      const gpgProcess = spawn(cmd[0], cmd.slice(1), this.getSpawnOptions());
-
-      // Kill the process if the abort signal fires
-      const abortListener = () => {
-        gpgProcess.kill();
-      };
-      signal?.addEventListener("abort", abortListener, { once: true });
-
-      // Handle the case where the signal was already aborted before we registered the listener
-      if (signal?.aborted) {
-        gpgProcess.kill();
-        const err = new Error("Decryption was cancelled");
-        err.name = "AbortError";
-        reject(err);
-        return;
-      }
-
-      let stdout = Buffer.alloc(0);
-      let stderr = Buffer.alloc(0);
-
-      // Write encrypted content to GPG stdin
-      gpgProcess.stdin.write(encryptedContent);
-      gpgProcess.stdin.end();
-
-      // Collect stdout (decrypted content)
-      gpgProcess.stdout.on("data", (chunk) => {
-        stdout = Buffer.concat([stdout, chunk]);
-      });
-
-      // Collect stderr (error messages)
-      gpgProcess.stderr.on("data", (chunk) => {
-        stderr = Buffer.concat([stderr, chunk]);
-      });
-
-      gpgProcess.on("close", async (code, exitSignal) => {
-        signal?.removeEventListener("abort", abortListener);
-        const errorMessage = stderr.toString("utf8");
-        if (signal?.aborted) {
-          const err = new Error("Decryption was cancelled");
-          err.name = "AbortError";
-          reject(err);
-          return;
-        }
-        if (exitSignal) {
-          reject(new Error(`Process terminated with signal ${exitSignal}`));
-          return;
-        } else if (code !== 0) {
-          reject(
-            new CryptoError(
-              `GPG decryption failed (exit code ${code}): ${errorMessage}`,
-            ),
-          );
-          return;
-        } else if (errorMessage.trim() && !isExpectedGpgStderr(errorMessage)) {
-          reject(
-            // n.b. use JSON.stringify() to sanitize the error since it's not what we expect
-            // and could be the result of some sort of injection attack
-            new CryptoError(
-              `GPG decryption emitted stderr: ${JSON.stringify(errorMessage.trim())}`,
-            ),
-          );
-          return;
-        }
-
-        // Messages are not gzipped, so return the decrypted content directly as string
-        resolve(stdout.toString("utf8"));
-      });
-
-      gpgProcess.on("error", (error) => {
-        signal?.removeEventListener("abort", abortListener);
-        reject(
-          new CryptoError(
-            `Failed to start GPG process: ${error.message}`,
-            error,
-          ),
-        );
-      });
-    });
+    const gpgProcess = spawnGpgProcess(cmd, this.getSpawnOptions(), "message");
+    return collectGpgMessage(gpgProcess, encryptedContent, signal);
   }
 
   /**
@@ -292,150 +917,62 @@ export class Crypto {
     filepath: string,
     signal?: AbortSignal,
   ): Promise<string> {
+    throwIfAborted(signal);
     const cmd = this.getGpgCommand();
     cmd.push("--decrypt", filepath);
+    const tempDir = storage.createTempDir("securedrop-decrypt-");
+    const tempGpgOutput = tempDir.join("decrypted.gz");
 
-    return new Promise((resolve, reject) => {
-      // Create temporary directory for this operation
-      const tempDir = storage.createTempDir("securedrop-decrypt-");
-      const tempGpgOutput = tempDir.join("decrypted.gz");
+    try {
+      const gpgProcess = spawnGpgProcess(cmd, this.getSpawnOptions(), "file");
+      await writeGpgOutputToFile(gpgProcess, tempGpgOutput, signal);
+      const finalOutputPath = await this.decompressGpgOutput(
+        tempGpgOutput,
+        itemDirectory,
+        filepath,
+        signal,
+      );
+      return finalOutputPath;
+    } finally {
+      await removeDirectoryIfExists(tempDir.path);
+    }
+  }
 
-      const gpgOutputFile = fs.createWriteStream(tempGpgOutput);
-      let stderr = Buffer.alloc(0);
-
-      const gpgProcess = spawn(cmd[0], cmd.slice(1), this.getSpawnOptions());
-
-      let isSettled = false;
-
-      // Kill the process if the abort signal fires
-      const abortListener = () => {
-        gpgProcess.kill();
-      };
-
-      // Destroy the write stream and wait for it to fully close before deleting
-      // the temp directory, to avoid a race between a pending fs.open and rmSync.
-      const destroyAndCleanup = async () => {
-        gpgOutputFile.destroy();
-        try {
-          await finished(gpgOutputFile);
-        } catch {
-          // ignore stream errors during cleanup
-        }
-        fs.rmSync(tempDir.path, { recursive: true, force: true });
-      };
-
-      signal?.addEventListener("abort", abortListener, { once: true });
-
-      // Handle the case where the signal was already aborted before we registered the listener
-      if (signal?.aborted) {
-        signal?.removeEventListener("abort", abortListener);
-        isSettled = true;
-        gpgProcess.kill();
-        void destroyAndCleanup().finally(() => {
-          const err = new Error("Decryption was cancelled");
-          err.name = "AbortError";
-          reject(err);
-        });
-        return;
+  private async decompressGpgOutput(
+    gzipFilePath: string,
+    itemDirectory: PathBuilder,
+    encryptedFilePath: string,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    let finalOutputPath: string | null = null;
+    try {
+      throwIfAborted(signal);
+      const originalFilename = await this.readGzipHeaderFilenameFromFile(
+        gzipFilePath,
+        signal,
+      );
+      const finalFilename =
+        originalFilename || path.basename(encryptedFilePath, ".gpg");
+      finalOutputPath = itemDirectory.join(finalFilename);
+      await this.decompressGzipFileAtomically(
+        gzipFilePath,
+        itemDirectory,
+        finalOutputPath,
+        signal,
+      );
+      return finalOutputPath;
+    } catch (error) {
+      if (isCancellation(error)) {
+        throw createAbortError();
       }
-
-      // Stream GPG output directly to temporary file (no memory accumulation)
-      gpgProcess.stdout.pipe(gpgOutputFile);
-
-      // Collect stderr (error messages)
-      gpgProcess.stderr.on("data", (chunk) => {
-        stderr = Buffer.concat([stderr, chunk]);
-      });
-
-      gpgProcess.on("close", async (code, exitSignal) => {
-        if (isSettled) {
-          return;
-        }
-
-        signal?.removeEventListener("abort", abortListener);
-        gpgOutputFile.end();
-        const errorMessage = stderr.toString("utf8");
-
-        if (signal?.aborted) {
-          await destroyAndCleanup();
-          const err = new Error("Decryption was cancelled");
-          err.name = "AbortError";
-          isSettled = true;
-          reject(err);
-          return;
-        }
-        if (exitSignal) {
-          await destroyAndCleanup();
-          isSettled = true;
-          reject(new Error(`Process terminated with signal ${exitSignal}`));
-          return;
-        } else if (code !== 0) {
-          await destroyAndCleanup();
-          isSettled = true;
-          reject(
-            new CryptoError(
-              `GPG file decryption failed (exit code ${code}): ${errorMessage}`,
-            ),
-          );
-          return;
-        } else if (errorMessage.trim() && !isExpectedGpgStderr(errorMessage)) {
-          await destroyAndCleanup();
-          isSettled = true;
-          reject(
-            // n.b. use JSON.stringify() to sanitize the error since it's not what we expect
-            // and could be the result of some sort of injection attack
-            new CryptoError(
-              `GPG file decryption emitted stderr: ${JSON.stringify(errorMessage.trim())}`,
-            ),
-          );
-          return;
-        }
-
-        try {
-          // Extract original filename from gzip header
-          const originalFilename =
-            await this.readGzipHeaderFilenameFromFile(tempGpgOutput);
-
-          // Create final output file path
-          const finalFilename =
-            originalFilename || path.basename(filepath, ".gpg");
-          const finalAbsolutePath = itemDirectory.join(finalFilename);
-
-          await this.decompressGzipFileAtomically(
-            tempGpgOutput,
-            itemDirectory,
-            finalAbsolutePath,
-          );
-
-          // Clean up temporary GPG output file
-          fs.unlink(tempGpgOutput, () => {});
-
-          isSettled = true;
-          resolve(finalAbsolutePath);
-        } catch (error) {
-          // Clean up temp directory on error
-          fs.rmSync(tempDir.path, { recursive: true, force: true });
-          isSettled = true;
-          reject(
-            new CryptoError(
-              "Failed to decompress decrypted file",
-              error instanceof Error ? error : new Error(String(error)),
-            ),
-          );
-        }
-      });
-
-      gpgProcess.on("error", async (error) => {
-        signal?.removeEventListener("abort", abortListener);
-        await destroyAndCleanup();
-        reject(
-          new CryptoError(
-            `Failed to start GPG process for file decryption: ${error.message}`,
-            error,
-          ),
-        );
-      });
-    });
+      if (error instanceof CryptoError) {
+        throw error;
+      }
+      throw new CryptoError(
+        "Failed to decompress decrypted file",
+        asError(error),
+      );
+    }
   }
 
   /**
@@ -462,29 +999,52 @@ export class Crypto {
   private async streamDecompressGzipFile(
     gzipFilePath: string,
     outputPath: string,
+    signal?: AbortSignal,
   ): Promise<void> {
     const readStream = fs.createReadStream(gzipFilePath);
     const writeStream = fs.createWriteStream(outputPath, { flags: "wx" });
     const gunzip = createGunzip();
 
-    await pipeline(readStream, gunzip, writeStream);
+    await pipeline(
+      readStream,
+      gunzip,
+      createDecryptedByteLimit("Decompressed file"),
+      writeStream,
+      { signal },
+    );
   }
 
   private async decompressGzipFileAtomically(
     gzipFilePath: string,
     itemDirectory: PathBuilder,
     finalOutputPath: string,
+    signal?: AbortSignal,
   ): Promise<void> {
+    throwIfAborted(signal);
     const temporaryDirectory = fs.mkdtempSync(
       itemDirectory.join(".securedrop-decrypt-"),
     );
     const temporaryOutputPath = path.join(temporaryDirectory, "plaintext");
 
     try {
-      await this.streamDecompressGzipFile(gzipFilePath, temporaryOutputPath);
-      fs.renameSync(temporaryOutputPath, finalOutputPath);
+      await settleAbortable(
+        this.streamDecompressGzipFile(
+          gzipFilePath,
+          temporaryOutputPath,
+          signal,
+        ),
+        signal,
+      );
+      throwIfAborted(signal);
+      await syncFile(temporaryOutputPath, signal);
+      throwIfAborted(signal);
+      await publishFileWithoutReplace(
+        temporaryOutputPath,
+        finalOutputPath,
+        signal,
+      );
     } finally {
-      fs.rmSync(temporaryDirectory, { force: true, recursive: true });
+      await removeDirectoryIfExists(temporaryDirectory);
     }
   }
 
@@ -493,92 +1053,46 @@ export class Crypto {
    */
   private async readGzipHeaderFilenameFromFile(
     filePath: string,
+    signal?: AbortSignal,
   ): Promise<UnsafePathComponent | null> {
-    return new Promise((resolve, reject) => {
-      const readStream = fs.createReadStream(filePath, { start: 0, end: 1023 }); // Read first 1KB for header
-      let headerData = Buffer.alloc(0);
-
-      readStream.on("data", (chunk: string | Buffer) => {
-        const bufferChunk = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-        headerData = Buffer.concat([headerData, bufferChunk]);
-      });
-
-      readStream.on("end", () => {
-        try {
-          const filename = this.readGzipHeaderFilename(headerData);
-          resolve(filename);
-        } catch (error) {
-          reject(error);
-        }
-      });
-
-      readStream.on("error", reject);
-    });
+    throwIfAborted(signal);
+    const file = await fs.promises.open(filePath, "r");
+    try {
+      throwIfAborted(signal);
+      const header = Buffer.alloc(GZIP_HEADER_READ_BYTES);
+      const { bytesRead } = await settleAbortable(
+        file.read(header, 0, GZIP_HEADER_READ_BYTES, 0),
+        signal,
+      );
+      return this.readGzipHeaderFilename(header.subarray(0, bytesRead));
+    } finally {
+      await file.close();
+    }
   }
 
   /**
    * Extract original filename from gzip header
    */
   private readGzipHeaderFilename(data: Buffer): UnsafePathComponent | null {
-    if (data.length < 10) {
+    if (data.length < GZIP_FIXED_HEADER_BYTES) {
       throw new Error("Data too short to be a valid gzip file");
     }
 
-    // Check gzip magic number
-    const GZIP_MAGIC = Buffer.from([0x1f, 0x8b]);
     if (!data.subarray(0, 2).equals(GZIP_MAGIC)) {
       throw new Error(
         `Not a gzipped file (got ${data.subarray(0, 2).toString("hex")})`,
       );
     }
 
-    // Check compression method
-    const compressionMethod = data[2];
-    if (compressionMethod !== 8) {
+    if (data[2] !== 8) {
       throw new Error("Unknown compression method");
     }
 
-    // Get flags
     const flags = data[3];
-    const FEXTRA = 4; // Extra fields present
-    const FNAME = 8; // Filename present
-
-    let offset = 10; // Skip fixed header
-
-    // Skip extra fields if present
-    if (flags & FEXTRA) {
-      if (offset + 2 > data.length) {
-        throw new Error("Incomplete gzip header");
-      }
-      const extraLen = data.readUInt16LE(offset);
-      offset += 2 + extraLen;
+    if ((flags & GZIP_FILENAME_FLAG) === 0) {
+      return null;
     }
-
-    // Read filename if present
-    if (flags & FNAME) {
-      const filenameStart = offset;
-      let filenameEnd = filenameStart;
-
-      // Find null terminator
-      while (filenameEnd < data.length && data[filenameEnd] !== 0) {
-        filenameEnd++;
-      }
-
-      if (filenameEnd >= data.length) {
-        throw new Error("Filename in gzip header not null-terminated");
-      }
-
-      const filename = data
-        .subarray(filenameStart, filenameEnd)
-        .toString("utf8");
-
-      if (filename.trim().length === 0) {
-        return null;
-      }
-      return new UnsafePathComponent(filename);
-    }
-
-    return null; // No filename in header
+    return decodeGzipFilename(data, gzipFilenameOffset(data));
   }
 }
 

--- a/app/src/main/crypto.ts
+++ b/app/src/main/crypto.ts
@@ -401,8 +401,11 @@ export class Crypto {
             originalFilename || path.basename(filepath, ".gpg");
           const finalAbsolutePath = itemDirectory.join(finalFilename);
 
-          // Stream decompress the gzipped content to final file
-          await this.streamDecompressGzipFile(tempGpgOutput, finalAbsolutePath);
+          await this.decompressGzipFileAtomically(
+            tempGpgOutput,
+            itemDirectory,
+            finalAbsolutePath,
+          );
 
           // Clean up temporary GPG output file
           fs.unlink(tempGpgOutput, () => {});
@@ -461,10 +464,28 @@ export class Crypto {
     outputPath: string,
   ): Promise<void> {
     const readStream = fs.createReadStream(gzipFilePath);
-    const writeStream = fs.createWriteStream(outputPath);
+    const writeStream = fs.createWriteStream(outputPath, { flags: "wx" });
     const gunzip = createGunzip();
 
     await pipeline(readStream, gunzip, writeStream);
+  }
+
+  private async decompressGzipFileAtomically(
+    gzipFilePath: string,
+    itemDirectory: PathBuilder,
+    finalOutputPath: string,
+  ): Promise<void> {
+    const temporaryDirectory = fs.mkdtempSync(
+      itemDirectory.join(".securedrop-decrypt-"),
+    );
+    const temporaryOutputPath = path.join(temporaryDirectory, "plaintext");
+
+    try {
+      await this.streamDecompressGzipFile(gzipFilePath, temporaryOutputPath);
+      fs.renameSync(temporaryOutputPath, finalOutputPath);
+    } finally {
+      fs.rmSync(temporaryDirectory, { force: true, recursive: true });
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

- bound GPG stdout for file decrypts before writing the temporary gzip payload
- bound post-gzip plaintext before publishing the final decrypted file
- cover OpenPGP expansion, gzip expansion, cancellation, and cleanup through the real `Crypto.decryptFile()` path

## Context

Closes https://github.com/freedomofpress/securedrop-client/issues/3434.

This PR is stacked on #3583 because the cap failure path needs the same atomic publication boundary: write to an item-local temporary file, then hard-link into place only after gzip validation succeeds. Once #3583 lands, GitHub should show this PR as the cap-specific commit on top.

## Test plan

Baseline vulnerable-side evidence against `origin/main`:

```sh
node ptp-notes/research/client/pocs/openpgp-file-temp-expansion-poc.mjs 32
```

Observed: confirmed 44,282 downloaded bytes expanding to 33,554,432 bytes of temporary GPG output with GPG exit 0 and empty stderr.

```sh
node ptp-notes/research/client/pocs/crypto-valid-gzip-expansion-poc.mjs .worktrees/sdc-3434-baseline 8388608
```

Observed: confirmed 8,176 gzip bytes expanding to an 8,388,608-byte final output file.

Patched proof:

```sh
cd app
pnpm exec vitest run --config vitest.config.ts --project=unit \
  src/main/__tests__/crypto.gpg.test.ts \
  src/main/__tests__/crypto.integration.test.ts \
  --no-coverage --no-file-parallelism
```

Observed: 80 tests passed, including real-GPG `Crypto.decryptFile()` tests for an OpenPGP packet one byte over the intermediate GPG-output limit and a gzip member one byte over the plaintext limit. Both rejected and left no operation temp dirs or final plaintext output.

```sh
cd app
pnpm run lint
```

Observed: Prettier, ESLint, and both TypeScript checks passed.

```sh
git diff --check origin/main...HEAD
```

Observed: passed with no output.

## Notes

The publication boundary is intentionally before the final hard link. Cancellation is honored through GPG output, gzip header parsing, decompression, fsync, and the pre-link abort check. After the hard link succeeds, the operation is committed and returns the complete output path rather than reporting cancellation while leaving a valid file behind.

Qubes testing has not been run.

## Checklist

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database