### PR TITLE
Add X-Request-ID header and logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,6 +1042,7 @@ dependencies = [
  "anyhow",
  "bindgen",
  "futures-util",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/app/integration_tests/proxy.test.ts
+++ b/app/integration_tests/proxy.test.ts
@@ -234,19 +234,22 @@ describe("Test executing streaming proxy", async () => {
   );
 
   it("stream proxy subcommand terminates with SIGTERM on timeout", async () => {
+    // Must be well-formed ("req-" + lowercase UUID) or the proxy rejects the
+    // request before the timeout can be exercised
+    const requestId = "req-72d64b57-4632-4d3e-96b0-24a0428f7ec1";
     const writeStream = new PassThrough();
     const response = (await proxyStreamRequestInner(
       {
         method: "GET",
         path_query: "/delay/10",
-        headers: { "X-Request-ID": "req-test" },
+        headers: { "X-Request-ID": requestId },
       },
       proxyCommand(100),
       writeStream,
       1,
     )) as ProxyStreamResponse;
     expect(response.error!.message).toEqual(
-      "req-test: Process terminated with signal SIGTERM",
+      `${requestId}: Process terminated with signal SIGTERM`,
     );
     expect(response.complete).toEqual(false);
   });

--- a/app/integration_tests/proxy.test.ts
+++ b/app/integration_tests/proxy.test.ts
@@ -239,14 +239,14 @@ describe("Test executing streaming proxy", async () => {
       {
         method: "GET",
         path_query: "/delay/10",
-        headers: {},
+        headers: { "X-Request-ID": "req-test" },
       },
       proxyCommand(100),
       writeStream,
       1,
     )) as ProxyStreamResponse;
     expect(response.error!.message).toEqual(
-      "Process terminated with signal SIGTERM",
+      "req-test: Process terminated with signal SIGTERM",
     );
     expect(response.complete).toEqual(false);
   });

--- a/app/integration_tests/proxy.test.ts
+++ b/app/integration_tests/proxy.test.ts
@@ -242,7 +242,7 @@ describe("Test executing streaming proxy", async () => {
       {
         method: "GET",
         path_query: "/delay/10",
-        headers: { "X-Request-ID": requestId },
+        headers: { "x-request-id": requestId },
       },
       proxyCommand(100),
       writeStream,

--- a/app/src/main/proxy.test.ts
+++ b/app/src/main/proxy.test.ts
@@ -355,12 +355,19 @@ describe("Test executing proxy with JSON requests", () => {
     expect(logSpy).toHaveBeenCalledWith(
       `[proxy] ${requestID} GET /api/v2/index`,
     );
+    // The response log records only that the request ID was echoed, not its
+    // value (which is already the request ID at the start of the line).
     expect(logSpy).toHaveBeenCalledWith(
       expect.stringContaining(`[proxy] ${requestID} response: status=200`),
     );
-    expect(logSpy).toHaveBeenCalledWith(
-      expect.stringContaining("echoed=req-echoed"),
-    );
+    const responseLog = logSpy.mock.calls
+      .map((call) => call[0])
+      .find(
+        (line) =>
+          typeof line === "string" && line.includes("response: status=200"),
+      ) as string;
+    expect(responseLog).toContain(" echoed");
+    expect(responseLog).not.toContain("req-echoed");
   });
 
   it("preserves a caller-provided X-Request-ID header", async () => {

--- a/app/src/main/proxy.test.ts
+++ b/app/src/main/proxy.test.ts
@@ -19,6 +19,9 @@ import { PassThrough } from "node:stream";
 
 vi.mock("child_process");
 
+const REQUEST_ID_PATTERN =
+  /^req-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
 const mockChildProcess = (): child_process.ChildProcess => {
   const proc = new EventEmitter() as child_process.ChildProcess;
 
@@ -310,6 +313,101 @@ describe("Test executing proxy with JSON requests", () => {
     const sent = JSON.parse(written.trim());
     expect(sent.timeout).toBe(45);
   });
+
+  it("generates an X-Request-ID header and logs the request and response", async () => {
+    const command: ProxyCommand = {
+      command: "",
+      options: [],
+      env: new Map(),
+      timeout: 100 as ms,
+    };
+
+    const request: ProxyRequest = {
+      method: "GET",
+      path_query: "/api/v2/index",
+      headers: {},
+    };
+
+    let written = "";
+    process.stdin = new Writable({
+      write(chunk, _encoding, callback) {
+        written += chunk.toString();
+        callback();
+      },
+    });
+
+    const logSpy = vi.spyOn(console, "log");
+
+    const proxyExec = proxyJSONRequestInner(request, command);
+
+    const response = {
+      status: 200,
+      headers: { "x-request-id": "req-echoed" },
+      body: {},
+    };
+    process.stdout?.emit("data", JSON.stringify(response));
+    process.emit("close", 0);
+    await proxyExec;
+
+    const sent = JSON.parse(written.trim());
+    const requestID = sent.headers["X-Request-ID"];
+    expect(requestID).toMatch(REQUEST_ID_PATTERN);
+    expect(logSpy).toHaveBeenCalledWith(
+      `[proxy] ${requestID} GET /api/v2/index`,
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`[proxy] ${requestID} response: status=200`),
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("echoed=req-echoed"),
+    );
+  });
+
+  it("preserves a caller-provided X-Request-ID header", async () => {
+    const command: ProxyCommand = {
+      command: "",
+      options: [],
+      env: new Map(),
+      timeout: 100 as ms,
+    };
+
+    const request: ProxyRequest = {
+      method: "GET",
+      path_query: "/api/v2/index",
+      headers: { "X-Request-ID": "req-preset" },
+    };
+
+    let written = "";
+    process.stdin = new Writable({
+      write(chunk, _encoding, callback) {
+        written += chunk.toString();
+        callback();
+      },
+    });
+
+    const proxyExec = proxyJSONRequestInner(request, command);
+
+    const response = { status: 200, headers: {}, body: {} };
+    process.stdout?.emit("data", JSON.stringify(response));
+    process.emit("close", 0);
+    await proxyExec;
+
+    const sent = JSON.parse(written.trim());
+    expect(sent.headers["X-Request-ID"]).toBe("req-preset");
+  });
+
+  it("includes the request ID in process failure errors", async () => {
+    const proxyExec = proxyJSONRequest({
+      headers: { "X-Request-ID": "req-preset" },
+    } as unknown as ProxyRequest);
+
+    process.stderr?.emit("data", "error");
+    process.emit("close", 1);
+
+    await expect(proxyExec).rejects.toThrowError(
+      "req-preset: Process exited with non-zero code 1: error",
+    );
+  });
 });
 
 const mockStreamingChildProcess = (): child_process.ChildProcess => {
@@ -372,7 +470,10 @@ describe("Test executing proxy with streaming requests", () => {
   });
 
   it("proxy should return on proxy-command exit error code", async () => {
-    const proxyExec = proxyStreamRequest({} as ProxyRequest, writeStream);
+    const proxyExec = proxyStreamRequest(
+      { headers: { "X-Request-ID": "req-test" } } as unknown as ProxyRequest,
+      writeStream,
+    );
 
     process.stderr?.emit("data", "error");
 
@@ -383,7 +484,7 @@ describe("Test executing proxy with streaming requests", () => {
     const { complete, error } = (await proxyExec) as ProxyStreamResponse;
     expect(!complete);
     expect(error!.message).toEqual(
-      "Process exited with non-zero code 1: error",
+      "req-test: Process exited with non-zero code 1: error",
     );
   });
 
@@ -433,7 +534,10 @@ describe("Test executing proxy with streaming requests", () => {
   });
 
   it("proxy should handle SIGTERM", async () => {
-    const proxyExec = proxyStreamRequest({} as ProxyRequest, writeStream);
+    const proxyExec = proxyStreamRequest(
+      { headers: { "X-Request-ID": "req-test" } } as unknown as ProxyRequest,
+      writeStream,
+    );
 
     setTimeout(() => {
       process.emit("close", 0, "SIGTERM");
@@ -441,6 +545,30 @@ describe("Test executing proxy with streaming requests", () => {
 
     const { complete, error } = (await proxyExec) as ProxyStreamResponse;
     expect(!complete);
-    expect(error!.message).toEqual("Process terminated with signal SIGTERM");
+    expect(error!.message).toEqual(
+      "req-test: Process terminated with signal SIGTERM",
+    );
+  });
+
+  it("generates an X-Request-ID header for stream requests", async () => {
+    const request = {
+      method: "GET",
+      path_query: "/api/v1/sources/abc/submissions/def/download",
+      headers: {},
+    } as ProxyRequest;
+
+    const proxyExec = proxyStreamRequest(request, writeStream);
+
+    if (process.stderr) {
+      process.stderr.emit("data", JSON.stringify({ headers: { etag: "x" } }));
+    }
+
+    setTimeout(() => {
+      process.emit("close", 0);
+    }, 10);
+
+    await proxyExec;
+
+    expect(request.headers["X-Request-ID"]).toMatch(REQUEST_ID_PATTERN);
   });
 });

--- a/app/src/main/proxy.test.ts
+++ b/app/src/main/proxy.test.ts
@@ -350,7 +350,7 @@ describe("Test executing proxy with JSON requests", () => {
     await proxyExec;
 
     const sent = JSON.parse(written.trim());
-    const requestID = sent.headers["X-Request-ID"];
+    const requestID = sent.headers["x-request-id"];
     expect(requestID).toMatch(REQUEST_ID_PATTERN);
     expect(logSpy).toHaveBeenCalledWith(
       `[proxy] ${requestID} GET /api/v2/index`,
@@ -381,7 +381,7 @@ describe("Test executing proxy with JSON requests", () => {
     const request: ProxyRequest = {
       method: "GET",
       path_query: "/api/v2/index",
-      headers: { "X-Request-ID": "req-preset" },
+      headers: { "x-request-id": "req-c5816c86-a6d8-4206-b58f-ec26ac4a653c" },
     };
 
     let written = "";
@@ -400,19 +400,21 @@ describe("Test executing proxy with JSON requests", () => {
     await proxyExec;
 
     const sent = JSON.parse(written.trim());
-    expect(sent.headers["X-Request-ID"]).toBe("req-preset");
+    expect(sent.headers["x-request-id"]).toBe(
+      "req-c5816c86-a6d8-4206-b58f-ec26ac4a653c",
+    );
   });
 
   it("includes the request ID in process failure errors", async () => {
     const proxyExec = proxyJSONRequest({
-      headers: { "X-Request-ID": "req-preset" },
+      headers: { "x-request-id": "req-c5816c86-a6d8-4206-b58f-ec26ac4a653c" },
     } as unknown as ProxyRequest);
 
     process.stderr?.emit("data", "error");
     process.emit("close", 1);
 
     await expect(proxyExec).rejects.toThrowError(
-      "req-preset: Process exited with non-zero code 1: error",
+      "req-c5816c86-a6d8-4206-b58f-ec26ac4a653c: Process exited with non-zero code 1: error",
     );
   });
 });
@@ -478,7 +480,9 @@ describe("Test executing proxy with streaming requests", () => {
 
   it("proxy should return on proxy-command exit error code", async () => {
     const proxyExec = proxyStreamRequest(
-      { headers: { "X-Request-ID": "req-test" } } as unknown as ProxyRequest,
+      {
+        headers: { "x-request-id": "req-23dd7b46-6dd9-4be9-b870-d55d4b7faa96" },
+      } as unknown as ProxyRequest,
       writeStream,
     );
 
@@ -491,7 +495,7 @@ describe("Test executing proxy with streaming requests", () => {
     const { complete, error } = (await proxyExec) as ProxyStreamResponse;
     expect(!complete);
     expect(error!.message).toEqual(
-      "req-test: Process exited with non-zero code 1: error",
+      "req-23dd7b46-6dd9-4be9-b870-d55d4b7faa96: Process exited with non-zero code 1: error",
     );
   });
 
@@ -542,7 +546,9 @@ describe("Test executing proxy with streaming requests", () => {
 
   it("proxy should handle SIGTERM", async () => {
     const proxyExec = proxyStreamRequest(
-      { headers: { "X-Request-ID": "req-test" } } as unknown as ProxyRequest,
+      {
+        headers: { "x-request-id": "req-a518a6e3-8767-4dac-99dd-01d411085abf" },
+      } as unknown as ProxyRequest,
       writeStream,
     );
 
@@ -553,7 +559,7 @@ describe("Test executing proxy with streaming requests", () => {
     const { complete, error } = (await proxyExec) as ProxyStreamResponse;
     expect(!complete);
     expect(error!.message).toEqual(
-      "req-test: Process terminated with signal SIGTERM",
+      "req-a518a6e3-8767-4dac-99dd-01d411085abf: Process terminated with signal SIGTERM",
     );
   });
 
@@ -576,6 +582,6 @@ describe("Test executing proxy with streaming requests", () => {
 
     await proxyExec;
 
-    expect(request.headers["X-Request-ID"]).toMatch(REQUEST_ID_PATTERN);
+    expect(request.headers["x-request-id"]).toMatch(REQUEST_ID_PATTERN);
   });
 });

--- a/app/src/main/proxy.test.ts
+++ b/app/src/main/proxy.test.ts
@@ -366,7 +366,6 @@ describe("Test executing proxy with JSON requests", () => {
         (line) =>
           typeof line === "string" && line.includes("response: status=200"),
       ) as string;
-    expect(responseLog).toContain(" echoed");
     expect(responseLog).not.toContain("req-echoed");
   });
 

--- a/app/src/main/proxy.ts
+++ b/app/src/main/proxy.ts
@@ -20,12 +20,18 @@ const DEFAULT_PROXY_VM_NAME = "sd-proxy";
 export const DEFAULT_PROXY_CMD_TIMEOUT_MS = 10_000 as ms;
 export const MESSAGE_REPLY_DOWNLOAD_TIMEOUT_MS = 20_000 as ms;
 
-// Tag the request with an X-Request-ID header (unless the caller already set one)
+// Tag the request with an X-Request-ID header (unless the caller already set
+// one).  This MUST be a v4 UUID per RFC 9562, here via crypto.randomUUID().
 function ensureRequestID(request: ProxyRequest): string {
   request.headers = request.headers ?? {};
-  if (!request.headers["X-Request-ID"]) {
-    request.headers["X-Request-ID"] = `req-${crypto.randomUUID()}`;
+  const existingKey = Object.keys(request.headers).find(
+    (key) => key.toLowerCase() === "x-request-id",
+  );
+  const existing = existingKey ? request.headers[existingKey] : undefined;
+  if (existingKey) {
+    delete request.headers[existingKey];
   }
+  request.headers["X-Request-ID"] = existing || `req-${crypto.randomUUID()}`;
   return request.headers["X-Request-ID"];
 }
 
@@ -51,7 +57,7 @@ function logJSONResponse(
   const echoed = getHeader(response.headers, "X-Request-ID");
   console.log(
     `[proxy] ${requestID} response: status=${response.status} size=${size}` +
-      (echoed ? ` echoed=${echoed}` : ""),
+      (echoed ? " echoed" : ""),
   );
 }
 
@@ -136,7 +142,11 @@ export async function proxyJSONRequestInner(
       } else {
         try {
           const response = parseJSONResponse(stdout);
-          logJSONResponse(requestID, response, stdout.length);
+          logJSONResponse(
+            requestID,
+            response,
+            Buffer.byteLength(stdout, "utf8"),
+          );
           resolve(response);
         } catch (err) {
           reject(err);
@@ -277,7 +287,7 @@ export async function proxyStreamRequestInner(
         // Convert buffer chunks to string only when needed for JSON parsing
         const stdout = Buffer.concat(stdoutChunks).toString("utf8");
         const response = parseJSONResponse(stdout);
-        logJSONResponse(requestID, response, stdout.length);
+        logJSONResponse(requestID, response, Buffer.byteLength(stdout, "utf8"));
         resolve(response);
       } catch {
         try {
@@ -288,7 +298,7 @@ export async function proxyStreamRequestInner(
           const echoed = getHeader(headers, "X-Request-ID");
           console.log(
             `[proxy] ${requestID} stream complete: bytesWritten=${bytesWritten}` +
-              (echoed ? ` echoed=${echoed}` : ""),
+              (echoed ? " echoed" : ""),
           );
           resolve({
             complete: true,

--- a/app/src/main/proxy.ts
+++ b/app/src/main/proxy.ts
@@ -1,4 +1,5 @@
 import child_process from "node:child_process";
+import crypto from "node:crypto";
 import path from "node:path";
 import { Writable } from "node:stream";
 import { finished } from "node:stream/promises";
@@ -18,6 +19,41 @@ const DEFAULT_PROXY_VM_NAME = "sd-proxy";
 // than the proxy's request-level timeout.
 export const DEFAULT_PROXY_CMD_TIMEOUT_MS = 10_000 as ms;
 export const MESSAGE_REPLY_DOWNLOAD_TIMEOUT_MS = 20_000 as ms;
+
+// Tag the request with an X-Request-ID header (unless the caller already set one)
+function ensureRequestID(request: ProxyRequest): string {
+  request.headers = request.headers ?? {};
+  if (!request.headers["X-Request-ID"]) {
+    request.headers["X-Request-ID"] = `req-${crypto.randomUUID()}`;
+  }
+  return request.headers["X-Request-ID"];
+}
+
+// The proxy returns lowercased header names, but don't depend on that.
+function getHeader(
+  headers: Map<string, string>,
+  name: string,
+): string | undefined {
+  const lower = name.toLowerCase();
+  for (const [key, value] of headers) {
+    if (key.toLowerCase() === lower) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function logJSONResponse(
+  requestID: string,
+  response: ProxyJSONResponse,
+  size: number,
+) {
+  const echoed = getHeader(response.headers, "X-Request-ID");
+  console.log(
+    `[proxy] ${requestID} response: status=${response.status} size=${size}` +
+      (echoed ? ` echoed=${echoed}` : ""),
+  );
+}
 
 function parseJSONResponse(response: string): ProxyJSONResponse {
   const result = JSON.parse(response);
@@ -66,6 +102,8 @@ export async function proxyJSONRequestInner(
   command: ProxyCommand,
 ): Promise<ProxyJSONResponse> {
   return new Promise((resolve, reject) => {
+    const requestID = ensureRequestID(request);
+
     // The path in `command.command` is hardcoded and not user input
     // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
     const process = child_process.spawn(command.command, command.options, {
@@ -86,14 +124,20 @@ export async function proxyJSONRequestInner(
 
     process.on("close", (code, signal) => {
       if (signal) {
-        reject(new Error(`Process terminated with signal ${signal}`));
+        reject(
+          new Error(`${requestID}: Process terminated with signal ${signal}`),
+        );
       } else if (code != 0) {
         reject(
-          new Error(`Process exited with non-zero code ${code}: ${stderr}`),
+          new Error(
+            `${requestID}: Process exited with non-zero code ${code}: ${stderr}`,
+          ),
         );
       } else {
         try {
-          resolve(parseJSONResponse(stdout));
+          const response = parseJSONResponse(stdout);
+          logJSONResponse(requestID, response, stdout.length);
+          resolve(response);
         } catch (err) {
           reject(err);
         }
@@ -114,6 +158,8 @@ export async function proxyJSONRequestInner(
     const timeoutInSeconds = Math.floor(command.timeout / 1000);
     const defaultInSeconds = Math.floor(DEFAULT_PROXY_CMD_TIMEOUT_MS / 1000);
     request.timeout = Math.max(timeoutInSeconds, defaultInSeconds) as sec;
+
+    console.log(`[proxy] ${requestID} ${request.method} ${request.path_query}`);
 
     try {
       process.stdin.write(JSON.stringify(request) + "\n");
@@ -153,6 +199,8 @@ export async function proxyStreamRequestInner(
   onProgress?: ProgressCallback,
 ): Promise<ProxyResponse> {
   return new Promise((resolve, reject) => {
+    const requestID = ensureRequestID(request);
+
     // The path in `command.command` is hardcoded and not user input
     // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
     const process = child_process.spawn(command.command, command.options, {
@@ -207,7 +255,9 @@ export async function proxyStreamRequestInner(
       if (signal) {
         resolve({
           complete: false,
-          error: new Error(`Process terminated with signal ${signal}`),
+          error: new Error(
+            `${requestID}: Process terminated with signal ${signal}`,
+          ),
           bytesWritten: bytesWritten,
         });
         return;
@@ -216,7 +266,7 @@ export async function proxyStreamRequestInner(
         resolve({
           complete: false,
           error: new Error(
-            `Process exited with non-zero code ${code}: ${stderr}`,
+            `${requestID}: Process exited with non-zero code ${code}: ${stderr}`,
           ),
           bytesWritten: bytesWritten,
         });
@@ -226,17 +276,29 @@ export async function proxyStreamRequestInner(
         // If we receive JSON data, parse and return
         // Convert buffer chunks to string only when needed for JSON parsing
         const stdout = Buffer.concat(stdoutChunks).toString("utf8");
-        resolve(parseJSONResponse(stdout));
+        const response = parseJSONResponse(stdout);
+        logJSONResponse(requestID, response, stdout.length);
+        resolve(response);
       } catch {
         try {
           const header = JSON.parse(stderr);
+          const headers: Map<string, string> = new Map(
+            Object.entries(header["headers"]),
+          );
+          const echoed = getHeader(headers, "X-Request-ID");
+          console.log(
+            `[proxy] ${requestID} stream complete: bytesWritten=${bytesWritten}` +
+              (echoed ? ` echoed=${echoed}` : ""),
+          );
           resolve({
             complete: true,
-            sha256sum: header["headers"]["etag"] || "",
+            sha256sum: getHeader(headers, "etag") || "",
             bytesWritten: bytesWritten,
           });
         } catch (err) {
-          reject(`Error reading headers from proxy stderr: ${err}`);
+          reject(
+            `${requestID}: Error reading headers from proxy stderr: ${err}`,
+          );
         }
       }
     });
@@ -258,6 +320,10 @@ export async function proxyStreamRequestInner(
     const timeoutInSeconds = Math.floor(command.timeout / 1000);
     const defaultInSeconds = Math.floor(DEFAULT_PROXY_CMD_TIMEOUT_MS / 1000);
     request.timeout = Math.max(timeoutInSeconds, defaultInSeconds) as sec;
+
+    console.log(
+      `[proxy] ${requestID} ${request.method} ${request.path_query} (stream)`,
+    );
 
     try {
       process.stdin.write(JSON.stringify(request) + "\n");

--- a/app/src/main/proxy.ts
+++ b/app/src/main/proxy.ts
@@ -54,10 +54,8 @@ function logJSONResponse(
   response: ProxyJSONResponse,
   size: number,
 ) {
-  const echoed = getHeader(response.headers, "x-request-id");
   console.log(
-    `[proxy] ${requestID} response: status=${response.status} size=${size}` +
-      (echoed ? " echoed" : ""),
+    `[proxy] ${requestID} response: status=${response.status} size=${size}`,
   );
 }
 
@@ -295,10 +293,8 @@ export async function proxyStreamRequestInner(
           const headers: Map<string, string> = new Map(
             Object.entries(header["headers"]),
           );
-          const echoed = getHeader(headers, "x-request-id");
           console.log(
-            `[proxy] ${requestID} stream complete: bytesWritten=${bytesWritten}` +
-              (echoed ? " echoed" : ""),
+            `[proxy] ${requestID} stream complete: bytesWritten=${bytesWritten}`,
           );
           resolve({
             complete: true,

--- a/app/src/main/proxy.ts
+++ b/app/src/main/proxy.ts
@@ -31,8 +31,8 @@ function ensureRequestID(request: ProxyRequest): string {
   if (existingKey) {
     delete request.headers[existingKey];
   }
-  request.headers["X-Request-ID"] = existing || `req-${crypto.randomUUID()}`;
-  return request.headers["X-Request-ID"];
+  request.headers["x-request-id"] = existing || `req-${crypto.randomUUID()}`;
+  return request.headers["x-request-id"];
 }
 
 // The proxy returns lowercased header names, but don't depend on that.
@@ -54,7 +54,7 @@ function logJSONResponse(
   response: ProxyJSONResponse,
   size: number,
 ) {
-  const echoed = getHeader(response.headers, "X-Request-ID");
+  const echoed = getHeader(response.headers, "x-request-id");
   console.log(
     `[proxy] ${requestID} response: status=${response.status} size=${size}` +
       (echoed ? " echoed" : ""),
@@ -295,7 +295,7 @@ export async function proxyStreamRequestInner(
           const headers: Map<string, string> = new Map(
             Object.entries(header["headers"]),
           );
-          const echoed = getHeader(headers, "X-Request-ID");
+          const echoed = getHeader(headers, "x-request-id");
           console.log(
             `[proxy] ${requestID} stream complete: bytesWritten=${bytesWritten}` +
               (echoed ? " echoed" : ""),

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -11,6 +11,7 @@ qubesdb = []
 [dependencies]
 anyhow = {version = "1.0.75"}
 futures-util = "0.3.30"
+regex = "1"
 reqwest = { version = "0.12", features = ["gzip", "stream", "socks"] }
 serde = {version = "1.0.188", features = ["derive"]}
 serde_json = "1.0.107"

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{bail, Result};
 use futures_util::StreamExt;
+use regex::Regex;
 use reqwest::header::HeaderMap;
 use reqwest::redirect::Policy as RedirectPolicy;
 use reqwest::{Client, Method, Proxy, Response};
@@ -12,6 +13,7 @@ use std::io::{BufRead, Write};
 use std::os::unix::net::UnixDatagram;
 use std::process::ExitCode;
 use std::str::FromStr;
+use std::sync::LazyLock;
 use std::time::Duration;
 use url::Url;
 
@@ -87,20 +89,18 @@ impl Syslog {
 }
 
 /// Whether `value` is a well-formed request ID: `req-` followed by a
-/// lowercase UUID.  A request carrying anything else is rejected so that a
-/// compromised client VM can't inject arbitrary strings into the proxy's
-/// and server's logs.
+/// lowercase RFC 9562 UUID.  A request carrying anything else is rejected.
+/// Kept in sync with the client-side generator in `app/src/main/proxy.ts`.
 fn valid_request_id(value: &str) -> bool {
-    let Some(uuid) = value.strip_prefix("req-") else {
-        return false;
-    };
-    if uuid.len() != 36 {
-        return false;
-    }
-    uuid.chars().enumerate().all(|(i, c)| match i {
-        8 | 13 | 18 | 23 => c == '-',
-        _ => c.is_ascii_digit() || ('a'..='f').contains(&c),
-    })
+    // `\A`/`\z` anchor the whole string so an embedded newline can't sneak a
+    // log-injection payload past a line-oriented `$`.
+    static REQUEST_ID: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"\Areq-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z",
+        )
+        .expect("request ID regex is valid")
+    });
+    REQUEST_ID.is_match(value)
 }
 
 #[derive(Debug, PartialEq)]
@@ -133,15 +133,12 @@ fn extract_request_id(headers: &mut HashMap<String, String>) -> RequestId {
     }
 }
 
-/// The server's echoed X-Request-ID, formatted for appending to a log line.
-fn echoed_request_id(resp: &Response) -> String {
-    match resp
-        .headers()
-        .get(REQUEST_ID_HEADER)
-        .and_then(|value| value.to_str().ok())
-    {
-        Some(echoed) => format!(" echoed={echoed}"),
-        None => String::new(),
+/// An ` echoed` marker for the log line when the server echoed back an X-Request-ID
+fn echoed_request_id(resp: &Response) -> &'static str {
+    if resp.headers().contains_key(REQUEST_ID_HEADER) {
+        " echoed"
+    } else {
+        ""
     }
 }
 

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -87,9 +87,9 @@ impl Syslog {
 }
 
 /// Whether `value` is a well-formed request ID: `req-` followed by a
-/// lowercase UUID.  Anything else is stripped by `extract_request_id()` so
-/// that a compromised client VM can't inject arbitrary strings into the
-/// proxy's and server's logs.
+/// lowercase UUID.  A request carrying anything else is rejected so that a
+/// compromised client VM can't inject arbitrary strings into the proxy's
+/// and server's logs.
 fn valid_request_id(value: &str) -> bool {
     let Some(uuid) = value.strip_prefix("req-") else {
         return false;
@@ -106,16 +106,16 @@ fn valid_request_id(value: &str) -> bool {
 #[derive(Debug, PartialEq)]
 enum RequestId {
     Valid(String),
-    /// The malformed value, which has been stripped from the request
+    /// The malformed value; the caller fails the request
     Invalid(String),
     Missing,
 }
 
-/// Validate the request's X-Request-ID header.  A malformed one is removed
-/// from the request: the Inbox always generates well-formed IDs, so a
-/// malformed one means a broken (or compromised) client, which the caller
-/// should log a warning about.  The request itself still proceeds either
-/// way — request IDs are an observability aid, not a gate.
+/// Validate the request's X-Request-ID header.  The Inbox always generates
+/// well-formed IDs, so a malformed one means a broken (or compromised)
+/// client: the caller logs a warning and fails the request.  A missing ID
+/// is not an error — the header is optional — and the request proceeds
+/// without one.
 fn extract_request_id(headers: &mut HashMap<String, String>) -> RequestId {
     let Some(key) = headers
         .keys()
@@ -275,13 +275,14 @@ async fn proxy() -> Result<()> {
         RequestId::Invalid(value) => {
             // {:?} escapes control characters so the malformed value can't
             // inject anything into the logs; truncate it for good measure.
+            let escaped =
+                format!("{:?}", value.chars().take(64).collect::<String>());
             syslog.warn(&format!(
-                "stripped invalid X-Request-ID header: {:?}",
-                value.chars().take(64).collect::<String>()
+                "rejected invalid X-Request-ID header: {escaped}"
             ));
-            // Apache-style placeholder in the log lines below
-            "-".to_string()
+            bail!("invalid X-Request-ID header: {escaped}");
         }
+        // Apache-style placeholder in the log lines below
         RequestId::Missing => "-".to_string(),
     };
     syslog.info(&format!(
@@ -431,7 +432,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_request_id_strips_invalid() {
+    fn test_extract_request_id_invalid() {
         let mut headers = HashMap::from([
             (
                 REQUEST_ID_HEADER.to_string(),
@@ -464,7 +465,7 @@ mod tests {
         assert!(message.starts_with("<14>securedrop-proxy["));
         assert!(message.ends_with("]: req-x request: method=GET body_size=0"));
 
-        syslog.warn("stripped invalid X-Request-ID header: \"nope\"");
+        syslog.warn("rejected invalid X-Request-ID header: \"nope\"");
         let n = receiver.recv(&mut buf).unwrap();
         let message = std::str::from_utf8(&buf[..n]).unwrap();
         assert!(message.starts_with("<12>securedrop-proxy["));

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::{self, Read};
 use std::io::{BufRead, Write};
+use std::os::unix::net::UnixDatagram;
 use std::process::ExitCode;
 use std::str::FromStr;
 use std::time::Duration;
@@ -32,6 +33,117 @@ const DISABLE_TOR: &str = "DISABLE_TOR";
 // Read a max of 5MB from stdin. This should be much higher than what a
 // server w/ 1k sources needs (~300KB), but still low enough to prevent a DoS.
 const STDIN_LIMIT: u64 = 5_000_000;
+
+// Requests are tagged with an X-Request-ID header
+const REQUEST_ID_HEADER: &str = "X-Request-ID";
+
+/// Best-effort logger that writes to the local syslog socket, from where
+/// messages are forwarded to sd-log by securedrop-log's rsyslog config.
+///
+/// stdout and stderr are the qrexec protocol channels back to the client, so
+/// logs MUST NOT be written to either. If the syslog socket is unavailable
+/// (e.g. in dev mode outside Qubes), messages are silently dropped: logging
+/// must never fail a request.
+struct Syslog {
+    socket: Option<UnixDatagram>,
+}
+
+// RFC 3164 severities, within facility "user" (1)
+const SYSLOG_WARNING: u8 = 4;
+const SYSLOG_INFO: u8 = 6;
+
+impl Syslog {
+    fn new() -> Self {
+        Self::connect("/dev/log")
+    }
+
+    fn connect(path: &str) -> Self {
+        let socket = UnixDatagram::unbound()
+            .ok()
+            .filter(|socket| socket.connect(path).is_ok());
+        Syslog { socket }
+    }
+
+    fn info(&self, message: &str) {
+        self.log(SYSLOG_INFO, message);
+    }
+
+    fn warn(&self, message: &str) {
+        self.log(SYSLOG_WARNING, message);
+    }
+
+    fn log(&self, severity: u8, message: &str) {
+        if let Some(socket) = &self.socket {
+            // RFC 3164 priority: facility "user" (1) * 8 + severity
+            let line = format!(
+                "<{}>securedrop-proxy[{}]: {}",
+                8 + severity,
+                std::process::id(),
+                message
+            );
+            let _ = socket.send(line.as_bytes());
+        }
+    }
+}
+
+/// Whether `value` is a well-formed request ID: `req-` followed by a
+/// lowercase UUID.  Anything else is stripped by `extract_request_id()` so
+/// that a compromised client VM can't inject arbitrary strings into the
+/// proxy's and server's logs.
+fn valid_request_id(value: &str) -> bool {
+    let Some(uuid) = value.strip_prefix("req-") else {
+        return false;
+    };
+    if uuid.len() != 36 {
+        return false;
+    }
+    uuid.chars().enumerate().all(|(i, c)| match i {
+        8 | 13 | 18 | 23 => c == '-',
+        _ => c.is_ascii_digit() || ('a'..='f').contains(&c),
+    })
+}
+
+#[derive(Debug, PartialEq)]
+enum RequestId {
+    Valid(String),
+    /// The malformed value, which has been stripped from the request
+    Invalid(String),
+    Missing,
+}
+
+/// Validate the request's X-Request-ID header.  A malformed one is removed
+/// from the request: the Inbox always generates well-formed IDs, so a
+/// malformed one means a broken (or compromised) client, which the caller
+/// should log a warning about.  The request itself still proceeds either
+/// way — request IDs are an observability aid, not a gate.
+fn extract_request_id(headers: &mut HashMap<String, String>) -> RequestId {
+    let Some(key) = headers
+        .keys()
+        .find(|key| key.eq_ignore_ascii_case(REQUEST_ID_HEADER))
+        .cloned()
+    else {
+        return RequestId::Missing;
+    };
+    let value = headers[&key].clone();
+    if valid_request_id(&value) {
+        RequestId::Valid(value)
+    } else {
+        headers.remove(&key);
+        RequestId::Invalid(value)
+    }
+}
+
+/// The server's echoed X-Request-ID, formatted for appending to a log line.
+fn echoed_request_id(resp: &Response) -> String {
+    match resp
+        .headers()
+        .get(REQUEST_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+    {
+        Some(echoed) => format!(" echoed={echoed}"),
+        None => String::new(),
+    }
+}
 
 /// Incoming HTTP requests (as JSON) received over stdin
 #[derive(Deserialize, Debug)]
@@ -87,29 +199,52 @@ fn headers_to_map(resp: &Response) -> Result<HashMap<String, String>> {
 }
 
 /// Given a `Response` that doesn't require stream processing, convert it to our `OutgoingResponse` and serialize to JSON on stdout.
-async fn handle_json_response(resp: Response) -> Result<()> {
+async fn handle_json_response(
+    resp: Response,
+    request_id: &str,
+    syslog: &Syslog,
+) -> Result<()> {
     let headers = headers_to_map(&resp)?;
+    let status = resp.status().as_u16();
+    let echoed = echoed_request_id(&resp);
+    let body = resp.text().await?;
+    syslog.info(&format!(
+        "{request_id} response: status={status} size={}{echoed}",
+        body.len()
+    ));
     let outgoing_response = OutgoingResponse {
-        status: resp.status().as_u16(),
+        status,
         headers,
-        body: resp.text().await?,
+        body,
     };
     println!("{}", serde_json::to_string(&outgoing_response)?);
     Ok(())
 }
 
 /// Given a `Response` that does require stream processing, forward it to stdout as we receive it, and then write the headers to stderr when we're done.
-async fn handle_stream_response(resp: Response) -> Result<()> {
+async fn handle_stream_response(
+    resp: Response,
+    request_id: &str,
+    syslog: &Syslog,
+) -> Result<()> {
     // Get the headers, will be output later but we want to fail early if it's missing/invalid
     let headers = headers_to_map(&resp)?;
+    let status = resp.status().as_u16();
+    let echoed = echoed_request_id(&resp);
+    let mut size: usize = 0;
     let mut stdout = io::stdout().lock();
     let mut stream = resp.bytes_stream();
     // Stream the response, printing bytes as we receive them
     while let Some(item) = stream.next().await {
-        stdout.write_all(&item?)?;
+        let item = item?;
+        size += item.len();
+        stdout.write_all(&item)?;
         // TODO: can we flush at smarter intervals?
         stdout.flush()?;
     }
+    syslog.info(&format!(
+        "{request_id} response: status={status} size={size} stream=true{echoed}"
+    ));
     // Emit the headers as stderr
     eprintln!(
         "{}",
@@ -133,7 +268,27 @@ async fn proxy() -> Result<()> {
     if buffer.len() == STDIN_LIMIT as usize && !buffer.ends_with('\n') {
         bail!("stdin is over the max bytes ({STDIN_LIMIT}), aborting");
     }
-    let incoming_request: IncomingRequest = serde_json::from_str(&buffer)?;
+    let mut incoming_request: IncomingRequest = serde_json::from_str(&buffer)?;
+    let syslog = Syslog::new();
+    let request_id = match extract_request_id(&mut incoming_request.headers) {
+        RequestId::Valid(request_id) => request_id,
+        RequestId::Invalid(value) => {
+            // {:?} escapes control characters so the malformed value can't
+            // inject anything into the logs; truncate it for good measure.
+            syslog.warn(&format!(
+                "stripped invalid X-Request-ID header: {:?}",
+                value.chars().take(64).collect::<String>()
+            ));
+            // Apache-style placeholder in the log lines below
+            "-".to_string()
+        }
+        RequestId::Missing => "-".to_string(),
+    };
+    syslog.info(&format!(
+        "{request_id} request: method={} body_size={}",
+        incoming_request.method,
+        incoming_request.body.as_deref().map_or(0, str::len)
+    ));
     // We construct the URL by first parsing the origin and then appending the
     // path query. This forces the path query to be part of the path and prevents
     // it from getting itself into the hostname.
@@ -170,16 +325,22 @@ async fn proxy() -> Result<()> {
         req = req.body(body);
     }
     // Fire off the request!
-    let resp = req.send().await?;
+    let resp = match req.send().await {
+        Ok(resp) => resp,
+        Err(err) => {
+            syslog.warn(&format!("{request_id} request failed: {err}"));
+            return Err(err.into());
+        }
+    };
     // We return the output in two ways, either a JSON blob or stream the output.
     // JSON is used for HTTP 4xx, 5xx, and all non-stream requests.
     if !incoming_request.stream
         || resp.status().is_client_error()
         || resp.status().is_server_error()
     {
-        handle_json_response(resp).await?;
+        handle_json_response(resp, &request_id, &syslog).await?;
     } else {
-        handle_stream_response(resp).await?;
+        handle_stream_response(resp, &request_id, &syslog).await?;
     }
     Ok(())
 }
@@ -211,5 +372,110 @@ async fn main() -> ExitCode {
             };
             ExitCode::FAILURE
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_request_id() {
+        assert!(valid_request_id("req-72d64b57-4632-4d3e-96b0-24a0428f7ec1"));
+        // missing prefix
+        assert!(!valid_request_id("72d64b57-4632-4d3e-96b0-24a0428f7ec1"));
+        // wrong prefix
+        assert!(!valid_request_id(
+            "seq-72d64b57-4632-4d3e-96b0-24a0428f7ec1"
+        ));
+        // uppercase hex
+        assert!(!valid_request_id(
+            "req-72D64B57-4632-4D3E-96B0-24A0428F7EC1"
+        ));
+        // too short / too long / empty
+        assert!(!valid_request_id("req-72d64b57"));
+        assert!(!valid_request_id(
+            "req-72d64b57-4632-4d3e-96b0-24a0428f7ec1ff"
+        ));
+        assert!(!valid_request_id(""));
+        // non-hex, log-injection attempts
+        assert!(!valid_request_id(
+            "req-72d64b57-4632-4d3e-96b0-24a0428f7ecz"
+        ));
+        assert!(!valid_request_id("req-injected\nmessage into the logs!"));
+    }
+
+    #[test]
+    fn test_extract_request_id_preserves_valid() {
+        let valid = "req-72d64b57-4632-4d3e-96b0-24a0428f7ec1";
+        // ... under any header-name casing
+        for name in [REQUEST_ID_HEADER, "x-request-id"] {
+            let mut headers =
+                HashMap::from([(name.to_string(), valid.to_string())]);
+            assert_eq!(
+                extract_request_id(&mut headers),
+                RequestId::Valid(valid.to_string())
+            );
+            assert_eq!(headers.len(), 1);
+            assert_eq!(headers[name], valid);
+        }
+    }
+
+    #[test]
+    fn test_extract_request_id_missing() {
+        let mut headers =
+            HashMap::from([("Accept".to_string(), "*/*".to_string())]);
+        assert_eq!(extract_request_id(&mut headers), RequestId::Missing);
+        // Other headers are untouched
+        assert_eq!(headers.len(), 1);
+    }
+
+    #[test]
+    fn test_extract_request_id_strips_invalid() {
+        let mut headers = HashMap::from([
+            (
+                REQUEST_ID_HEADER.to_string(),
+                "not a request ID".to_string(),
+            ),
+            ("Accept".to_string(), "*/*".to_string()),
+        ]);
+        assert_eq!(
+            extract_request_id(&mut headers),
+            RequestId::Invalid("not a request ID".to_string())
+        );
+        // The malformed header is removed; other headers are untouched
+        assert_eq!(headers.len(), 1);
+        assert_eq!(headers["Accept"], "*/*");
+    }
+
+    #[test]
+    fn test_syslog_message_format() {
+        let path = std::env::temp_dir()
+            .join(format!("sdproxy-test-syslog-{}", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let receiver = UnixDatagram::bind(&path).unwrap();
+        let mut buf = [0u8; 1024];
+
+        let syslog = Syslog::connect(path.to_str().unwrap());
+
+        syslog.info("req-x request: method=GET body_size=0");
+        let n = receiver.recv(&mut buf).unwrap();
+        let message = std::str::from_utf8(&buf[..n]).unwrap();
+        assert!(message.starts_with("<14>securedrop-proxy["));
+        assert!(message.ends_with("]: req-x request: method=GET body_size=0"));
+
+        syslog.warn("stripped invalid X-Request-ID header: \"nope\"");
+        let n = receiver.recv(&mut buf).unwrap();
+        let message = std::str::from_utf8(&buf[..n]).unwrap();
+        assert!(message.starts_with("<12>securedrop-proxy["));
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_syslog_unavailable_is_silently_dropped() {
+        let syslog = Syslog::connect("/nonexistent/syslog/socket");
+        // Must not panic or error
+        syslog.info("req-x request: method=GET body_size=0");
     }
 }

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -127,15 +127,6 @@ fn extract_request_id(headers: &mut HashMap<String, String>) -> RequestId {
     }
 }
 
-/// An ` echoed` marker for the log line when the server echoed back an X-Request-ID
-fn echoed_request_id(resp: &Response) -> &'static str {
-    if resp.headers().contains_key(REQUEST_ID_HEADER) {
-        " echoed"
-    } else {
-        ""
-    }
-}
-
 /// Incoming HTTP requests (as JSON) received over stdin
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
@@ -197,10 +188,9 @@ async fn handle_json_response(
 ) -> Result<()> {
     let headers = headers_to_map(&resp)?;
     let status = resp.status().as_u16();
-    let echoed = echoed_request_id(&resp);
     let body = resp.text().await?;
     syslog.info(&format!(
-        "{request_id} response: status={status} size={}{echoed}",
+        "{request_id} response: status={status} size={}",
         body.len()
     ));
     let outgoing_response = OutgoingResponse {
@@ -221,7 +211,6 @@ async fn handle_stream_response(
     // Get the headers, will be output later but we want to fail early if it's missing/invalid
     let headers = headers_to_map(&resp)?;
     let status = resp.status().as_u16();
-    let echoed = echoed_request_id(&resp);
     let mut size: usize = 0;
     let mut stdout = io::stdout().lock();
     let mut stream = resp.bytes_stream();
@@ -234,7 +223,7 @@ async fn handle_stream_response(
         stdout.flush()?;
     }
     syslog.info(&format!(
-        "{request_id} response: status={status} size={size} stream=true{echoed}"
+        "{request_id} response: status={status} size={size} stream=true"
     ));
     // Emit the headers as stderr
     eprintln!(

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -37,7 +37,7 @@ const DISABLE_TOR: &str = "DISABLE_TOR";
 const STDIN_LIMIT: u64 = 5_000_000;
 
 // Requests are tagged with an X-Request-ID header
-const REQUEST_ID_HEADER: &str = "X-Request-ID";
+const REQUEST_ID_HEADER: &str = "x-request-id";
 
 /// Best-effort logger that writes to the local syslog socket, from where
 /// messages are forwarded to sd-log by securedrop-log's rsyslog config.
@@ -117,19 +117,13 @@ enum RequestId {
 /// is not an error — the header is optional — and the request proceeds
 /// without one.
 fn extract_request_id(headers: &mut HashMap<String, String>) -> RequestId {
-    let Some(key) = headers
-        .keys()
-        .find(|key| key.eq_ignore_ascii_case(REQUEST_ID_HEADER))
-        .cloned()
-    else {
+    let Some(value) = headers.get(REQUEST_ID_HEADER) else {
         return RequestId::Missing;
     };
-    let value = headers[&key].clone();
-    if valid_request_id(&value) {
-        RequestId::Valid(value)
+    if valid_request_id(value) {
+        RequestId::Valid(value.clone())
     } else {
-        headers.remove(&key);
-        RequestId::Invalid(value)
+        RequestId::Invalid(value.clone())
     }
 }
 
@@ -441,9 +435,6 @@ mod tests {
             extract_request_id(&mut headers),
             RequestId::Invalid("not a request ID".to_string())
         );
-        // The malformed header is removed; other headers are untouched
-        assert_eq!(headers.len(), 1);
-        assert_eq!(headers["Accept"], "*/*");
     }
 
     #[test]

--- a/proxy/tests/conftest.py
+++ b/proxy/tests/conftest.py
@@ -4,6 +4,8 @@ import json
 import os
 import subprocess
 import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 import pytest
@@ -21,6 +23,33 @@ def proxy_bin() -> str:
     # default debug path, expects `cargo build` to already have been run
     metadata = subprocess.check_output(["cargo", "metadata"])
     return json.loads(metadata)["target_directory"] + "/debug/securedrop-proxy"
+
+
+@pytest.fixture
+def header_echo_server():
+    """Origin that echoes the request headers into the response body (and the
+    request's X-Request-ID into the response headers).  httpbin can't be used
+    to observe forwarded request headers here because it hides X-Request-Id
+    from /headers as an "environment header" (httpbin.helpers.ENV_HEADERS)."""
+
+    class EchoHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            body = json.dumps({"headers": dict(self.headers)}).encode()
+            self.send_response(200)
+            request_id = self.headers.get("X-Request-ID")
+            if request_id:
+                self.send_header("X-Request-ID", request_id)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), EchoHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    yield f"http://127.0.0.1:{server.server_port}"
+    server.shutdown()
 
 
 @pytest.fixture

--- a/proxy/tests/conftest.py
+++ b/proxy/tests/conftest.py
@@ -50,6 +50,7 @@ def header_echo_server():
     threading.Thread(target=server.serve_forever, daemon=True).start()
     yield f"http://127.0.0.1:{server.server_port}"
     server.shutdown()
+    server.server_close()
 
 
 @pytest.fixture

--- a/proxy/tests/conftest.py
+++ b/proxy/tests/conftest.py
@@ -36,9 +36,9 @@ def header_echo_server():
         def do_GET(self):
             body = json.dumps({"headers": dict(self.headers)}).encode()
             self.send_response(200)
-            request_id = self.headers.get("X-Request-ID")
+            request_id = self.headers.get("x-request-id")
             if request_id:
-                self.send_header("X-Request-ID", request_id)
+                self.send_header("x-request-id", request_id)
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)

--- a/proxy/tests/test_proxy.py
+++ b/proxy/tests/test_proxy.py
@@ -168,10 +168,10 @@ def test_request_id_not_added_when_missing(proxy_request, header_echo_server):
         "req-injected message into the logs!",
     ],
 )
-def test_request_id_invalid_stripped(proxy_request, header_echo_server, invalid):
-    """A malformed X-Request-ID is stripped from the request (and logged as a
-    warning), so a compromised client VM can't inject arbitrary strings into
-    the proxy's or server's logs; the request itself still proceeds"""
+def test_request_id_invalid_rejected(proxy_request, header_echo_server, invalid):
+    """A malformed X-Request-ID fails the request (and is logged as a
+    warning), so a broken or compromised client VM can't inject arbitrary
+    strings into the proxy's or server's logs; nothing is sent upstream"""
     test_input = {
         "method": "GET",
         "path_query": "/",
@@ -180,10 +180,11 @@ def test_request_id_invalid_stripped(proxy_request, header_echo_server, invalid)
     }
 
     result = proxy_request(input=test_input, origin=header_echo_server)
-    assert result.returncode == 0
-    response = json.loads(result.stdout.decode())
-    assert response["status"] == 200
-    assert sent_request_id(response) is None
+    assert result.returncode == 1
+    # Nothing was proxied: the request is rejected before anything is sent
+    assert result.stdout == b""
+    error = json.loads(result.stderr.decode())
+    assert error["error"].startswith("invalid X-Request-ID header: ")
 
 
 def test_body(proxy_request):

--- a/proxy/tests/test_proxy.py
+++ b/proxy/tests/test_proxy.py
@@ -145,8 +145,8 @@ def test_request_id_forwarded(proxy_request, header_echo_server):
 
 
 def test_request_id_not_added_when_missing(proxy_request, header_echo_server):
-    """The proxy doesn't invent an X-Request-ID when the client doesn't send
-    one: end-to-end correlation is only as good as what the client provides"""
+    """If the request didn't specify an `X-Request-ID`, then the response must not have one
+    either."""
     test_input = {
         "method": "GET",
         "path_query": "/",

--- a/proxy/tests/test_proxy.py
+++ b/proxy/tests/test_proxy.py
@@ -4,6 +4,14 @@ import time
 import pytest
 
 
+def sent_request_id(response: dict) -> str | None:
+    """Extract the X-Request-ID the proxy sent upstream from a
+    header_echo_server response, tolerating header-name casing."""
+    body = json.loads(response["body"])
+    headers = {name.lower(): value for name, value in body["headers"].items()}
+    return headers.get("x-request-id")
+
+
 def test_json_response(proxy_request):
     """test a JSON response"""
     test_input = {
@@ -115,6 +123,67 @@ def test_headers(proxy_request):
     assert response["status"] == 200
     body = json.loads(response["body"])
     assert body["headers"]["X-Test-Header"] == "th"
+
+
+def test_request_id_forwarded(proxy_request, header_echo_server):
+    """A well-formed X-Request-ID is forwarded to the server unmodified, and
+    the server's echoed X-Request-ID is passed back in the response headers"""
+    request_id = "req-72d64b57-4632-4d3e-96b0-24a0428f7ec1"
+    test_input = {
+        "method": "GET",
+        "path_query": "/",
+        "stream": False,
+        "headers": {"X-Request-ID": request_id},
+    }
+
+    result = proxy_request(input=test_input, origin=header_echo_server)
+    assert result.returncode == 0
+    response = json.loads(result.stdout.decode())
+    assert response["status"] == 200
+    assert sent_request_id(response) == request_id
+    assert response["headers"]["x-request-id"] == request_id
+
+
+def test_request_id_not_added_when_missing(proxy_request, header_echo_server):
+    """The proxy doesn't invent an X-Request-ID when the client doesn't send
+    one: end-to-end correlation is only as good as what the client provides"""
+    test_input = {
+        "method": "GET",
+        "path_query": "/",
+        "stream": False,
+    }
+
+    result = proxy_request(input=test_input, origin=header_echo_server)
+    assert result.returncode == 0
+    response = json.loads(result.stdout.decode())
+    assert response["status"] == 200
+    assert sent_request_id(response) is None
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [
+        "not a request ID",
+        "req-72D64B57-4632-4D3E-96B0-24A0428F7EC1",
+        "req-injected message into the logs!",
+    ],
+)
+def test_request_id_invalid_stripped(proxy_request, header_echo_server, invalid):
+    """A malformed X-Request-ID is stripped from the request (and logged as a
+    warning), so a compromised client VM can't inject arbitrary strings into
+    the proxy's or server's logs; the request itself still proceeds"""
+    test_input = {
+        "method": "GET",
+        "path_query": "/",
+        "stream": False,
+        "headers": {"X-Request-ID": invalid},
+    }
+
+    result = proxy_request(input=test_input, origin=header_echo_server)
+    assert result.returncode == 0
+    response = json.loads(result.stdout.decode())
+    assert response["status"] == 200
+    assert sent_request_id(response) is None
 
 
 def test_body(proxy_request):

--- a/proxy/tests/test_proxy.py
+++ b/proxy/tests/test_proxy.py
@@ -133,7 +133,7 @@ def test_request_id_forwarded(proxy_request, header_echo_server):
         "method": "GET",
         "path_query": "/",
         "stream": False,
-        "headers": {"X-Request-ID": request_id},
+        "headers": {"x-request-id": request_id},
     }
 
     result = proxy_request(input=test_input, origin=header_echo_server)
@@ -145,7 +145,7 @@ def test_request_id_forwarded(proxy_request, header_echo_server):
 
 
 def test_request_id_not_added_when_missing(proxy_request, header_echo_server):
-    """If the request didn't specify an `X-Request-ID`, then the response must not have one
+    """If the request didn't specify an `x-request-id`, then the response must not have one
     either."""
     test_input = {
         "method": "GET",
@@ -176,7 +176,7 @@ def test_request_id_invalid_rejected(proxy_request, header_echo_server, invalid)
         "method": "GET",
         "path_query": "/",
         "stream": False,
-        "headers": {"X-Request-ID": invalid},
+        "headers": {"x-request-id": invalid},
     }
 
     result = proxy_request(input=test_input, origin=header_echo_server)

--- a/proxy/usr.bin.securedrop-proxy
+++ b/proxy/usr.bin.securedrop-proxy
@@ -9,4 +9,8 @@ include <tunables/global>
   include <abstractions/ssl_certs>
 
   /usr/bin/securedrop-proxy mr,
+
+  # Allow logging
+  /dev/log w,
+  /{,var/}run/systemd/journal/dev-log w,
 }


### PR DESCRIPTION
Fixes #3481

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

Test setup:

- In the `securedrop` repo, check out the branch `micahflee/x-request-id` (this PR https://github.com/freedomofpress/securedrop/pull/7887)
- Start the dev server with `make dev-tor`
- In dom0, in a recent `securedrop-workstation` clone, test the PR with `./scripts/try-client-pr.py 3607`

Test steps:

In dom0 run `make run-app` to launch the app. Open a terminal in `sd-app` and watch the logs by running: `sudo journalctl -t securedrop-inbox -f`. You should see proxy logs with the request IDs, and with the responses echoed, like this:

```
Jul 16 10:28:02 sd-app securedrop-inbox[1605]: [proxy] req-a88adab6-826d-465e-b2c8-bdfe638afc36 GET /api/v2/index
Jul 16 10:28:03 sd-app securedrop-inbox[1605]: [proxy] req-a88adab6-826d-465e-b2c8-bdfe638afc36 response: status=304 size=273 echoed=req-a88adab6-826d-465e-b2c8-bdfe638afc36
```

Open a terminal is `securedrop-proxy` and run `sudo journalctl -t securedrop-proxy -f`. You should see pairs of logs where the request ID matches, like this:

```
Jul 16 10:30:05 sd-proxy securedrop-proxy[1517]: req-ab75282d-b8fb-41e5-8f9e-3236b49d1900 request: method=GET body_size=0
Jul 16 10:30:07 sd-proxy securedrop-proxy[1517]: req-ab75282d-b8fb-41e5-8f9e-3236b49d1900 response: status=304 size=0 echoed=req-ab75282d-b8fb-41e5-8f9e-3236b49d1900
Jul 16 10:31:07 sd-proxy securedrop-proxy[1530]: req-f0474cd9-b072-4e3e-ab57-e2929744b534 request: method=GET body_size=0
Jul 16 10:31:08 sd-proxy securedrop-proxy[1530]: req-f0474cd9-b072-4e3e-ab57-e2929744b534 response: status=304 size=0 echoed=req-f0474cd9-b072-4e3e-ab57-e2929744b534
Jul 16 10:32:08 sd-proxy securedrop-proxy[1604]: req-94903a59-1235-441b-95b7-1fe606dc1ed2 request: method=GET body_size=0
Jul 16 10:32:10 sd-proxy securedrop-proxy[1604]: req-94903a59-1235-441b-95b7-1fe606dc1ed2 response: status=304 size=0 echoed=req-94903a59-1235-441b-95b7-1fe606dc1ed2
```

In `sd-dev`, in the logs for the dev server, you should see request IDs too, like:

```
[2026-07-16 17:37:19,294] INFO in __init__: req-5ab786a4-c02e-4ace-ae70-35bdff1ec540 method=GET path=/api/v2/index status=304
127.0.0.1 - - [16/Jul/2026 17:37:19] "GET /api/v2/index HTTP/1.1" 304 -
```

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
