### PR TITLE
Ensure rsyslog can access /dev/xen

### DIFF
--- a/debian/securedrop-log.install
+++ b/debian/securedrop-log.install
@@ -2,3 +2,4 @@ log/log_client_files/sd-rsyslog usr/sbin/
 log/log_client_files/sdlog.conf etc/rsyslog.d/
 log/log_client_files/sd-rsyslog.conf etc/
 log/securedrop.Log etc/qubes-rpc/
+log/systemd/rsyslog.service.d/35_securedrop-xen.conf usr/lib/systemd/system/rsyslog.service.d

--- a/log/systemd/rsyslog.service.d/35_securedrop-xen.conf
+++ b/log/systemd/rsyslog.service.d/35_securedrop-xen.conf
@@ -1,0 +1,4 @@
+# Our plugin invokes qrexec-client-vm, which needs /dev/xen to
+# survive the PrivateDevices=yes hardening
+[Service]
+BindPaths=-/dev/xen


### PR DESCRIPTION
Our plugin invokes qrexec-client-vm, which needs to write to devices inside /dev/xen. trixie's rsyslog now has PrivateDevices=yes, which hides it, so set BindPaths to exempt /dev/xen.

Fixes #3609.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
Functional test (@nathandyer)

* [ ] Use try-client-pr to check this PR out on a trixie system
* [ ] Start Inbox, have it sync, see logs are flowing
* [ ] in e.g. sd-app, look at journalctl and don't see rsyslog errors

Code review (@deeplow)
* [ ] verify `/dev/xen` is future-proof enough

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
