### PR TITLE
fix(database): use stable conversation pagination cursors

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -32,6 +32,8 @@ import {
   FirstRunStatus,
   PendingEventData,
   SourceItemCounts,
+  GetSourceWithItemsOptions,
+  ConversationPaginationCursor,
 } from "../../types";
 import { Crypto } from "../crypto";
 import { Search } from "./search";
@@ -44,6 +46,23 @@ export const DEFAULT_PENDING_EVENTS_LIMIT = 20;
 
 interface KeyObject {
   [key: string]: object;
+}
+
+interface PaginationItemRow extends ItemRow {
+  interaction_count: number | null;
+}
+
+interface SourceItemsPage {
+  itemRows: PaginationItemRow[];
+  hasMoreHistoricalItems: boolean;
+  paginationCursor: ConversationPaginationCursor | undefined;
+  paginationGeneration: number;
+  paginationRestarted: boolean;
+}
+
+interface PendingConversationSeenRollback {
+  createdSnowflakeId: string;
+  previousEvent: { snowflake_id: string; data: string } | undefined;
 }
 
 const sortKeys = (_: string, value: KeyObject) =>
@@ -75,94 +94,107 @@ export class DB {
   private firstRunStatus: FirstRunStatus = null;
 
   // Prepared statements
-  private selectVersion: Statement<[], { version: string }>;
-  private insertVersion: Statement<[string], void>;
+  private selectVersion!: Statement<[], { version: string }>;
+  private insertVersion!: Statement<[string], void>;
+  private selectPaginationGeneration!: Statement<[], { generation: number }>;
 
-  private selectAllSourceVersion: Statement<
+  private selectAllSourceVersion!: Statement<
     [],
     { uuid: string; version: string }
   >;
-  private selectUnprojectedSourceVersion: Statement<
+  private selectUnprojectedSourceVersion!: Statement<
     { uuid: string },
     { version: string }
   >;
-  private upsertSource: Statement<
+  private upsertSource!: Statement<
     { uuid: string; data: string; version: string },
     void
   >;
-  private deleteSource: Statement<{ uuid: string }, void>;
+  private deleteSource!: Statement<{ uuid: string }, void>;
 
-  private selectAllItemVersion: Statement<
+  private selectAllItemVersion!: Statement<
     [],
     { uuid: string; version: string }
   >;
-  private selectUnprojectedItemVersion: Statement<
+  private selectUnprojectedItemVersion!: Statement<
     { uuid: string },
     { version: string }
   >;
-  private selectMessageItemsProcessable: Statement<
+  private selectMessageItemsProcessable!: Statement<
     { limit: number },
     { uuid: string }
   >;
-  private selectFileItemsProcessable: Statement<
+  private selectFileItemsProcessable!: Statement<
     { limit: number },
     { uuid: string }
   >;
-  private deleteUnprojectedItemsBySource: Statement<
+  private deleteUnprojectedItemsBySource!: Statement<
     { source_uuid: string },
     void
   >;
-  private upsertItem: Statement<
+  private upsertItem!: Statement<
     { uuid: string; data: string; version: string },
     void
   >;
-  private deleteItem: Statement<{ uuid: string }, void>;
-  private deleteItemMany: Statement<{ uuids_json: string }, void>;
-  private updateItemFetchStatus: Statement<{
+  private deleteItem!: Statement<{ uuid: string }, void>;
+  private deleteItemMany!: Statement<{ uuids_json: string }, void>;
+  private updateItemFetchStatus!: Statement<{
     uuid: string;
     fetch_status: number;
   }>;
-  private updateItemFetchStatusWithReset: Statement<{
+  private updateItemFetchStatusWithReset!: Statement<{
     uuid: string;
     fetch_status: number;
   }>;
-  private updateItemsFetchStatusBySource: Statement<{
+  private updateItemsFetchStatusBySource!: Statement<{
     source_uuid: string;
     fetch_status: number;
   }>;
-  private updateItemsFetchStatusBySourceUpTo: Statement<{
+  private updateItemsFetchStatusBySourceUpTo!: Statement<{
     source_uuid: string;
     upper_bound: number;
     fetch_status: number;
   }>;
-  private selectItem: Statement<{ uuid: string }, ItemRow>;
-  private selectItemMany: Statement<{ uuids_json: string }, ItemRow>;
+  private selectItem!: Statement<{ uuid: string }, ItemRow>;
+  private selectItemMany!: Statement<{ uuids_json: string }, ItemRow>;
 
-  private selectAllJournalistVersion: Statement<
+  private selectAllJournalistVersion!: Statement<
     [],
     { uuid: string; version: string }
   >;
-  private upsertJournalist: Statement<
+  private upsertJournalist!: Statement<
     { uuid: string; data: string; version: string },
     void
   >;
-  private selectJournalist: Statement<{ uuid: string }, JournalistRow>;
+  private selectJournalist!: Statement<{ uuid: string }, JournalistRow>;
 
-  private deleteJournalist: Statement<{ uuid: string }, void>;
+  private deleteJournalist!: Statement<{ uuid: string }, void>;
 
-  private selectAllSources: Statement<[], SourceRow>;
-  private selectSourceById: Statement<[string], SourceRow>;
-  private selectItemsBySourceId: Statement<[string, number], ItemRow>;
-  private selectItemsBySourceIdBefore: Statement<
-    [string, number, number],
-    ItemRow
+  private selectAllSources!: Statement<[], SourceRow>;
+  private selectSourceById!: Statement<[string], SourceRow>;
+  private selectItemsBySourceId!: Statement<
+    [string, number],
+    PaginationItemRow
   >;
-  private selectItemCountsBySourceUuids: Statement<
+  private selectItemsBySourceIdBefore!: Statement<
+    [string, number, number],
+    PaginationItemRow
+  >;
+  private selectItemsBySourceIdBeforeCursor!: Statement<
+    {
+      source_uuid: string;
+      before_interaction_count: number | null;
+      before_item_uuid: string;
+      limit: number;
+    },
+    PaginationItemRow
+  >;
+  private selectItemCountsBySourceUuids!: Statement<
     { uuids_json: string },
     { messages: number; files: number; replies: number }
   >;
-  private selectAllJournalists: Statement<[], JournalistRow>;
-  private insertSourcePendingEvent: Statement<
+  private selectAllJournalists!: Statement<[], JournalistRow>;
+  private insertSourcePendingEvent!: Statement<
     {
       snowflake_id: string;
       source_uuid: string;
@@ -171,7 +203,7 @@ export class DB {
     },
     void
   >;
-  private insertItemPendingEvent: Statement<
+  private insertItemPendingEvent!: Statement<
     {
       snowflake_id: string;
       item_uuid?: string;
@@ -180,28 +212,33 @@ export class DB {
     },
     void
   >;
-  private selectSourceConversationSeenEvent: Statement<
+  private selectSourceConversationSeenEvent!: Statement<
     { source_uuid: string },
     { snowflake_id: string; data: string }
   >;
-  private selectUnprojectedUnseenItemsCount: Statement<
+  private selectUnprojectedUnseenItemsCount!: Statement<
     { source_uuid: string; upper_bound: number },
     { count: number }
   >;
-  private deletePendingEvent: Statement<{ snowflake_id: string }, void>;
-  private incrementPendingEventRetry: Statement<
+  private deletePendingEvent!: Statement<{ snowflake_id: string }, void>;
+  private incrementPendingEventRetry!: Statement<
     { snowflake_id: string; status: number },
     void
   >;
-  private setPendingEventStatus: Statement<
+  private setPendingEventStatus!: Statement<
     { snowflake_id: string; status: number },
     void
   >;
-  private selectPendingEvents: Statement<[{ limit: number }], PendingEventRow>;
-  private deletePendingEventsBySourceScope: Statement<
+  private selectPendingEvents!: Statement<[{ limit: number }], PendingEventRow>;
+  private deletePendingEventsBySourceScope!: Statement<
     { source_uuid: string },
     void
   >;
+  private pendingSeenOwners = new Map<string, string>();
+  private pendingSeenRollbacks = new Map<
+    string,
+    PendingConversationSeenRollback | null
+  >();
 
   protected constructor(crypto: Crypto, dbDir?: string) {
     this.crypto = crypto;
@@ -265,32 +302,40 @@ export class DB {
     // Initialize search index
     this.searchIndex = new Search(db);
 
-    // Prepare statements
-    this.selectVersion = this.db.prepare("SELECT version FROM state");
-    this.insertVersion = this.db.prepare(
+    this.prepareStateStatements(db);
+    this.prepareItemStatements(db);
+    this.prepareJournalistStatements(db);
+    this.prepareConversationStatements(db);
+    this.preparePendingEventStatements(db);
+  }
+
+  private prepareStateStatements(db: Database.Database): void {
+    this.selectVersion = db.prepare("SELECT version FROM state");
+    this.insertVersion = db.prepare(
       "INSERT INTO state_history (version) VALUES (?)",
     );
+    this.selectPaginationGeneration = db.prepare(
+      "SELECT generation FROM pagination_state WHERE id = 1",
+    );
 
-    this.selectAllSourceVersion = this.db.prepare(
+    this.selectAllSourceVersion = db.prepare(
       "SELECT uuid, version FROM sources",
     );
-    this.selectUnprojectedSourceVersion = this.db.prepare(
+    this.selectUnprojectedSourceVersion = db.prepare(
       "SELECT version FROM sources WHERE uuid = @uuid",
     );
-    this.upsertSource = this.db.prepare(
+    this.upsertSource = db.prepare(
       "INSERT INTO sources (uuid, data, version) VALUES (@uuid, @data, @version) ON CONFLICT(uuid) DO UPDATE SET data=@data, version=@version",
     );
-    this.deleteSource = this.db.prepare(
-      "DELETE FROM sources WHERE uuid = @uuid",
-    );
+    this.deleteSource = db.prepare("DELETE FROM sources WHERE uuid = @uuid");
+  }
 
-    this.selectAllItemVersion = this.db.prepare(
-      "SELECT uuid, version FROM items",
-    );
-    this.selectUnprojectedItemVersion = this.db.prepare(
+  private prepareItemStatements(db: Database.Database): void {
+    this.selectAllItemVersion = db.prepare("SELECT uuid, version FROM items");
+    this.selectUnprojectedItemVersion = db.prepare(
       "SELECT version FROM items WHERE uuid = @uuid",
     );
-    this.selectMessageItemsProcessable = this.db.prepare(
+    this.selectMessageItemsProcessable = db.prepare(
       `SELECT items.uuid FROM items
       JOIN sources ON items.source_uuid = sources.uuid
       WHERE kind <> 'file'
@@ -298,7 +343,7 @@ export class DB {
       ORDER BY json_extract(sources.data, '$.last_updated') DESC, interaction_count DESC, items.uuid ASC
       LIMIT @limit`,
     );
-    this.selectFileItemsProcessable = this.db.prepare(
+    this.selectFileItemsProcessable = db.prepare(
       `SELECT items.uuid FROM items
       JOIN sources ON items.source_uuid = sources.uuid
       WHERE kind = 'file'
@@ -306,51 +351,58 @@ export class DB {
       ORDER BY json_extract(sources.data, '$.last_updated') DESC, interaction_count DESC, items.uuid ASC
       LIMIT @limit`,
     );
-    this.deleteUnprojectedItemsBySource = this.db.prepare(
+    this.deleteUnprojectedItemsBySource = db.prepare(
       "DELETE FROM items WHERE source_uuid = @source_uuid",
     );
-    this.updateItemFetchStatus = this.db.prepare(
+    this.updateItemFetchStatus = db.prepare(
       "UPDATE items SET fetch_status = @fetch_status WHERE uuid = @uuid",
     );
-    this.updateItemFetchStatusWithReset = this.db.prepare(
+    this.updateItemFetchStatusWithReset = db.prepare(
       "UPDATE items SET fetch_status = @fetch_status, fetch_progress = 0 WHERE uuid = @uuid",
     );
-    this.updateItemsFetchStatusBySource = this.db.prepare(
+    this.updateItemsFetchStatusBySource = db.prepare(
       "UPDATE items SET fetch_status = @fetch_status WHERE source_uuid = @source_uuid",
     );
-    this.updateItemsFetchStatusBySourceUpTo = this.db.prepare(
+    this.updateItemsFetchStatusBySourceUpTo = db.prepare(
       "UPDATE items SET fetch_status = @fetch_status WHERE source_uuid = @source_uuid AND interaction_count <= @upper_bound",
     );
-    this.upsertItem = this.db.prepare(
+    this.upsertItem = db.prepare(
       "INSERT INTO items (uuid, data, version) VALUES (@uuid, @data, @version) ON CONFLICT(uuid) DO UPDATE SET data=@data, version=@version",
     );
-    this.deleteItem = this.db.prepare("DELETE FROM items WHERE uuid = @uuid");
-    this.deleteItemMany = this.db.prepare(
+    this.deleteItem = db.prepare("DELETE FROM items WHERE uuid = @uuid");
+    this.deleteItemMany = db.prepare(
       "DELETE FROM items WHERE uuid IN (SELECT value FROM json_each(@uuids_json))",
     );
-    this.selectItem = this.db.prepare(
+    this.selectItem = db.prepare(
       `SELECT uuid, data, plaintext, filename, fetch_status, fetch_progress, decrypted_size FROM items WHERE uuid = @uuid`,
     );
-    this.selectItemMany = this.db.prepare(
+    this.selectItemMany = db.prepare(
       `SELECT uuid, data, plaintext, filename, fetch_status, fetch_progress, decrypted_size FROM items WHERE uuid IN (SELECT value FROM json_each(@uuids_json))`,
     );
+  }
 
-    this.selectAllJournalistVersion = this.db.prepare(
+  private prepareJournalistStatements(db: Database.Database): void {
+    this.selectAllJournalistVersion = db.prepare(
       "SELECT uuid, version FROM journalists",
     );
 
-    this.selectJournalist = this.db.prepare(
+    this.selectJournalist = db.prepare(
       "SELECT uuid, data FROM journalists WHERE uuid = @uuid",
     );
 
-    this.upsertJournalist = this.db.prepare(
+    this.upsertJournalist = db.prepare(
       "INSERT INTO journalists (uuid, data, version) VALUES (@uuid, @data, @version) ON CONFLICT(uuid) DO UPDATE SET data=@data, version=@version",
     );
-    this.deleteJournalist = this.db.prepare(
+    this.deleteJournalist = db.prepare(
       "DELETE FROM journalists WHERE uuid = @uuid",
     );
+    this.selectAllJournalists = db.prepare(`
+      SELECT uuid, data FROM journalists
+    `);
+  }
 
-    this.selectAllSources = this.db.prepare(`
+  private prepareConversationStatements(db: Database.Database): void {
+    this.selectAllSources = db.prepare(`
       SELECT
         s.uuid,
         s.data,
@@ -365,7 +417,7 @@ export class DB {
         ON s.uuid = i.source_uuid
         AND i.rn = 1;
     `);
-    this.selectSourceById = this.db.prepare(`
+    this.selectSourceById = db.prepare(`
       SELECT
         s.uuid,
         s.data,
@@ -380,19 +432,49 @@ export class DB {
         ON s.uuid = i.source_uuid AND i.rn = 1
       WHERE s.uuid = ?
     `);
-    this.selectItemsBySourceId = this.db.prepare(`
-      SELECT uuid, data, plaintext, filename, fetch_status, fetch_progress, decrypted_size, is_read FROM items_projected
+    this.selectItemsBySourceId = db.prepare(`
+      SELECT uuid, data, plaintext, filename, fetch_status, fetch_progress,
+        decrypted_size, is_read, interaction_count
+      FROM items_projected
       WHERE source_uuid = ?
-      ORDER BY interaction_count DESC
+      ORDER BY interaction_count DESC, uuid DESC
       LIMIT ?
     `);
-    this.selectItemsBySourceIdBefore = this.db.prepare(`
-      SELECT uuid, data, plaintext, filename, fetch_status, fetch_progress, decrypted_size FROM items_projected
+    this.selectItemsBySourceIdBefore = db.prepare(`
+      SELECT uuid, data, plaintext, filename, fetch_status, fetch_progress,
+        decrypted_size, is_read, interaction_count
+      FROM items_projected
       WHERE source_uuid = ? AND interaction_count < ?
-      ORDER BY interaction_count DESC
+      ORDER BY interaction_count DESC, uuid DESC
       LIMIT ?
     `);
-    this.selectItemCountsBySourceUuids = this.db.prepare(`
+    this.selectItemsBySourceIdBeforeCursor = db.prepare(`
+      SELECT uuid, data, plaintext, filename, fetch_status, fetch_progress,
+        decrypted_size, is_read, interaction_count
+      FROM items_projected
+      WHERE source_uuid = @source_uuid
+        AND (
+          (
+            @before_interaction_count IS NULL
+            AND interaction_count IS NULL
+            AND uuid < @before_item_uuid
+          )
+          OR (
+            @before_interaction_count IS NOT NULL
+            AND (
+              interaction_count IS NULL
+              OR interaction_count < @before_interaction_count
+              OR (
+                interaction_count = @before_interaction_count
+                AND uuid < @before_item_uuid
+              )
+            )
+          )
+        )
+      ORDER BY interaction_count DESC, uuid DESC
+      LIMIT @limit
+    `);
+    this.selectItemCountsBySourceUuids = db.prepare(`
       SELECT
         COALESCE(SUM(CASE WHEN kind = 'message' THEN 1 ELSE 0 END), 0) AS messages,
         COALESCE(SUM(CASE WHEN kind = 'file' THEN 1 ELSE 0 END), 0) AS files,
@@ -400,23 +482,22 @@ export class DB {
       FROM items_projected
       WHERE source_uuid IN (SELECT value FROM json_each(@uuids_json))
     `);
-    this.selectAllJournalists = this.db.prepare(`
-      SELECT uuid, data FROM journalists
-    `);
+  }
 
-    this.insertSourcePendingEvent = this.db.prepare(`
+  private preparePendingEventStatements(db: Database.Database): void {
+    this.insertSourcePendingEvent = db.prepare(`
       INSERT INTO pending_events (snowflake_id, source_uuid, type, data) VALUES (@snowflake_id, @source_uuid, @type, @data)
     `);
 
-    this.insertItemPendingEvent = this.db.prepare(`
+    this.insertItemPendingEvent = db.prepare(`
       INSERT INTO pending_events (snowflake_id, item_uuid, type, data) VALUES(@snowflake_id, @item_uuid, @type, @data)
     `);
 
-    this.selectSourceConversationSeenEvent = this.db.prepare(`
+    this.selectSourceConversationSeenEvent = db.prepare(`
       SELECT snowflake_id, data FROM pending_events
       WHERE source_uuid = @source_uuid AND type = 'source_conversation_seen'
     `);
-    this.selectUnprojectedUnseenItemsCount = this.db.prepare(`
+    this.selectUnprojectedUnseenItemsCount = db.prepare(`
       SELECT
         COUNT(*) AS count
       FROM items
@@ -424,27 +505,27 @@ export class DB {
         AND interaction_count <= @upper_bound
         AND is_read = 0
     `);
-    this.deletePendingEvent = this.db.prepare(
+    this.deletePendingEvent = db.prepare(
       `DELETE FROM pending_events WHERE snowflake_id = @snowflake_id`,
     );
-    this.incrementPendingEventRetry = this.db.prepare(`
+    this.incrementPendingEventRetry = db.prepare(`
       UPDATE pending_events
       SET retry_attempts = retry_attempts + 1, last_event_status = @status
       WHERE snowflake_id = @snowflake_id
     `);
-    this.setPendingEventStatus = this.db.prepare(`
+    this.setPendingEventStatus = db.prepare(`
       UPDATE pending_events
       SET last_event_status = @status
       WHERE snowflake_id = @snowflake_id
     `);
     // Schedule previously-failed events later, and exclude events already reported
     // and accepted on the server that are just awaiting completion.
-    this.selectPendingEvents = this.db.prepare(`
+    this.selectPendingEvents = db.prepare(`
       SELECT snowflake_id, source_uuid, item_uuid, type, data FROM pending_events
       WHERE last_event_status IS NOT ${EventStatus.AlreadyReported}
       ORDER BY retry_attempts ASC, snowflake_id ASC LIMIT @limit
     `);
-    this.deletePendingEventsBySourceScope = this.db.prepare(`
+    this.deletePendingEventsBySourceScope = db.prepare(`
       DELETE FROM pending_events
       WHERE source_uuid = @source_uuid
          OR item_uuid IN (
@@ -823,99 +904,177 @@ export class DB {
     return new Map(rows.map((row) => [row.uuid, this.toSource(row)]));
   }
 
-  getSourceWithItems(
-    sourceUuid: string,
-    options?: {
-      limit?: number;
-      beforeInteractionCount?: number;
-      journalistUuid?: string;
-    },
-  ): SourceWithItems {
+  getConversationPaginationGeneration(): number {
     if (!this.db) {
       throw new Error("Database is not open");
     }
-
-    const sourceRow = this.selectSourceById.get(sourceUuid) as
-      | SourceRow
-      | undefined;
-
-    if (!sourceRow) {
-      throw new Error(`Source with UUID ${sourceUuid} not found`);
+    const row = this.selectPaginationGeneration.get();
+    if (!row) {
+      throw new Error("Pagination generation state is missing");
     }
+    return row.generation;
+  }
 
-    const sourceData = JSON.parse(sourceRow.data);
+  private shouldRestartPagination(
+    options: GetSourceWithItemsOptions | undefined,
+    currentGeneration: number,
+  ): boolean {
+    return (
+      options?.beforeInteractionCount !== undefined &&
+      options.paginationGeneration !== undefined &&
+      options.paginationGeneration !== currentGeneration
+    );
+  }
 
-    let limit = DEFAULT_ITEM_LIMIT;
-    if (options?.limit) {
-      limit = options?.limit;
+  private selectSourceItemRows(
+    sourceUuid: string,
+    options: GetSourceWithItemsOptions | undefined,
+    fetchLimit: number,
+    paginationRestarted: boolean,
+  ): PaginationItemRow[] {
+    if (
+      !paginationRestarted &&
+      options?.beforeInteractionCount !== undefined &&
+      options.beforeItemUuid !== undefined
+    ) {
+      return this.selectItemsBySourceIdBeforeCursor.all({
+        source_uuid: sourceUuid,
+        before_interaction_count: options.beforeInteractionCount,
+        before_item_uuid: options.beforeItemUuid,
+        limit: fetchLimit,
+      });
     }
-    // Fetch limit+1 rows to detect if there are more historical items
-    const fetchLimit = limit + 1;
-    let rows: ItemRow[];
-    if (options?.beforeInteractionCount) {
-      rows = this.selectItemsBySourceIdBefore.all(
+    if (
+      !paginationRestarted &&
+      typeof options?.beforeInteractionCount === "number"
+    ) {
+      return this.selectItemsBySourceIdBefore.all(
         sourceUuid,
         options.beforeInteractionCount,
         fetchLimit,
       );
-    } else {
-      rows = this.selectItemsBySourceId.all(sourceUuid, fetchLimit);
     }
-    const hasMoreHistoricalItems = rows.length > limit;
-    // Take at most `limit` rows (DESC order), then reverse to ASC for display
-    const itemRows = rows.slice(0, limit).reverse();
+    return this.selectItemsBySourceId.all(sourceUuid, fetchLimit);
+  }
 
-    const items = itemRows.map((row) => {
+  private getSourceItemsPage(
+    sourceUuid: string,
+    options?: GetSourceWithItemsOptions,
+  ): SourceItemsPage {
+    const limit = options?.limit || DEFAULT_ITEM_LIMIT;
+    const paginationGeneration = this.getConversationPaginationGeneration();
+    const paginationRestarted = this.shouldRestartPagination(
+      options,
+      paginationGeneration,
+    );
+    const rows = this.selectSourceItemRows(
+      sourceUuid,
+      options,
+      limit + 1,
+      paginationRestarted,
+    );
+    const itemRows = rows.slice(0, limit).reverse();
+    const oldestRow = itemRows[0];
+    return {
+      itemRows,
+      hasMoreHistoricalItems: rows.length > limit,
+      paginationCursor: oldestRow
+        ? {
+            interactionCount: oldestRow.interaction_count,
+            itemUuid: oldestRow.uuid,
+          }
+        : undefined,
+      paginationGeneration,
+      paginationRestarted,
+    };
+  }
+
+  private toItems(rows: ItemRow[]): Item[] {
+    return rows.map((row) => {
       const data = JSON.parse(row.data) as ItemMetadata;
       if (row.is_read !== undefined && "is_read" in data) {
-        (data as { is_read: boolean }).is_read = this.isTruthy(row.is_read);
+        data.is_read = this.isTruthy(row.is_read);
       }
       return {
         uuid: row.uuid,
         data,
         plaintext: row.plaintext,
         filename: row.filename,
-        fetch_status: row.fetch_status,
+        fetch_status: row.fetch_status as FetchStatus,
         fetch_progress: row.fetch_progress,
         decrypted_size: row.decrypted_size,
       };
     });
+  }
 
-    // Return most recently seen message: all replies are seen, if journalistUuid is specified
-    // use seen_by field, otherwise fallback to the is_read field
-    const journalistUuid = options?.journalistUuid;
+  private getLastSeenInteractionCount(
+    items: Item[],
+    journalistUuid?: string,
+  ): number | null {
     let maxSeenInteractionCount: number | null = null;
     for (const item of items) {
-      const interaction = item.data.interaction_count ?? null;
-      if (interaction === null) {
+      const interaction = item.data.interaction_count;
+      if (interaction === null || interaction === undefined) {
         continue;
       }
-      let hasBeenSeen: boolean;
-      if (journalistUuid) {
-        hasBeenSeen = item.data.seen_by.includes(journalistUuid);
-      } else if (item.data.kind !== "reply") {
-        hasBeenSeen = item.data.is_read;
-      } else {
-        hasBeenSeen = true;
+      if (!this.hasItemBeenSeen(item, journalistUuid)) {
+        continue;
       }
-      if (
-        hasBeenSeen &&
-        (maxSeenInteractionCount === null ||
-          interaction > maxSeenInteractionCount)
-      ) {
-        maxSeenInteractionCount = interaction;
-      }
+      maxSeenInteractionCount =
+        maxSeenInteractionCount === null
+          ? interaction
+          : Math.max(maxSeenInteractionCount, interaction);
     }
-    // If nothing has been seen, return null
-    const lastSeenInteractionCount = maxSeenInteractionCount ?? null;
+    return maxSeenInteractionCount;
+  }
 
+  private hasItemBeenSeen(item: Item, journalistUuid?: string): boolean {
+    if (journalistUuid) {
+      return item.data.seen_by.includes(journalistUuid);
+    }
+    return item.data.kind === "reply" || item.data.is_read;
+  }
+
+  private getSourceWithItemsSnapshot(
+    sourceUuid: string,
+    options?: GetSourceWithItemsOptions,
+  ): SourceWithItems {
+    const sourceRow = this.selectSourceById.get(sourceUuid) as
+      | SourceRow
+      | undefined;
+    if (!sourceRow) {
+      throw new Error(`Source with UUID ${sourceUuid} not found`);
+    }
+    const page = this.getSourceItemsPage(sourceUuid, options);
+    const items = this.toItems(page.itemRows);
     return {
       uuid: sourceRow.uuid,
-      data: sourceData as SourceMetadata,
+      data: JSON.parse(sourceRow.data) as SourceMetadata,
       items,
-      hasMoreHistoricalItems,
-      lastSeenInteractionCount,
+      hasMoreHistoricalItems: page.hasMoreHistoricalItems,
+      lastSeenInteractionCount: this.getLastSeenInteractionCount(
+        items,
+        options?.journalistUuid,
+      ),
+      ...(page.paginationCursor
+        ? { paginationCursor: page.paginationCursor }
+        : {}),
+      paginationGeneration: page.paginationGeneration,
+      paginationRestarted: page.paginationRestarted,
     };
+  }
+
+  getSourceWithItems(
+    sourceUuid: string,
+    options?: GetSourceWithItemsOptions,
+  ): SourceWithItems {
+    if (!this.db) {
+      throw new Error("Database is not open");
+    }
+    const readSnapshot = this.db.transaction(() =>
+      this.getSourceWithItemsSnapshot(sourceUuid, options),
+    );
+    return readSnapshot();
   }
 
   getSourceItemCounts(sourceUuids: string[]): SourceItemCounts {
@@ -1121,47 +1280,69 @@ export class DB {
     });
   }
 
+  private applyPendingSourceEventEffects(
+    sourceUuid: string,
+    type: PendingEventType,
+    data?: PendingEventData,
+  ): void {
+    if (type === PendingEventType.SourceDeleted) {
+      this.purgePendingEventsForSource(sourceUuid);
+      this.markSourceItemsScheduledDeletion(sourceUuid);
+      return;
+    }
+    if (type !== PendingEventType.SourceConversationTruncated) {
+      return;
+    }
+    this.purgePendingEventsForSource(sourceUuid);
+    if (data?.upper_bound !== undefined) {
+      this.markSourceItemsScheduledDeletionUpTo(sourceUuid, data.upper_bound);
+    }
+  }
+
+  private insertPendingSourceEventRow(
+    snowflakeId: string,
+    sourceUuid: string,
+    type: PendingEventType,
+    data?: PendingEventData,
+  ): boolean {
+    try {
+      this.insertSourcePendingEvent.run({
+        snowflake_id: snowflakeId,
+        source_uuid: sourceUuid,
+        type,
+        data: data ? JSON.stringify(data) : null,
+      });
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "SQLITE_CONSTRAINT_FOREIGNKEY"
+      ) {
+        return false;
+      }
+      throw error;
+    }
+    return true;
+  }
+
   addPendingSourceEvent(
     sourceUuid: string,
     type: PendingEventType,
     data?: PendingEventData,
   ): string | null {
     return this.db!.transaction(() => {
-      const snowflakeID = this.snowflake
+      const snowflakeId = this.snowflake
         .generate({ timestamp: Date.now() })
         .toString();
-
-      if (type === PendingEventType.SourceDeleted) {
-        this.purgePendingEventsForSource(sourceUuid);
-        this.markSourceItemsScheduledDeletion(sourceUuid);
-      } else if (type === PendingEventType.SourceConversationTruncated) {
-        this.purgePendingEventsForSource(sourceUuid);
-        if (data?.upper_bound !== undefined) {
-          this.markSourceItemsScheduledDeletionUpTo(
-            sourceUuid,
-            data.upper_bound,
-          );
-        }
-      }
-
-      try {
-        this.insertSourcePendingEvent.run({
-          snowflake_id: snowflakeID,
-          source_uuid: sourceUuid,
-          type: type,
-          data: data ? JSON.stringify(data) : null,
-        });
-      } catch (err) {
-        if (err instanceof Error && "code" in err) {
-          if (err.code === "SQLITE_CONSTRAINT_FOREIGNKEY") {
-            return null;
-          } else {
-            throw err;
-          }
-        }
-      }
-
-      return snowflakeID;
+      this.applyPendingSourceEventEffects(sourceUuid, type, data);
+      return this.insertPendingSourceEventRow(
+        snowflakeId,
+        sourceUuid,
+        type,
+        data,
+      )
+        ? snowflakeId
+        : null;
     })();
   }
 
@@ -1250,8 +1431,10 @@ export class DB {
   addPendingSourceConversationSeen(
     sourceUuid: string,
     upperBound: number,
+    requestToken?: string,
   ): string | null {
-    return this.db!.transaction(() => {
+    let rollback: PendingConversationSeenRollback | null = null;
+    const snowflakeId = this.db!.transaction(() => {
       const unseen = this.selectUnprojectedUnseenItemsCount.get({
         source_uuid: sourceUuid,
         upper_bound: upperBound,
@@ -1274,12 +1457,12 @@ export class DB {
         this.deletePendingEvent.run({ snowflake_id: existing.snowflake_id });
       }
 
-      const snowflakeId = this.snowflake
+      const nextSnowflakeId = this.snowflake
         .generate({ timestamp: Date.now() })
         .toString();
       try {
         this.insertSourcePendingEvent.run({
-          snowflake_id: snowflakeId,
+          snowflake_id: nextSnowflakeId,
           source_uuid: sourceUuid,
           type: PendingEventType.SourceConversationSeen,
           data: JSON.stringify({ upper_bound: upperBound }),
@@ -1294,7 +1477,94 @@ export class DB {
         }
       }
 
-      return snowflakeId;
+      rollback = {
+        createdSnowflakeId: nextSnowflakeId,
+        previousEvent: existing,
+      };
+      return nextSnowflakeId;
+    })();
+    if (requestToken) {
+      const inheritedRollback = this.claimPendingSeenOwnership(
+        sourceUuid,
+        requestToken,
+      );
+      this.pendingSeenRollbacks.set(
+        requestToken,
+        this.collapsePendingSeenRollback(rollback, inheritedRollback),
+      );
+      return snowflakeId ?? inheritedRollback?.createdSnowflakeId ?? null;
+    }
+    return snowflakeId;
+  }
+
+  private claimPendingSeenOwnership(
+    sourceUuid: string,
+    requestToken: string | undefined,
+  ): PendingConversationSeenRollback | null | undefined {
+    if (!requestToken) {
+      return undefined;
+    }
+    const previousOwner = this.pendingSeenOwners.get(sourceUuid);
+    const inherited = previousOwner
+      ? this.pendingSeenRollbacks.get(previousOwner)
+      : undefined;
+    if (previousOwner) {
+      this.pendingSeenRollbacks.delete(previousOwner);
+    }
+    this.pendingSeenOwners.set(sourceUuid, requestToken);
+    return inherited;
+  }
+
+  private collapsePendingSeenRollback(
+    rollback: PendingConversationSeenRollback | null,
+    inherited: PendingConversationSeenRollback | null | undefined,
+  ): PendingConversationSeenRollback | null {
+    if (!rollback) {
+      return inherited ?? null;
+    }
+    if (
+      inherited &&
+      rollback.previousEvent?.snowflake_id === inherited.createdSnowflakeId
+    ) {
+      rollback.previousEvent = inherited.previousEvent;
+    }
+    return rollback;
+  }
+
+  finalizePendingSourceConversationSeen(
+    sourceUuid: string,
+    requestToken: string,
+    keep: boolean,
+  ): boolean {
+    const ownsChange = this.pendingSeenOwners.get(sourceUuid) === requestToken;
+    const rollback = this.pendingSeenRollbacks.get(requestToken);
+    this.pendingSeenRollbacks.delete(requestToken);
+    if (!ownsChange) {
+      return false;
+    }
+    this.pendingSeenOwners.delete(sourceUuid);
+    if (keep || !rollback) {
+      return false;
+    }
+    return this.db!.transaction(() => {
+      const current = this.selectSourceConversationSeenEvent.get({
+        source_uuid: sourceUuid,
+      });
+      if (current?.snowflake_id !== rollback.createdSnowflakeId) {
+        return false;
+      }
+      this.deletePendingEvent.run({
+        snowflake_id: rollback.createdSnowflakeId,
+      });
+      if (rollback.previousEvent) {
+        this.insertSourcePendingEvent.run({
+          snowflake_id: rollback.previousEvent.snowflake_id,
+          source_uuid: sourceUuid,
+          type: PendingEventType.SourceConversationSeen,
+          data: rollback.previousEvent.data,
+        });
+      }
+      return true;
     })();
   }
 

--- a/app/src/main/database/migrations/20260710000000_conversation_pagination_generation.sql
+++ b/app/src/main/database/migrations/20260710000000_conversation_pagination_generation.sql
@@ -1,0 +1,127 @@
+-- migrate:up
+
+CREATE TABLE pagination_state (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    generation INTEGER NOT NULL
+);
+
+INSERT INTO pagination_state (id, generation) VALUES (1, 0);
+
+CREATE TRIGGER items_pagination_generation_insert
+AFTER INSERT ON items
+BEGIN
+    UPDATE pagination_state SET generation = generation + 1 WHERE id = 1;
+END;
+
+CREATE TRIGGER items_pagination_generation_update
+AFTER UPDATE OF uuid, data ON items
+WHEN OLD.uuid IS NOT NEW.uuid
+    OR json_extract(OLD.data, '$.source') IS NOT
+        json_extract(NEW.data, '$.source')
+    OR json_extract(OLD.data, '$.interaction_count') IS NOT
+        json_extract(NEW.data, '$.interaction_count')
+BEGIN
+    UPDATE pagination_state SET generation = generation + 1 WHERE id = 1;
+END;
+
+CREATE TRIGGER items_pagination_generation_delete
+AFTER DELETE ON items
+BEGIN
+    UPDATE pagination_state SET generation = generation + 1 WHERE id = 1;
+END;
+
+CREATE TRIGGER pending_events_pagination_generation_insert
+AFTER INSERT ON pending_events
+WHEN NEW.type IN (
+    'item_deleted',
+    'reply_sent',
+    'source_conversation_truncated',
+    'source_deleted'
+)
+BEGIN
+    UPDATE pagination_state SET generation = generation + 1 WHERE id = 1;
+END;
+
+CREATE TRIGGER pending_events_pagination_generation_update
+AFTER UPDATE OF snowflake_id, type, data, source_uuid, item_uuid ON pending_events
+WHEN (
+        OLD.type IS NOT NEW.type
+        AND (
+            OLD.type IN (
+                'item_deleted',
+                'reply_sent',
+                'source_conversation_truncated',
+                'source_deleted'
+            )
+            OR NEW.type IN (
+                'item_deleted',
+                'reply_sent',
+                'source_conversation_truncated',
+                'source_deleted'
+            )
+        )
+    )
+    OR (
+        OLD.type = 'item_deleted'
+        AND NEW.type = 'item_deleted'
+        AND (
+            OLD.snowflake_id IS NOT NEW.snowflake_id
+            OR OLD.item_uuid IS NOT NEW.item_uuid
+        )
+    )
+    OR (
+        OLD.type = 'reply_sent'
+        AND NEW.type = 'reply_sent'
+        AND (
+            OLD.snowflake_id IS NOT NEW.snowflake_id
+            OR json_extract(OLD.data, '$.metadata.uuid') IS NOT
+                json_extract(NEW.data, '$.metadata.uuid')
+            OR json_extract(OLD.data, '$.metadata.source') IS NOT
+                json_extract(NEW.data, '$.metadata.source')
+            OR json_extract(OLD.data, '$.metadata.interaction_count') IS NOT
+                json_extract(NEW.data, '$.metadata.interaction_count')
+        )
+    )
+    OR (
+        OLD.type = 'source_conversation_truncated'
+        AND NEW.type = 'source_conversation_truncated'
+        AND (
+            OLD.snowflake_id IS NOT NEW.snowflake_id
+            OR OLD.source_uuid IS NOT NEW.source_uuid
+            OR json_extract(OLD.data, '$.upper_bound') IS NOT
+                json_extract(NEW.data, '$.upper_bound')
+        )
+    )
+    OR (
+        OLD.type = 'source_deleted'
+        AND NEW.type = 'source_deleted'
+        AND (
+            OLD.snowflake_id IS NOT NEW.snowflake_id
+            OR OLD.source_uuid IS NOT NEW.source_uuid
+        )
+    )
+BEGIN
+    UPDATE pagination_state SET generation = generation + 1 WHERE id = 1;
+END;
+
+CREATE TRIGGER pending_events_pagination_generation_delete
+AFTER DELETE ON pending_events
+WHEN OLD.type IN (
+    'item_deleted',
+    'reply_sent',
+    'source_conversation_truncated',
+    'source_deleted'
+)
+BEGIN
+    UPDATE pagination_state SET generation = generation + 1 WHERE id = 1;
+END;
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS pending_events_pagination_generation_delete;
+DROP TRIGGER IF EXISTS pending_events_pagination_generation_update;
+DROP TRIGGER IF EXISTS pending_events_pagination_generation_insert;
+DROP TRIGGER IF EXISTS items_pagination_generation_delete;
+DROP TRIGGER IF EXISTS items_pagination_generation_update;
+DROP TRIGGER IF EXISTS items_pagination_generation_insert;
+DROP TABLE IF EXISTS pagination_state;

--- a/app/src/main/database/schema.sql
+++ b/app/src/main/database/schema.sql
@@ -273,6 +273,113 @@ WHERE
             pending_events.type = 'source_deleted'
     )
 /* sources_projected(uuid,data,version,has_attachment,is_seen) */;
+CREATE TABLE pagination_state (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    generation INTEGER NOT NULL
+);
+CREATE TRIGGER items_pagination_generation_insert
+AFTER INSERT ON items
+BEGIN
+    UPDATE pagination_state SET generation = generation + 1 WHERE id = 1;
+END;
+CREATE TRIGGER items_pagination_generation_update
+AFTER UPDATE OF uuid, data ON items
+WHEN OLD.uuid IS NOT NEW.uuid
+    OR json_extract(OLD.data, '$.source') IS NOT
+        json_extract(NEW.data, '$.source')
+    OR json_extract(OLD.data, '$.interaction_count') IS NOT
+        json_extract(NEW.data, '$.interaction_count')
+BEGIN
+    UPDATE pagination_state SET generation = generation + 1 WHERE id = 1;
+END;
+CREATE TRIGGER items_pagination_generation_delete
+AFTER DELETE ON items
+BEGIN
+    UPDATE pagination_state SET generation = generation + 1 WHERE id = 1;
+END;
+CREATE TRIGGER pending_events_pagination_generation_insert
+AFTER INSERT ON pending_events
+WHEN NEW.type IN (
+    'item_deleted',
+    'reply_sent',
+    'source_conversation_truncated',
+    'source_deleted'
+)
+BEGIN
+    UPDATE pagination_state SET generation = generation + 1 WHERE id = 1;
+END;
+CREATE TRIGGER pending_events_pagination_generation_update
+AFTER UPDATE OF snowflake_id, type, data, source_uuid, item_uuid ON pending_events
+WHEN (
+        OLD.type IS NOT NEW.type
+        AND (
+            OLD.type IN (
+                'item_deleted',
+                'reply_sent',
+                'source_conversation_truncated',
+                'source_deleted'
+            )
+            OR NEW.type IN (
+                'item_deleted',
+                'reply_sent',
+                'source_conversation_truncated',
+                'source_deleted'
+            )
+        )
+    )
+    OR (
+        OLD.type = 'item_deleted'
+        AND NEW.type = 'item_deleted'
+        AND (
+            OLD.snowflake_id IS NOT NEW.snowflake_id
+            OR OLD.item_uuid IS NOT NEW.item_uuid
+        )
+    )
+    OR (
+        OLD.type = 'reply_sent'
+        AND NEW.type = 'reply_sent'
+        AND (
+            OLD.snowflake_id IS NOT NEW.snowflake_id
+            OR json_extract(OLD.data, '$.metadata.uuid') IS NOT
+                json_extract(NEW.data, '$.metadata.uuid')
+            OR json_extract(OLD.data, '$.metadata.source') IS NOT
+                json_extract(NEW.data, '$.metadata.source')
+            OR json_extract(OLD.data, '$.metadata.interaction_count') IS NOT
+                json_extract(NEW.data, '$.metadata.interaction_count')
+        )
+    )
+    OR (
+        OLD.type = 'source_conversation_truncated'
+        AND NEW.type = 'source_conversation_truncated'
+        AND (
+            OLD.snowflake_id IS NOT NEW.snowflake_id
+            OR OLD.source_uuid IS NOT NEW.source_uuid
+            OR json_extract(OLD.data, '$.upper_bound') IS NOT
+                json_extract(NEW.data, '$.upper_bound')
+        )
+    )
+    OR (
+        OLD.type = 'source_deleted'
+        AND NEW.type = 'source_deleted'
+        AND (
+            OLD.snowflake_id IS NOT NEW.snowflake_id
+            OR OLD.source_uuid IS NOT NEW.source_uuid
+        )
+    )
+BEGIN
+    UPDATE pagination_state SET generation = generation + 1 WHERE id = 1;
+END;
+CREATE TRIGGER pending_events_pagination_generation_delete
+AFTER DELETE ON pending_events
+WHEN OLD.type IN (
+    'item_deleted',
+    'reply_sent',
+    'source_conversation_truncated',
+    'source_deleted'
+)
+BEGIN
+    UPDATE pagination_state SET generation = generation + 1 WHERE id = 1;
+END;
 -- Dbmate schema migrations
 INSERT INTO "schema_migrations" (version) VALUES
   ('20260203225412'),
@@ -283,4 +390,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20260416000000'),
   ('20260507000000'),
   ('20260511000000'),
-  ('20260624000000');
+  ('20260624000000'),
+  ('20260710000000');

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -10,6 +10,7 @@ import {
   Journalist,
   JournalistMetadata,
   SubmissionMetadata,
+  SourceWithItems,
 } from "../types";
 import { Crypto } from "./crypto";
 import { Datastore } from "./datastore";
@@ -244,6 +245,114 @@ describe("Datastore Method Tests", () => {
       seen_by: [],
       interaction_count: interaction_count,
     };
+  }
+
+  function paginationUuid(index: number): string {
+    return `00000000-0000-4000-8000-${index.toString().padStart(12, "0")}`;
+  }
+
+  const paginationSourceUuid = "10000000-0000-4000-8000-000000000000";
+
+  function paginationItems(counts: number[]): Record<string, ItemMetadata> {
+    return Object.fromEntries(
+      counts.map((interactionCount, index) => {
+        const uuid = paginationUuid(index + 1);
+        return [
+          uuid,
+          mockItemMetadata(
+            uuid,
+            paginationSourceUuid,
+            "message",
+            interactionCount,
+          ),
+        ];
+      }),
+    );
+  }
+
+  function traverseConversation(limit: number): {
+    items: SourceWithItems["items"];
+    pageLengths: number[];
+    hasMoreStates: boolean[];
+  } {
+    let page = db.getSourceWithItems(paginationSourceUuid, { limit });
+    let items = page.items;
+    const pageLengths = [page.items.length];
+    const hasMoreStates = [page.hasMoreHistoricalItems ?? false];
+    while (page.hasMoreHistoricalItems) {
+      const cursor = page.paginationCursor;
+      if (!cursor) {
+        throw new Error("Paginated response is missing its cursor");
+      }
+      page = db.getSourceWithItems(paginationSourceUuid, {
+        limit,
+        beforeInteractionCount: cursor.interactionCount,
+        beforeItemUuid: cursor.itemUuid,
+        paginationGeneration: page.paginationGeneration,
+      });
+      items = page.paginationRestarted ? page.items : [...page.items, ...items];
+      pageLengths.push(page.items.length);
+      hasMoreStates.push(page.hasMoreHistoricalItems ?? false);
+    }
+    return { items, pageLengths, hasMoreStates };
+  }
+
+  async function traverseLargeConversation(
+    limit: number,
+  ): Promise<{ items: SourceWithItems["items"]; pageCount: number }> {
+    let page = db.getSourceWithItems(paginationSourceUuid, { limit });
+    let items = page.items;
+    let pageCount = 1;
+    while (page.hasMoreHistoricalItems) {
+      const cursor = page.paginationCursor;
+      if (!cursor) {
+        throw new Error("Paginated response is missing its cursor");
+      }
+      page = db.getSourceWithItems(paginationSourceUuid, {
+        limit,
+        beforeInteractionCount: cursor.interactionCount,
+        beforeItemUuid: cursor.itemUuid,
+        paginationGeneration: page.paginationGeneration,
+      });
+      items = [...page.items, ...items];
+      pageCount += 1;
+      if (pageCount % 10 === 0) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+    }
+    return { items, pageCount };
+  }
+
+  function sortedPaginationUuids(
+    items: Record<string, ItemMetadata>,
+  ): string[] {
+    return Object.entries(items)
+      .sort(([uuidA, itemA], [uuidB, itemB]) => {
+        const countDifference =
+          itemA.interaction_count - itemB.interaction_count;
+        if (countDifference !== 0) {
+          return countDifference;
+        }
+        return uuidA < uuidB ? -1 : uuidA > uuidB ? 1 : 0;
+      })
+      .map(([uuid]) => uuid);
+  }
+
+  function paginationGeneration(): number {
+    return db["db"]!.prepare(
+      "SELECT generation FROM pagination_state WHERE id = 1",
+    )
+      .pluck()
+      .get() as number;
+  }
+
+  function expectPaginationGenerationDelta(
+    expectedDelta: number,
+    operation: () => unknown,
+  ): void {
+    const before = paginationGeneration();
+    operation();
+    expect(paginationGeneration() - before).toBe(expectedDelta);
   }
 
   it("getJournalistbyID should return the first matching journalist", () => {
@@ -687,6 +796,744 @@ describe("Datastore Method Tests", () => {
 
     // Verify the returned items are already sorted
     expect(items).toEqual(sortedItems);
+  });
+
+  it.each([
+    {
+      name: "unique counts",
+      counts: Array.from({ length: 251 }, (_, index) => index + 1),
+      pageLengths: [100, 100, 51],
+    },
+    {
+      name: "all tied counts",
+      counts: Array.from({ length: 151 }, () => 100),
+      pageLengths: [100, 51],
+    },
+    {
+      name: "mixed negative, zero, and fractional counts",
+      counts: [-7.5, 0, 0.5, 1, 100].flatMap((count) =>
+        Array.from({ length: 61 }, () => count),
+      ),
+      pageLengths: [100, 100, 100, 5],
+    },
+  ])("paginates $name exactly once", ({ counts, pageLengths }) => {
+    db.updateSources({
+      [paginationSourceUuid]: mockSourceMetadata(paginationSourceUuid),
+    });
+    const items = paginationItems(counts);
+    db.updateItems(items);
+
+    const traversal = traverseConversation(100);
+
+    expect(traversal.pageLengths).toEqual(pageLengths);
+    expect(traversal.hasMoreStates).toEqual(
+      pageLengths.map((_, index) => index < pageLengths.length - 1),
+    );
+    expect(new Set(traversal.items.map((item) => item.uuid)).size).toBe(
+      counts.length,
+    );
+    expect(traversal.items.map((item) => item.uuid)).toEqual(
+      sortedPaginationUuids(items),
+    );
+  });
+
+  it("traverses schema-permitted null counts and malformed UUIDs", () => {
+    db.updateSources({
+      [paginationSourceUuid]: mockSourceMetadata(paginationSourceUuid),
+    });
+    const validItems = paginationItems(Array.from({ length: 101 }, () => 1));
+    db.updateItems(validItems);
+    const malformedUuids = Array.from(
+      { length: 101 },
+      (_, index) => `malformed-item-${(index + 1).toString().padStart(3, "0")}`,
+    );
+    const insert = db["db"]!.prepare(
+      "INSERT INTO items (uuid, data) VALUES (?, ?)",
+    );
+    const insertMalformed = db["db"]!.transaction(() => {
+      for (const uuid of malformedUuids) {
+        insert.run(
+          uuid,
+          JSON.stringify({
+            is_read: false,
+            kind: "message",
+            seen_by: [],
+            size: 1,
+            source: paginationSourceUuid,
+            uuid,
+          }),
+        );
+      }
+    });
+    insertMalformed();
+
+    const traversal = traverseConversation(100);
+
+    expect(traversal.pageLengths).toEqual([100, 100, 2]);
+    expect(traversal.hasMoreStates).toEqual([true, true, false]);
+    expect(traversal.items).toHaveLength(202);
+    expect(new Set(traversal.items.map((item) => item.uuid)).size).toBe(202);
+    expect(traversal.items.map((item) => item.uuid)).toEqual([
+      ...malformedUuids,
+      ...sortedPaginationUuids(validItems),
+    ]);
+  });
+
+  it("traverses 20,000 tied rows exactly once with an inspected query plan", async () => {
+    db.updateSources({
+      [paginationSourceUuid]: mockSourceMetadata(paginationSourceUuid),
+    });
+    const items = paginationItems(Array.from({ length: 20_000 }, () => 100));
+    db.updateItems(items);
+    const raw = db["db"]!;
+    const plan = raw
+      .prepare(
+        `EXPLAIN QUERY PLAN
+           SELECT uuid, interaction_count
+           FROM items_projected
+           WHERE source_uuid = @source_uuid
+             AND (
+               interaction_count < @before_interaction_count
+               OR (
+                 interaction_count = @before_interaction_count
+                 AND uuid < @before_item_uuid
+               )
+             )
+           ORDER BY interaction_count DESC, uuid DESC
+           LIMIT @limit`,
+      )
+      .all({
+        source_uuid: paginationSourceUuid,
+        before_interaction_count: 100,
+        before_item_uuid: paginationUuid(19_901),
+        limit: 101,
+      }) as { detail: string }[];
+    const started = performance.now();
+    const traversal = await traverseLargeConversation(100);
+    const elapsedMs = performance.now() - started;
+
+    expect(traversal.items).toHaveLength(20_000);
+    expect(new Set(traversal.items.map((item) => item.uuid)).size).toBe(20_000);
+    expect(traversal.items.map((item) => item.uuid)).toEqual(
+      sortedPaginationUuids(items),
+    );
+    expect(traversal.pageCount).toBe(200);
+    expect(
+      plan.some((row) => row.detail.includes("idx_items_source_uuid")),
+    ).toBe(true);
+    expect(elapsedMs).toBeLessThan(60_000);
+    console.log(
+      `PAGINATION_20K=${JSON.stringify({ elapsedMs, pages: 200, plan })}`,
+    );
+  }, 120_000);
+
+  it("preserves legacy count-only pagination", () => {
+    db.updateSources({
+      [paginationSourceUuid]: mockSourceMetadata(paginationSourceUuid),
+    });
+    db.updateItems(
+      paginationItems(Array.from({ length: 151 }, (_, index) => index + 1)),
+    );
+
+    const olderPage = db.getSourceWithItems(paginationSourceUuid, {
+      limit: 100,
+      beforeInteractionCount: 52,
+    });
+
+    expect(olderPage.items).toHaveLength(51);
+    expect(olderPage.items[0].data.interaction_count).toBe(1);
+    expect(olderPage.items[50].data.interaction_count).toBe(51);
+    expect(olderPage.hasMoreHistoricalItems).toBe(false);
+  });
+
+  it("restarts when an unloaded item moves above the cursor", () => {
+    db.updateSources({
+      [paginationSourceUuid]: mockSourceMetadata(paginationSourceUuid),
+    });
+    const items = paginationItems(Array.from({ length: 151 }, () => 100));
+    db.updateItems(items);
+    const firstPage = db.getSourceWithItems(paginationSourceUuid, {
+      limit: 100,
+    });
+    const movedUuid = paginationUuid(1);
+    items[movedUuid] = {
+      ...items[movedUuid],
+      interaction_count: 101,
+    };
+    db.updateBatch({
+      sources: {},
+      items: { [movedUuid]: items[movedUuid] },
+      journalists: {},
+      events: {},
+    });
+
+    const cursor = firstPage.items[0];
+    const restartedPage = db.getSourceWithItems(paginationSourceUuid, {
+      limit: 100,
+      beforeInteractionCount: cursor.data.interaction_count,
+      beforeItemUuid: cursor.uuid,
+      paginationGeneration: firstPage.paginationGeneration,
+    });
+
+    expect(restartedPage.paginationRestarted).toBe(true);
+    expect(restartedPage.paginationGeneration).not.toBe(
+      firstPage.paginationGeneration,
+    );
+    expect(restartedPage.items.map((item) => item.uuid)).toContain(movedUuid);
+    const restartedCursor = restartedPage.items[0];
+    const finalPage = db.getSourceWithItems(paginationSourceUuid, {
+      limit: 100,
+      beforeInteractionCount: restartedCursor.data.interaction_count,
+      beforeItemUuid: restartedCursor.uuid,
+      paginationGeneration: restartedPage.paginationGeneration,
+    });
+    const recoveredItems = [...finalPage.items, ...restartedPage.items];
+    expect(finalPage.items).toHaveLength(51);
+    expect(finalPage.hasMoreHistoricalItems).toBe(false);
+    expect(new Set(recoveredItems.map((item) => item.uuid)).size).toBe(151);
+    expect(recoveredItems.map((item) => item.uuid)).toEqual(
+      sortedPaginationUuids(items),
+    );
+  });
+
+  it("does not restart pagination for a conversation-seen event", () => {
+    db.updateSources({
+      [paginationSourceUuid]: mockSourceMetadata(paginationSourceUuid),
+    });
+    db.updateItems(paginationItems(Array.from({ length: 151 }, () => 100)));
+    const firstPage = db.getSourceWithItems(paginationSourceUuid, {
+      limit: 100,
+    });
+    expect(
+      db.addPendingSourceConversationSeen(paginationSourceUuid, 100),
+    ).not.toBeNull();
+
+    const cursor = firstPage.items[0];
+    const olderPage = db.getSourceWithItems(paginationSourceUuid, {
+      limit: 100,
+      beforeInteractionCount: cursor.data.interaction_count,
+      beforeItemUuid: cursor.uuid,
+      paginationGeneration: firstPage.paginationGeneration,
+    });
+
+    expect(olderPage.paginationRestarted).toBe(false);
+    expect(olderPage.paginationGeneration).toBe(firstPage.paginationGeneration);
+    expect(olderPage.items).toHaveLength(51);
+    expect(olderPage.hasMoreHistoricalItems).toBe(false);
+    expect(
+      db
+        .getPendingEvents()
+        .filter(
+          (event) => event.type === PendingEventType.SourceConversationSeen,
+        ),
+    ).toHaveLength(1);
+  });
+
+  it("advances generation only for item cursor-dataset changes", () => {
+    const itemUuid = paginationUuid(1);
+    const original = paginationItems([1])[itemUuid] as SubmissionMetadata;
+    db.updateSources({
+      [paginationSourceUuid]: mockSourceMetadata(paginationSourceUuid),
+      source2: mockSourceMetadata("source2"),
+    });
+    db.updateItems({ [itemUuid]: original });
+
+    expectPaginationGenerationDelta(0, () =>
+      db.updateItems({ [itemUuid]: original }),
+    );
+    expectPaginationGenerationDelta(0, () =>
+      db.updateItems({ [itemUuid]: { ...original, size: 2 } }),
+    );
+    expectPaginationGenerationDelta(0, () =>
+      db.updateItems({ [itemUuid]: { ...original, seen_by: ["journalist"] } }),
+    );
+    expectPaginationGenerationDelta(0, () =>
+      db.updateItems({ [itemUuid]: { ...original, is_read: true } }),
+    );
+    expectPaginationGenerationDelta(0, () =>
+      db.updateDownloadInProgress(itemUuid, 10),
+    );
+    expectPaginationGenerationDelta(0, () =>
+      db.updateFetchStatus(itemUuid, FetchStatus.ScheduledDeletion),
+    );
+
+    expectPaginationGenerationDelta(1, () =>
+      db.updateItems({
+        [itemUuid]: { ...original, interaction_count: 2 },
+      }),
+    );
+    expectPaginationGenerationDelta(1, () =>
+      db.updateItems({ [itemUuid]: { ...original, source: "source2" } }),
+    );
+    const replacementUuid = paginationUuid(2);
+    expectPaginationGenerationDelta(1, () =>
+      db["db"]!.prepare("UPDATE items SET uuid = ? WHERE uuid = ?").run(
+        replacementUuid,
+        itemUuid,
+      ),
+    );
+    expectPaginationGenerationDelta(1, () =>
+      db.updateItems({ [replacementUuid]: null }),
+    );
+    expectPaginationGenerationDelta(1, () =>
+      db.updateItems({ [itemUuid]: original }),
+    );
+    expectPaginationGenerationDelta(1, () =>
+      db["db"]!.prepare(
+        "UPDATE items SET data = json_remove(data, '$.interaction_count') WHERE uuid = ?",
+      ).run(itemUuid),
+    );
+    expectPaginationGenerationDelta(1, () =>
+      db.updateItems({ [itemUuid]: original }),
+    );
+  });
+
+  it("excludes seen and starred events from the pagination generation", () => {
+    const itemUuid = paginationUuid(1);
+    db.updateSources({
+      [paginationSourceUuid]: mockSourceMetadata(paginationSourceUuid),
+    });
+    db.updateItems({ [itemUuid]: paginationItems([1])[itemUuid] });
+
+    expectPaginationGenerationDelta(0, () =>
+      db.addPendingSourceConversationSeen(paginationSourceUuid, 1),
+    );
+    expectPaginationGenerationDelta(0, () =>
+      db.addPendingSourceEvent(paginationSourceUuid, PendingEventType.Starred),
+    );
+    expectPaginationGenerationDelta(0, () =>
+      db["db"]!.prepare(
+        `INSERT INTO pending_events
+            (snowflake_id, item_uuid, type, data)
+          VALUES ('seen', ?, 'item_seen', NULL)`,
+      ).run(itemUuid),
+    );
+  });
+
+  it("advances generation for membership-changing pending events", async () => {
+    const itemUuid = paginationUuid(1);
+    db.updateSources({
+      [paginationSourceUuid]: mockSourceMetadata(paginationSourceUuid),
+    });
+    db.updateItems({ [itemUuid]: paginationItems([1])[itemUuid] });
+
+    expectPaginationGenerationDelta(1, () =>
+      db.addPendingItemEvent(itemUuid, PendingEventType.ItemDeleted),
+    );
+    const beforeReply = paginationGeneration();
+    await db.addPendingReplySentEvent("reply", paginationSourceUuid, 2);
+    expect(paginationGeneration() - beforeReply).toBe(1);
+    expectPaginationGenerationDelta(1, () =>
+      db["db"]!.prepare(
+        `INSERT INTO pending_events
+            (snowflake_id, source_uuid, type, data)
+          VALUES ('truncated', ?, 'source_conversation_truncated', ?)`,
+      ).run(paginationSourceUuid, JSON.stringify({ upper_bound: 1 })),
+    );
+    expectPaginationGenerationDelta(1, () =>
+      db["db"]!.prepare(
+        `INSERT INTO pending_events
+            (snowflake_id, source_uuid, type, data)
+          VALUES ('deleted', ?, 'source_deleted', NULL)`,
+      ).run(paginationSourceUuid),
+    );
+  });
+
+  it("does not advance generation for no-op pending-event updates", () => {
+    const itemUuid = paginationUuid(1);
+    db.updateSources({
+      [paginationSourceUuid]: mockSourceMetadata(paginationSourceUuid),
+    });
+    db.updateItems({ [itemUuid]: paginationItems([1])[itemUuid] });
+    const raw = db["db"]!;
+    const replyData = JSON.stringify({
+      metadata: mockItemMetadata(
+        paginationUuid(2),
+        paginationSourceUuid,
+        "reply",
+        2,
+      ),
+      plaintext: "reply",
+    });
+    raw
+      .prepare(
+        `INSERT INTO pending_events
+          (snowflake_id, item_uuid, type, data)
+         VALUES ('deleted', ?, 'item_deleted', NULL)`,
+      )
+      .run(itemUuid);
+    raw
+      .prepare(
+        `INSERT INTO pending_events
+          (snowflake_id, source_uuid, type, data)
+         VALUES ('reply', ?, 'reply_sent', ?)`,
+      )
+      .run(paginationSourceUuid, replyData);
+    raw
+      .prepare(
+        `INSERT INTO pending_events
+          (snowflake_id, source_uuid, type, data)
+         VALUES ('truncated', ?, 'source_conversation_truncated', ?)`,
+      )
+      .run(paginationSourceUuid, JSON.stringify({ upper_bound: 1 }));
+    raw
+      .prepare(
+        `INSERT INTO pending_events
+          (snowflake_id, source_uuid, type, data)
+         VALUES ('source-deleted', ?, 'source_deleted', NULL)`,
+      )
+      .run(paginationSourceUuid);
+
+    for (const snowflakeId of [
+      "deleted",
+      "reply",
+      "truncated",
+      "source-deleted",
+    ]) {
+      expectPaginationGenerationDelta(0, () =>
+        raw
+          .prepare(
+            `UPDATE pending_events
+             SET snowflake_id = snowflake_id,
+                 type = type,
+                 data = data,
+                 source_uuid = source_uuid,
+                 item_uuid = item_uuid
+             WHERE snowflake_id = ?`,
+          )
+          .run(snowflakeId),
+      );
+      expectPaginationGenerationDelta(0, () =>
+        raw
+          .prepare(
+            `UPDATE pending_events
+             SET retry_attempts = retry_attempts + 1,
+                 last_event_status = 500
+             WHERE snowflake_id = ?`,
+          )
+          .run(snowflakeId),
+      );
+    }
+    expectPaginationGenerationDelta(0, () =>
+      raw
+        .prepare(
+          `UPDATE pending_events
+           SET data = json_set(data, '$.plaintext', 'changed')
+           WHERE snowflake_id = 'reply'`,
+        )
+        .run(),
+    );
+    for (const snowflakeId of [
+      "deleted",
+      "reply",
+      "truncated",
+      "source-deleted",
+    ]) {
+      expectPaginationGenerationDelta(1, () =>
+        raw
+          .prepare("DELETE FROM pending_events WHERE snowflake_id = ?")
+          .run(snowflakeId),
+      );
+    }
+  });
+
+  it("advances generation for each pending-event cursor signature", () => {
+    const firstItemUuid = paginationUuid(1);
+    const secondItemUuid = paginationUuid(2);
+    db.updateSources({
+      [paginationSourceUuid]: mockSourceMetadata(paginationSourceUuid),
+      source2: mockSourceMetadata("source2"),
+    });
+    db.updateItems(paginationItems([1, 2]));
+    const raw = db["db"]!;
+    const replyData = JSON.stringify({
+      metadata: mockItemMetadata(
+        paginationUuid(3),
+        paginationSourceUuid,
+        "reply",
+        3,
+      ),
+      plaintext: "reply",
+    });
+    raw
+      .prepare(
+        `INSERT INTO pending_events
+          (snowflake_id, item_uuid, type, data)
+         VALUES ('deleted', ?, 'item_deleted', NULL)`,
+      )
+      .run(firstItemUuid);
+    raw
+      .prepare(
+        `INSERT INTO pending_events
+          (snowflake_id, source_uuid, type, data)
+         VALUES ('reply', ?, 'reply_sent', ?)`,
+      )
+      .run(paginationSourceUuid, replyData);
+    raw
+      .prepare(
+        `INSERT INTO pending_events
+          (snowflake_id, source_uuid, type, data)
+         VALUES ('truncated', ?, 'source_conversation_truncated', ?)`,
+      )
+      .run(paginationSourceUuid, JSON.stringify({ upper_bound: 1 }));
+    raw
+      .prepare(
+        `INSERT INTO pending_events
+          (snowflake_id, source_uuid, type, data)
+         VALUES ('source-deleted', ?, 'source_deleted', NULL)`,
+      )
+      .run(paginationSourceUuid);
+    raw
+      .prepare(
+        `INSERT INTO pending_events
+          (snowflake_id, source_uuid, type, data)
+         VALUES ('starred', ?, 'starred', NULL)`,
+      )
+      .run("source2");
+
+    expectPaginationGenerationDelta(1, () =>
+      raw
+        .prepare(
+          "UPDATE pending_events SET item_uuid = ? WHERE snowflake_id = 'deleted'",
+        )
+        .run(secondItemUuid),
+    );
+    expectPaginationGenerationDelta(1, () =>
+      raw
+        .prepare(
+          `UPDATE pending_events SET snowflake_id = 'deleted-2'
+           WHERE snowflake_id = 'deleted'`,
+        )
+        .run(),
+    );
+    expectPaginationGenerationDelta(1, () =>
+      raw
+        .prepare(
+          `UPDATE pending_events
+           SET data = json_set(data, '$.metadata.interaction_count', 4)
+           WHERE snowflake_id = 'reply'`,
+        )
+        .run(),
+    );
+    expectPaginationGenerationDelta(1, () =>
+      raw
+        .prepare(
+          `UPDATE pending_events
+           SET data = json_set(data, '$.metadata.uuid', ?)
+           WHERE snowflake_id = 'reply'`,
+        )
+        .run(paginationUuid(4)),
+    );
+    expectPaginationGenerationDelta(1, () =>
+      raw
+        .prepare(
+          `UPDATE pending_events
+           SET data = json_set(data, '$.metadata.source', 'source2')
+           WHERE snowflake_id = 'reply'`,
+        )
+        .run(),
+    );
+    expectPaginationGenerationDelta(1, () =>
+      raw
+        .prepare(
+          `UPDATE pending_events SET snowflake_id = 'reply-2'
+           WHERE snowflake_id = 'reply'`,
+        )
+        .run(),
+    );
+    expectPaginationGenerationDelta(1, () =>
+      raw
+        .prepare(
+          `UPDATE pending_events
+           SET data = json_set(data, '$.upper_bound', 2)
+           WHERE snowflake_id = 'truncated'`,
+        )
+        .run(),
+    );
+    expectPaginationGenerationDelta(1, () =>
+      raw
+        .prepare(
+          `UPDATE pending_events SET source_uuid = 'source2'
+           WHERE snowflake_id = 'truncated'`,
+        )
+        .run(),
+    );
+    expectPaginationGenerationDelta(1, () =>
+      raw
+        .prepare(
+          `UPDATE pending_events SET snowflake_id = 'truncated-2'
+           WHERE snowflake_id = 'truncated'`,
+        )
+        .run(),
+    );
+    expectPaginationGenerationDelta(1, () =>
+      raw
+        .prepare(
+          `UPDATE pending_events SET source_uuid = 'source2'
+           WHERE snowflake_id = 'source-deleted'`,
+        )
+        .run(),
+    );
+    expectPaginationGenerationDelta(1, () =>
+      raw
+        .prepare(
+          `UPDATE pending_events SET snowflake_id = 'source-deleted-2'
+           WHERE snowflake_id = 'source-deleted'`,
+        )
+        .run(),
+    );
+    expectPaginationGenerationDelta(1, () =>
+      raw
+        .prepare(
+          `UPDATE pending_events SET type = 'source_deleted'
+           WHERE snowflake_id = 'starred'`,
+        )
+        .run(),
+    );
+  });
+
+  it("uses null-safe comparisons for pagination trigger fields", () => {
+    const itemUuid = paginationUuid(1);
+    db.updateSources({
+      [paginationSourceUuid]: mockSourceMetadata(paginationSourceUuid),
+    });
+    db.updateItems({ [itemUuid]: paginationItems([1])[itemUuid] });
+    const raw = db["db"]!;
+
+    expectPaginationGenerationDelta(1, () =>
+      raw
+        .prepare(
+          "UPDATE items SET data = json_remove(data, '$.source') WHERE uuid = ?",
+        )
+        .run(itemUuid),
+    );
+    expectPaginationGenerationDelta(0, () =>
+      raw
+        .prepare(
+          "UPDATE items SET data = json_remove(data, '$.source') WHERE uuid = ?",
+        )
+        .run(itemUuid),
+    );
+    expectPaginationGenerationDelta(1, () =>
+      raw
+        .prepare(
+          `UPDATE items SET data = json_set(data, '$.source', ?) WHERE uuid = ?`,
+        )
+        .run(paginationSourceUuid, itemUuid),
+    );
+  });
+
+  it("rolls back only the seen change owned by a stale request", () => {
+    db.updateSources({
+      [paginationSourceUuid]: mockSourceMetadata(paginationSourceUuid),
+    });
+    db.updateItems(paginationItems([1, 2]));
+
+    const firstEvent = db.addPendingSourceConversationSeen(
+      paginationSourceUuid,
+      1,
+      "request-a",
+    );
+    expect(firstEvent).not.toBeNull();
+    expect(
+      db.addPendingSourceConversationSeen(paginationSourceUuid, 1, "request-b"),
+    ).toBe(firstEvent);
+    expect(
+      db.finalizePendingSourceConversationSeen(
+        paginationSourceUuid,
+        "request-a",
+        false,
+      ),
+    ).toBe(false);
+    db.finalizePendingSourceConversationSeen(
+      paginationSourceUuid,
+      "request-b",
+      true,
+    );
+
+    const raisedEvent = db.addPendingSourceConversationSeen(
+      paginationSourceUuid,
+      2,
+      "request-c",
+    );
+    expect(raisedEvent).not.toBe(firstEvent);
+    expect(
+      db.finalizePendingSourceConversationSeen(
+        paginationSourceUuid,
+        "request-c",
+        false,
+      ),
+    ).toBe(true);
+    const seenEvents = db
+      .getPendingEvents()
+      .filter(
+        (event) => event.type === PendingEventType.SourceConversationSeen,
+      );
+    expect(seenEvents).toHaveLength(1);
+    expect(seenEvents[0].id).toBe(firstEvent);
+    expect(seenEvents[0].data).toEqual({ upper_bound: 1 });
+  });
+
+  it("transfers seen rollback ownership across stale same-source requests", () => {
+    db.updateSources({
+      [paginationSourceUuid]: mockSourceMetadata(paginationSourceUuid),
+    });
+    db.updateItems({
+      [paginationUuid(1)]: paginationItems([1])[paginationUuid(1)],
+    });
+
+    const firstEvent = db.addPendingSourceConversationSeen(
+      paginationSourceUuid,
+      1,
+      "request-a",
+    );
+    expect(firstEvent).not.toBeNull();
+    expect(
+      db.addPendingSourceConversationSeen(paginationSourceUuid, 1, "request-b"),
+    ).toBe(firstEvent);
+    expect(
+      db.finalizePendingSourceConversationSeen(
+        paginationSourceUuid,
+        "request-a",
+        false,
+      ),
+    ).toBe(false);
+    expect(
+      db.finalizePendingSourceConversationSeen(
+        paginationSourceUuid,
+        "request-b",
+        false,
+      ),
+    ).toBe(true);
+    expect(
+      db
+        .getPendingEvents()
+        .filter(
+          (event) => event.type === PendingEventType.SourceConversationSeen,
+        ),
+    ).toHaveLength(0);
+
+    db.addPendingSourceConversationSeen(paginationSourceUuid, 1, "request-c");
+    db.addPendingSourceConversationSeen(paginationSourceUuid, 2, "request-d");
+    db.finalizePendingSourceConversationSeen(
+      paginationSourceUuid,
+      "request-c",
+      false,
+    );
+    expect(
+      db.finalizePendingSourceConversationSeen(
+        paginationSourceUuid,
+        "request-d",
+        false,
+      ),
+    ).toBe(true);
+    expect(
+      db
+        .getPendingEvents()
+        .filter(
+          (event) => event.type === PendingEventType.SourceConversationSeen,
+        ),
+    ).toHaveLength(0);
   });
 
   it("pending ItemDeleted event should delete reply", () => {

--- a/app/src/main/index.test.ts
+++ b/app/src/main/index.test.ts
@@ -52,6 +52,7 @@ const testState = vi.hoisted(() => {
           registeredHandlers.set(channel, handler);
         },
       ),
+      on: vi.fn(),
     },
     session: {
       defaultSession: {
@@ -211,6 +212,7 @@ describe("syncMetadata IPC handler", () => {
 
     testState.dialog.showMessageBox.mockClear();
     testState.ipcMain.handle.mockClear();
+    testState.ipcMain.on.mockClear();
     testState.session.defaultSession.webRequest.onHeadersReceived.mockClear();
     testState.optimizer.watchWindowShortcuts.mockClear();
 

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -32,6 +32,7 @@ import {
   type DeviceStatus,
   type SearchResult,
   type FirstRunStatus,
+  type GetSourceWithItemsOptions,
   FetchStatus,
   PendingEventType,
   SyncStatus,
@@ -425,16 +426,15 @@ if (!gotTheLock) {
         async (
           _event,
           sourceUuid: string,
-          options?: {
-            limit?: number;
-            beforeInteractionCount?: number;
-            journalistUuid?: string;
-          },
+          options?: GetSourceWithItemsOptions,
         ): Promise<SourceWithItems> => {
           const sourceWithItems = db.getSourceWithItems(sourceUuid, options);
           return sourceWithItems;
         },
       );
+      ipcMain.on("getConversationPaginationGeneration", (event) => {
+        event.returnValue = db.getConversationPaginationGeneration();
+      });
 
       ipcMain.handle(
         "getSourceItemCounts",
@@ -608,8 +608,28 @@ if (!gotTheLock) {
           _event,
           sourceUuid: string,
           upperBound: number,
+          requestToken?: string,
         ): Promise<string | null> => {
-          return db.addPendingSourceConversationSeen(sourceUuid, upperBound);
+          return db.addPendingSourceConversationSeen(
+            sourceUuid,
+            upperBound,
+            requestToken,
+          );
+        },
+      );
+      ipcMain.handle(
+        "finalizePendingSourceConversationSeen",
+        async (
+          _event,
+          sourceUuid: string,
+          requestToken: string,
+          keep: boolean,
+        ): Promise<boolean> => {
+          return db.finalizePendingSourceConversationSeen(
+            sourceUuid,
+            requestToken,
+            keep,
+          );
         },
       );
 

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -12,6 +12,7 @@ import {
   type LoginResult,
   type SearchResult,
   type FirstRunStatus,
+  type GetSourceWithItemsOptions,
   Item,
   PendingEventType,
   SyncStatus,
@@ -67,15 +68,11 @@ const electronAPI = {
   ),
   getSourceWithItems: logIpcCall<SourceWithItems>(
     "getSourceWithItems",
-    (
-      sourceUuid: string,
-      options?: {
-        limit?: number;
-        beforeInteractionCount?: number;
-        journalistUuid?: string;
-      },
-    ) => ipcRenderer.invoke("getSourceWithItems", sourceUuid, options),
+    (sourceUuid: string, options?: GetSourceWithItemsOptions) =>
+      ipcRenderer.invoke("getSourceWithItems", sourceUuid, options),
   ),
+  getConversationPaginationGeneration: (): number =>
+    ipcRenderer.sendSync("getConversationPaginationGeneration"),
   getSourceItemCounts: logIpcCall<SourceItemCounts>(
     "getSourceItemCounts",
     (sourceUuids: string[]) =>
@@ -125,11 +122,22 @@ const electronAPI = {
   ),
   addPendingSourceConversationSeen: logIpcCall<string | null>(
     "addPendingSourceConversationSeen",
-    (sourceUuid: string, upperBound: number) =>
+    (sourceUuid: string, upperBound: number, requestToken?: string) =>
       ipcRenderer.invoke(
         "addPendingSourceConversationSeen",
         sourceUuid,
         upperBound,
+        requestToken,
+      ),
+  ),
+  finalizePendingSourceConversationSeen: logIpcCall<boolean>(
+    "finalizePendingSourceConversationSeen",
+    (sourceUuid: string, requestToken: string, keep: boolean) =>
+      ipcRenderer.invoke(
+        "finalizePendingSourceConversationSeen",
+        sourceUuid,
+        requestToken,
+        keep,
       ),
   ),
   shouldAutoLogin: logIpcCall<boolean>("shouldAutoLogin", () =>

--- a/app/src/renderer/features/conversation/conversationSlice.test.ts
+++ b/app/src/renderer/features/conversation/conversationSlice.test.ts
@@ -1,8 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { configureStore } from "@reduxjs/toolkit";
-import { FetchStatus, type SourceWithItems } from "../../../types";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import {
+  FetchStatus,
+  type GetSourceWithItemsOptions,
+  type ItemMetadata,
+  type SourceWithItems,
+} from "../../../types";
+import { Datastore } from "../../../main/datastore";
 import conversationSlice, {
   fetchConversation,
+  fetchOlderConversationItems,
   clearError,
   clearConversation,
   updateItem,
@@ -63,6 +73,8 @@ const mockSourceWithItems: SourceWithItems = {
       fetch_status: 3,
     },
   ],
+  hasMoreHistoricalItems: true,
+  paginationGeneration: 10,
 };
 
 const mockSourceWithItems2: SourceWithItems = {
@@ -97,12 +109,34 @@ const mockSourceWithItems2: SourceWithItems = {
       fetch_status: 3,
     },
   ],
+  hasMoreHistoricalItems: false,
+  paginationGeneration: 10,
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+const idleTraversalState = {
+  traversalEpoch: 0,
+  traversalSourceUuid: null,
+  activeConversationRequest: null,
+  activeOlderRequest: null,
 };
 
 describe("conversationSlice", () => {
   let store: ReturnType<typeof configureStore>;
   const mockGetSourceWithItems = vi.fn();
   const mockAddPendingSourceConversationSeen = vi.fn();
+  const mockFinalizePendingSourceConversationSeen = vi.fn();
+  const mockGetConversationPaginationGeneration = vi.fn();
+  const mockGetSources = vi.fn();
 
   beforeEach(() => {
     // Create a test store with conversations slice
@@ -119,11 +153,19 @@ describe("conversationSlice", () => {
     (window as any).electronAPI = {
       getSourceWithItems: mockGetSourceWithItems,
       addPendingSourceConversationSeen: mockAddPendingSourceConversationSeen,
+      finalizePendingSourceConversationSeen:
+        mockFinalizePendingSourceConversationSeen,
+      getConversationPaginationGeneration:
+        mockGetConversationPaginationGeneration,
+      getSources: mockGetSources,
     };
 
     // Default mock implementations
     mockGetSourceWithItems.mockResolvedValue(mockSourceWithItems);
     mockAddPendingSourceConversationSeen.mockResolvedValue(null);
+    mockFinalizePendingSourceConversationSeen.mockResolvedValue(false);
+    mockGetConversationPaginationGeneration.mockReturnValue(10);
+    mockGetSources.mockResolvedValue({});
   });
 
   afterEach(() => {
@@ -140,6 +182,7 @@ describe("conversationSlice", () => {
         lastFetchTime: null,
         hasMoreHistoricalItems: false,
         olderItemsLoading: false,
+        ...idleTraversalState,
       });
     });
   });
@@ -154,6 +197,7 @@ describe("conversationSlice", () => {
         lastFetchTime: null,
         hasMoreHistoricalItems: false,
         olderItemsLoading: false,
+        ...idleTraversalState,
       };
 
       const action = clearError();
@@ -175,6 +219,7 @@ describe("conversationSlice", () => {
         lastFetchTime: 123456789,
         hasMoreHistoricalItems: false,
         olderItemsLoading: false,
+        ...idleTraversalState,
       };
 
       const action = clearConversation();
@@ -199,6 +244,11 @@ describe("conversationSlice", () => {
       expect(state.loading).toBe(false);
       expect(state.error).toBeNull();
       expect(state.lastFetchTime).toBeGreaterThan(0);
+      expect(mockAddPendingSourceConversationSeen).toHaveBeenCalledWith(
+        "source-1",
+        2,
+        expect.stringContaining("source-1:1:"),
+      );
     });
 
     it("handles fetch error", async () => {
@@ -239,6 +289,665 @@ describe("conversationSlice", () => {
       // Check loading state is false after completion
       expect((store.getState() as any).conversation.loading).toBe(false);
     });
+
+    it("discards an older navigation response and its seen effects", async () => {
+      const sourceARequest = deferred<SourceWithItems>();
+      mockGetSourceWithItems
+        .mockReturnValueOnce(sourceARequest.promise)
+        .mockResolvedValueOnce(mockSourceWithItems2);
+      mockAddPendingSourceConversationSeen.mockResolvedValue("created");
+
+      const sourceADispatch = (store.dispatch as any)(
+        fetchConversation("source-1"),
+      );
+      await (store.dispatch as any)(fetchConversation("source-2"));
+      mockAddPendingSourceConversationSeen.mockClear();
+      mockGetSources.mockClear();
+
+      sourceARequest.resolve(mockSourceWithItems);
+      await sourceADispatch;
+
+      const state = (store.getState() as any).conversation;
+      expect(state.conversation).toEqual(mockSourceWithItems2);
+      expect(state.traversalSourceUuid).toBe("source-2");
+      expect(mockAddPendingSourceConversationSeen).not.toHaveBeenCalled();
+      expect(mockGetSources).not.toHaveBeenCalled();
+    });
+
+    it("rolls back a seen write completed after navigation", async () => {
+      const seenWrite = deferred<string | null>();
+      mockGetSourceWithItems.mockImplementation((sourceUuid: string) =>
+        Promise.resolve(
+          sourceUuid === "source-1"
+            ? mockSourceWithItems
+            : mockSourceWithItems2,
+        ),
+      );
+      mockAddPendingSourceConversationSeen.mockImplementation(
+        (sourceUuid: string) =>
+          sourceUuid === "source-1" ? seenWrite.promise : Promise.resolve(null),
+      );
+
+      const staleDispatch = (store.dispatch as any)(
+        fetchConversation("source-1"),
+      );
+      await vi.waitFor(() => {
+        expect(mockAddPendingSourceConversationSeen).toHaveBeenCalled();
+      });
+      await (store.dispatch as any)(fetchConversation("source-2"));
+      mockGetSources.mockClear();
+
+      seenWrite.resolve("stale-seen-id");
+      await staleDispatch;
+
+      const staleToken = mockAddPendingSourceConversationSeen.mock.calls[0][2];
+      expect(mockFinalizePendingSourceConversationSeen).toHaveBeenCalledWith(
+        "source-1",
+        staleToken,
+        false,
+      );
+      expect(mockGetSources).not.toHaveBeenCalled();
+      const state = (store.getState() as any).conversation;
+      expect(state.conversation).toEqual(mockSourceWithItems2);
+      expect(state.loading).toBe(false);
+    });
+
+    it("refreshes from a seen event adopted by the current request", async () => {
+      const staleSeenWrite = deferred<string | null>();
+      mockAddPendingSourceConversationSeen
+        .mockReturnValueOnce(staleSeenWrite.promise)
+        .mockResolvedValueOnce("adopted-seen-id");
+
+      const staleDispatch = (store.dispatch as any)(
+        fetchConversation("source-1"),
+      );
+      await vi.waitFor(() => {
+        expect(mockAddPendingSourceConversationSeen).toHaveBeenCalledTimes(1);
+      });
+      const currentDispatch = (store.dispatch as any)(
+        fetchConversation("source-1"),
+      );
+      await currentDispatch;
+
+      expect(mockGetSources).toHaveBeenCalledTimes(1);
+      const currentToken =
+        mockAddPendingSourceConversationSeen.mock.calls[1][2];
+      expect(mockFinalizePendingSourceConversationSeen).toHaveBeenCalledWith(
+        "source-1",
+        currentToken,
+        true,
+      );
+
+      staleSeenWrite.resolve("stale-seen-id");
+      await staleDispatch;
+
+      const staleToken = mockAddPendingSourceConversationSeen.mock.calls[0][2];
+      expect(mockFinalizePendingSourceConversationSeen).toHaveBeenCalledWith(
+        "source-1",
+        staleToken,
+        false,
+      );
+      const state = (store.getState() as any).conversation;
+      expect(state.conversation).toEqual(mockSourceWithItems);
+      expect(state.loading).toBe(false);
+    });
+
+    it("binds initial results to the captured epoch when request IDs repeat", async () => {
+      const stalePage = deferred<SourceWithItems>();
+      const currentPage = deferred<SourceWithItems>();
+      mockGetSourceWithItems
+        .mockReturnValueOnce(stalePage.promise)
+        .mockReturnValueOnce(currentPage.promise);
+      const originalRandom = Math.random;
+      Math.random = () => 0;
+      try {
+        const staleDispatch = (store.dispatch as any)(
+          fetchConversation("source-1"),
+        );
+        const currentDispatch = (store.dispatch as any)(
+          fetchConversation("source-1"),
+        );
+        expect(staleDispatch.requestId).toBe(currentDispatch.requestId);
+
+        stalePage.resolve({
+          ...mockSourceWithItems,
+          data: {
+            ...mockSourceWithItems.data,
+            journalist_designation: "stale",
+          },
+        });
+        await staleDispatch;
+        currentPage.resolve({
+          ...mockSourceWithItems,
+          data: {
+            ...mockSourceWithItems.data,
+            journalist_designation: "current",
+          },
+        });
+        await currentDispatch;
+
+        const state = (store.getState() as any).conversation;
+        expect(state.conversation.data.journalist_designation).toBe("current");
+        expect(state.activeConversationRequest).toBeNull();
+        expect(state.loading).toBe(false);
+        expect(state.traversalEpoch).toBe(2);
+        expect(mockAddPendingSourceConversationSeen).toHaveBeenCalledTimes(1);
+      } finally {
+        Math.random = originalRandom;
+      }
+    });
+
+    it("re-reads an initial page changed before renderer fulfillment", async () => {
+      const staleRead = deferred<SourceWithItems>();
+      const currentPage: SourceWithItems = {
+        ...mockSourceWithItems,
+        items: [mockSourceWithItems.items[1]],
+        paginationGeneration: 11,
+      };
+      mockGetSourceWithItems
+        .mockReturnValueOnce(staleRead.promise)
+        .mockResolvedValueOnce(currentPage);
+      mockGetConversationPaginationGeneration.mockReturnValue(11);
+
+      const dispatch = (store.dispatch as any)(fetchConversation("source-1"));
+      staleRead.resolve(mockSourceWithItems);
+      await dispatch;
+
+      expect(mockGetSourceWithItems).toHaveBeenCalledTimes(2);
+      expect(mockAddPendingSourceConversationSeen).toHaveBeenCalledTimes(1);
+      const state = (store.getState() as any).conversation;
+      expect(state.conversation).toEqual(currentPage);
+      expect(state.loading).toBe(false);
+    });
+
+    it("removes a real seen event written after navigation", async () => {
+      const dbDir = fs.mkdtempSync(path.join(os.tmpdir(), "seen-race-"));
+      const realDb = new Datastore(
+        {} as never,
+        {
+          deleteItemFs: async () => undefined,
+          deleteSourceFs: async () => undefined,
+        } as never,
+        dbDir,
+      );
+      const sourceA = "10000000-0000-4000-8000-000000000000";
+      const sourceB = "20000000-0000-4000-8000-000000000000";
+      const itemUuid = "30000000-0000-4000-8000-000000000001";
+      realDb.updateSources({
+        [sourceA]: { ...mockSourceWithItems.data, uuid: sourceA },
+        [sourceB]: { ...mockSourceWithItems2.data, uuid: sourceB },
+      });
+      realDb.updateItems({
+        [itemUuid]: {
+          interaction_count: 1,
+          is_read: false,
+          kind: "message",
+          seen_by: [],
+          size: 1,
+          source: sourceA,
+          uuid: itemUuid,
+        },
+      });
+      const seenStarted = deferred<void>();
+      const releaseSeen = deferred<void>();
+      let refreshes = 0;
+      (window as any).electronAPI = {
+        addPendingSourceConversationSeen: async (
+          sourceUuid: string,
+          upperBound: number,
+          token: string,
+        ) => {
+          if (sourceUuid === sourceA) {
+            seenStarted.resolve();
+            await releaseSeen.promise;
+          }
+          return realDb.addPendingSourceConversationSeen(
+            sourceUuid,
+            upperBound,
+            token,
+          );
+        },
+        finalizePendingSourceConversationSeen: async (
+          sourceUuid: string,
+          token: string,
+          keep: boolean,
+        ) =>
+          realDb.finalizePendingSourceConversationSeen(sourceUuid, token, keep),
+        getConversationPaginationGeneration: () =>
+          realDb.getConversationPaginationGeneration(),
+        getSourceWithItems: async (
+          sourceUuid: string,
+          options?: GetSourceWithItemsOptions,
+        ) => realDb.getSourceWithItems(sourceUuid, options),
+        getSources: async () => {
+          refreshes += 1;
+          return {};
+        },
+      };
+
+      try {
+        const staleDispatch = (store.dispatch as any)(
+          fetchConversation(sourceA),
+        );
+        await seenStarted.promise;
+        await (store.dispatch as any)(fetchConversation(sourceB));
+        releaseSeen.resolve();
+        await staleDispatch;
+
+        const seenForA = realDb
+          .getPendingEvents()
+          .filter(
+            (event) =>
+              event.type === "source_conversation_seen" &&
+              "source_uuid" in event.target &&
+              event.target.source_uuid === sourceA,
+          );
+        expect(seenForA).toHaveLength(0);
+        expect(refreshes).toBe(0);
+        expect((store.getState() as any).conversation.conversation.uuid).toBe(
+          sourceB,
+        );
+      } finally {
+        realDb.close();
+      }
+    });
+  });
+
+  describe("fetchOlderConversationItems async thunk", () => {
+    const olderItem = {
+      ...mockSourceWithItems.items[0],
+      uuid: "item-0",
+      data: {
+        ...mockSourceWithItems.items[0].data,
+        uuid: "item-0",
+        interaction_count: 0,
+      },
+    };
+    const olderPage: SourceWithItems = {
+      ...mockSourceWithItems,
+      items: [olderItem],
+      hasMoreHistoricalItems: false,
+      paginationGeneration: 10,
+    };
+
+    it("merges a successful page and updates hasMore", async () => {
+      await (store.dispatch as any)(fetchConversation("source-1"));
+      mockGetSourceWithItems.mockClear();
+      mockGetSourceWithItems.mockResolvedValue(olderPage);
+
+      const action = await (store.dispatch as any)(
+        fetchOlderConversationItems("source-1"),
+      );
+
+      expect(mockGetSourceWithItems).toHaveBeenCalledWith("source-1", {
+        limit: 100,
+        beforeInteractionCount: 1,
+        beforeItemUuid: "item-1",
+        paginationGeneration: 10,
+      });
+      expect(action.payload.request.sourceUuid).toBe("source-1");
+      const state = (store.getState() as any).conversation;
+      expect(state.conversation.items.map((item: any) => item.uuid)).toEqual([
+        "item-0",
+        "item-1",
+        "item-2",
+      ]);
+      expect(state.hasMoreHistoricalItems).toBe(false);
+      expect(state.conversation.hasMoreHistoricalItems).toBe(false);
+      expect(state.olderItemsLoading).toBe(false);
+      expect(mockAddPendingSourceConversationSeen).toHaveBeenCalledTimes(1);
+    });
+
+    it("discards a stale fulfillment after switching sources", async () => {
+      await (store.dispatch as any)(fetchConversation("source-1"));
+      mockGetSourceWithItems.mockClear();
+      mockAddPendingSourceConversationSeen.mockResolvedValue("created");
+      const sourceARequest = deferred<SourceWithItems>();
+      mockGetSourceWithItems
+        .mockReturnValueOnce(sourceARequest.promise)
+        .mockResolvedValueOnce(mockSourceWithItems2);
+
+      const sourceADispatch = (store.dispatch as any)(
+        fetchOlderConversationItems("source-1"),
+      );
+      await (store.dispatch as any)(fetchConversation("source-2"));
+      mockAddPendingSourceConversationSeen.mockClear();
+      mockGetSources.mockClear();
+      sourceARequest.resolve(olderPage);
+      await sourceADispatch;
+
+      const state = (store.getState() as any).conversation;
+      expect(state.conversation).toEqual(mockSourceWithItems2);
+      expect(state.conversation.items.map((item: any) => item.uuid)).toEqual([
+        "item-3",
+      ]);
+      expect(state.hasMoreHistoricalItems).toBe(false);
+      expect(state.olderItemsLoading).toBe(false);
+      expect(mockAddPendingSourceConversationSeen).not.toHaveBeenCalled();
+      expect(mockGetSources).not.toHaveBeenCalled();
+    });
+
+    it("discards an A to B to A page without clearing the new request", async () => {
+      await (store.dispatch as any)(fetchConversation("source-1"));
+      mockGetSourceWithItems.mockClear();
+      const staleRequest = deferred<SourceWithItems>();
+      const currentRequest = deferred<SourceWithItems>();
+      const currentSourceA = {
+        ...mockSourceWithItems,
+        paginationGeneration: 30,
+      };
+      const currentOlderPage = {
+        ...olderPage,
+        paginationGeneration: 30,
+      };
+      mockGetSourceWithItems
+        .mockReturnValueOnce(staleRequest.promise)
+        .mockResolvedValueOnce(mockSourceWithItems2)
+        .mockResolvedValueOnce(currentSourceA)
+        .mockReturnValueOnce(currentRequest.promise);
+
+      const staleDispatch = (store.dispatch as any)(
+        fetchOlderConversationItems("source-1"),
+      );
+      await (store.dispatch as any)(fetchConversation("source-2"));
+      mockGetConversationPaginationGeneration.mockReturnValue(30);
+      await (store.dispatch as any)(fetchConversation("source-1"));
+      const currentDispatch = (store.dispatch as any)(
+        fetchOlderConversationItems("source-1"),
+      );
+      mockAddPendingSourceConversationSeen.mockClear();
+      mockGetSources.mockClear();
+
+      staleRequest.resolve(olderPage);
+      await staleDispatch;
+
+      let state = (store.getState() as any).conversation;
+      expect(state.conversation).toEqual(currentSourceA);
+      expect(state.olderItemsLoading).toBe(true);
+      expect(state.activeOlderRequest).not.toBeNull();
+      expect(mockAddPendingSourceConversationSeen).not.toHaveBeenCalled();
+      expect(mockGetSources).not.toHaveBeenCalled();
+
+      currentRequest.resolve(currentOlderPage);
+      await currentDispatch;
+      state = (store.getState() as any).conversation;
+      expect(state.conversation.items.map((item: any) => item.uuid)).toEqual([
+        "item-0",
+        "item-1",
+        "item-2",
+      ]);
+      expect(state.conversation.paginationGeneration).toBe(30);
+      expect(state.olderItemsLoading).toBe(false);
+    });
+
+    it("preserves hasMore when the request is rejected", async () => {
+      await (store.dispatch as any)(fetchConversation("source-1"));
+      mockGetSourceWithItems.mockRejectedValue(new Error("IPC failed"));
+
+      await (store.dispatch as any)(fetchOlderConversationItems("source-1"));
+
+      const state = (store.getState() as any).conversation;
+      expect(state.conversation).toEqual(mockSourceWithItems);
+      expect(state.hasMoreHistoricalItems).toBe(true);
+      expect(state.olderItemsLoading).toBe(false);
+    });
+
+    it("discards a stale rejection after switching sources", async () => {
+      await (store.dispatch as any)(fetchConversation("source-1"));
+      mockGetSourceWithItems.mockClear();
+      const sourceARequest = deferred<SourceWithItems>();
+      mockGetSourceWithItems
+        .mockReturnValueOnce(sourceARequest.promise)
+        .mockResolvedValueOnce(mockSourceWithItems2);
+
+      const sourceADispatch = (store.dispatch as any)(
+        fetchOlderConversationItems("source-1"),
+      );
+      await (store.dispatch as any)(fetchConversation("source-2"));
+      sourceARequest.reject(new Error("source A failed"));
+      await sourceADispatch;
+
+      const state = (store.getState() as any).conversation;
+      expect(state.conversation).toEqual(mockSourceWithItems2);
+      expect(state.hasMoreHistoricalItems).toBe(false);
+      expect(state.olderItemsLoading).toBe(false);
+    });
+
+    it("invalidates an older request when the conversation is cleared", async () => {
+      await (store.dispatch as any)(fetchConversation("source-1"));
+      const request = deferred<SourceWithItems>();
+      mockGetSourceWithItems.mockReturnValue(request.promise);
+
+      const dispatch = (store.dispatch as any)(
+        fetchOlderConversationItems("source-1"),
+      );
+      store.dispatch(clearConversation());
+      request.resolve(olderPage);
+      await dispatch;
+
+      const state = (store.getState() as any).conversation;
+      expect(state.conversation).toBeNull();
+      expect(state.olderItemsLoading).toBe(false);
+      expect(state.activeOlderRequest).toBeNull();
+      expect(state.traversalSourceUuid).toBeNull();
+    });
+
+    it("suppresses a duplicate dispatch while a page is pending", async () => {
+      await (store.dispatch as any)(fetchConversation("source-1"));
+      mockGetSourceWithItems.mockClear();
+      const request = deferred<SourceWithItems>();
+      mockGetSourceWithItems.mockReturnValue(request.promise);
+
+      const firstDispatch = (store.dispatch as any)(
+        fetchOlderConversationItems("source-1"),
+      );
+      const duplicateAction = await (store.dispatch as any)(
+        fetchOlderConversationItems("source-1"),
+      );
+
+      expect(mockGetSourceWithItems).toHaveBeenCalledTimes(1);
+      expect(duplicateAction.meta.condition).toBe(true);
+      request.resolve(olderPage);
+      await firstDispatch;
+      const state = (store.getState() as any).conversation;
+      expect(state.conversation.items.map((item: any) => item.uuid)).toEqual([
+        "item-0",
+        "item-1",
+        "item-2",
+      ]);
+      expect(state.hasMoreHistoricalItems).toBe(false);
+    });
+
+    it("replaces the traversal when the datastore generation changes", async () => {
+      await (store.dispatch as any)(fetchConversation("source-1"));
+      const restartedPage: SourceWithItems = {
+        ...mockSourceWithItems,
+        items: [olderItem],
+        hasMoreHistoricalItems: true,
+        paginationGeneration: 11,
+        paginationRestarted: true,
+      };
+      mockGetSourceWithItems.mockResolvedValue(restartedPage);
+      mockGetConversationPaginationGeneration.mockReturnValue(11);
+
+      await (store.dispatch as any)(fetchOlderConversationItems("source-1"));
+
+      const state = (store.getState() as any).conversation;
+      expect(state.conversation).toEqual(restartedPage);
+      expect(state.hasMoreHistoricalItems).toBe(true);
+      expect(state.olderItemsLoading).toBe(false);
+    });
+
+    it("re-reads a page changed after its database read", async () => {
+      await (store.dispatch as any)(fetchConversation("source-1"));
+      mockGetSourceWithItems.mockClear();
+      const staleRead = deferred<SourceWithItems>();
+      const restartedPage: SourceWithItems = {
+        ...mockSourceWithItems,
+        items: [mockSourceWithItems.items[1]],
+        hasMoreHistoricalItems: true,
+        paginationGeneration: 11,
+        paginationRestarted: true,
+      };
+      mockGetSourceWithItems
+        .mockReturnValueOnce(staleRead.promise)
+        .mockResolvedValueOnce(restartedPage);
+
+      const dispatch = (store.dispatch as any)(
+        fetchOlderConversationItems("source-1"),
+      );
+      mockGetConversationPaginationGeneration.mockReturnValue(11);
+      staleRead.resolve(olderPage);
+      await dispatch;
+
+      expect(mockGetSourceWithItems).toHaveBeenCalledTimes(2);
+      const state = (store.getState() as any).conversation;
+      expect(state.conversation).toEqual(restartedPage);
+      expect(state.hasMoreHistoricalItems).toBe(true);
+      expect(state.olderItemsLoading).toBe(false);
+    });
+
+    it("rejects a real SQLite page mutated after read", async () => {
+      const dbDir = fs.mkdtempSync(path.join(os.tmpdir(), "pagination-race-"));
+      const realDb = new Datastore(
+        {} as never,
+        {
+          deleteItemFs: async () => undefined,
+          deleteSourceFs: async () => undefined,
+        } as never,
+        dbDir,
+      );
+      const sourceUuid = "10000000-0000-4000-8000-000000000000";
+      const itemUuid = (index: number) =>
+        `30000000-0000-4000-8000-${index.toString().padStart(12, "0")}`;
+      const items: Record<string, ItemMetadata> = {};
+      for (let index = 1; index <= 151; index += 1) {
+        const uuid = itemUuid(index);
+        items[uuid] = {
+          interaction_count: 100,
+          is_read: false,
+          kind: "message",
+          seen_by: [],
+          size: 1,
+          source: sourceUuid,
+          uuid,
+        };
+      }
+      realDb.updateSources({
+        [sourceUuid]: { ...mockSourceWithItems.data, uuid: sourceUuid },
+      });
+      realDb.updateItems(items);
+      const held = deferred<SourceWithItems>();
+      let holdOlderPage = false;
+      let stalePage: SourceWithItems | undefined;
+      (window as any).electronAPI = {
+        addPendingSourceConversationSeen: async () => null,
+        finalizePendingSourceConversationSeen: async () => false,
+        getConversationPaginationGeneration: () =>
+          realDb.getConversationPaginationGeneration(),
+        getSourceWithItems: async (
+          requestedSourceUuid: string,
+          options?: GetSourceWithItemsOptions,
+        ) => {
+          const page = realDb.getSourceWithItems(requestedSourceUuid, options);
+          if (holdOlderPage && options?.beforeItemUuid !== undefined) {
+            holdOlderPage = false;
+            stalePage = page;
+            return held.promise;
+          }
+          return page;
+        },
+        getSources: async () => ({}),
+      };
+
+      try {
+        await (store.dispatch as any)(fetchConversation(sourceUuid));
+        holdOlderPage = true;
+        const olderDispatch = (store.dispatch as any)(
+          fetchOlderConversationItems(sourceUuid),
+        );
+        expect(stalePage?.items).toHaveLength(51);
+        const deletedUuid = stalePage!.items[0].uuid;
+        realDb.updateItems({ [deletedUuid]: null });
+        const currentGeneration = realDb.getConversationPaginationGeneration();
+
+        held.resolve(stalePage!);
+        await olderDispatch;
+
+        const state = (store.getState() as any).conversation;
+        expect(state.conversation.paginationGeneration).toBe(currentGeneration);
+        expect(
+          state.conversation.items.some(
+            (item: { uuid: string }) => item.uuid === deletedUuid,
+          ),
+        ).toBe(false);
+        expect(state.conversation.items).toHaveLength(100);
+        expect(state.hasMoreHistoricalItems).toBe(true);
+      } finally {
+        realDb.close();
+      }
+    });
+
+    it("converges after repeated generation changes become quiescent", async () => {
+      await (store.dispatch as any)(fetchConversation("source-1"));
+      mockGetSourceWithItems.mockClear();
+      const restartAt11: SourceWithItems = {
+        ...olderPage,
+        paginationGeneration: 11,
+        paginationRestarted: true,
+      };
+      const restartAt12: SourceWithItems = {
+        ...olderPage,
+        paginationGeneration: 12,
+        paginationRestarted: true,
+      };
+      mockGetSourceWithItems
+        .mockResolvedValueOnce(olderPage)
+        .mockResolvedValueOnce(restartAt11)
+        .mockResolvedValueOnce(restartAt12);
+      mockGetConversationPaginationGeneration
+        .mockReturnValueOnce(11)
+        .mockReturnValueOnce(12)
+        .mockReturnValue(12);
+
+      await (store.dispatch as any)(fetchOlderConversationItems("source-1"));
+
+      expect(mockGetSourceWithItems).toHaveBeenCalledTimes(3);
+      const state = (store.getState() as any).conversation;
+      expect(state.conversation).toEqual(restartAt12);
+      expect(state.olderItemsLoading).toBe(false);
+    });
+
+    it("discards a non-restart page from a different generation", async () => {
+      await (store.dispatch as any)(fetchConversation("source-1"));
+      mockGetSourceWithItems.mockResolvedValue({
+        ...olderPage,
+        paginationGeneration: 11,
+      });
+      mockGetConversationPaginationGeneration.mockReturnValue(11);
+
+      await (store.dispatch as any)(fetchOlderConversationItems("source-1"));
+
+      const state = (store.getState() as any).conversation;
+      expect(state.conversation).toEqual(mockSourceWithItems);
+      expect(state.hasMoreHistoricalItems).toBe(true);
+      expect(state.olderItemsLoading).toBe(false);
+    });
+
+    it("discards a page whose returned source differs from the request", async () => {
+      await (store.dispatch as any)(fetchConversation("source-1"));
+      mockGetSourceWithItems.mockResolvedValue({
+        ...olderPage,
+        uuid: "source-2",
+      });
+
+      await (store.dispatch as any)(fetchOlderConversationItems("source-1"));
+
+      const state = (store.getState() as any).conversation;
+      expect(state.conversation).toEqual(mockSourceWithItems);
+      expect(state.hasMoreHistoricalItems).toBe(true);
+      expect(state.olderItemsLoading).toBe(false);
+    });
   });
 
   describe("selectors", () => {
@@ -271,6 +980,7 @@ describe("conversationSlice", () => {
         lastFetchTime: 123456789,
         hasMoreHistoricalItems: false,
         olderItemsLoading: false,
+        ...idleTraversalState,
       },
       sync: {
         error: null,
@@ -404,6 +1114,7 @@ describe("conversationSlice", () => {
       lastFetchTime: null,
       hasMoreHistoricalItems: false,
       olderItemsLoading: false,
+      ...idleTraversalState,
     };
 
     it("does not resurrect a Cancelled item", () => {

--- a/app/src/renderer/features/conversation/conversationSlice.ts
+++ b/app/src/renderer/features/conversation/conversationSlice.ts
@@ -1,4 +1,9 @@
-import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import {
+  createSlice,
+  createAsyncThunk,
+  createAction,
+  type ActionReducerMapBuilder,
+} from "@reduxjs/toolkit";
 import {
   Item,
   NONPROCESSABLE_FETCH_STATUSES,
@@ -15,6 +20,20 @@ export interface ConversationState {
   lastFetchTime: number | null;
   hasMoreHistoricalItems: boolean;
   olderItemsLoading: boolean;
+  traversalEpoch: number;
+  traversalSourceUuid: string | null;
+  activeConversationRequest: ConversationRequest | null;
+  activeOlderRequest: OlderConversationRequest | null;
+}
+
+interface ConversationRequest {
+  sourceUuid: string;
+  traversalEpoch: number;
+  requestId: string;
+}
+
+interface OlderConversationRequest extends ConversationRequest {
+  requestedGeneration: number | undefined;
 }
 
 const initialState: ConversationState = {
@@ -24,70 +43,413 @@ const initialState: ConversationState = {
   lastFetchTime: null,
   hasMoreHistoricalItems: false,
   olderItemsLoading: false,
+  traversalEpoch: 0,
+  traversalSourceUuid: null,
+  activeConversationRequest: null,
+  activeOlderRequest: null,
 };
 
 const CONVERSATION_PAGE_SIZE = 100;
 
-export const fetchConversation = createAsyncThunk(
+interface OlderConversationItemsResult {
+  request: OlderConversationRequest;
+  sourceWithItems: SourceWithItems;
+}
+
+interface ConversationItemsResult {
+  request: ConversationRequest;
+  sourceWithItems: SourceWithItems;
+}
+
+interface ConversationFetchError {
+  message: string;
+  request: ConversationRequest;
+}
+
+interface OlderConversationFetchError {
+  message: string;
+  request: OlderConversationRequest;
+}
+
+interface PendingSeenEffect {
+  created: boolean;
+  token: string;
+}
+
+interface OlderConversationTraversal {
+  beforeInteractionCount: number | null | undefined;
+  beforeItemUuid: string | undefined;
+  request: OlderConversationRequest;
+}
+
+type OlderConversationCursor = Omit<OlderConversationTraversal, "request">;
+
+const commitConversationPage = createAction<ConversationItemsResult>(
+  "conversation/commitConversationPage",
+);
+const commitOlderConversationPage = createAction<OlderConversationItemsResult>(
+  "conversation/commitOlderConversationPage",
+);
+
+function sameConversationRequest(
+  first: ConversationRequest | null,
+  second: ConversationRequest,
+): boolean {
+  return (
+    first?.sourceUuid === second.sourceUuid &&
+    first.traversalEpoch === second.traversalEpoch &&
+    first.requestId === second.requestId
+  );
+}
+
+function isActiveConversationRequest(
+  state: ConversationState,
+  request: ConversationRequest,
+): boolean {
+  return (
+    sameConversationRequest(state.activeConversationRequest, request) &&
+    request.traversalEpoch === state.traversalEpoch &&
+    state.traversalSourceUuid === request.sourceUuid
+  );
+}
+
+function sameOlderRequest(
+  first: OlderConversationRequest | null,
+  second: OlderConversationRequest,
+): boolean {
+  return (
+    sameConversationRequest(first, second) &&
+    first?.requestedGeneration === second.requestedGeneration
+  );
+}
+
+function isActiveOlderRequest(
+  state: ConversationState,
+  request: OlderConversationRequest,
+  actionRequestId: string,
+): boolean {
+  return (
+    actionRequestId === request.requestId &&
+    sameOlderRequest(state.activeOlderRequest, request) &&
+    state.traversalEpoch === request.traversalEpoch &&
+    state.traversalSourceUuid === request.sourceUuid
+  );
+}
+
+function hasAcceptableGeneration(
+  conversation: SourceWithItems,
+  page: SourceWithItems,
+  request: OlderConversationRequest,
+): boolean {
+  if (conversation.paginationGeneration !== request.requestedGeneration) {
+    return false;
+  }
+  if (page.paginationRestarted) {
+    return page.paginationGeneration !== request.requestedGeneration;
+  }
+  return page.paginationGeneration === request.requestedGeneration;
+}
+
+function canAcceptOlderPage(
+  state: ConversationState,
+  page: SourceWithItems,
+  request: OlderConversationRequest,
+): boolean {
+  const conversation = state.conversation;
+  if (!conversation || conversation.uuid !== request.sourceUuid) {
+    return false;
+  }
+  if (page.uuid !== request.sourceUuid) {
+    return false;
+  }
+  return hasAcceptableGeneration(conversation, page, request);
+}
+
+function activeConversationRequest(
+  state: ConversationState,
+  sourceUuid: string,
+  requestId: string,
+): ConversationRequest {
+  const request = state.activeConversationRequest;
+  if (
+    !request ||
+    request.sourceUuid !== sourceUuid ||
+    request.requestId !== requestId
+  ) {
+    throw new Error("Conversation request is no longer active");
+  }
+  return { ...request };
+}
+
+function requestToken(request: ConversationRequest): string {
+  return [request.sourceUuid, request.traversalEpoch, request.requestId].join(
+    ":",
+  );
+}
+
+function pageGenerationIsCurrent(page: SourceWithItems): boolean {
+  return (
+    window.electronAPI.getConversationPaginationGeneration() ===
+    page.paginationGeneration
+  );
+}
+
+function rejectionMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error) {
+    return error.message || fallback;
+  }
+  return typeof error === "string" ? error : fallback;
+}
+
+async function requestConversationPage(
+  sourceUuid: string,
+  options: Parameters<typeof window.electronAPI.getSourceWithItems>[1],
+): Promise<SourceWithItems> {
+  const page = await window.electronAPI.getSourceWithItems(sourceUuid, options);
+  if (page.uuid !== sourceUuid) {
+    throw new Error("Conversation response source does not match request");
+  }
+  return page;
+}
+
+async function beginConversationSeen(
+  page: SourceWithItems,
+  request: ConversationRequest,
+): Promise<PendingSeenEffect | null> {
+  const maxInteractionCount = page.items.reduce(
+    (max, item) => Math.max(max, item.data.interaction_count ?? 0),
+    0,
+  );
+  if (maxInteractionCount <= 0) {
+    return null;
+  }
+  const token = requestToken(request);
+  const created = await window.electronAPI.addPendingSourceConversationSeen(
+    request.sourceUuid,
+    maxInteractionCount,
+    token,
+  );
+  return { created: created !== null, token };
+}
+
+async function rollbackConversationSeen(
+  request: ConversationRequest,
+  effect: PendingSeenEffect | null,
+): Promise<void> {
+  if (!effect) {
+    return;
+  }
+  await window.electronAPI.finalizePendingSourceConversationSeen(
+    request.sourceUuid,
+    effect.token,
+    false,
+  );
+}
+
+function confirmConversationSeen(
+  request: ConversationRequest,
+  effect: PendingSeenEffect | null,
+  dispatch: (action: ReturnType<typeof fetchSources>) => unknown,
+): void {
+  if (!effect) {
+    return;
+  }
+  if (effect.created) {
+    dispatch(fetchSources());
+  }
+  void window.electronAPI.finalizePendingSourceConversationSeen(
+    request.sourceUuid,
+    effect.token,
+    true,
+  );
+}
+
+function conversationWasCommitted(
+  state: ConversationState,
+  request: ConversationRequest,
+  page: SourceWithItems,
+): boolean {
+  return (
+    state.activeConversationRequest === null &&
+    state.traversalEpoch === request.traversalEpoch &&
+    state.traversalSourceUuid === request.sourceUuid &&
+    state.conversation?.uuid === page.uuid &&
+    state.conversation.paginationGeneration === page.paginationGeneration
+  );
+}
+
+function olderPageWasCommitted(
+  state: ConversationState,
+  request: OlderConversationRequest,
+): boolean {
+  return (
+    state.activeOlderRequest === null &&
+    state.traversalEpoch === request.traversalEpoch &&
+    state.traversalSourceUuid === request.sourceUuid
+  );
+}
+
+function oldestConversationCursor(
+  conversation: SourceWithItems,
+): OlderConversationCursor {
+  const paginationCursor = conversation.paginationCursor;
+  if (paginationCursor) {
+    return {
+      beforeInteractionCount: paginationCursor.interactionCount,
+      beforeItemUuid: paginationCursor.itemUuid,
+    };
+  }
+  const oldestItem = conversation.items[0];
+  return {
+    beforeInteractionCount: oldestItem?.data.interaction_count,
+    beforeItemUuid: oldestItem?.uuid,
+  };
+}
+
+function captureOlderConversationTraversal(
+  state: ConversationState,
+  sourceUuid: string,
+  requestId: string,
+): OlderConversationTraversal {
+  const conversation = state.conversation;
+  const request = state.activeOlderRequest;
+  if (
+    !conversation ||
+    !request ||
+    request.requestId !== requestId ||
+    request.sourceUuid !== sourceUuid
+  ) {
+    throw new Error("Older conversation request is no longer active");
+  }
+  return {
+    ...oldestConversationCursor(conversation),
+    request: { ...request },
+  };
+}
+
+function commitValidatedOlderPage(
+  state: ConversationState,
+  sourceWithItems: SourceWithItems,
+  request: OlderConversationRequest,
+  dispatch: (action: ReturnType<typeof commitOlderConversationPage>) => unknown,
+): void {
+  if (!canAcceptOlderPage(state, sourceWithItems, request)) {
+    throw new Error("Older conversation response cannot be committed");
+  }
+  dispatch(commitOlderConversationPage({ request, sourceWithItems }));
+}
+
+export const fetchConversation = createAsyncThunk<
+  ConversationItemsResult,
+  string,
+  { rejectValue: ConversationFetchError }
+>(
   "conversation/fetchConversation",
-  async (sourceUuid: string, { dispatch }) => {
-    const sourceWithItems = await window.electronAPI.getSourceWithItems(
+  async (sourceUuid, { dispatch, getState, rejectWithValue, requestId }) => {
+    const request = activeConversationRequest(
+      (getState() as RootState).conversation,
       sourceUuid,
-      { limit: CONVERSATION_PAGE_SIZE },
+      requestId,
     );
-
-    // Mark all items in this conversation as seen
-    const maxInteractionCount = sourceWithItems.items.reduce(
-      (max, item) => Math.max(max, item.data.interaction_count ?? 0),
-      0,
-    );
-    if (maxInteractionCount > 0) {
-      const created = await window.electronAPI.addPendingSourceConversationSeen(
-        sourceUuid,
-        maxInteractionCount,
+    const requestIsActive = () =>
+      isActiveConversationRequest(
+        (getState() as RootState).conversation,
+        request,
       );
-      if (created) {
-        dispatch(fetchSources());
+    try {
+      while (requestIsActive()) {
+        const sourceWithItems = await requestConversationPage(sourceUuid, {
+          limit: CONVERSATION_PAGE_SIZE,
+        });
+        if (!requestIsActive() || !pageGenerationIsCurrent(sourceWithItems)) {
+          continue;
+        }
+        const seenEffect = await beginConversationSeen(
+          sourceWithItems,
+          request,
+        );
+        if (!requestIsActive() || !pageGenerationIsCurrent(sourceWithItems)) {
+          await rollbackConversationSeen(request, seenEffect);
+          continue;
+        }
+        dispatch(commitConversationPage({ request, sourceWithItems }));
+        const state = (getState() as RootState).conversation;
+        if (conversationWasCommitted(state, request, sourceWithItems)) {
+          confirmConversationSeen(request, seenEffect, dispatch);
+          return { request, sourceWithItems };
+        }
+        await rollbackConversationSeen(request, seenEffect);
       }
+      throw new Error("Conversation request was superseded");
+    } catch (error) {
+      const message = rejectionMessage(error, "Failed to fetch conversation");
+      return rejectWithValue({ message, request });
     }
-
-    return { sourceUuid, sourceWithItems };
   },
 );
 
-export const fetchOlderConversationItems = createAsyncThunk(
+export const fetchOlderConversationItems = createAsyncThunk<
+  OlderConversationItemsResult,
+  string,
+  { rejectValue: OlderConversationFetchError }
+>(
   "conversation/fetchOlderConversationItems",
-  async (sourceUuid: string, { getState, dispatch }) => {
-    const state = getState() as RootState;
-    const conversation = state.conversation.conversation;
-    if (!conversation || conversation.uuid !== sourceUuid) {
-      return null;
-    }
-
-    const oldestItem = conversation.items[0];
-    const beforeInteractionCount = oldestItem?.data.interaction_count;
-
-    const sourceWithItems = await window.electronAPI.getSourceWithItems(
+  async (sourceUuid, { dispatch, getState, rejectWithValue, requestId }) => {
+    const traversal = captureOlderConversationTraversal(
+      (getState() as RootState).conversation,
       sourceUuid,
-      { limit: CONVERSATION_PAGE_SIZE, beforeInteractionCount },
+      requestId,
     );
-
-    // Mark all older items in this conversation as seen
-    const maxInteractionCount = sourceWithItems.items.reduce(
-      (max, item) => Math.max(max, item.data.interaction_count ?? 0),
-      0,
-    );
-    if (maxInteractionCount > 0) {
-      const created = await window.electronAPI.addPendingSourceConversationSeen(
-        sourceUuid,
-        maxInteractionCount,
+    const capturedRequest = traversal.request;
+    const requestIsActive = () =>
+      isActiveOlderRequest(
+        (getState() as RootState).conversation,
+        capturedRequest,
+        requestId,
       );
-      if (created) {
-        dispatch(fetchSources());
-      }
-    }
 
-    return sourceWithItems;
+    try {
+      while (requestIsActive()) {
+        const sourceWithItems = await requestConversationPage(sourceUuid, {
+          limit: CONVERSATION_PAGE_SIZE,
+          beforeInteractionCount: traversal.beforeInteractionCount,
+          beforeItemUuid: traversal.beforeItemUuid,
+          paginationGeneration: capturedRequest.requestedGeneration,
+        });
+        if (!requestIsActive() || !pageGenerationIsCurrent(sourceWithItems)) {
+          continue;
+        }
+        commitValidatedOlderPage(
+          (getState() as RootState).conversation,
+          sourceWithItems,
+          capturedRequest,
+          dispatch,
+        );
+        const state = (getState() as RootState).conversation;
+        if (olderPageWasCommitted(state, capturedRequest)) {
+          return { request: capturedRequest, sourceWithItems };
+        }
+      }
+      throw new Error("Older conversation request was superseded");
+    } catch (error) {
+      const message = rejectionMessage(
+        error,
+        "Failed to fetch older conversation items",
+      );
+      return rejectWithValue({ message, request: capturedRequest });
+    }
+  },
+  {
+    condition: (sourceUuid, { getState }) => {
+      const state = (getState() as RootState).conversation;
+      return (
+        state.conversation?.uuid === sourceUuid &&
+        state.traversalSourceUuid === sourceUuid &&
+        state.activeConversationRequest === null &&
+        state.hasMoreHistoricalItems &&
+        !state.olderItemsLoading
+      );
+    },
   },
 );
 
@@ -126,6 +488,132 @@ export const deleteItem = createAsyncThunk(
   },
 );
 
+function addConversationFetchReducers(
+  builder: ActionReducerMapBuilder<ConversationState>,
+): void {
+  builder
+    .addCase(fetchConversation.pending, (state, action) => {
+      state.traversalEpoch += 1;
+      state.traversalSourceUuid = action.meta.arg;
+      state.activeConversationRequest = {
+        sourceUuid: action.meta.arg,
+        traversalEpoch: state.traversalEpoch,
+        requestId: action.meta.requestId,
+      };
+      state.activeOlderRequest = null;
+      state.loading = true;
+      state.olderItemsLoading = false;
+      state.error = null;
+    })
+    .addCase(commitConversationPage, (state, action) => {
+      const { request, sourceWithItems } = action.payload;
+      if (!isActiveConversationRequest(state, request)) {
+        return;
+      }
+      state.activeConversationRequest = null;
+      state.loading = false;
+      state.error = null;
+      state.conversation = sourceWithItems;
+      state.hasMoreHistoricalItems =
+        sourceWithItems.hasMoreHistoricalItems ?? false;
+      state.lastFetchTime = Date.now();
+    })
+    .addCase(fetchConversation.rejected, (state, action) => {
+      const failure = action.payload;
+      if (!failure || !isActiveConversationRequest(state, failure.request)) {
+        return;
+      }
+      state.activeConversationRequest = null;
+      state.loading = false;
+      state.error = failure.message;
+    });
+}
+
+function addOlderConversationFetchReducers(
+  builder: ActionReducerMapBuilder<ConversationState>,
+): void {
+  builder
+    .addCase(fetchOlderConversationItems.pending, (state, action) => {
+      const conversation = state.conversation;
+      if (!conversation) {
+        return;
+      }
+      state.activeOlderRequest = {
+        sourceUuid: action.meta.arg,
+        traversalEpoch: state.traversalEpoch,
+        requestId: action.meta.requestId,
+        requestedGeneration: conversation.paginationGeneration,
+      };
+      state.olderItemsLoading = true;
+    })
+    .addCase(commitOlderConversationPage, (state, action) => {
+      const { request, sourceWithItems } = action.payload;
+      if (!isActiveOlderRequest(state, request, request.requestId)) {
+        return;
+      }
+      const conversation = state.conversation;
+      if (
+        !conversation ||
+        !canAcceptOlderPage(state, sourceWithItems, request)
+      ) {
+        return;
+      }
+      state.activeOlderRequest = null;
+      state.olderItemsLoading = false;
+      const { items, hasMoreHistoricalItems } = sourceWithItems;
+      if (sourceWithItems.paginationRestarted) {
+        state.conversation = sourceWithItems;
+        state.hasMoreHistoricalItems = hasMoreHistoricalItems ?? false;
+        return;
+      }
+      const existingUuids = new Set(
+        conversation.items.map((item) => item.uuid),
+      );
+      const olderItems = items.filter((item) => !existingUuids.has(item.uuid));
+      conversation.items = [...olderItems, ...conversation.items];
+      if (sourceWithItems.paginationCursor) {
+        conversation.paginationCursor = sourceWithItems.paginationCursor;
+      }
+      conversation.paginationGeneration = sourceWithItems.paginationGeneration;
+      conversation.hasMoreHistoricalItems = hasMoreHistoricalItems;
+      state.hasMoreHistoricalItems = hasMoreHistoricalItems ?? false;
+    })
+    .addCase(fetchOlderConversationItems.rejected, (state, action) => {
+      const failure = action.payload;
+      if (
+        !failure ||
+        !isActiveOlderRequest(state, failure.request, action.meta.requestId)
+      ) {
+        return;
+      }
+      state.activeOlderRequest = null;
+      state.olderItemsLoading = false;
+    });
+}
+
+function addConversationMutationReducers(
+  builder: ActionReducerMapBuilder<ConversationState>,
+): void {
+  builder
+    .addCase(updateItemFetchStatus.fulfilled, (state, action) => {
+      const { item: updatedItem } = action.payload;
+      if (state.conversation) {
+        state.conversation.items = state.conversation.items.map((item) => {
+          if (updatedItem && item.uuid === updatedItem.uuid) {
+            return updatedItem;
+          }
+          return item;
+        });
+      }
+      state.lastFetchTime = Date.now();
+    })
+    .addCase(deleteItem.fulfilled, (state, action) => {
+      const { sourceWithItems } = action.payload;
+      state.conversation = sourceWithItems;
+      state.lastFetchTime = Date.now();
+    });
+}
+
 const conversationSlice = createSlice({
   name: "conversation",
   initialState,
@@ -135,9 +623,14 @@ const conversationSlice = createSlice({
     },
     clearConversation: (state) => {
       state.conversation = null;
+      state.loading = false;
       state.lastFetchTime = null;
       state.hasMoreHistoricalItems = false;
       state.olderItemsLoading = false;
+      state.traversalEpoch += 1;
+      state.traversalSourceUuid = null;
+      state.activeConversationRequest = null;
+      state.activeOlderRequest = null;
     },
     updateItem: (state, action) => {
       const updatedItem: Item = action.payload;
@@ -163,60 +656,9 @@ const conversationSlice = createSlice({
     },
   },
   extraReducers: (builder) => {
-    builder
-      .addCase(fetchConversation.pending, (state) => {
-        state.loading = true;
-        state.error = null;
-      })
-      .addCase(fetchConversation.fulfilled, (state, action) => {
-        state.loading = false;
-        state.error = null;
-        const { sourceWithItems } = action.payload;
-        state.conversation = sourceWithItems;
-        state.hasMoreHistoricalItems =
-          sourceWithItems.hasMoreHistoricalItems ?? false;
-        state.lastFetchTime = Date.now();
-      })
-      .addCase(fetchConversation.rejected, (state, action) => {
-        state.loading = false;
-        state.error = action.error.message || "Failed to fetch conversation";
-      })
-      .addCase(fetchOlderConversationItems.pending, (state) => {
-        state.olderItemsLoading = true;
-      })
-      .addCase(fetchOlderConversationItems.fulfilled, (state, action) => {
-        state.olderItemsLoading = false;
-        if (!action.payload || !state.conversation) {
-          return;
-        }
-        const { items, hasMoreHistoricalItems } = action.payload;
-        const existingUuids = new Set(
-          state.conversation.items.map((i) => i.uuid),
-        );
-        const olderItems = items.filter((i) => !existingUuids.has(i.uuid));
-        state.conversation.items = [...olderItems, ...state.conversation.items];
-        state.hasMoreHistoricalItems = hasMoreHistoricalItems ?? false;
-      })
-      .addCase(fetchOlderConversationItems.rejected, (state) => {
-        state.olderItemsLoading = false;
-      })
-      .addCase(updateItemFetchStatus.fulfilled, (state, action) => {
-        const { item: updatedItem } = action.payload;
-        if (state.conversation) {
-          state.conversation.items = state.conversation.items.map((item, _) => {
-            if (updatedItem && item.uuid === updatedItem.uuid) {
-              return updatedItem;
-            }
-            return item;
-          });
-        }
-        state.lastFetchTime = Date.now();
-      })
-      .addCase(deleteItem.fulfilled, (state, action) => {
-        const { sourceWithItems } = action.payload;
-        state.conversation = sourceWithItems;
-        state.lastFetchTime = Date.now();
-      });
+    addConversationFetchReducers(builder);
+    addOlderConversationFetchReducers(builder);
+    addConversationMutationReducers(builder);
   },
 });
 

--- a/app/src/renderer/features/journalists/journalistsSlice.test.ts
+++ b/app/src/renderer/features/journalists/journalistsSlice.test.ts
@@ -213,6 +213,10 @@ describe("journalistsSlice", () => {
         lastFetchTime: null,
         hasMoreHistoricalItems: false,
         olderItemsLoading: false,
+        traversalEpoch: 0,
+        traversalSourceUuid: null,
+        activeConversationRequest: null,
+        activeOlderRequest: null,
       },
       sync: {
         error: null,

--- a/app/src/renderer/features/sources/sourcesSlice.test.ts
+++ b/app/src/renderer/features/sources/sourcesSlice.test.ts
@@ -303,6 +303,10 @@ describe("sourcesSlice", () => {
       lastFetchTime: null,
       hasMoreHistoricalItems: false,
       olderItemsLoading: false,
+      traversalEpoch: 0,
+      traversalSourceUuid: null,
+      activeConversationRequest: null,
+      activeOlderRequest: null,
     };
 
     it("selectSources returns sources map", () => {

--- a/app/src/renderer/test-component-setup.tsx
+++ b/app/src/renderer/test-component-setup.tsx
@@ -193,7 +193,10 @@ beforeEach(() => {
           },
         },
       ],
+      hasMoreHistoricalItems: false,
+      paginationGeneration: 0,
     }),
+    getConversationPaginationGeneration: vi.fn().mockReturnValue(0),
     getSourceItemCounts: vi
       .fn()
       .mockResolvedValue({ messages: 0, files: 0, replies: 0 }),
@@ -231,6 +234,7 @@ beforeEach(() => {
     addPendingReplySentEvent: vi.fn().mockResolvedValue(BigInt(456)),
     addPendingItemEvent: vi.fn().mockResolvedValue(BigInt(789)),
     addPendingSourceConversationSeen: vi.fn().mockResolvedValue(null),
+    finalizePendingSourceConversationSeen: vi.fn().mockResolvedValue(false),
     shouldAutoLogin: vi.fn().mockResolvedValue(false),
     clearClipboard: vi.fn().mockResolvedValue(null),
     openFile: vi.fn().mockResolvedValue(undefined),

--- a/app/src/renderer/views/Inbox/MainContent.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent.test.tsx
@@ -98,12 +98,18 @@ const mockSourceWithItems: SourceWithItems = {
       fetch_status: 3,
     },
   ],
+  hasMoreHistoricalItems: false,
+  paginationGeneration: 0,
 };
 
 describe("MainContent accessibility", () => {
   beforeEach(() => {
     (window as any).electronAPI = {
       getSourceWithItems: vi.fn().mockResolvedValue(null),
+      getConversationPaginationGeneration: vi.fn().mockReturnValue(0),
+      addPendingSourceConversationSeen: vi.fn().mockResolvedValue(null),
+      finalizePendingSourceConversationSeen: vi.fn().mockResolvedValue(false),
+      getSources: vi.fn().mockResolvedValue({}),
       addPendingItemsSeenBatch: vi.fn().mockResolvedValue(undefined),
       getWhistleflowEnabled: vi.fn().mockResolvedValue(false),
     };
@@ -125,6 +131,10 @@ describe("MainContent accessibility", () => {
             lastFetchTime: null,
             hasMoreHistoricalItems: false,
             olderItemsLoading: false,
+            traversalEpoch: 0,
+            traversalSourceUuid: null,
+            activeConversationRequest: null,
+            activeOlderRequest: null,
           },
         },
       },
@@ -140,6 +150,10 @@ describe("MainContent Component", () => {
     // Mock electronAPI
     (window as any).electronAPI = {
       getSourceWithItems: vi.fn().mockResolvedValue(mockSourceWithItems),
+      getConversationPaginationGeneration: vi.fn().mockReturnValue(0),
+      addPendingSourceConversationSeen: vi.fn().mockResolvedValue(null),
+      finalizePendingSourceConversationSeen: vi.fn().mockResolvedValue(false),
+      getSources: vi.fn().mockResolvedValue({}),
       addPendingItemsSeenBatch: vi.fn().mockResolvedValue(undefined),
       getWhistleflowEnabled: vi.fn().mockResolvedValue(false),
     };
@@ -170,6 +184,10 @@ describe("MainContent Component", () => {
             lastFetchTime: null,
             hasMoreHistoricalItems: false,
             olderItemsLoading: false,
+            traversalEpoch: 0,
+            traversalSourceUuid: sourceUuid ?? null,
+            activeConversationRequest: null,
+            activeOlderRequest: null,
           },
         },
       },
@@ -206,6 +224,10 @@ describe("MainContent Component", () => {
               lastFetchTime: Date.now(),
               hasMoreHistoricalItems: false,
               olderItemsLoading: false,
+              traversalEpoch: 0,
+              traversalSourceUuid: "source-1",
+              activeConversationRequest: null,
+              activeOlderRequest: null,
             },
           },
         },
@@ -393,6 +415,10 @@ describe("MainContent Component", () => {
               lastFetchTime: Date.now(),
               hasMoreHistoricalItems: false,
               olderItemsLoading: false,
+              traversalEpoch: 0,
+              traversalSourceUuid: "source-1",
+              activeConversationRequest: null,
+              activeOlderRequest: null,
             },
           },
         },

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -186,6 +186,22 @@ export type SourceWithItems = {
   items: Item[];
   hasMoreHistoricalItems?: boolean;
   lastSeenInteractionCount?: number | null;
+  paginationCursor?: ConversationPaginationCursor;
+  paginationGeneration?: number;
+  paginationRestarted?: boolean;
+};
+
+export type ConversationPaginationCursor = {
+  interactionCount: number | null;
+  itemUuid: string;
+};
+
+export type GetSourceWithItemsOptions = {
+  limit?: number;
+  beforeInteractionCount?: number | null;
+  beforeItemUuid?: string;
+  paginationGeneration?: number;
+  journalistUuid?: string;
 };
 
 export type SourceItemCounts = {

--- a/architecture-decisions/002-conversation-pagination-generation.md
+++ b/architecture-decisions/002-conversation-pagination-generation.md
@@ -1,0 +1,47 @@
+# Conversation pagination generation
+
+## Summary
+
+Historical conversation traversal is bound to a database generation. If item ordering
+or membership changes between pages, the database returns a fresh first page and the
+renderer replaces the old traversal.
+
+## Context
+
+Conversation pages use `(interaction_count, uuid)` as a descending keyset cursor. The
+cursor is complete for a stable dataset, but an unloaded item can become unreachable
+if synchronization raises its interaction count above the cursor between page reads.
+Local pending replies, item deletions, and conversation truncation can also change the
+projected pagination dataset outside a metadata sync.
+
+## Decision
+
+SQLite triggers maintain one persisted generation for changes that can alter item
+cursor order or membership. Item inserts and deletes advance it. Updates advance it
+only when the physical UUID, metadata source UUID, or metadata interaction count
+changes. Membership-changing pending events also advance it. Seen, read-state,
+fetch-status, fetch-progress, and other metadata-only updates do not advance it because
+they leave the cursor dataset unchanged.
+
+Every page returns its generation. A continuation sends that generation with its
+cursor. The database reads the generation and page in one transaction. On a mismatch,
+it ignores the cursor and returns the current first page with a restart marker. The
+renderer replaces its loaded items for that source and can continue from the new page.
+Each renderer navigation starts a traversal epoch, and each continuation records its
+request identity and requested generation. A continuation can merge or replace state
+only while that source, epoch, request, and generation relationship are still current.
+Stale continuations perform no seen write or source refresh; opening the conversation
+already marks through the maximum interaction count, which covers every older page.
+
+The generation is global rather than per source. A mutation in another source can
+therefore cause an unnecessary restart, but it avoids per-source generation lifecycle
+and trigger logic while preserving correctness.
+
+## Rejected alternative
+
+Making each item's `(interaction_count, uuid)` tuple immutable would keep cursors
+stable, but `interaction_count` is authoritative server metadata that can be corrected
+during sync. Rejecting such an update would abort a batch or retain stale metadata and
+would require conflict and restart behavior at the sync boundary. Restarting a
+generation-bound traversal preserves server authority and confines recovery to the UI
+read path.


### PR DESCRIPTION
## Summary

- Adds a deterministic conversation pagination cursor over `(interaction_count, uuid)` so tied interaction counts are traversed exactly once instead of skipped at page boundaries.
- Tracks a database pagination generation for ordering and membership changes, and restarts stale historical traversals instead of merging pages from different datasets.
- Binds renderer conversation requests to source, traversal epoch, request ID, and generation, with token-owned finalization or rollback for pending seen writes.

## Context

Fixes #3577.

This follows the existing migration-backed database-invariant pattern used for projected item state, while keeping server-provided `interaction_count` metadata authoritative and recovering stale reads in the pagination path.

## Test plan

```sh
python3.13 -B ptp-notes/research/client/pocs/duplicate-interaction-pagination-poc.py .worktrees/sdc-3577-baseline-current
```

Result: reproduced the issue on current `origin/main` (`6e0d25ab`): the duplicate-count case returned `confirmed: true`, with `missing_rows_after_one_older_fetch: 51`, `older_page_count: 0`, and `total_rows: 151`; the unique-count control reached all 151 rows.

```sh
cd app && PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec vitest run --config vitest.config.ts --project=unit src/main/datastore.test.ts --no-coverage --no-file-parallelism
```

Result: `src/main/datastore.test.ts` passed, 83 tests. The regression `traverses 20,000 tied rows exactly once with an inspected query plan` passed.

```sh
cd app && PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec vitest run --config vitest.config.ts --project=component src/renderer/features/conversation/conversationSlice.test.ts src/renderer/features/sources/sourcesSlice.test.ts src/renderer/features/journalists/journalistsSlice.test.ts src/renderer/views/Inbox/MainContent.test.tsx --no-coverage --no-file-parallelism
```

Result: 4 files passed, 82 tests.

```sh
cd app && PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec vitest run --config vitest.config.ts --project=unit src/main/index.test.ts --no-coverage --no-file-parallelism
```

Result: `src/main/index.test.ts` passed, 4 tests.

```sh
cd app && PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm test
```

Result: 52 files passed, 923 tests passed.

```sh
cd app && tmp_home=$(mktemp -d); mkdir -p "$tmp_home/.config/SecureDrop"; HOME="$tmp_home" PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm run dbmate:check; rc=$?; if command -v trash >/dev/null 2>&1; then trash "$tmp_home"; fi; exit "$rc"
```

Result: migrations applied through `20260710000000_conversation_pagination_generation.sql`; schema dump matched `src/main/database/schema.sql`.

```sh
cd app && PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm run lint
```

Result: Prettier, ESLint with `--max-warnings 0`, `typecheck:node`, and `typecheck:web` passed.

```sh
cd app && PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm build:linux
```

Result: production Vite build and `electron-builder --linux` completed successfully.

```sh
git diff --check HEAD~1..HEAD
```

Result: no whitespace errors.

## Notes

Server tests were not run locally; this patch is limited to local database pagination, Electron IPC/preload wiring, and renderer state handling, and does not require the shared SecureDrop server test slot.

The pagination generation is intentionally global. A mutation in another source can cause an unnecessary traversal restart, but that keeps the trigger lifecycle small while preserving correctness.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [x] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
