### PR TITLE
Have proxy explicitly depend on curl, for user debugging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -52,7 +52,7 @@ Description: Python module and qrexec service to store logs for SecureDrop Works
 
 Package: securedrop-proxy
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, tor, libqubesdb, python3, python3-qubesdb
+Depends: ${misc:Depends}, ${shlibs:Depends}, tor, libqubesdb, python3, python3-qubesdb, curl
 Description: This is securedrop Qubes proxy service
  This package provides the network proxy on Qubes to talk to the SecureDrop server.
 


### PR DESCRIPTION
Currently we install curl as a transitive dependency via qubes-vm-recommended. Since we recommend it to end users for debugging, let's explicitly install it.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] visual review is sufficient
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
