### PR TITLE
fix(database): complete truncation cleanup before sync

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -32,6 +32,7 @@ import {
   FirstRunStatus,
   PendingEventData,
   SourceItemCounts,
+  PendingSourceCleanup,
 } from "../../types";
 import { Crypto } from "../crypto";
 import { Search } from "./search";
@@ -41,6 +42,17 @@ import { Search } from "./search";
 export const MESSAGE_PREVIEW_LENGTH = 200;
 const DEFAULT_ITEM_LIMIT = 100;
 export const DEFAULT_PENDING_EVENTS_LIMIT = 20;
+
+type PendingSourceCleanupRow = {
+  snowflake_id: string;
+  source_uuid: string;
+  data: string | null;
+};
+
+type SourceCleanupData = {
+  upper_bound: number;
+  local_cleanup_item_uuids?: string[];
+};
 
 interface KeyObject {
   [key: string]: object;
@@ -157,6 +169,10 @@ export class DB {
     [string, number, number],
     ItemRow
   >;
+  private selectSourceItemsUpTo: Statement<
+    { source_uuid: string; upper_bound: number },
+    ItemRow
+  >;
   private selectItemCountsBySourceUuids: Statement<
     { uuids_json: string },
     { messages: number; files: number; replies: number }
@@ -168,6 +184,7 @@ export class DB {
       source_uuid: string;
       type: string;
       data: string | null;
+      local_cleanup_pending: number;
     },
     void
   >;
@@ -198,6 +215,27 @@ export class DB {
     void
   >;
   private selectPendingEvents: Statement<[{ limit: number }], PendingEventRow>;
+  private selectPendingSourceCleanup: Statement<
+    { snowflake_id: string },
+    PendingSourceCleanupRow
+  >;
+  private selectPendingSourceCleanups: Statement<[], PendingSourceCleanupRow>;
+  private selectPendingSourceTruncations: Statement<
+    [],
+    PendingSourceCleanupRow
+  >;
+  private selectPendingSourceCleanupBySource: Statement<
+    { source_uuid: string },
+    { present: number }
+  >;
+  private updatePendingSourceCleanup: Statement<
+    { snowflake_id: string; data: string },
+    void
+  >;
+  private completePendingSourceCleanup: Statement<
+    { snowflake_id: string },
+    void
+  >;
   private deletePendingEventsBySourceScope: Statement<
     { source_uuid: string },
     void
@@ -310,10 +348,12 @@ export class DB {
       "DELETE FROM items WHERE source_uuid = @source_uuid",
     );
     this.updateItemFetchStatus = this.db.prepare(
-      "UPDATE items SET fetch_status = @fetch_status WHERE uuid = @uuid",
+      `UPDATE items SET fetch_status = @fetch_status
+       WHERE uuid = @uuid AND fetch_status != ${FetchStatus.ScheduledDeletion}`,
     );
     this.updateItemFetchStatusWithReset = this.db.prepare(
-      "UPDATE items SET fetch_status = @fetch_status, fetch_progress = 0 WHERE uuid = @uuid",
+      `UPDATE items SET fetch_status = @fetch_status, fetch_progress = 0
+       WHERE uuid = @uuid AND fetch_status != ${FetchStatus.ScheduledDeletion}`,
     );
     this.updateItemsFetchStatusBySource = this.db.prepare(
       "UPDATE items SET fetch_status = @fetch_status WHERE source_uuid = @source_uuid",
@@ -392,6 +432,13 @@ export class DB {
       ORDER BY interaction_count DESC
       LIMIT ?
     `);
+    this.selectSourceItemsUpTo = this.db.prepare(`
+      SELECT uuid, data, plaintext, filename, fetch_status, fetch_progress, decrypted_size
+      FROM items
+      WHERE source_uuid = @source_uuid
+        AND interaction_count <= @upper_bound
+      ORDER BY interaction_count ASC
+    `);
     this.selectItemCountsBySourceUuids = this.db.prepare(`
       SELECT
         COALESCE(SUM(CASE WHEN kind = 'message' THEN 1 ELSE 0 END), 0) AS messages,
@@ -405,7 +452,11 @@ export class DB {
     `);
 
     this.insertSourcePendingEvent = this.db.prepare(`
-      INSERT INTO pending_events (snowflake_id, source_uuid, type, data) VALUES (@snowflake_id, @source_uuid, @type, @data)
+      INSERT INTO pending_events (
+        snowflake_id, source_uuid, type, data, local_cleanup_pending
+      ) VALUES (
+        @snowflake_id, @source_uuid, @type, @data, @local_cleanup_pending
+      )
     `);
 
     this.insertItemPendingEvent = this.db.prepare(`
@@ -442,7 +493,50 @@ export class DB {
     this.selectPendingEvents = this.db.prepare(`
       SELECT snowflake_id, source_uuid, item_uuid, type, data FROM pending_events
       WHERE last_event_status IS NOT ${EventStatus.AlreadyReported}
+        AND local_cleanup_pending = 0
       ORDER BY retry_attempts ASC, snowflake_id ASC LIMIT @limit
+    `);
+    this.selectPendingSourceCleanup = this.db.prepare(`
+      SELECT snowflake_id, source_uuid, data
+      FROM pending_events
+      WHERE snowflake_id = @snowflake_id
+        AND type = '${PendingEventType.SourceConversationTruncated}'
+        AND local_cleanup_pending = 1
+    `);
+    this.selectPendingSourceCleanups = this.db.prepare(`
+      SELECT snowflake_id, source_uuid, data
+      FROM pending_events
+      WHERE type = '${PendingEventType.SourceConversationTruncated}'
+        AND local_cleanup_pending = 1
+      ORDER BY snowflake_id ASC
+    `);
+    this.selectPendingSourceTruncations = this.db.prepare(`
+      SELECT snowflake_id, source_uuid, data
+      FROM pending_events
+      WHERE type = '${PendingEventType.SourceConversationTruncated}'
+      ORDER BY snowflake_id ASC
+    `);
+    this.selectPendingSourceCleanupBySource = this.db.prepare(`
+      SELECT 1 AS present
+      FROM pending_events
+      WHERE source_uuid = @source_uuid
+        AND type = '${PendingEventType.SourceConversationTruncated}'
+        AND local_cleanup_pending = 1
+      LIMIT 1
+    `);
+    this.updatePendingSourceCleanup = this.db.prepare(`
+      UPDATE pending_events
+      SET data = @data
+      WHERE snowflake_id = @snowflake_id
+        AND local_cleanup_pending = 1
+    `);
+    this.completePendingSourceCleanup = this.db.prepare(`
+      UPDATE pending_events
+      SET
+        data = json_remove(data, '$.local_cleanup_item_uuids'),
+        local_cleanup_pending = 0
+      WHERE snowflake_id = @snowflake_id
+        AND local_cleanup_pending = 1
     `);
     this.deletePendingEventsBySourceScope = this.db.prepare(`
       DELETE FROM pending_events
@@ -697,6 +791,13 @@ export class DB {
             this.upsertSource.run({ uuid: sourceid, data: info, version });
             this.searchIndex.indexSource(sourceid);
           } else {
+            if (
+              this.selectPendingSourceCleanupBySource.get({
+                source_uuid: sourceid,
+              })
+            ) {
+              return;
+            }
             deletedSourceUuids.push(sourceid);
             this.deleteSourceAndItems(sourceid);
           }
@@ -726,6 +827,8 @@ export class DB {
           this.searchIndex.removeItem(itemid);
         }
       });
+      this.refreshPendingSourceCleanups();
+      this.markPendingSourceTruncationsScheduledDeletion();
     })(items);
     return deletedItems;
   }
@@ -1007,59 +1110,93 @@ export class DB {
     };
   }
 
-  completePlaintextItem(itemUuid: string, plaintext: string) {
+  protected getSourceItemsUpTo(sourceUuid: string, upperBound: number): Item[] {
+    const rows = this.selectSourceItemsUpTo.all({
+      source_uuid: sourceUuid,
+      upper_bound: upperBound,
+    });
+    return rows.map((row) => ({
+      uuid: row.uuid,
+      data: JSON.parse(row.data) as ItemMetadata,
+      plaintext: row.plaintext,
+      filename: row.filename,
+      fetch_status: row.fetch_status as FetchStatus,
+      fetch_progress: row.fetch_progress,
+      decrypted_size: row.decrypted_size,
+    }));
+  }
+
+  completePlaintextItem(itemUuid: string, plaintext: string): boolean {
     const stmt: Statement<{ uuid: string; plaintext: string }, void> =
       this.db!.prepare(
-        `UPDATE items SET fetch_progress = null, fetch_status = ${FetchStatus.Complete}, plaintext = @plaintext, fetch_last_updated_at = CURRENT_TIMESTAMP WHERE uuid = @uuid`,
+        `UPDATE items SET fetch_progress = null, fetch_status = ${FetchStatus.Complete}, plaintext = @plaintext, fetch_last_updated_at = CURRENT_TIMESTAMP
+         WHERE uuid = @uuid AND fetch_status != ${FetchStatus.ScheduledDeletion}`,
       );
-    stmt.run({
+    const result = stmt.run({
       uuid: itemUuid,
       plaintext: plaintext,
     });
-    this.searchIndex.indexItem(itemUuid);
+    if (result.changes !== 0) {
+      this.searchIndex.indexItem(itemUuid);
+      return true;
+    }
+    return false;
   }
 
-  completeFileItem(itemUuid: string, filename: string, decryptedSize: number) {
+  completeFileItem(
+    itemUuid: string,
+    filename: string,
+    decryptedSize: number,
+  ): boolean {
     const stmt: Statement<
       { uuid: string; filename: string; decrypted_size: number },
       void
     > = this.db!.prepare(
-      `UPDATE items SET fetch_progress = null, fetch_status = ${FetchStatus.Complete}, filename = @filename, decrypted_size = @decrypted_size, fetch_last_updated_at = CURRENT_TIMESTAMP WHERE uuid = @uuid`,
+      `UPDATE items SET fetch_progress = null, fetch_status = ${FetchStatus.Complete}, filename = @filename, decrypted_size = @decrypted_size, fetch_last_updated_at = CURRENT_TIMESTAMP
+       WHERE uuid = @uuid AND fetch_status != ${FetchStatus.ScheduledDeletion}`,
     );
-    stmt.run({
+    const result = stmt.run({
       uuid: itemUuid,
       filename: filename,
       decrypted_size: decryptedSize,
     });
-    this.searchIndex.indexItem(itemUuid);
+    if (result.changes !== 0) {
+      this.searchIndex.indexItem(itemUuid);
+      return true;
+    }
+    return false;
   }
 
   terminallyFailItem(itemUuid: string) {
     const stmt: Statement<{ uuid: string }, void> = this.db!.prepare(
-      `UPDATE ITEMS set fetch_status = ${FetchStatus.FailedTerminal}, fetch_retry_attempts = fetch_retry_attempts + 1, fetch_last_updated_at = CURRENT_TIMESTAMP WHERE uuid = @uuid`,
+      `UPDATE items SET fetch_status = ${FetchStatus.FailedTerminal}, fetch_retry_attempts = fetch_retry_attempts + 1, fetch_last_updated_at = CURRENT_TIMESTAMP
+       WHERE uuid = @uuid AND fetch_status != ${FetchStatus.ScheduledDeletion}`,
     );
     stmt.run({ uuid: itemUuid });
   }
 
   pauseItem(itemUuid: string) {
     const stmt: Statement<{ uuid: string }, void> = this.db!.prepare(
-      `UPDATE ITEMS set fetch_status = ${FetchStatus.Paused}, fetch_last_updated_at = CURRENT_TIMESTAMP WHERE uuid = @uuid`,
+      `UPDATE items SET fetch_status = ${FetchStatus.Paused}, fetch_last_updated_at = CURRENT_TIMESTAMP
+       WHERE uuid = @uuid AND fetch_status != ${FetchStatus.ScheduledDeletion}`,
     );
     stmt.run({ uuid: itemUuid });
   }
 
   resumeItem(itemUuid: string) {
     const stmt: Statement<{ uuid: string }, void> = this.db!.prepare(
-      `UPDATE ITEMS set fetch_status = ${FetchStatus.DownloadInProgress}, fetch_last_updated_at = CURRENT_TIMESTAMP WHERE uuid = @uuid`,
+      `UPDATE items SET fetch_status = ${FetchStatus.DownloadInProgress}, fetch_last_updated_at = CURRENT_TIMESTAMP
+       WHERE uuid = @uuid AND fetch_status != ${FetchStatus.ScheduledDeletion}`,
     );
     stmt.run({ uuid: itemUuid });
   }
 
-  startDownloadInProgress(itemUuid: string) {
+  startDownloadInProgress(itemUuid: string): boolean {
     const stmt: Statement<{ uuid: string }, void> = this.db!.prepare(
-      `UPDATE items SET fetch_status = ${FetchStatus.DownloadInProgress}, fetch_last_updated_at = CURRENT_TIMESTAMP WHERE uuid = @uuid`,
+      `UPDATE items SET fetch_status = ${FetchStatus.DownloadInProgress}, fetch_last_updated_at = CURRENT_TIMESTAMP
+       WHERE uuid = @uuid AND fetch_status != ${FetchStatus.ScheduledDeletion}`,
     );
-    stmt.run({ uuid: itemUuid });
+    return stmt.run({ uuid: itemUuid }).changes !== 0;
   }
 
   // Updates a download in progress if it is still in a processable state. Returns true
@@ -1076,23 +1213,26 @@ export class DB {
     return result.changes !== 0;
   }
 
-  setDecryptionInProgress(itemUuid: string) {
+  setDecryptionInProgress(itemUuid: string): boolean {
     const stmt: Statement<{ uuid: string }, void> = this.db!.prepare(
-      `UPDATE items SET fetch_status = ${FetchStatus.DecryptionInProgress}, fetch_last_updated_at = CURRENT_TIMESTAMP WHERE uuid = @uuid`,
+      `UPDATE items SET fetch_status = ${FetchStatus.DecryptionInProgress}, fetch_last_updated_at = CURRENT_TIMESTAMP
+       WHERE uuid = @uuid AND fetch_status != ${FetchStatus.ScheduledDeletion}`,
     );
-    stmt.run({ uuid: itemUuid });
+    return stmt.run({ uuid: itemUuid }).changes !== 0;
   }
 
   failDownload(itemUuid: string) {
     const stmt: Statement<{ uuid: string }, void> = this.db!.prepare(
-      `UPDATE items SET fetch_status = ${FetchStatus.FailedDownloadRetryable}, fetch_retry_attempts = fetch_retry_attempts + 1, fetch_last_updated_at = CURRENT_TIMESTAMP WHERE uuid = @uuid`,
+      `UPDATE items SET fetch_status = ${FetchStatus.FailedDownloadRetryable}, fetch_retry_attempts = fetch_retry_attempts + 1, fetch_last_updated_at = CURRENT_TIMESTAMP
+       WHERE uuid = @uuid AND fetch_status != ${FetchStatus.ScheduledDeletion}`,
     );
     stmt.run({ uuid: itemUuid });
   }
 
   failDecryption(itemUuid: string) {
     const stmt: Statement<{ uuid: string }, void> = this.db!.prepare(
-      `UPDATE items SET fetch_status = ${FetchStatus.FailedDecryptionRetryable}, fetch_retry_attempts = fetch_retry_attempts + 1, fetch_last_updated_at = CURRENT_TIMESTAMP WHERE uuid = @uuid`,
+      `UPDATE items SET fetch_status = ${FetchStatus.FailedDecryptionRetryable}, fetch_retry_attempts = fetch_retry_attempts + 1, fetch_last_updated_at = CURRENT_TIMESTAMP
+       WHERE uuid = @uuid AND fetch_status != ${FetchStatus.ScheduledDeletion}`,
     );
     stmt.run({ uuid: itemUuid });
   }
@@ -1121,48 +1261,177 @@ export class DB {
     });
   }
 
+  private refreshPendingSourceCleanupRow(
+    row: PendingSourceCleanupRow,
+  ): PendingSourceCleanup {
+    if (!row.data) {
+      throw new Error(
+        `Invariant violation: pending cleanup ${row.snowflake_id} has no data`,
+      );
+    }
+    const data = JSON.parse(row.data) as SourceCleanupData;
+    const itemUuids = new Set(data.local_cleanup_item_uuids ?? []);
+    for (const item of this.getSourceItemsUpTo(
+      row.source_uuid,
+      data.upper_bound,
+    )) {
+      itemUuids.add(item.uuid);
+    }
+    this.markSourceItemsScheduledDeletionUpTo(
+      row.source_uuid,
+      data.upper_bound,
+    );
+    const storedData: SourceCleanupData = {
+      upper_bound: data.upper_bound,
+      local_cleanup_item_uuids: [...itemUuids],
+    };
+    this.updatePendingSourceCleanup.run({
+      snowflake_id: row.snowflake_id,
+      data: JSON.stringify(storedData),
+    });
+    return {
+      id: row.snowflake_id,
+      sourceUuid: row.source_uuid,
+      upperBound: data.upper_bound,
+      itemUuids: storedData.local_cleanup_item_uuids ?? [],
+    };
+  }
+
+  private refreshPendingSourceCleanups(): void {
+    for (const row of this.selectPendingSourceCleanups.all()) {
+      this.refreshPendingSourceCleanupRow(row);
+    }
+  }
+
+  private markPendingSourceTruncationsScheduledDeletion(): void {
+    for (const row of this.selectPendingSourceTruncations.all()) {
+      if (!row.data) {
+        continue;
+      }
+      const data = JSON.parse(row.data) as Partial<SourceCleanupData>;
+      if (typeof data.upper_bound !== "number") {
+        continue;
+      }
+      this.markSourceItemsScheduledDeletionUpTo(
+        row.source_uuid,
+        data.upper_bound,
+      );
+    }
+  }
+
+  getPendingSourceCleanup(snowflakeId: string): PendingSourceCleanup | null {
+    return this.db!.transaction(() => {
+      const row = this.selectPendingSourceCleanup.get({
+        snowflake_id: snowflakeId,
+      });
+      return row ? this.refreshPendingSourceCleanupRow(row) : null;
+    })();
+  }
+
+  getPendingSourceCleanups(): PendingSourceCleanup[] {
+    return this.db!.transaction(() => {
+      return this.selectPendingSourceCleanups
+        .all()
+        .map((row) => this.refreshPendingSourceCleanupRow(row));
+    })();
+  }
+
+  finishPendingSourceCleanup(
+    snowflakeId: string,
+    deletedItemUuids: string[],
+  ): boolean {
+    return this.db!.transaction(() => {
+      const row = this.selectPendingSourceCleanup.get({
+        snowflake_id: snowflakeId,
+      });
+      if (!row) {
+        return true;
+      }
+      const cleanup = this.refreshPendingSourceCleanupRow(row);
+      const deleted = new Set(deletedItemUuids);
+      if (cleanup.itemUuids.some((uuid) => !deleted.has(uuid))) {
+        return false;
+      }
+      this.completePendingSourceCleanup.run({
+        snowflake_id: snowflakeId,
+      });
+      return true;
+    })();
+  }
+
   addPendingSourceEvent(
     sourceUuid: string,
     type: PendingEventType,
     data?: PendingEventData,
   ): string | null {
-    return this.db!.transaction(() => {
-      const snowflakeID = this.snowflake
-        .generate({ timestamp: Date.now() })
-        .toString();
+    try {
+      return this.db!.transaction(() => {
+        const snowflakeID = this.snowflake
+          .generate({ timestamp: Date.now() })
+          .toString();
+        let eventData = data ? JSON.stringify(data) : null;
+        let localCleanupPending = 0;
 
-      if (type === PendingEventType.SourceDeleted) {
-        this.purgePendingEventsForSource(sourceUuid);
-        this.markSourceItemsScheduledDeletion(sourceUuid);
-      } else if (type === PendingEventType.SourceConversationTruncated) {
-        this.purgePendingEventsForSource(sourceUuid);
-        if (data?.upper_bound !== undefined) {
-          this.markSourceItemsScheduledDeletionUpTo(
-            sourceUuid,
-            data.upper_bound,
+        if (type === PendingEventType.SourceDeleted) {
+          this.purgePendingEventsForSource(sourceUuid);
+          this.markSourceItemsScheduledDeletion(sourceUuid);
+        } else if (type === PendingEventType.SourceConversationTruncated) {
+          const existingCleanups = this.selectPendingSourceCleanups
+            .all()
+            .filter((row) => row.source_uuid === sourceUuid)
+            .map((row) => {
+              if (!row.data) {
+                throw new Error(
+                  `Invariant violation: pending cleanup ${row.snowflake_id} has no data`,
+                );
+              }
+              return JSON.parse(row.data) as SourceCleanupData;
+            });
+          const itemUuids = new Set(
+            existingCleanups.flatMap(
+              (cleanup) => cleanup.local_cleanup_item_uuids ?? [],
+            ),
           );
+          this.purgePendingEventsForSource(sourceUuid);
+          if (data?.upper_bound !== undefined) {
+            const upperBound = Math.max(
+              data.upper_bound,
+              ...existingCleanups.map((cleanup) => cleanup.upper_bound),
+            );
+            this.markSourceItemsScheduledDeletionUpTo(sourceUuid, upperBound);
+            for (const item of this.getSourceItemsUpTo(
+              sourceUuid,
+              upperBound,
+            )) {
+              itemUuids.add(item.uuid);
+            }
+            eventData = JSON.stringify({
+              upper_bound: upperBound,
+              local_cleanup_item_uuids: [...itemUuids],
+            } satisfies SourceCleanupData);
+            localCleanupPending = 1;
+          }
         }
-      }
 
-      try {
         this.insertSourcePendingEvent.run({
           snowflake_id: snowflakeID,
           source_uuid: sourceUuid,
           type: type,
-          data: data ? JSON.stringify(data) : null,
+          data: eventData,
+          local_cleanup_pending: localCleanupPending,
         });
-      } catch (err) {
-        if (err instanceof Error && "code" in err) {
-          if (err.code === "SQLITE_CONSTRAINT_FOREIGNKEY") {
-            return null;
-          } else {
-            throw err;
-          }
-        }
+        return snowflakeID;
+      })();
+    } catch (err) {
+      if (
+        err instanceof Error &&
+        "code" in err &&
+        err.code === "SQLITE_CONSTRAINT_FOREIGNKEY"
+      ) {
+        return null;
       }
-
-      return snowflakeID;
-    })();
+      throw err;
+    }
   }
 
   addPendingSourceEventBatch(
@@ -1220,6 +1489,7 @@ export class DB {
       source_uuid: sourceUuid,
       type: PendingEventType.ReplySent,
       data: JSON.stringify(replyData, sortKeys),
+      local_cleanup_pending: 0,
     });
     return snowflakeID;
   }
@@ -1283,6 +1553,7 @@ export class DB {
           source_uuid: sourceUuid,
           type: PendingEventType.SourceConversationSeen,
           data: JSON.stringify({ upper_bound: upperBound }),
+          local_cleanup_pending: 0,
         });
       } catch (err) {
         if (err instanceof Error && "code" in err) {

--- a/app/src/main/database/migrations/20260711000000_pending_truncation_cleanup.sql
+++ b/app/src/main/database/migrations/20260711000000_pending_truncation_cleanup.sql
@@ -1,0 +1,196 @@
+-- migrate:up
+-- Keep truncation events local until their covered plaintext has been removed.
+ALTER TABLE pending_events
+ADD COLUMN local_cleanup_pending INTEGER NOT NULL DEFAULT 0
+CHECK (local_cleanup_pending IN (0, 1));
+
+DROP VIEW IF EXISTS items_projected;
+CREATE VIEW items_projected AS
+SELECT
+    items.uuid,
+    items.data,
+    items.version,
+    items.plaintext,
+    items.filename,
+    items.kind,
+    CASE
+        WHEN items.is_read THEN 1
+        WHEN EXISTS (
+            SELECT 1 FROM pending_events
+            WHERE pending_events.item_uuid = items.uuid
+                AND pending_events.type = 'item_seen'
+        ) THEN 1
+        WHEN EXISTS (
+            SELECT 1 FROM pending_events
+            WHERE pending_events.source_uuid = items.source_uuid
+                AND pending_events.type = 'source_conversation_seen'
+                AND CAST(json_extract(pending_events.data, '$.upper_bound') AS INTEGER) >= items.interaction_count
+        ) THEN 1
+        ELSE 0
+    END AS is_read,
+    items.last_updated,
+    items.source_uuid,
+    items.fetch_progress,
+    items.fetch_status,
+    items.fetch_last_updated_at,
+    items.fetch_retry_attempts,
+    items.interaction_count,
+    items.decrypted_size
+FROM items
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM pending_events
+    WHERE pending_events.item_uuid = items.uuid
+        AND pending_events.type = 'item_deleted'
+)
+    AND NOT EXISTS (
+        SELECT 1
+        FROM pending_events
+        WHERE pending_events.source_uuid = items.source_uuid
+            AND pending_events.type = 'source_deleted'
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM pending_events
+        WHERE pending_events.source_uuid = items.source_uuid
+            AND pending_events.type = 'source_conversation_truncated'
+            AND CAST(json_extract(pending_events.data, '$.upper_bound') AS INTEGER) >= items.interaction_count
+    )
+UNION ALL
+SELECT
+    json_extract(pending_events.data, '$.metadata.uuid') AS uuid,
+    json_extract(pending_events.data, '$.metadata') AS data,
+    NULL AS version,
+    json_extract(pending_events.data, '$.plaintext') AS plaintext,
+    NULL AS filename,
+    'reply' AS kind,
+    1 AS is_read,
+    NULL AS last_updated,
+    json_extract(pending_events.data, '$.metadata.source') AS source_uuid,
+    NULL AS fetch_progress,
+    NULL AS fetch_status,
+    NULL AS fetch_last_updated_at,
+    NULL AS fetch_retry_attempts,
+    json_extract(pending_events.data, '$.metadata.interaction_count') AS interaction_count,
+    NULL AS decrypted_size
+FROM pending_events
+WHERE pending_events.type = 'reply_sent'
+    AND NOT EXISTS (
+        SELECT 1
+        FROM pending_events later
+        WHERE (
+            (
+                later.source_uuid = json_extract(pending_events.data, '$.metadata.source')
+                AND later.type = 'source_deleted'
+            )
+            OR
+            (
+                later.source_uuid = json_extract(pending_events.data, '$.metadata.source')
+                AND later.type = 'source_conversation_truncated'
+                AND CAST(json_extract(later.data, '$.upper_bound') AS INTEGER) >= CAST(json_extract(pending_events.data, '$.metadata.interaction_count') AS INTEGER)
+            )
+            OR
+            (
+                later.item_uuid = json_extract(pending_events.data, '$.metadata.uuid')
+                AND later.type = 'item_deleted'
+            )
+        )
+        AND later.snowflake_id > pending_events.snowflake_id
+    );
+
+-- migrate:down
+DROP VIEW IF EXISTS items_projected;
+CREATE VIEW items_projected AS
+SELECT
+    items.uuid,
+    items.data,
+    items.version,
+    items.plaintext,
+    items.filename,
+    items.kind,
+    CASE
+        WHEN items.is_read THEN 1
+        WHEN EXISTS (
+            SELECT 1 FROM pending_events
+            WHERE pending_events.item_uuid = items.uuid
+                AND pending_events.type = 'item_seen'
+        ) THEN 1
+        WHEN EXISTS (
+            SELECT 1 FROM pending_events
+            WHERE pending_events.source_uuid = items.source_uuid
+                AND pending_events.type = 'source_conversation_seen'
+                AND CAST(json_extract(pending_events.data, '$.upper_bound') AS INTEGER) >= items.interaction_count
+        ) THEN 1
+        ELSE 0
+    END AS is_read,
+    items.last_updated,
+    items.source_uuid,
+    items.fetch_progress,
+    items.fetch_status,
+    items.fetch_last_updated_at,
+    items.fetch_retry_attempts,
+    items.interaction_count,
+    items.decrypted_size
+FROM items
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM pending_events
+    WHERE pending_events.item_uuid = items.uuid
+        AND pending_events.type = 'item_deleted'
+)
+    AND NOT EXISTS (
+        SELECT 1
+        FROM pending_events
+        WHERE pending_events.source_uuid = items.source_uuid
+            AND pending_events.type = 'source_deleted'
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM pending_events
+        WHERE pending_events.source_uuid = items.source_uuid
+            AND pending_events.type = 'source_conversation_truncated'
+            AND CAST(json_extract(pending_events.data, '$.upper_bound') AS INTEGER) >= items.interaction_count
+    )
+UNION ALL
+SELECT
+    json_extract(pending_events.data, '$.metadata.uuid') AS uuid,
+    json_extract(pending_events.data, '$.metadata') AS data,
+    NULL AS version,
+    json_extract(pending_events.data, '$.plaintext') AS plaintext,
+    NULL AS filename,
+    'reply' AS kind,
+    1 AS is_read,
+    NULL AS last_updated,
+    json_extract(pending_events.data, '$.metadata.source') AS source_uuid,
+    NULL AS fetch_progress,
+    NULL AS fetch_status,
+    NULL AS fetch_last_updated_at,
+    NULL AS fetch_retry_attempts,
+    json_extract(pending_events.data, '$.metadata.interaction_count') AS interaction_count,
+    NULL AS decrypted_size
+FROM pending_events
+WHERE pending_events.type = 'reply_sent'
+    AND NOT EXISTS (
+        SELECT 1
+        FROM pending_events later
+        WHERE (
+            (
+                later.source_uuid = json_extract(pending_events.data, '$.metadata.source')
+                AND later.type = 'source_deleted'
+            )
+            OR
+            (
+                later.source_uuid = json_extract(pending_events.data, '$.metadata.source')
+                AND later.type = 'source_conversation_truncated'
+                AND CAST(json_extract(later.data, '$.upper_bound') AS INTEGER) >= CAST(json_extract(pending_events.data, '$.metadata.interaction_count') AS INTEGER)
+            )
+            OR
+            (
+                later.item_uuid = json_extract(pending_events.data, '$.metadata.uuid')
+                AND later.type = 'item_deleted'
+            )
+        )
+        AND later.snowflake_id > pending_events.snowflake_id
+    );
+
+ALTER TABLE pending_events DROP COLUMN local_cleanup_pending;

--- a/app/src/main/database/schema.sql
+++ b/app/src/main/database/schema.sql
@@ -38,7 +38,8 @@ CREATE TABLE pending_events (
     source_uuid TEXT REFERENCES sources(uuid) ON DELETE CASCADE,
     item_uuid TEXT REFERENCES items(uuid) ON DELETE CASCADE,
     type TEXT NOT NULL,
-    data JSON, retry_attempts INTEGER NOT NULL DEFAULT 0, last_event_status INTEGER,
+    data JSON, retry_attempts INTEGER NOT NULL DEFAULT 0, last_event_status INTEGER, local_cleanup_pending INTEGER NOT NULL DEFAULT 0
+CHECK (local_cleanup_pending IN (0, 1)),
     CHECK (NOT (source_uuid IS NOT NULL AND item_uuid IS NOT NULL))
 );
 CREATE VIEW state AS
@@ -74,99 +75,6 @@ WHEN json_extract(OLD.data, '$.kind') IS NOT NULL
 BEGIN
     SELECT RAISE(ABORT, 'items.kind is immutable');
 END;
-CREATE VIEW items_projected AS
-SELECT
-    items.uuid,
-    items.data,
-    items.version,
-    items.plaintext,
-    items.filename,
-    items.kind,
-    CASE
-        WHEN items.is_read THEN 1
-        WHEN EXISTS (
-            SELECT 1 FROM pending_events
-            WHERE pending_events.item_uuid = items.uuid
-                AND pending_events.type = 'item_seen'
-        ) THEN 1
-        WHEN EXISTS (
-            SELECT 1 FROM pending_events
-            WHERE pending_events.source_uuid = items.source_uuid
-                AND pending_events.type = 'source_conversation_seen'
-                AND CAST(json_extract(pending_events.data, '$.upper_bound') AS INTEGER) >= items.interaction_count
-        ) THEN 1
-        ELSE 0
-    END AS is_read,
-    items.last_updated,
-    items.source_uuid,
-    items.fetch_progress,
-    items.fetch_status,
-    items.fetch_last_updated_at,
-    items.fetch_retry_attempts,
-    items.interaction_count,
-    items.decrypted_size
-FROM items
-WHERE NOT EXISTS (
-    SELECT 1
-    FROM pending_events
-    WHERE pending_events.item_uuid = items.uuid
-        AND pending_events.type = 'item_deleted'
-)
-    AND NOT EXISTS (
-        SELECT 1
-        FROM pending_events
-        WHERE pending_events.source_uuid = items.source_uuid
-            AND pending_events.type = 'source_deleted'
-    )
-    AND NOT EXISTS (
-        SELECT 1
-        FROM pending_events
-        WHERE pending_events.source_uuid = items.source_uuid
-            AND pending_events.type = 'source_conversation_truncated'
-            AND CAST(json_extract(pending_events.data, '$.upper_bound') AS INTEGER) >= items.interaction_count
-    )
-UNION ALL
-SELECT
-    json_extract(pending_events.data, '$.metadata.uuid') AS uuid,
-    json_extract(pending_events.data, '$.metadata') AS data,
-    NULL AS version,
-    json_extract(pending_events.data, '$.plaintext') AS plaintext,
-    NULL AS filename,
-    'reply' AS kind,
-    1 AS is_read,
-    NULL AS last_updated,
-    json_extract(pending_events.data, '$.metadata.source') AS source_uuid,
-    NULL AS fetch_progress,
-    NULL AS fetch_status,
-    NULL AS fetch_last_updated_at,
-    NULL AS fetch_retry_attempts,
-    json_extract(pending_events.data, '$.metadata.interaction_count') AS interaction_count,
-    NULL AS decrypted_size
-FROM pending_events
-WHERE pending_events.type = 'reply_sent'
-    AND NOT EXISTS (
-        SELECT 1
-        FROM pending_events later
-        WHERE (
-            (
-                later.source_uuid = json_extract(pending_events.data, '$.metadata.source')
-                AND later.type = 'source_deleted'
-            )
-            OR
-            (
-                later.source_uuid = json_extract(pending_events.data, '$.metadata.source')
-                AND later.type = 'source_conversation_truncated'
-                AND CAST(json_extract(later.data, '$.upper_bound') AS INTEGER) >= CAST(json_extract(pending_events.data, '$.metadata.interaction_count') AS INTEGER)
-            )
-            OR
-            (
-                later.item_uuid = json_extract(pending_events.data, '$.metadata.uuid')
-                AND later.type = 'item_deleted'
-            )
-        )
-        AND later.snowflake_id > pending_events.snowflake_id
-    )
-/* items_projected(uuid,data,version,plaintext,filename,kind,is_read,last_updated,source_uuid,fetch_progress,fetch_status,fetch_last_updated_at,fetch_retry_attempts,interaction_count,decrypted_size) */;
 CREATE VIEW sorted_items AS
 SELECT
     *,
@@ -273,6 +181,99 @@ WHERE
             pending_events.type = 'source_deleted'
     )
 /* sources_projected(uuid,data,version,has_attachment,is_seen) */;
+CREATE VIEW items_projected AS
+SELECT
+    items.uuid,
+    items.data,
+    items.version,
+    items.plaintext,
+    items.filename,
+    items.kind,
+    CASE
+        WHEN items.is_read THEN 1
+        WHEN EXISTS (
+            SELECT 1 FROM pending_events
+            WHERE pending_events.item_uuid = items.uuid
+                AND pending_events.type = 'item_seen'
+        ) THEN 1
+        WHEN EXISTS (
+            SELECT 1 FROM pending_events
+            WHERE pending_events.source_uuid = items.source_uuid
+                AND pending_events.type = 'source_conversation_seen'
+                AND CAST(json_extract(pending_events.data, '$.upper_bound') AS INTEGER) >= items.interaction_count
+        ) THEN 1
+        ELSE 0
+    END AS is_read,
+    items.last_updated,
+    items.source_uuid,
+    items.fetch_progress,
+    items.fetch_status,
+    items.fetch_last_updated_at,
+    items.fetch_retry_attempts,
+    items.interaction_count,
+    items.decrypted_size
+FROM items
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM pending_events
+    WHERE pending_events.item_uuid = items.uuid
+        AND pending_events.type = 'item_deleted'
+)
+    AND NOT EXISTS (
+        SELECT 1
+        FROM pending_events
+        WHERE pending_events.source_uuid = items.source_uuid
+            AND pending_events.type = 'source_deleted'
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM pending_events
+        WHERE pending_events.source_uuid = items.source_uuid
+            AND pending_events.type = 'source_conversation_truncated'
+            AND CAST(json_extract(pending_events.data, '$.upper_bound') AS INTEGER) >= items.interaction_count
+    )
+UNION ALL
+SELECT
+    json_extract(pending_events.data, '$.metadata.uuid') AS uuid,
+    json_extract(pending_events.data, '$.metadata') AS data,
+    NULL AS version,
+    json_extract(pending_events.data, '$.plaintext') AS plaintext,
+    NULL AS filename,
+    'reply' AS kind,
+    1 AS is_read,
+    NULL AS last_updated,
+    json_extract(pending_events.data, '$.metadata.source') AS source_uuid,
+    NULL AS fetch_progress,
+    NULL AS fetch_status,
+    NULL AS fetch_last_updated_at,
+    NULL AS fetch_retry_attempts,
+    json_extract(pending_events.data, '$.metadata.interaction_count') AS interaction_count,
+    NULL AS decrypted_size
+FROM pending_events
+WHERE pending_events.type = 'reply_sent'
+    AND NOT EXISTS (
+        SELECT 1
+        FROM pending_events later
+        WHERE (
+            (
+                later.source_uuid = json_extract(pending_events.data, '$.metadata.source')
+                AND later.type = 'source_deleted'
+            )
+            OR
+            (
+                later.source_uuid = json_extract(pending_events.data, '$.metadata.source')
+                AND later.type = 'source_conversation_truncated'
+                AND CAST(json_extract(later.data, '$.upper_bound') AS INTEGER) >= CAST(json_extract(pending_events.data, '$.metadata.interaction_count') AS INTEGER)
+            )
+            OR
+            (
+                later.item_uuid = json_extract(pending_events.data, '$.metadata.uuid')
+                AND later.type = 'item_deleted'
+            )
+        )
+        AND later.snowflake_id > pending_events.snowflake_id
+    )
+/* items_projected(uuid,data,version,plaintext,filename,kind,is_read,last_updated,source_uuid,fetch_progress,fetch_status,fetch_last_updated_at,fetch_retry_attempts,interaction_count,decrypted_size) */;
 -- Dbmate schema migrations
 INSERT INTO "schema_migrations" (version) VALUES
   ('20260203225412'),
@@ -283,4 +284,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20260416000000'),
   ('20260507000000'),
   ('20260511000000'),
-  ('20260624000000');
+  ('20260624000000'),
+  ('20260711000000');

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import fs from "fs";
 import path from "path";
 import os from "os";
+import { execFileSync } from "node:child_process";
 import {
   FetchStatus,
   ItemMetadata,
@@ -151,7 +152,10 @@ describe("DB Component Tests", () => {
 });
 
 describe("Datastore Method Tests", () => {
-  const testHomeDir = path.join(os.tmpdir(), "test-home-datastore");
+  const testHomeDir = path.join(
+    fs.realpathSync(os.tmpdir()),
+    `test-home-datastore-${process.pid}`,
+  );
   const originalHomedir = os.homedir;
   let db: Datastore;
   let crypto: Crypto;
@@ -246,6 +250,48 @@ describe("Datastore Method Tests", () => {
     };
   }
 
+  async function completeTruncation(
+    sourceUuid: string,
+    upperBound: number,
+  ): Promise<string> {
+    const eventId = db.addPendingSourceEvent(
+      sourceUuid,
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: upperBound },
+    );
+    expect(eventId).not.toBeNull();
+    await db.runPendingSourceCleanup(eventId!);
+    return eventId!;
+  }
+
+  function seedFileItems(
+    sourceUuid: string,
+    interactionCounts: number[],
+    createPlaintext = true,
+  ): string[] {
+    const storage = new Storage();
+    const items: Record<string, ItemMetadata> = {};
+    const directories: string[] = [];
+    db.updateSources({ [sourceUuid]: mockSourceMetadata(sourceUuid) });
+    interactionCounts.forEach((interactionCount, index) => {
+      const uuid = `${sourceUuid}-file-${index + 1}`;
+      const metadata = mockItemMetadata(
+        uuid,
+        sourceUuid,
+        "file",
+        interactionCount,
+      );
+      items[uuid] = metadata;
+      const directory = storage.itemDirectory(metadata);
+      if (createPlaintext) {
+        fs.writeFileSync(directory.join("payload"), "plaintext");
+      }
+      directories.push(directory.path);
+    });
+    db.updateItems(items);
+    return directories;
+  }
+
   it("getJournalistbyID should return the first matching journalist", () => {
     // Insert two Journalists
     db.updateJournalists({
@@ -286,7 +332,7 @@ describe("Datastore Method Tests", () => {
     expect([...sources.keys()]).toEqual(["source1", "source2"]);
   });
 
-  it("pending SourceConversationTruncated should remove items up to and including upper_bound", () => {
+  it("pending SourceConversationTruncated should remove items up to and including upper_bound", async () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),
     });
@@ -300,16 +346,12 @@ describe("Datastore Method Tests", () => {
     let sourceWithItems = db.getSourceWithItems("source1");
     expect(sourceWithItems.items.length).toEqual(3);
 
-    db.addPendingSourceEvent(
-      "source1",
-      PendingEventType.SourceConversationTruncated,
-      { upper_bound: 2 },
-    );
+    await completeTruncation("source1", 2);
     sourceWithItems = db.getSourceWithItems("source1");
     expect(sourceWithItems.items.length).toEqual(1);
   });
 
-  it("pending SourceConversationTruncated event should only affect given source", () => {
+  it("pending SourceConversationTruncated event should only affect given source", async () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),
     });
@@ -323,11 +365,7 @@ describe("Datastore Method Tests", () => {
     let sourceWithItems = db.getSourceWithItems("source1");
     expect(sourceWithItems.items.length).toEqual(3);
 
-    db.addPendingSourceEvent(
-      "source1",
-      PendingEventType.SourceConversationTruncated,
-      { upper_bound: 3 },
-    );
+    await completeTruncation("source1", 3);
     sourceWithItems = db.getSourceWithItems("source1");
     expect(sourceWithItems.items.length).toEqual(0);
 
@@ -413,7 +451,7 @@ describe("Datastore Method Tests", () => {
     expect(source1Item2).not.toBeNull();
   });
 
-  it("pending SourceConversationTruncated should update has_attachment based on remaining items", () => {
+  it("pending SourceConversationTruncated should update has_attachment based on remaining items", async () => {
     db.updateSources({
       source1: { ...mockSourceMetadata("source1"), has_attachment: true },
     });
@@ -427,17 +465,13 @@ describe("Datastore Method Tests", () => {
     expect(sources.get("source1")!.hasAttachment).toBe(true);
 
     // Truncate only the file item
-    db.addPendingSourceEvent(
-      "source1",
-      PendingEventType.SourceConversationTruncated,
-      { upper_bound: 1 },
-    );
+    await completeTruncation("source1", 1);
 
     sources = db.getSources();
     expect(sources.get("source1")!.hasAttachment).toBe(false);
   });
 
-  it("pending SourceConversationTruncated should preserve has_attachment when file items remain", () => {
+  it("pending SourceConversationTruncated should preserve has_attachment when file items remain", async () => {
     db.updateSources({
       source1: { ...mockSourceMetadata("source1"), has_attachment: true },
     });
@@ -449,17 +483,13 @@ describe("Datastore Method Tests", () => {
     });
 
     // Truncate only first file item; second file item remains
-    db.addPendingSourceEvent(
-      "source1",
-      PendingEventType.SourceConversationTruncated,
-      { upper_bound: 1 },
-    );
+    await completeTruncation("source1", 1);
 
     const sources = db.getSources();
     expect(sources.get("source1")!.hasAttachment).toBe(true);
   });
 
-  it("pending SourceConversationTruncated should mark source as read when all items removed", () => {
+  it("pending SourceConversationTruncated should mark source as read when all items removed", async () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),
     });
@@ -473,17 +503,13 @@ describe("Datastore Method Tests", () => {
     expect(sources.get("source1")!.isRead).toBe(false);
 
     // Truncate all items
-    db.addPendingSourceEvent(
-      "source1",
-      PendingEventType.SourceConversationTruncated,
-      { upper_bound: 2 },
-    );
+    await completeTruncation("source1", 2);
 
     sources = db.getSources();
     expect(sources.get("source1")!.isRead).toBe(true);
   });
 
-  it("pending SourceConversationTruncated should mark source as read when remaining items are all read", () => {
+  it("pending SourceConversationTruncated should mark source as read when remaining items are all read", async () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),
     });
@@ -500,11 +526,7 @@ describe("Datastore Method Tests", () => {
     });
 
     // Only remove item2 (the unread item with ic=1)
-    db.addPendingSourceEvent(
-      "source1",
-      PendingEventType.SourceConversationTruncated,
-      { upper_bound: 1 },
-    );
+    await completeTruncation("source1", 1);
 
     const sources = db.getSources();
     expect(sources.get("source1")!.isRead).toBe(true);
@@ -689,6 +711,326 @@ describe("Datastore Method Tests", () => {
     expect(items).toEqual(sortedItems);
   });
 
+  it("publishes a truncation event only after all covered directories are gone", async () => {
+    const storage = new Storage();
+    db.updateSources({
+      source1: mockSourceMetadata("source1"),
+      source2: mockSourceMetadata("source2"),
+    });
+
+    const items: Record<string, ItemMetadata> = {};
+    const source1Directories: string[] = [];
+    for (
+      let interactionCount = 1;
+      interactionCount <= 151;
+      interactionCount += 1
+    ) {
+      const uuid = `source1-file-${interactionCount}`;
+      const metadata = mockItemMetadata(
+        uuid,
+        "source1",
+        "file",
+        interactionCount,
+      );
+      items[uuid] = metadata;
+      const directory = storage.itemDirectory(metadata);
+      fs.writeFileSync(directory.join("payload"), "plaintext");
+      source1Directories.push(directory.path);
+    }
+
+    const unrelated = mockItemMetadata("source2-file", "source2", "file", 1);
+    items[unrelated.uuid] = unrelated;
+    const unrelatedDirectory = storage.itemDirectory(unrelated);
+    fs.writeFileSync(unrelatedDirectory.join("payload"), "keep");
+    db.updateItems(items);
+
+    const eventId = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 151 },
+    );
+
+    expect(eventId).not.toBeNull();
+    expect(
+      source1Directories.every((directory) => fs.existsSync(directory)),
+    ).toBe(true);
+    expect(db.getSourceWithItems("source1").items).toHaveLength(0);
+    expect(db.getPendingEvents()).toHaveLength(0);
+
+    const deletedCount = await db.runPendingSourceCleanup(eventId!);
+
+    expect(deletedCount).toBe(151);
+    expect(
+      source1Directories.every((directory) => !fs.existsSync(directory)),
+    ).toBe(true);
+    expect(fs.existsSync(unrelatedDirectory.path)).toBe(true);
+    expect(db.getItem("source1-file-1")?.fetch_status).toBe(
+      FetchStatus.ScheduledDeletion,
+    );
+    expect(db.getItem("source1-file-151")?.fetch_status).toBe(
+      FetchStatus.ScheduledDeletion,
+    );
+    expect(db.getSourceWithItems("source1").items).toHaveLength(0);
+    expect(db.getPendingEvents()).toHaveLength(1);
+    await expect(db.runPendingSourceCleanup(eventId!)).resolves.toBe(0);
+  });
+
+  it.each([0, 1, 100, 101, 151, 201])(
+    "cleans every covered directory for a %i-item conversation",
+    async (itemCount) => {
+      const counts = Array.from({ length: itemCount }, (_, index) => index + 1);
+      const directories = seedFileItems("source1", counts);
+      const eventId = db.addPendingSourceEvent(
+        "source1",
+        PendingEventType.SourceConversationTruncated,
+        { upper_bound: itemCount },
+      )!;
+
+      expect(db.getPendingEvents()).toHaveLength(0);
+      await expect(db.runPendingSourceCleanup(eventId)).resolves.toBe(
+        itemCount,
+      );
+      expect(directories.every((directory) => !fs.existsSync(directory))).toBe(
+        true,
+      );
+      expect(db.getPendingSourceCleanups()).toHaveLength(0);
+      expect(db.getPendingEvents()).toHaveLength(1);
+    },
+  );
+
+  it("cleans all duplicate counts within a partial upper bound", async () => {
+    const directories = seedFileItems("source1", [1, 2, 2, 3]);
+    const eventId = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 2 },
+    )!;
+
+    await expect(db.runPendingSourceCleanup(eventId)).resolves.toBe(3);
+    expect(directories.slice(0, 3).every((path) => !fs.existsSync(path))).toBe(
+      true,
+    );
+    expect(fs.existsSync(directories[3])).toBe(true);
+    expect(db.getItem("source1-file-4")?.fetch_status).toBe(
+      FetchStatus.Initial,
+    );
+  });
+
+  it("leaves rows above a partial bound in a 201-item conversation", async () => {
+    const counts = Array.from({ length: 201 }, (_, index) => index + 1);
+    const directories = seedFileItems("source1", counts);
+    const eventId = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 101 },
+    )!;
+
+    await expect(db.runPendingSourceCleanup(eventId)).resolves.toBe(101);
+    expect(
+      directories.slice(0, 101).every((directory) => !fs.existsSync(directory)),
+    ).toBe(true);
+    expect(
+      directories.slice(101).every((directory) => fs.existsSync(directory)),
+    ).toBe(true);
+    expect(db.getItem("source1-file-101")?.fetch_status).toBe(
+      FetchStatus.ScheduledDeletion,
+    );
+    expect(db.getItem("source1-file-102")?.fetch_status).toBe(
+      FetchStatus.Initial,
+    );
+  });
+
+  it("preserves the broader bound when truncation is requested again", async () => {
+    const directories = seedFileItems("source1", [1, 2, 3, 4, 5]);
+    const broadEventId = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 5 },
+    )!;
+    const replacementEventId = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 2 },
+    )!;
+
+    expect(db.getPendingSourceCleanup(broadEventId)).toBeNull();
+    expect(db.getPendingSourceCleanup(replacementEventId)?.upperBound).toBe(5);
+    await expect(db.runPendingSourceCleanup(replacementEventId)).resolves.toBe(
+      5,
+    );
+    expect(directories.every((directory) => !fs.existsSync(directory))).toBe(
+      true,
+    );
+    expect(db.getPendingEvents()[0].data).toEqual({ upper_bound: 5 });
+  });
+
+  it("treats missing covered directories as idempotent success", async () => {
+    seedFileItems("source1", [1], false);
+    const eventId = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 1 },
+    )!;
+
+    await expect(db.runPendingSourceCleanup(eventId)).resolves.toBe(1);
+    await expect(db.runPendingSourceCleanup(eventId)).resolves.toBe(0);
+    expect(db.getPendingEvents()).toHaveLength(1);
+  });
+
+  it.runIf(process.platform === "darwin")(
+    "keeps cleanup pending after a real immutable-file failure",
+    async () => {
+      const [directory] = seedFileItems("source1", [1]);
+      const plaintextPath = path.join(directory, "payload");
+      const eventId = db.addPendingSourceEvent(
+        "source1",
+        PendingEventType.SourceConversationTruncated,
+        { upper_bound: 1 },
+      )!;
+      execFileSync("/usr/bin/chflags", ["uchg", plaintextPath]);
+
+      try {
+        await expect(db.runPendingSourceCleanup(eventId)).rejects.toMatchObject(
+          { code: "EPERM" },
+        );
+        expect(fs.existsSync(plaintextPath)).toBe(true);
+        expect(db.getPendingSourceCleanups()).toHaveLength(1);
+        expect(db.getPendingEvents()).toHaveLength(0);
+      } finally {
+        if (fs.existsSync(plaintextPath)) {
+          execFileSync("/usr/bin/chflags", ["nouchg", plaintextPath]);
+        }
+      }
+
+      await expect(db.runPendingSourceCleanup(eventId)).resolves.toBe(1);
+      expect(fs.existsSync(directory)).toBe(false);
+      expect(db.getPendingEvents()).toHaveLength(1);
+    },
+  );
+
+  it("rolls back truncation state when pending event insertion fails", () => {
+    const storage = new Storage();
+    const metadata = mockItemMetadata("source1-file", "source1", "file", 1);
+    db.updateSources({ source1: mockSourceMetadata("source1") });
+    db.updateItems({ [metadata.uuid]: metadata });
+    const directory = storage.itemDirectory(metadata);
+    const filename = directory.join("payload");
+    fs.writeFileSync(filename, "plaintext");
+    db.completeFileItem(metadata.uuid, filename, 9);
+    db["db"]!.exec(`
+      CREATE TEMP TRIGGER reject_truncation_event
+      BEFORE INSERT ON pending_events
+      WHEN NEW.type = 'source_conversation_truncated'
+      BEGIN
+        SELECT RAISE(ABORT, 'forced insertion failure');
+      END;
+    `);
+
+    expect(() =>
+      db.addPendingSourceEvent(
+        "source1",
+        PendingEventType.SourceConversationTruncated,
+        { upper_bound: 1 },
+      ),
+    ).toThrow("forced insertion failure");
+
+    expect(fs.existsSync(filename)).toBe(true);
+    expect(db.getItem(metadata.uuid)?.fetch_status).toBe(FetchStatus.Complete);
+    expect(db.getPendingSourceCleanups()).toHaveLength(0);
+    expect(db.getPendingEvents()).toHaveLength(0);
+  });
+
+  it("retries partial filesystem cleanup after restart", async () => {
+    class FailOnceStorage extends Storage {
+      private failed = false;
+
+      override async deleteItemDirectory(
+        sourceUuid: string,
+        itemUuid: string,
+      ): Promise<void> {
+        if (itemUuid === "source1-file-2" && !this.failed) {
+          this.failed = true;
+          throw Object.assign(new Error("immutable plaintext"), {
+            code: "EPERM",
+          });
+        }
+        await super.deleteItemDirectory(sourceUuid, itemUuid);
+      }
+    }
+
+    const storage = new Storage();
+    db.updateSources({ source1: mockSourceMetadata("source1") });
+    const items: Record<string, ItemMetadata> = {};
+    const directories: string[] = [];
+    for (let count = 1; count <= 3; count += 1) {
+      const metadata = mockItemMetadata(
+        `source1-file-${count}`,
+        "source1",
+        "file",
+        count,
+      );
+      items[metadata.uuid] = metadata;
+      const directory = storage.itemDirectory(metadata);
+      fs.writeFileSync(directory.join("payload"), "plaintext");
+      directories.push(directory.path);
+    }
+    db.updateItems(items);
+    db.close();
+    db = new Datastore(crypto, new FailOnceStorage());
+
+    const eventId = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 3 },
+    )!;
+    await expect(db.runPendingSourceCleanup(eventId)).rejects.toMatchObject({
+      code: "EPERM",
+    });
+    expect(db.getPendingEvents()).toHaveLength(0);
+    expect(db.getPendingSourceCleanups()).toHaveLength(1);
+    expect(db.getSourceWithItems("source1").items).toHaveLength(0);
+    expect(fs.existsSync(directories[1])).toBe(true);
+
+    db.close();
+    db = new Datastore(crypto, new Storage());
+    await expect(db.runPendingSourceCleanup(eventId)).resolves.toBe(3);
+    expect(directories.every((directory) => !fs.existsSync(directory))).toBe(
+      true,
+    );
+    expect(db.getPendingSourceCleanups()).toHaveLength(0);
+    expect(db.getPendingEvents()).toHaveLength(1);
+    expect(db.getSourceWithItems("source1").items).toHaveLength(0);
+  });
+
+  it("keeps covered sync-upserted items non-processable after cleanup is publishable", async () => {
+    seedFileItems("source1", [1]);
+    const eventId = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.SourceConversationTruncated,
+      { upper_bound: 2 },
+    )!;
+    await expect(db.runPendingSourceCleanup(eventId)).resolves.toBe(1);
+    expect(db.getPendingSourceCleanups()).toHaveLength(0);
+    expect(db.getPendingEvents()).toHaveLength(1);
+
+    db.updateItems({
+      "source1-file-2": mockItemMetadata(
+        "source1-file-2",
+        "source1",
+        "file",
+        2,
+      ),
+    });
+
+    expect(db.getItem("source1-file-2")?.fetch_status).toBe(
+      FetchStatus.ScheduledDeletion,
+    );
+    expect(db.getSourceWithItems("source1").items).toHaveLength(0);
+    expect(
+      db.getItemsToProcess({ messageLimit: 10, fileLimit: 10 }),
+    ).not.toContain("source1-file-2");
+  });
+
   it("pending ItemDeleted event should delete reply", () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),
@@ -739,11 +1081,7 @@ describe("Datastore Method Tests", () => {
     let sourceWithItems = db.getSourceWithItems("source1");
     expect(sourceWithItems.items.length).toEqual(3);
 
-    db.addPendingSourceEvent(
-      "source1",
-      PendingEventType.SourceConversationTruncated,
-      { upper_bound: 3 },
-    );
+    await completeTruncation("source1", 3);
     sourceWithItems = db.getSourceWithItems("source1");
     expect(sourceWithItems.items.length).toEqual(0);
   });
@@ -763,6 +1101,7 @@ describe("Datastore Method Tests", () => {
       PendingEventType.SourceConversationTruncated,
       { upper_bound: 2 },
     )!;
+    await db.runPendingSourceCleanup(snowflake1);
     let sourceWithItems = db.getSourceWithItems("source1");
     expect(sourceWithItems.items.length).toEqual(0);
 
@@ -1972,11 +2311,7 @@ describe("Datastore Method Tests", () => {
       }
 
       // Delete conversation (not the whole source), covering all 30 items
-      db.addPendingSourceEvent(
-        "source1",
-        PendingEventType.SourceConversationTruncated,
-        { upper_bound: 30 },
-      );
+      await completeTruncation("source1", 30);
 
       // Events purged except the delete event itself
       const events = db.getPendingEvents();

--- a/app/src/main/datastore.ts
+++ b/app/src/main/datastore.ts
@@ -22,6 +22,24 @@ export class Datastore extends DB {
     this.storage = storage;
   }
 
+  private deleteItemFsInBackground(item: Item): void {
+    void this.storage.deleteItemFs(item).catch((error: unknown) => {
+      console.error("Background item filesystem cleanup failed", {
+        item: item.uuid,
+        error,
+      });
+    });
+  }
+
+  private deleteSourceFsInBackground(sourceUuid: string): void {
+    void this.storage.deleteSourceFs(sourceUuid).catch((error: unknown) => {
+      console.error("Background source filesystem cleanup failed", {
+        sourceUuid,
+        error,
+      });
+    });
+  }
+
   async deleteItemsAsync(items: string[]): Promise<Item[]> {
     const deletedItems = super.deleteItems(items);
     // TODO: Consider routing FS deletions to the fetch worker so that FS I/O
@@ -50,7 +68,7 @@ export class Datastore extends DB {
   override updateItems(items: { [uuid: string]: ItemMetadata | null }): Item[] {
     const deletedItems = super.updateItems(items);
     for (const item of deletedItems) {
-      void this.storage.deleteItemFs(item);
+      this.deleteItemFsInBackground(item);
     }
     return deletedItems;
   }
@@ -60,7 +78,7 @@ export class Datastore extends DB {
   }): string[] {
     const deletedSourceUuids = super.updateSources(sources);
     for (const uuid of deletedSourceUuids) {
-      void this.storage.deleteSourceFs(uuid);
+      this.deleteSourceFsInBackground(uuid);
     }
     return deletedSourceUuids;
   }
@@ -79,10 +97,10 @@ export class Datastore extends DB {
     const result = super.updateBatch(batchResponse);
     // Perform all filesystem cleanups as necessary
     for (const item of result.deleted_items) {
-      void this.storage.deleteItemFs(item);
+      this.deleteItemFsInBackground(item);
     }
     for (const uuid of result.deleted_sources) {
-      void this.storage.deleteSourceFs(uuid);
+      this.deleteSourceFsInBackground(uuid);
     }
     return result;
   }
@@ -93,5 +111,31 @@ export class Datastore extends DB {
 
   async deleteItemFs(item: Item): Promise<void> {
     return this.storage.deleteItemFs(item);
+  }
+
+  async runPendingSourceCleanup(snowflakeId: string): Promise<number> {
+    let deletedCount = 0;
+    while (true) {
+      const cleanup = super.getPendingSourceCleanup(snowflakeId);
+      if (!cleanup) {
+        return deletedCount;
+      }
+      for (
+        let i = 0;
+        i < cleanup.itemUuids.length;
+        i += this.DELETE_BATCH_SIZE
+      ) {
+        const batch = cleanup.itemUuids.slice(i, i + this.DELETE_BATCH_SIZE);
+        await Promise.all(
+          batch.map((itemUuid) =>
+            this.storage.deleteItemDirectory(cleanup.sourceUuid, itemUuid),
+          ),
+        );
+      }
+      deletedCount = cleanup.itemUuids.length;
+      if (super.finishPendingSourceCleanup(snowflakeId, cleanup.itemUuids)) {
+        return deletedCount;
+      }
+    }
   }
 }

--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -21,6 +21,14 @@ const mockProxyStreamRequest = vi.hoisted(() => {
   return vi.fn();
 });
 const MOCK_FILE_CONTENT = vi.hoisted(() => Buffer.from("fake file content"));
+const mockFsPromises = vi.hoisted(() => ({
+  mkdir: vi.fn(),
+  writeFile: vi.fn(),
+  readFile: vi.fn(),
+  unlink: vi.fn(),
+  rm: vi.fn(),
+  stat: vi.fn(() => Promise.resolve({ size: 1024 })),
+}));
 vi.mock("../proxy", async () => {
   const actual = await vi.importActual("../proxy");
   return {
@@ -47,13 +55,7 @@ vi.mock("../crypto", async () => {
 // Mock fs for file operations
 vi.mock("fs", () => ({
   default: {
-    promises: {
-      mkdir: vi.fn(),
-      writeFile: vi.fn(),
-      readFile: vi.fn(),
-      unlink: vi.fn(),
-      stat: vi.fn(() => Promise.resolve({ size: 1024 })),
-    },
+    promises: mockFsPromises,
     createWriteStream: vi.fn(() => new PassThrough()),
     createReadStream: vi.fn(() => Readable.from([MOCK_FILE_CONTENT])),
   },
@@ -62,6 +64,7 @@ vi.mock("fs", () => ({
   mkdtempSync: vi.fn((prefix) => prefix + "XXXXXX"),
   mkdirSync: vi.fn(),
   rmSync: vi.fn(),
+  promises: mockFsPromises,
 }));
 
 // SHA-256 of MOCK_FILE_CONTENT — matches what the mocked createReadStream returns
@@ -78,11 +81,11 @@ function createMockDB() {
     getItemsToProcess: vi.fn(),
     getItem: vi.fn(),
     getSource: vi.fn(),
-    completePlaintextItem: vi.fn(),
-    completeFileItem: vi.fn(),
-    startDownloadInProgress: vi.fn(),
+    completePlaintextItem: vi.fn(() => true),
+    completeFileItem: vi.fn(() => true),
+    startDownloadInProgress: vi.fn(() => true),
     updateDownloadInProgress: vi.fn(() => true),
-    setDecryptionInProgress: vi.fn(),
+    setDecryptionInProgress: vi.fn(() => true),
     setSourceMessagePreview: vi.fn(),
     failDownload: vi.fn(),
     failDecryption: vi.fn(),
@@ -1511,11 +1514,12 @@ describe("TaskQueue - Four-Queue Download and Decryption", () => {
 
       await new Promise((r) => setTimeout(r, 10));
 
-      queue.abortSourceFetch("source1");
+      const abortPromise = queue.abortSourceFetch("source1");
 
       rejectProxy!(new Error("AbortError: The operation was aborted"));
 
       await expect(processPromise).resolves.toBeUndefined();
+      await expect(abortPromise).resolves.toBeUndefined();
     });
 
     it("should not abort downloads for unrelated sources", async () => {
@@ -1541,7 +1545,7 @@ describe("TaskQueue - Four-Queue Download and Decryption", () => {
       queue.authToken = "test-token";
 
       // Abort for a different source
-      queue.abortSourceFetch("source2");
+      await queue.abortSourceFetch("source2");
 
       // Download should still complete normally
       await queue.processDownload({ id: "msg1" }, db);
@@ -1699,6 +1703,68 @@ describe("TaskQueue - Four-Queue Download and Decryption", () => {
 
       expect(mockCrypto.decryptFile).toHaveBeenCalled();
       expect(db.completeFileItem).not.toHaveBeenCalled();
+      expect(fs.promises.rm).toHaveBeenCalledWith(
+        expect.stringContaining("source1/file1"),
+        { recursive: true, force: true },
+      );
+    });
+
+    it("propagates failure to remove a late decrypted file", async () => {
+      const db = createMockDB();
+      const metadata = {
+        kind: "file",
+        source: "source1",
+        size: 1000,
+        uuid: "file1",
+      } as ItemMetadata;
+      db.getItem = vi
+        .fn()
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.DecryptionInProgress, 0),
+        )
+        .mockReturnValueOnce(
+          mockItem(metadata, FetchStatus.ScheduledDeletion, 0),
+        );
+      mockCrypto.decryptFile.mockResolvedValue(
+        "/tmp/source1/file1/decrypted.txt",
+      );
+      const deletionError = Object.assign(new Error("immutable plaintext"), {
+        code: "EPERM",
+      });
+      mockFsPromises.rm.mockRejectedValueOnce(deletionError);
+
+      const queue = new TaskQueue(db);
+
+      await expect(queue.processDecrypt({ id: "file1" }, db)).rejects.toBe(
+        deletionError,
+      );
+      expect(db.completeFileItem).not.toHaveBeenCalled();
+    });
+
+    it("removes a file if deletion wins after the post-decrypt check", async () => {
+      const db = createMockDB();
+      const metadata = {
+        kind: "file",
+        source: "source1",
+        size: 1000,
+        uuid: "file1",
+      } as ItemMetadata;
+      db.getItem = vi.fn(() =>
+        mockItem(metadata, FetchStatus.DecryptionInProgress, 0),
+      );
+      db.completeFileItem = vi.fn(() => false);
+      mockCrypto.decryptFile.mockResolvedValue(
+        "/tmp/source1/file1/decrypted.txt",
+      );
+
+      const queue = new TaskQueue(db);
+      await queue.processDecrypt({ id: "file1" }, db);
+
+      expect(db.completeFileItem).toHaveBeenCalled();
+      expect(fs.promises.rm).toHaveBeenCalledWith(
+        expect.stringContaining("source1/file1"),
+        { recursive: true, force: true },
+      );
     });
 
     it("should drop retry decryption result if item is deleted during retry", async () => {
@@ -2212,7 +2278,7 @@ describe("TaskQueue - Four-Queue Download and Decryption", () => {
 
       await new Promise((r) => setTimeout(r, 10));
 
-      queue.abortSourceFetch("source1");
+      const abortPromise = queue.abortSourceFetch("source1");
 
       for (const reject of rejects) {
         reject(new Error("AbortError: The operation was aborted"));
@@ -2220,6 +2286,7 @@ describe("TaskQueue - Four-Queue Download and Decryption", () => {
 
       await expect(p1).resolves.toBeUndefined();
       await expect(p2).resolves.toBeUndefined();
+      await expect(abortPromise).resolves.toBeUndefined();
     });
   });
 });

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -134,22 +134,29 @@ export class TaskQueue {
     }
   }
 
-  abortSourceFetch(sourceUuid: string) {
+  private hasActiveSourceFetch(sourceUuid: string): boolean {
+    return [this.activeDownloads, this.activeDecryptions].some((active) =>
+      [...active.values()].some((entry) => entry.sourceUuid === sourceUuid),
+    );
+  }
+
+  async abortSourceFetch(sourceUuid: string): Promise<void> {
     console.debug(
       "Source has been deleted: aborting downloads + decryptions: ",
       sourceUuid,
     );
-    for (const [itemId, entry] of this.activeDownloads) {
+    for (const entry of this.activeDownloads.values()) {
       if (entry.sourceUuid === sourceUuid) {
         entry.controller.abort();
-        this.activeDownloads.delete(itemId);
       }
     }
-    for (const [itemId, entry] of this.activeDecryptions) {
+    for (const entry of this.activeDecryptions.values()) {
       if (entry.sourceUuid === sourceUuid) {
         entry.controller.abort();
-        this.activeDecryptions.delete(itemId);
       }
+    }
+    while (this.hasActiveSourceFetch(sourceUuid)) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
     }
   }
 
@@ -312,7 +319,9 @@ export class TaskQueue {
       }
 
       // Transition to decrypt phase — the decrypt queue will pick this up on the next refill.
-      db.setDecryptionInProgress(item.id);
+      if (!db.setDecryptionInProgress(item.id)) {
+        return;
+      }
     } finally {
       // After every download tick, post item state to the main thread.
       if (this.port) {
@@ -426,7 +435,9 @@ export class TaskQueue {
       controller: abortController,
     });
     try {
-      db.startDownloadInProgress(item.id);
+      if (!db.startDownloadInProgress(item.id)) {
+        throw new DownloadCancelledError();
+      }
       await this.innerDownload(
         item,
         db,
@@ -606,7 +617,9 @@ export class TaskQueue {
       controller: abortController,
     });
 
-    db.setDecryptionInProgress(item.id);
+    if (!db.setDecryptionInProgress(item.id)) {
+      throw new DownloadCancelledError();
+    }
     try {
       if (metadata.kind === "file") {
         await this.decryptFile(
@@ -693,20 +706,17 @@ export class TaskQueue {
 
       // Re-check: if the item was deleted during decryption, drop the result
       if (!this.isProcessable(item.id, db)) {
-        try {
-          await fs.promises.unlink(finalAbsolutePath);
-        } catch (error) {
-          console.warn(
-            `Failed to clean up decrypted file after deletion: ${error}`,
-          );
-        }
+        await this.storage.deleteItemDirectory(metadata.source, item.id);
         return;
       }
 
       // Get the decrypted file size to display to the user
       const fileStats = await fs.promises.stat(finalAbsolutePath);
       const decryptedSize = fileStats.size;
-      db.completeFileItem(item.id, finalAbsolutePath, decryptedSize);
+      if (!db.completeFileItem(item.id, finalAbsolutePath, decryptedSize)) {
+        await this.storage.deleteItemDirectory(metadata.source, item.id);
+        return;
+      }
       console.log(`Successfully decrypted ${metadata.kind} ${item.id}`);
     } catch (error) {
       if (error instanceof CryptoError) {

--- a/app/src/main/fetch/worker.ts
+++ b/app/src/main/fetch/worker.ts
@@ -37,7 +37,22 @@ port.on("message", (message: FetchWorkerMessage) => {
       q.cancelDownload(message.itemId);
       break;
     case "abortSourceFetch":
-      q.abortSourceFetch(message.sourceUuid);
+      void q
+        .abortSourceFetch(message.sourceUuid)
+        .then(() => {
+          if (message.requestId) {
+            port.postMessage({
+              type: "sourceFetchAborted",
+              requestId: message.requestId,
+            });
+          }
+        })
+        .catch((error: unknown) => {
+          console.error("Failed to abort source fetch", {
+            sourceUuid: message.sourceUuid,
+            error,
+          });
+        });
       break;
     case "authedRequest":
       q.queueFetches(message.request);

--- a/app/src/main/index.test.ts
+++ b/app/src/main/index.test.ts
@@ -132,6 +132,7 @@ vi.mock("./crypto", () => ({
 vi.mock("./datastore", () => ({
   Datastore: class {
     getPendingEvents = vi.fn(() => []);
+    getPendingSourceCleanups = vi.fn(() => []);
     close = testState.datastoreClose;
   },
 }));

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -235,6 +235,11 @@ if (!gotTheLock) {
       if (!result) {
         return;
       }
+      if (result.type === "sourceFetchAborted") {
+        pendingSourceFetchAborts.get(result.requestId)?.();
+        pendingSourceFetchAborts.delete(result.requestId);
+        return;
+      }
       // Check if worker update is Source or Item
       if (result && "messagePreview" in result) {
         mainWindow.webContents.send("source-update", result);
@@ -249,6 +254,10 @@ if (!gotTheLock) {
 
     worker.on("exit", (err) => {
       console.log("Worker exited with code ", err);
+      for (const resolve of pendingSourceFetchAborts.values()) {
+        resolve();
+      }
+      pendingSourceFetchAborts.clear();
     });
 
     worker.on("messageerror", (err) => {
@@ -259,6 +268,8 @@ if (!gotTheLock) {
   }
 
   let fetchWorker: Worker | null = null;
+  const pendingSourceFetchAborts = new Map<string, () => void>();
+  let sourceFetchAbortSequence = 0;
   let authToken: string | null = null;
   let syncLoopTimer: NodeJS.Timeout | null = null;
   let lastHintedRecords: number | undefined;
@@ -271,12 +282,29 @@ if (!gotTheLock) {
     fetchWorker.postMessage({ type: "authedRequest", request: { authToken } });
   }
 
+  function abortSourceFetch(sourceUuid: string): Promise<void> {
+    const worker = fetchWorker;
+    if (!worker) {
+      return Promise.resolve();
+    }
+    sourceFetchAbortSequence += 1;
+    const requestId = sourceFetchAbortSequence.toString();
+    return new Promise((resolve) => {
+      pendingSourceFetchAborts.set(requestId, resolve);
+      worker.postMessage({
+        type: "abortSourceFetch",
+        sourceUuid,
+        requestId,
+      });
+    });
+  }
+
   // This method will be called when Electron has finished
   // initialization and is ready to create browser windows.
   // Some APIs can only be used after this event occurs.
   app
     .whenReady()
-    .then(() => {
+    .then(async () => {
       // Set strict Content Security Policy via HTTP header with nonce
       session.defaultSession.webRequest.onHeadersReceived(
         (details, callback) => {
@@ -493,12 +521,10 @@ if (!gotTheLock) {
         return systemLanguage;
       });
 
-      // Handle cleanup from source event: in cases of deletion or truncation,
-      // we should abort fetches and delete from the fs
+      // Handle cleanup that must precede non-truncation source events.
       async function sourceEventCleanup(
         sourceUuid: string,
         type: PendingEventType,
-        data?: PendingEventData,
       ) {
         // Immediately delete any source files from the fs on pending deletion
         if (type === PendingEventType.SourceDeleted) {
@@ -511,24 +537,27 @@ if (!gotTheLock) {
             });
           }
         }
-        // For truncation, abort in-flight downloads and delete truncated item files from the fs
-        if (type === PendingEventType.SourceConversationTruncated) {
-          // Abort any in-flight downloads for this source in the fetch worker
-          if (fetchWorker) {
-            fetchWorker.postMessage({
-              type: "abortSourceFetch",
-              sourceUuid,
+      }
+
+      async function finishPendingSourceCleanup(
+        sourceUuid: string,
+        snowflakeId: string,
+      ): Promise<void> {
+        await abortSourceFetch(sourceUuid);
+        await db.runPendingSourceCleanup(snowflakeId);
+      }
+
+      async function retryPendingSourceCleanups(): Promise<void> {
+        const cleanups = db.getPendingSourceCleanups();
+        for (const cleanup of cleanups) {
+          try {
+            await finishPendingSourceCleanup(cleanup.sourceUuid, cleanup.id);
+          } catch (error) {
+            console.error("Pending conversation cleanup remains retryable", {
+              sourceUuid: cleanup.sourceUuid,
+              eventId: cleanup.id,
+              error,
             });
-          }
-          if (data?.upper_bound) {
-            const items = db.getSourceWithItems(sourceUuid, {
-              beforeInteractionCount: data?.upper_bound + 1,
-            }).items;
-            const DELETE_BATCH_SIZE = 8;
-            for (let i = 0; i < items.length; i += DELETE_BATCH_SIZE) {
-              const batch = items.slice(i, i + DELETE_BATCH_SIZE);
-              await Promise.all(batch.map((item) => db.deleteItemFs(item)));
-            }
           }
         }
       }
@@ -541,8 +570,17 @@ if (!gotTheLock) {
           type: PendingEventType,
           data?: PendingEventData,
         ): Promise<string | null> => {
-          await sourceEventCleanup(sourceUuid, type, data);
-          return db.addPendingSourceEvent(sourceUuid, type, data);
+          if (type !== PendingEventType.SourceConversationTruncated) {
+            await sourceEventCleanup(sourceUuid, type);
+          }
+          const eventId = db.addPendingSourceEvent(sourceUuid, type, data);
+          if (
+            eventId &&
+            type === PendingEventType.SourceConversationTruncated
+          ) {
+            await finishPendingSourceCleanup(sourceUuid, eventId);
+          }
+          return eventId;
         },
       );
 
@@ -556,16 +594,25 @@ if (!gotTheLock) {
             data?: PendingEventData;
           }>,
         ): Promise<(string | null)[]> => {
-          const EVENT_BATCH_SIZE = 8;
-          for (let i = 0; i < events.length; i += EVENT_BATCH_SIZE) {
-            const batch = events.slice(i, i + EVENT_BATCH_SIZE);
-            await Promise.all(
-              batch.map(({ sourceUuid, type, data }) =>
-                sourceEventCleanup(sourceUuid, type, data),
-              ),
-            );
+          for (const { sourceUuid, type } of events) {
+            if (type !== PendingEventType.SourceConversationTruncated) {
+              await sourceEventCleanup(sourceUuid, type);
+            }
           }
-          return db.addPendingSourceEventBatch(events);
+          const eventIds = db.addPendingSourceEventBatch(events);
+          await Promise.all(
+            events.map(({ sourceUuid, type }, index) => {
+              const eventId = eventIds[index];
+              if (
+                !eventId ||
+                type !== PendingEventType.SourceConversationTruncated
+              ) {
+                return Promise.resolve();
+              }
+              return finishPendingSourceCleanup(sourceUuid, eventId);
+            }),
+          );
+          return eventIds;
         },
       );
 
@@ -595,7 +642,7 @@ if (!gotTheLock) {
           if (type === PendingEventType.ItemDeleted) {
             const item = db.getItem(itemUuid);
             if (item) {
-              db.deleteItemFs(item);
+              await db.deleteItemFs(item);
             }
           }
           return db.addPendingItemEvent(itemUuid, type);
@@ -846,6 +893,8 @@ if (!gotTheLock) {
         },
       );
 
+      await retryPendingSourceCleanups();
+
       const mainWindow = createWindow();
 
       fetchWorker = spawnFetchWorker(mainWindow);
@@ -874,6 +923,7 @@ if (!gotTheLock) {
           if (!authToken) {
             return SyncStatus.FORBIDDEN;
           }
+          await retryPendingSourceCleanups();
           if (shouldSkipSync(db, request.hintedVersion)) {
             console.log(`Already at ${request.hintedVersion}; skipping sync`);
             wakeFetchWorkerIfNeeded();

--- a/app/src/main/storage.ts
+++ b/app/src/main/storage.ts
@@ -142,21 +142,33 @@ export class Storage {
         sourceID,
         error: err,
       });
+      throw err;
     }
   }
 
   async deleteItemFs(item: Item): Promise<void> {
+    await this.deleteItemDirectory(item.data.source, item.uuid);
+  }
+
+  async deleteItemDirectory(
+    sourceUuid: string,
+    itemUuid: string,
+  ): Promise<void> {
     try {
-      const itemDirectory = this.itemDirectory(item.data, false);
+      const itemDirectory = this.sourceDirectory(
+        sourceUuid,
+        false,
+      ).getSubBuilder(itemUuid);
       await fs.promises.rm(itemDirectory.path, {
         recursive: true,
         force: true,
       });
     } catch (err) {
       console.error("Failed to delete item from filesystem", {
-        item: item.uuid,
+        item: itemUuid,
         error: err,
       });
+      throw err;
     }
   }
 }

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -103,6 +103,12 @@ export type WorkerAuthedRequest = {
 export type AbortSourceFetch = {
   type: "abortSourceFetch";
   sourceUuid: string;
+  requestId?: string;
+};
+
+export type SourceFetchAborted = {
+  type: "sourceFetchAborted";
+  requestId: string;
 };
 
 // Message sent to the fetch worker to cancel a single item download
@@ -258,6 +264,13 @@ export type PendingEventRow = {
   item_uuid: string | null;
   type: string;
   data: string; // JSON stringified PendingEventData
+};
+
+export type PendingSourceCleanup = {
+  id: string;
+  sourceUuid: string;
+  upperBound: number;
+  itemUuids: string[];
 };
 
 export enum FetchStatus {


### PR DESCRIPTION
## Summary

- Adds a local cleanup state for source conversation truncation events so they are not submitted to sync until covered item directories have been removed.
- Uses an unpaginated raw item query to collect every item up to the truncation bound, including conversations beyond the normal first item page.
- Keeps truncation-covered rows hidden and non-processable while cleanup is pending or the truncation event is still awaiting server acknowledgement.

## Context

Refs https://github.com/freedomofpress/securedrop-client/issues/3580.
This follows the existing pending-event projection pattern while adding a local-only cleanup gate before sync publication.

## Test plan

```sh
python3.13 -B ptp-notes/research/client/pocs/paginated-truncation-cleanup-poc.py .worktrees/sdc-3577-baseline-current
```

Observed on upstream `origin/main`: `confirmed` was `true`; 151 items were covered by the truncation, the old first-page cleanup selected 100 items, and 51 plaintext directories remained after the pending truncation hid all projected rows.

```sh
python3.13 -B ptp-notes/research/client/pocs/paginated-truncation-cleanup-poc.py .worktrees/sdc-3580-pr
```

Observed: the PoC exits on its source-invariant gate because the vulnerable paginated cleanup path and missing limit override are no longer present:

```text
RuntimeError: source invariant check failed for: truncation cleanup uses paginated source items, cleanup does not override limit
```

```sh
cd app
PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec vitest run --config vitest.config.ts --project=unit src/main/database/search.test.ts src/main/datastore.test.ts src/main/fetch/queue.test.ts src/main/index.test.ts --no-coverage --no-file-parallelism
```

Observed: 4 test files passed, 203 tests passed.

```sh
cd app
tmp_home=$(mktemp -d); mkdir -p "$tmp_home/.config/SecureDrop"; HOME="$tmp_home" PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm run dbmate:check
```

Observed: passed.

```sh
cd app
PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm run lint
```

Observed: Prettier, ESLint, `typecheck:node`, and `typecheck:web` passed.

```sh
cd app
PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm test
```

Observed: 52 test files passed, 905 tests passed. Existing component-test stderr warnings were emitted, but the command exited successfully.

```sh
cd app
PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm build:linux
```

Observed: passed.

```sh
git diff --check HEAD~1..HEAD
```

Observed: no output.

## Notes

I did not run the server/Electron acceptance suite locally because the shared SecureDrop server-test slot is reserved for another issue. The local coverage above exercises the production database, storage, fetch queue, and main-process paths affected by this change.

## Checklist

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes) - not run locally.
- [x] any needed updates to the [AppArmor profile] for files beyond the application code - no AppArmor profile changes needed.
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
