### PR TITLE
fix(conversation): defer paginated seen events

### DIFF
--- a/app/src/renderer/features/conversation/conversationSlice.test.ts
+++ b/app/src/renderer/features/conversation/conversationSlice.test.ts
@@ -3,6 +3,7 @@ import { configureStore } from "@reduxjs/toolkit";
 import { FetchStatus, type SourceWithItems } from "../../../types";
 import conversationSlice, {
   fetchConversation,
+  fetchOlderConversationItems,
   clearError,
   clearConversation,
   updateItem,
@@ -98,6 +99,39 @@ const mockSourceWithItems2: SourceWithItems = {
     },
   ],
 };
+
+const mockMessageItem = (interactionCount: number) => ({
+  uuid: `item-${interactionCount}`,
+  data: {
+    kind: "message" as const,
+    uuid: `item-${interactionCount}`,
+    source: "source-1",
+    size: 1024,
+    is_read: false,
+    seen_by: [],
+    interaction_count: interactionCount,
+  },
+  plaintext: `message-${interactionCount}`,
+  filename: null,
+  decrypted_size: null,
+  fetch_progress: 1024,
+  fetch_status: FetchStatus.Complete,
+});
+
+const mockMessageItems = (first: number, last: number) =>
+  Array.from({ length: last - first + 1 }, (_, index) =>
+    mockMessageItem(first + index),
+  );
+
+const mockSourcePage = (
+  firstInteractionCount: number,
+  lastInteractionCount: number,
+  hasMoreHistoricalItems: boolean,
+): SourceWithItems => ({
+  ...mockSourceWithItems,
+  items: mockMessageItems(firstInteractionCount, lastInteractionCount),
+  hasMoreHistoricalItems,
+});
 
 describe("conversationSlice", () => {
   let store: ReturnType<typeof configureStore>;
@@ -238,6 +272,80 @@ describe("conversationSlice", () => {
 
       // Check loading state is false after completion
       expect((store.getState() as any).conversation.loading).toBe(false);
+    });
+
+    it("does not mark a paginated first page as seen", async () => {
+      mockGetSourceWithItems.mockResolvedValue(mockSourcePage(52, 151, true));
+
+      await (store.dispatch as any)(fetchConversation("source-1"));
+
+      expect(mockAddPendingSourceConversationSeen).not.toHaveBeenCalled();
+
+      const state = (store.getState() as any).conversation;
+      expect(state.hasMoreHistoricalItems).toBe(true);
+      expect(state.conversation.items).toHaveLength(100);
+    });
+
+    it("marks a complete initial conversation page as seen", async () => {
+      mockGetSourceWithItems.mockResolvedValue(mockSourcePage(1, 2, false));
+
+      await (store.dispatch as any)(fetchConversation("source-1"));
+
+      expect(mockAddPendingSourceConversationSeen).toHaveBeenCalledOnce();
+      expect(mockAddPendingSourceConversationSeen).toHaveBeenCalledWith(
+        "source-1",
+        2,
+      );
+    });
+  });
+
+  describe("fetchOlderConversationItems async thunk", () => {
+    it("marks loaded history only after the final older page", async () => {
+      mockGetSourceWithItems
+        .mockResolvedValueOnce(mockSourcePage(52, 151, true))
+        .mockResolvedValueOnce(mockSourcePage(1, 51, false));
+
+      await (store.dispatch as any)(fetchConversation("source-1"));
+      expect(mockAddPendingSourceConversationSeen).not.toHaveBeenCalled();
+
+      await (store.dispatch as any)(fetchOlderConversationItems("source-1"));
+
+      expect(mockGetSourceWithItems).toHaveBeenLastCalledWith("source-1", {
+        limit: 100,
+        beforeInteractionCount: 52,
+      });
+      expect(mockAddPendingSourceConversationSeen).toHaveBeenCalledOnce();
+      expect(mockAddPendingSourceConversationSeen).toHaveBeenCalledWith(
+        "source-1",
+        151,
+      );
+
+      const state = (store.getState() as any).conversation;
+      expect(state.hasMoreHistoricalItems).toBe(false);
+      expect(state.conversation.items).toHaveLength(151);
+    });
+
+    it("continues deferring seen events while older pages remain", async () => {
+      mockGetSourceWithItems
+        .mockResolvedValueOnce(mockSourcePage(102, 201, true))
+        .mockResolvedValueOnce(mockSourcePage(52, 101, true))
+        .mockResolvedValueOnce(mockSourcePage(1, 51, false));
+
+      await (store.dispatch as any)(fetchConversation("source-1"));
+      await (store.dispatch as any)(fetchOlderConversationItems("source-1"));
+      expect(mockAddPendingSourceConversationSeen).not.toHaveBeenCalled();
+
+      await (store.dispatch as any)(fetchOlderConversationItems("source-1"));
+
+      expect(mockAddPendingSourceConversationSeen).toHaveBeenCalledOnce();
+      expect(mockAddPendingSourceConversationSeen).toHaveBeenCalledWith(
+        "source-1",
+        201,
+      );
+
+      const state = (store.getState() as any).conversation;
+      expect(state.hasMoreHistoricalItems).toBe(false);
+      expect(state.conversation.items).toHaveLength(201);
     });
   });
 

--- a/app/src/renderer/features/conversation/conversationSlice.ts
+++ b/app/src/renderer/features/conversation/conversationSlice.ts
@@ -28,6 +28,17 @@ const initialState: ConversationState = {
 
 const CONVERSATION_PAGE_SIZE = 100;
 
+const highestLoadedInteractionCount = (items: Item[]) => {
+  let highest = 0;
+  for (const item of items) {
+    const interactionCount = item.data.interaction_count;
+    if (interactionCount !== undefined && interactionCount > highest) {
+      highest = interactionCount;
+    }
+  }
+  return highest;
+};
+
 export const fetchConversation = createAsyncThunk(
   "conversation/fetchConversation",
   async (sourceUuid: string, { dispatch }) => {
@@ -36,18 +47,19 @@ export const fetchConversation = createAsyncThunk(
       { limit: CONVERSATION_PAGE_SIZE },
     );
 
-    // Mark all items in this conversation as seen
-    const maxInteractionCount = sourceWithItems.items.reduce(
-      (max, item) => Math.max(max, item.data.interaction_count ?? 0),
-      0,
-    );
-    if (maxInteractionCount > 0) {
-      const created = await window.electronAPI.addPendingSourceConversationSeen(
-        sourceUuid,
-        maxInteractionCount,
+    if (!sourceWithItems.hasMoreHistoricalItems) {
+      const highestInteractionCount = highestLoadedInteractionCount(
+        sourceWithItems.items,
       );
-      if (created) {
-        dispatch(fetchSources());
+      if (highestInteractionCount > 0) {
+        const created =
+          await window.electronAPI.addPendingSourceConversationSeen(
+            sourceUuid,
+            highestInteractionCount,
+          );
+        if (created) {
+          dispatch(fetchSources());
+        }
       }
     }
 
@@ -72,18 +84,20 @@ export const fetchOlderConversationItems = createAsyncThunk(
       { limit: CONVERSATION_PAGE_SIZE, beforeInteractionCount },
     );
 
-    // Mark all older items in this conversation as seen
-    const maxInteractionCount = sourceWithItems.items.reduce(
-      (max, item) => Math.max(max, item.data.interaction_count ?? 0),
-      0,
-    );
-    if (maxInteractionCount > 0) {
-      const created = await window.electronAPI.addPendingSourceConversationSeen(
-        sourceUuid,
-        maxInteractionCount,
-      );
-      if (created) {
-        dispatch(fetchSources());
+    if (!sourceWithItems.hasMoreHistoricalItems) {
+      const highestInteractionCount = highestLoadedInteractionCount([
+        ...conversation.items,
+        ...sourceWithItems.items,
+      ]);
+      if (highestInteractionCount > 0) {
+        const created =
+          await window.electronAPI.addPendingSourceConversationSeen(
+            sourceUuid,
+            highestInteractionCount,
+          );
+        if (created) {
+          dispatch(fetchSources());
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- Defers `source_conversation_seen` creation while the loaded conversation page still has older historical items.
- Emits the existing upper-bound seen event only after the final historical page is loaded, using the highest interaction count across all loaded items.
- Adds renderer thunk coverage for first-page pagination, final-page completion, and multi-page deferral.

## Context

Refs https://github.com/freedomofpress/securedrop-client/issues/3576.

This keeps the existing `source_conversation_seen` event contract and uses the existing `hasMoreHistoricalItems` pagination signal instead of changing the API event shape.

## Test plan

```sh
cd app
pnpm run lint
```

Observed result:

```text
Checking formatting...
All matched files use Prettier code style!
tsc --noEmit -p tsconfig.node.json --composite false
tsc --noEmit -p tsconfig.web.json --composite false
```

```sh
cd app
tmpdir=$(mktemp -d)
mkdir -p "$tmpdir/.config/SecureDrop"
HOME="$tmpdir" pnpm dbmate:check
```

Observed result:

```text
Creating: .../.config/SecureDrop/db.sqlite
Applying: 20260624000000_pending_events_retry_tracking.sql
Writing: ./src/main/database/schema.sql
Writing: ./src/main/database/schema.sql
```

```sh
cd app
pnpm exec vitest run --config vitest.config.ts --project=component src/renderer/features/conversation/conversationSlice.test.ts --no-coverage --no-file-parallelism
```

Observed result:

```text
✓ |component| src/renderer/features/conversation/conversationSlice.test.ts (21 tests) 14ms
Test Files  1 passed (1)
Tests  21 passed (21)
```

```sh
cd app
pnpm test
```

Observed result:

```text
Test Files  52 passed (52)
Tests  892 passed (892)
```

```sh
cd app
pnpm run build:linux
```

Observed result:

```text
✓ built in 3.34s
• building target=snap arch=x64 file=dist/securedrop-app_1.5.0-rc1_amd64.snap
• building target=AppImage arch=x64 file=dist/securedrop-app-1.5.0-rc1.AppImage
```

```sh
git diff --check HEAD~1..HEAD
```

Observed result: no output.

## Notes

I ran the app checks locally with Node 24.16.0 to match the app workflow's Node 24 setup.

I did not run `pnpm server-test` locally because the shared SecureDrop server-test slot was reserved for another acceptance run. This patch is renderer-only and keeps the server/API event contract unchanged.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [x] any needed updates to the [AppArmor profile] for files beyond the application code
- [x] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
