### PR TITLE
Clean up source menu, add "delete source option"

### DIFF
--- a/app/src/renderer/components/deleteSourceRequester.ts
+++ b/app/src/renderer/components/deleteSourceRequester.ts
@@ -1,0 +1,11 @@
+let openDeleteModal: ((sources: Set<string>) => void) | null = null;
+
+export function requestDeleteSource(sources: Set<string>) {
+  openDeleteModal?.(sources);
+}
+
+export function setDeleteSourceHandler(
+  handler: ((sources: Set<string>) => void) | null,
+) {
+  openDeleteModal = handler;
+}

--- a/app/src/renderer/locales/en.json
+++ b/app/src/renderer/locales/en.json
@@ -36,7 +36,7 @@
       "exportSourceToWhistleflow": "Send Transcript and Files",
       "exportTranscriptToWhistleflow": "Send Transcript",
       "printTranscript": "Print Transcript",
-      "deleteSource": "Delete Source Account",
+      "deleteSource": "Delete Source",
       "deleteConversation": "Delete Files and Messages",
       "clickToOpen": "Click to open"
     },

--- a/app/src/renderer/locales/en.json
+++ b/app/src/renderer/locales/en.json
@@ -29,11 +29,15 @@
       "replyPositionAriaLabel": "Reply {{index}} of {{total}}"
     },
     "menu": {
+      "ExportGroup": "Export to USB",
       "exportTranscript": "Export Transcript",
-      "exportTranscriptToWhistleflow": "Export Transcript to Whistleflow",
       "exportSource": "Export Transcript and Files",
-      "exportSourceToWhistleflow": "Export Transcript and Files to Whistleflow",
+      "WhistleflowExportGroup": "Send to Whistleflow",
+      "exportSourceToWhistleflow": "Send Transcript and Files",
+      "exportTranscriptToWhistleflow": "Send Transcript",
       "printTranscript": "Print Transcript",
+      "deleteSource": "Delete Source Account",
+      "deleteConversation": "Delete Files and Messages",
       "clickToOpen": "Click to open"
     },
     "itemFetching": "Fetching message...",

--- a/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.test.tsx
@@ -7,6 +7,11 @@ import {
   renderWithProviders,
 } from "../../../../test-component-setup";
 import { FetchStatus, type SourceWithItems } from "../../../../../types";
+import { requestDeleteSource } from "../../../../components/deleteSourceRequester";
+
+vi.mock("../../../../components/deleteSourceRequester", () => ({
+  requestDeleteSource: vi.fn(),
+}));
 
 describe("SourceMenu Component", () => {
   beforeEach(() => {
@@ -315,6 +320,19 @@ describe("SourceMenu Component", () => {
         expect(screen.getByText("Preparing to print.")).toBeInTheDocument();
         expect(screen.getByText("source transcript")).toBeInTheDocument();
       });
+    });
+
+    it("calls requestDeleteSource with the source uuid when Delete Source Account is clicked", async () => {
+      renderWithProviders(<SourceMenu sourceWithItems={s} />);
+      const menuButton = screen.getByRole("button");
+      await userEvent.click(menuButton);
+
+      const deleteSourceItem = await screen.findByRole("menuitem", {
+        name: /delete source/i,
+      });
+      await userEvent.click(deleteSourceItem);
+
+      expect(requestDeleteSource).toHaveBeenCalledWith(new Set(["source-1"]));
     });
   });
 });

--- a/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.tsx
@@ -11,6 +11,7 @@ import { ExportWizard } from "../Conversation/Item/Export";
 import { PrintWizard } from "../Conversation/Item/Print";
 import { MenuProps, Dropdown, Button, Tooltip } from "antd";
 import { MoreOutlined } from "@ant-design/icons";
+import { requestDeleteSource } from "../../../../components/deleteSourceRequester";
 
 interface SourceMenuProps {
   sourceWithItems: SourceWithItems;
@@ -117,6 +118,9 @@ const SourceMenu = memo(function SourceMenu({
           console.error("Failed to print transcript:", error);
         }
         break;
+      case "deleteSource":
+        requestDeleteSource(new Set([sourceWithItems.uuid]));
+        break;
       default:
         break;
     }
@@ -179,12 +183,6 @@ const SourceMenu = memo(function SourceMenu({
       : []),
     {
       type: "divider",
-    },
-    {
-      key: "deleteConversation",
-      label: t("menu.deleteConversation"),
-      disabled: !hasConversation,
-      danger: true,
     },
     {
       key: "deleteSource",

--- a/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.tsx
@@ -134,37 +134,62 @@ const SourceMenu = memo(function SourceMenu({
 
   const items: MenuProps["items"] = [
     {
-      key: "exportTranscript",
-      label: t("menu.exportTranscript"),
-      disabled: !hasConversation,
+      type: "group",
+      label: t("menu.ExportGroup"),
+      children: [
+        {
+          key: "exportTranscript",
+          label: t("menu.exportTranscript"),
+          disabled: !hasConversation,
+        },
+        {
+          key: "exportSource",
+          label: t("menu.exportSource"),
+          disabled: !hasConversation,
+        },
+      ],
     },
-    ...(whistleflowEnabled
-      ? [
-          {
-            key: "exportTranscriptToWhistleflow",
-            label: t("menu.exportTranscriptToWhistleflow"),
-            disabled: !hasConversation,
-          },
-        ]
-      : []),
-    {
-      key: "exportSource",
-      label: t("menu.exportSource"),
-      disabled: !hasConversation,
-    },
-    ...(whistleflowEnabled
-      ? [
-          {
-            key: "exportSourceToWhistleflow",
-            label: t("menu.exportSourceToWhistleflow"),
-            disabled: !hasConversation,
-          },
-        ]
-      : []),
     {
       key: "printTranscript",
       label: t("menu.printTranscript"),
       disabled: !hasConversation,
+    },
+    ...(whistleflowEnabled
+      ? [
+          {
+            type: "divider",
+          },
+          {
+            type: "group",
+            label: t("menu.WhistleflowExportGroup"),
+            children: [
+              {
+                key: "exportTranscriptToWhistleflow",
+                label: t("menu.exportTranscriptToWhistleflow"),
+                disabled: !hasConversation,
+              },
+              {
+                key: "exportSourceToWhistleflow",
+                label: t("menu.exportSourceToWhistleflow"),
+                disabled: !hasConversation,
+              },
+            ],
+          },
+        ]
+      : []),
+    {
+      type: "divider",
+    },
+    {
+      key: "deleteConversation",
+      label: t("menu.deleteConversation"),
+      disabled: !hasConversation,
+      danger: true,
+    },
+    {
+      key: "deleteSource",
+      label: t("menu.deleteSource"),
+      danger: true,
     },
   ];
 

--- a/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Header/SourceMenu.tsx
@@ -136,6 +136,28 @@ const SourceMenu = memo(function SourceMenu({
 
   const hasConversation: boolean = sourceWithItems.items.length > 0;
 
+  const whistleFlowItems: MenuProps["items"] = [
+    {
+      type: "divider",
+    },
+    {
+      type: "group",
+      label: t("menu.WhistleflowExportGroup"),
+      children: [
+        {
+          key: "exportTranscriptToWhistleflow",
+          label: t("menu.exportTranscriptToWhistleflow"),
+          disabled: !hasConversation,
+        },
+        {
+          key: "exportSourceToWhistleflow",
+          label: t("menu.exportSourceToWhistleflow"),
+          disabled: !hasConversation,
+        },
+      ],
+    },
+  ];
+
   const items: MenuProps["items"] = [
     {
       type: "group",
@@ -158,29 +180,7 @@ const SourceMenu = memo(function SourceMenu({
       label: t("menu.printTranscript"),
       disabled: !hasConversation,
     },
-    ...(whistleflowEnabled
-      ? [
-          {
-            type: "divider",
-          },
-          {
-            type: "group",
-            label: t("menu.WhistleflowExportGroup"),
-            children: [
-              {
-                key: "exportTranscriptToWhistleflow",
-                label: t("menu.exportTranscriptToWhistleflow"),
-                disabled: !hasConversation,
-              },
-              {
-                key: "exportSourceToWhistleflow",
-                label: t("menu.exportSourceToWhistleflow"),
-                disabled: !hasConversation,
-              },
-            ],
-          },
-        ]
-      : []),
+    ...(whistleflowEnabled ? whistleFlowItems : []),
     {
       type: "divider",
     },

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { screen, waitFor, fireEvent, act } from "@testing-library/react";
 import { expect, describe, it, vi, beforeEach, afterEach } from "vitest";
 import userEvent from "@testing-library/user-event";
 import React from "react";
@@ -8,6 +8,7 @@ import type { SearchResult, Source as SourceType } from "../../../../types";
 import { PendingEventType } from "../../../../types";
 import type { SourceProps } from "./SourceList/Source";
 import { renderWithProviders } from "../../../test-component-setup";
+import { requestDeleteSource } from "../../../components/deleteSourceRequester";
 
 // Mock react-window to render all items instead of virtualizing
 vi.mock("react-window", () => ({
@@ -1263,6 +1264,110 @@ describe("Sources Component", () => {
 
       // Modal should still be open (not re-triggered)
       expect(screen.getByTestId("delete-modal")).toBeInTheDocument();
+    });
+  });
+
+  describe("Delete source requester integration (used by the source menu)", () => {
+    beforeEach(() => {
+      window.electronAPI.addPendingSourceEventBatch = vi
+        .fn()
+        .mockResolvedValue(["123"]);
+    });
+
+    it("opens the delete modal for the requested source while mounted", async () => {
+      renderSourceList(mockSources, false, "/source/source-1");
+
+      await waitFor(() => {
+        expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+      });
+
+      act(() => {
+        requestDeleteSource(new Set(["source-1"]));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("delete-modal")).toBeInTheDocument();
+        expect(screen.getByTestId("delete-modal-title")).toHaveTextContent(
+          "Do you want to delete the source's account or just the conversation?",
+        );
+      });
+    });
+
+    it("does not disturb existing checkbox selection", async () => {
+      renderSourceList(mockSources, false, "/source/source-1");
+
+      await waitFor(() => {
+        expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByTestId("source-checkbox-source-2"));
+      expect(screen.getByTestId("source-checkbox-source-2")).toBeChecked();
+
+      act(() => {
+        requestDeleteSource(new Set(["source-1"]));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("delete-modal")).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId("source-checkbox-source-1")).not.toBeChecked();
+      expect(screen.getByTestId("source-checkbox-source-2")).toBeChecked();
+    });
+
+    it("deletes only the requested source, independent of the checked selection", async () => {
+      renderSourceList(mockSources, false, "/source/source-1");
+
+      await waitFor(() => {
+        expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+      });
+
+      // Check a different source in the sidebar - it should not be affected
+      await userEvent.click(screen.getByTestId("source-checkbox-source-2"));
+
+      act(() => {
+        requestDeleteSource(new Set(["source-1"]));
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("delete-modal-delete-account-button"),
+        ).toBeInTheDocument();
+      });
+
+      await userEvent.click(
+        screen.getByTestId("delete-modal-delete-account-button"),
+      );
+
+      await waitFor(() => {
+        expect(
+          window.electronAPI.addPendingSourceEventBatch,
+        ).toHaveBeenCalledWith([
+          {
+            sourceUuid: "source-1",
+            type: PendingEventType.SourceDeleted,
+            data: undefined,
+          },
+        ]);
+      });
+    });
+
+    it("does nothing when called after SourceList has unmounted", async () => {
+      const { unmount } = renderSourceList(
+        mockSources,
+        false,
+        "/source/source-1",
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("source-source-1")).toBeInTheDocument();
+      });
+
+      unmount();
+
+      expect(() => {
+        requestDeleteSource(new Set(["source-1"]));
+      }).not.toThrow();
     });
   });
 

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList.tsx
@@ -20,6 +20,7 @@ import {
   type Source as SourceType,
 } from "../../../../types";
 import { useSidebarShortcuts, useShortcut } from "../../../shortcuts";
+import { setDeleteSourceHandler } from "../../../components/deleteSourceRequester";
 import type { FocusedPanel } from "../../Inbox";
 
 interface SourceRowProps {
@@ -210,6 +211,12 @@ function SourceList({ focusedPanel }: { focusedPanel: FocusedPanel }) {
   const handleBulkDelete = useCallback(async () => {
     await openDeleteModal(new Set(selectedSources));
   }, [selectedSources, openDeleteModal]);
+
+  // Allow other components (e.g. the source menu) to open the delete modal
+  useEffect(() => {
+    setDeleteSourceHandler((sources) => void openDeleteModal(sources));
+    return () => setDeleteSourceHandler(null);
+  }, [openDeleteModal]);
 
   // Keyboard shortcut: Ctrl+Delete deletes the current source
   useShortcut(


### PR DESCRIPTION
Fixes #3476 

- Reorganizes source menu, splitting export options into a group, splitting whistleflow options into a separate group if enabled, and adding a "delete sources" option
- Adds a deleteSourceRequestor component (similar to the helpRequestor one already added for the help modal) to allow the SourceList's delete modal to be called from the source menu, and adds the corresponding menu handler.

## Test plan
- [ ] CI is passing
- [ ] with whistleflow disabled, menu is displayed as described and print/export options work correctly
- [ ] with whistleflow enabled, menu is displayed as described with the addition of whistleflow options, and all options work correctly
- [ ] choosing "Delete Source" displays the deletion modal for the active source, and deletion operations work as expected
- [ ] check multiple sources in the list and choose "Delete Source" from the source menu - only the active source is deleted.