### PR TITLE
schema: validate that uuid matches metadata.uuid

### DIFF
--- a/app/src/main/sync/index.test.ts
+++ b/app/src/main/sync/index.test.ts
@@ -162,7 +162,7 @@ describe("syncMetadata", () => {
         [SOURCE_UUID_1]: "abc",
       },
       items: {
-        [SOURCE_UUID_2]: "def",
+        [ITEM_UUID_1]: "def",
       },
       journalists: {
         [JOURNALIST_UUID_1]: "ghi",
@@ -173,7 +173,7 @@ describe("syncMetadata", () => {
         [SOURCE_UUID_1]: mockSourceMetadata(SOURCE_UUID_1),
       },
       items: {
-        [SOURCE_UUID_2]: mockItemMetadata(ITEM_UUID_1, SOURCE_UUID_1),
+        [ITEM_UUID_1]: mockItemMetadata(ITEM_UUID_1, SOURCE_UUID_1),
       },
       journalists: {
         [JOURNALIST_UUID_1]: mockJournalistMetadata(JOURNALIST_UUID_1),
@@ -204,6 +204,86 @@ describe("syncMetadata", () => {
     expect(proxyMock).toHaveBeenCalledTimes(2);
     // Should update sources and items with new data
     expect(db.updateBatch).toHaveBeenCalledWith(batch);
+  });
+
+  it("rejects a batch item whose map key differs from its metadata UUID", async () => {
+    const serverIndex: Index = {
+      sources: {},
+      items: { [ITEM_UUID_2]: "def" },
+      journalists: {},
+    };
+    const batch: BatchResponse = {
+      sources: {},
+      items: {
+        [ITEM_UUID_2]: mockItemMetadata(ITEM_UUID_1, SOURCE_UUID_1),
+      },
+      journalists: {},
+      events: {},
+    };
+    const proxyMock = mockProxyResponses([
+      { status: 200, error: false, data: serverIndex, headers: new Map() },
+      { status: 200, error: false, data: batch, headers: new Map() },
+    ]);
+
+    await expect(syncModule.syncMetadata(db, "")).rejects.toThrow(
+      "item UUID does not match its metadata uuid",
+    );
+
+    expect(proxyMock).toHaveBeenCalledTimes(2);
+    expect(db.updateBatch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a batch source whose map key differs from its metadata UUID", async () => {
+    const serverIndex: Index = {
+      sources: { [SOURCE_UUID_2]: "abc" },
+      items: {},
+      journalists: {},
+    };
+    const batch: BatchResponse = {
+      sources: {
+        [SOURCE_UUID_2]: mockSourceMetadata(SOURCE_UUID_1),
+      },
+      items: {},
+      journalists: {},
+      events: {},
+    };
+    const proxyMock = mockProxyResponses([
+      { status: 200, error: false, data: serverIndex, headers: new Map() },
+      { status: 200, error: false, data: batch, headers: new Map() },
+    ]);
+
+    await expect(syncModule.syncMetadata(db, "")).rejects.toThrow(
+      "source UUID does not match its metadata uuid",
+    );
+
+    expect(proxyMock).toHaveBeenCalledTimes(2);
+    expect(db.updateBatch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a batch journalist whose map key differs from its metadata UUID", async () => {
+    const serverIndex: Index = {
+      sources: {},
+      items: {},
+      journalists: { [JOURNALIST_UUID_1]: "ghi" },
+    };
+    const mismatchedJournalistUuid = "770e8400-e29b-41d4-a716-446655440002";
+    const batch: BatchResponse = {
+      sources: {},
+      items: {},
+      journalists: {
+        [JOURNALIST_UUID_1]: mockJournalistMetadata(mismatchedJournalistUuid),
+      },
+      events: {},
+    };
+    const proxyMock = mockProxyResponses([
+      { status: 200, error: false, data: serverIndex, headers: new Map() },
+      { status: 200, error: false, data: batch, headers: new Map() },
+    ]);
+    await expect(syncModule.syncMetadata(db, "")).rejects.toThrow(
+      "journalist UUID does not match its metadata uuid",
+    );
+    expect(proxyMock).toHaveBeenCalledTimes(2);
+    expect(db.updateBatch).not.toHaveBeenCalled();
   });
 
   it("passes estimated timeouts to proxyJSONRequest", async () => {

--- a/app/src/schemas.ts
+++ b/app/src/schemas.ts
@@ -100,11 +100,27 @@ export const IndexSized: SizedSchema = {
   description: "index",
 };
 
-// Metadata, maps UUIDs to full metadata objects
+// A record whose keys must equal each value's own `uuid` field.
+const uuidKeyedRecord = <T extends z.ZodType<{ uuid: string }>>(
+  value: T,
+  label: string,
+) =>
+  z.record(UUIDSchema, value.nullable()).superRefine((data, ctx) => {
+    for (const [uuid, metadata] of Object.entries(data)) {
+      if (metadata && uuid !== metadata.uuid) {
+        ctx.addIssue({
+          code: "custom",
+          message: `${label} UUID does not match its metadata uuid`,
+          path: [uuid],
+        });
+      }
+    }
+  });
+
 export const BatchResponseSchema = z.object({
-  sources: z.record(UUIDSchema, SourceMetadataSchema.nullable()),
-  items: z.record(UUIDSchema, ItemMetadataSchema.nullable()),
-  journalists: z.record(UUIDSchema, JournalistMetadataSchema.nullable()),
+  sources: uuidKeyedRecord(SourceMetadataSchema, "source"),
+  items: uuidKeyedRecord(ItemMetadataSchema, "item"),
+  journalists: uuidKeyedRecord(JournalistMetadataSchema, "journalist"),
   events: z.record(z.string(), z.tuple([z.number(), z.string().nullable()])),
 });
 


### PR DESCRIPTION
Fixes #3565 

Updates the zod schema for `BatchResponse` types to validate that the entity's uuid matches the content of `metadata.uuid`. This ensures that no malformed response will be validated, preventing potential bugs leading to an item's contents being decrypted into the wrong directory or other potential issues.

## Test plan
Unit tests

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
