### PR TITLE
[1.5.0] Backport "Ensure rsyslog can access /dev/xen"

### DIFF
--- a/debian/securedrop-log.install
+++ b/debian/securedrop-log.install
@@ -2,3 +2,4 @@ log/log_client_files/sd-rsyslog usr/sbin/
 log/log_client_files/sdlog.conf etc/rsyslog.d/
 log/log_client_files/sd-rsyslog.conf etc/
 log/securedrop.Log etc/qubes-rpc/
+log/systemd/rsyslog.service.d/35_securedrop-xen.conf usr/lib/systemd/system/rsyslog.service.d

--- a/log/systemd/rsyslog.service.d/35_securedrop-xen.conf
+++ b/log/systemd/rsyslog.service.d/35_securedrop-xen.conf
@@ -1,0 +1,4 @@
+# Our plugin invokes qrexec-client-vm, which needs /dev/xen to
+# survive the PrivateDevices=yes hardening
+[Service]
+BindPaths=-/dev/xen


### PR DESCRIPTION
Backport of #3610.

## Testing

* [ ] base is `release/1.5.0`
* [ ] Only contains changes from #3610.
