### PR TITLE
Have audio/vnd.wave open in audacious

### DIFF
--- a/workstation-config/mimeapps.list.sd-app
+++ b/workstation-config/mimeapps.list.sd-app
@@ -160,6 +160,7 @@ audio/x-scpls=open-in-dvm.desktop;
 audio/x-speex=open-in-dvm.desktop;
 audio/x-stm=open-in-dvm.desktop;
 audio/x-tta=open-in-dvm.desktop;
+audio/vnd.wave=open-in-dvm.desktop;
 audio/x-wav=open-in-dvm.desktop;
 audio/x-wavpack=open-in-dvm.desktop;
 audio/x-vorbis=open-in-dvm.desktop;

--- a/workstation-config/mimeapps.list.sd-devices
+++ b/workstation-config/mimeapps.list.sd-devices
@@ -161,6 +161,7 @@ audio/x-scpls=open-in-dvm.desktop;
 audio/x-speex=open-in-dvm.desktop;
 audio/x-stm=open-in-dvm.desktop;
 audio/x-tta=open-in-dvm.desktop;
+audio/vnd.wave=open-in-dvm.desktop;
 audio/x-wav=open-in-dvm.desktop;
 audio/x-wavpack=open-in-dvm.desktop;
 audio/x-vorbis=open-in-dvm.desktop;

--- a/workstation-config/mimeapps.list.sd-viewer
+++ b/workstation-config/mimeapps.list.sd-viewer
@@ -15,6 +15,7 @@ application/x-desktop=org.gnome.TextEditor.desktop
 audio/mp4=audacious.desktop
 audio/mpeg=audacious.desktop
 audio/x-vorbis+ogg=audacious.desktop
+audio/vnd.wave=audacious.desktop;
 audio/x-wav=audacious.desktop
 video/quicktime=org.gnome.Totem.desktop
 video/x-theora+ogg=org.gnome.Totem.desktop


### PR DESCRIPTION
shared-mime-info in trixie prefers this over the previous mime of audio/x-wav.

Fixes #3615.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] try-client-pr w/ this on staging (trixie VMs)
* [ ] send .wav file directly in Inbox, open it, it should play with no issue
 
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
