### PR TITLE
fix(sync): validate lifecycle counts before persistence

### DIFF
--- a/app/src/schemas.ts
+++ b/app/src/schemas.ts
@@ -53,6 +53,18 @@ export const SourceMetadataSchema = z.object({
   fingerprint: z.string(),
 });
 
+export const InteractionCountSchema = z
+  .number()
+  .int()
+  .min(1)
+  .max(Number.MAX_SAFE_INTEGER);
+
+export const InteractionCountUpperBoundSchema = z
+  .number()
+  .int()
+  .min(0)
+  .max(Number.MAX_SAFE_INTEGER - 1);
+
 export const ReplyMetadataSchema = z.object({
   kind: z.literal("reply"),
   uuid: UUIDSchema,
@@ -61,7 +73,7 @@ export const ReplyMetadataSchema = z.object({
   journalist_uuid: UUIDSchema,
   is_deleted_by_source: z.boolean(),
   seen_by: z.array(UUIDSchema),
-  interaction_count: z.number(),
+  interaction_count: InteractionCountSchema,
 });
 
 export const SubmissionMetadataSchema = z.object({
@@ -71,7 +83,7 @@ export const SubmissionMetadataSchema = z.object({
   size: z.number(),
   is_read: z.boolean(),
   seen_by: z.array(UUIDSchema),
-  interaction_count: z.number(),
+  interaction_count: InteractionCountSchema,
 });
 
 // Item metadata is either a reply or submission
@@ -151,10 +163,12 @@ const BasePendingEvent = {
   target: z.union([SourceTargetSchema, ItemTargetSchema]),
 };
 
-const SourceConversationSeenDataSchema = z.object({ upper_bound: z.number() });
+export const SourceConversationSeenDataSchema = z.object({
+  upper_bound: InteractionCountUpperBoundSchema,
+});
 
-const SourceConversationTruncatedDataSchema = z.object({
-  upper_bound: z.number(),
+export const SourceConversationTruncatedDataSchema = z.object({
+  upper_bound: InteractionCountUpperBoundSchema,
 });
 
 export const PendingEventDataSchema = z.union([


### PR DESCRIPTION
## Summary

- Enforces positive safe-integer lifecycle counts for server-provided item `interaction_count` metadata and source conversation event `upper_bound` payloads.
- Validates source-conversation truncation IPC payloads before filesystem cleanup, worker aborts, or pending-event database writes.
- Adds focused schema, sync, and main-process coverage for zero, negative, fractional, and unsafe lifecycle values.

## Context

Fixes #3572.
Fixes #3574.
Fixes #3578.
Fixes #3579.

This is the validation-focused interaction-count fix discussed for the public interaction-count issue cluster; duplicate positive interaction counts are handled separately by #3598.

## Test plan

```sh
python3.13 -B ptp-notes/research/client/pocs/truncate-zero-bound-file-leak-poc.py .worktrees/sdc-3577-baseline-current
```

Observed on clean `origin/main` at `6e0d25ab`: the zero-bound case skipped cleanup, left plaintext on disk, hid the projected row, and still satisfied the raw `openFile` predicate; the positive one-bound control cleaned the file.

```sh
python3.13 -B ptp-notes/research/client/pocs/fractional-truncation-projection-poc.py .worktrees/sdc-3577-baseline-current
python3.13 -B ptp-notes/research/client/pocs/zero-cursor-pagination-loop-poc.py .worktrees/sdc-3577-baseline-current
python3.13 -B ptp-notes/research/client/pocs/zero-count-seen-event-poc.py .worktrees/sdc-3577-baseline-current
```

Observed on clean `origin/main` at `6e0d25ab`: the fractional truncation PoC returned `vulnerable: true`; the zero-cursor PoC returned `confirmed: true` with 51 stranded rows; the zero-count seen PoC returned `confirmed: true` with no pending seen event for the zero-count case.

```sh
python3.13 -B ptp-notes/research/client/pocs/fractional-truncation-projection-poc.py .worktrees/sdc-3574-validation-pr
python3.13 -B ptp-notes/research/client/pocs/zero-cursor-pagination-loop-poc.py .worktrees/sdc-3574-validation-pr
python3.13 -B ptp-notes/research/client/pocs/zero-count-seen-event-poc.py .worktrees/sdc-3574-validation-pr
```

Observed on this branch: each PoC exits at its source-invariant gate because the vulnerable loose `z.number()` lifecycle-count schema is no longer present.

```sh
cd app
PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec vitest run --config vitest.config.ts --project=unit src/main/schemas.test.ts src/main/sync/index.test.ts src/main/index.test.ts --no-coverage --no-file-parallelism
```

Observed: 3 test files passed, 51 tests passed. This covers schema rejection, inbound sync rejection before `Datastore.updateBatch`, outgoing sync rejection before submit, and main-process IPC rejection before cleanup, worker abort, or pending-event DB mutation.

```sh
cd app
PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm run lint
```

Observed: Prettier, ESLint, `typecheck:node`, and `typecheck:web` passed.

```sh
cd app
tmp_home=$(mktemp -d); mkdir -p "$tmp_home/.config/SecureDrop"; HOME="$tmp_home" PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm run dbmate:check
```

Observed: passed.

```sh
cd app
PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm test
```

Observed: 53 test files passed, 912 tests passed. Existing component-test stderr warnings were emitted, but the command exited successfully.

```sh
cd app
PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm build:linux
```

Observed: passed. Electron Builder emitted existing packaging warnings about Linux desktop metadata, optional dbmate platform binaries, and default icon/category settings.

```sh
git diff --check HEAD~1..HEAD
```

Observed: no output.

## Notes

This PR rejects newly received or newly submitted invalid lifecycle counts. It does not attempt to repair already-synced legacy invalid rows, and it does not address duplicate positive interaction counts.

I did not run the server/Electron acceptance suite locally because the shared SecureDrop server-test slot is reserved for another issue. The local coverage above exercises the schema, sync, and main-process IPC paths affected by this change.

## Checklist

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes) - not run locally.
- [x] any needed updates to the [AppArmor profile] for files beyond the application code - no AppArmor profile changes needed.
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`) - no migration needed; `dbmate:check` passed.

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
