### PR TITLE
datastore: reject updates to immutable metadata fields

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -33,6 +33,7 @@ import {
   PendingEventData,
   SourceItemCounts,
 } from "../../types";
+import { SOURCE_IMMUTABLE_FIELDS, ITEM_IMMUTABLE_FIELDS } from "../../schemas";
 import { Crypto } from "../crypto";
 import { Search } from "./search";
 
@@ -64,6 +65,23 @@ const sortKeys = (_: string, value: KeyObject) =>
 // security, and CRC32 is too collision-prone.
 function computeVersion(blob: string): string {
   return blake.blake2sHex(blob);
+}
+
+// Validates that JSON metadata payload does not change the immutable fields.
+// Use this to detect invalid metadata changes from the server.
+function assertImmutableFieldsUnchanged<T>(
+  entity: string,
+  fields: readonly (keyof T)[],
+  existing: T,
+  incoming: T,
+): void {
+  for (const field of fields) {
+    if (existing[field] !== incoming[field]) {
+      throw new Error(
+        `${entity} immutable field '${String(field)}' cannot be changed`,
+      );
+    }
+  }
 }
 
 export class DB {
@@ -692,6 +710,16 @@ export class DB {
         Object.keys(sources).forEach((sourceid: string) => {
           const metadata = sources[sourceid];
           if (metadata) {
+            // For existing sources, cannot update the designation, public key, or fingerprint
+            const existing = this.getSource(sourceid)?.data;
+            if (existing) {
+              assertImmutableFieldsUnchanged(
+                "source",
+                SOURCE_IMMUTABLE_FIELDS,
+                existing,
+                metadata,
+              );
+            }
             const info = JSON.stringify(metadata, sortKeys);
             const version = computeVersion(info);
             this.upsertSource.run({ uuid: sourceid, data: info, version });
@@ -714,6 +742,16 @@ export class DB {
       Object.keys(items).forEach((itemid: string) => {
         const metadata = items[itemid];
         if (metadata) {
+          // Items cannot update the kind, source, or interaction_acount
+          const existing = this.getItem(itemid)?.data;
+          if (existing) {
+            assertImmutableFieldsUnchanged(
+              "item",
+              ITEM_IMMUTABLE_FIELDS,
+              existing,
+              metadata,
+            );
+          }
           const blob = JSON.stringify(metadata, sortKeys);
           const version = computeVersion(blob);
           this.upsertItem.run({ uuid: itemid, data: blob, version });

--- a/app/src/main/database/search.test.ts
+++ b/app/src/main/database/search.test.ts
@@ -414,14 +414,6 @@ describe("Search", () => {
       });
     });
 
-    it("updates source name on re-index", () => {
-      db.updateSources({ ["source1"]: mockSource("source1", "old name") });
-      db.updateSources({ ["source1"]: mockSource("source1", "new name") });
-
-      expect(db.search("old")).toHaveLength(0);
-      expect(db.search("new name")).toHaveLength(1);
-    });
-
     it("does not duplicate source rows on re-index", () => {
       db.updateSources({
         ["source1"]: mockSource("source1", "dramatic dolphin"),

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -148,6 +148,173 @@ describe("DB Component Tests", () => {
       ).toThrow("items.kind is immutable");
     });
   });
+
+  describe("source immutable metadata", () => {
+    const sourceUuid = "11111111-1111-4111-8111-111111111111";
+
+    function sourceData({
+      designation = "alpha bravo",
+      publicKey = "source-public-key-a",
+      fingerprint = "source-fingerprint-a",
+      isStarred = false,
+      lastUpdated = "2026-07-09T00:00:00Z",
+    } = {}) {
+      return JSON.stringify({
+        uuid: sourceUuid,
+        journalist_designation: designation,
+        is_starred: isStarred,
+        is_seen: false,
+        has_attachment: false,
+        last_updated: lastUpdated,
+        public_key: publicKey,
+        fingerprint,
+      });
+    }
+
+    function sourceMetadata(options = {}): SourceMetadata {
+      return JSON.parse(sourceData(options)) as SourceMetadata;
+    }
+
+    it("can update mutable source metadata fields", () => {
+      db = new Datastore(crypto, new Storage());
+
+      db.updateSources({ [sourceUuid]: sourceMetadata() });
+      db.updateSources({
+        [sourceUuid]: sourceMetadata({
+          isStarred: true,
+          lastUpdated: "2026-07-10T00:00:00Z",
+        }),
+      });
+
+      const stored = db.getSource(sourceUuid)?.data;
+      expect(stored?.is_starred).toBe(true);
+      expect(stored?.last_updated).toBe("2026-07-10T00:00:00Z");
+      expect(stored?.journalist_designation).toBe("alpha bravo");
+      expect(stored?.public_key).toBe("source-public-key-a");
+    });
+
+    it("rejects source key replacement", () => {
+      db = new Datastore(crypto, new Storage());
+
+      db.updateSources({ [sourceUuid]: sourceMetadata() });
+
+      expect(() =>
+        db.updateSources({
+          [sourceUuid]: sourceMetadata({
+            publicKey: "source-public-key-b",
+          }),
+        }),
+      ).toThrow("source immutable field 'public_key' cannot be changed");
+    });
+
+    it("rejects journalist designation changes", () => {
+      db = new Datastore(crypto, new Storage());
+
+      db.updateSources({ [sourceUuid]: sourceMetadata() });
+
+      expect(() =>
+        db.updateSources({
+          [sourceUuid]: sourceMetadata({ designation: "charlie delta" }),
+        }),
+      ).toThrow(
+        "source immutable field 'journalist_designation' cannot be changed",
+      );
+      expect(db.getSource(sourceUuid)?.data.journalist_designation).toBe(
+        "alpha bravo",
+      );
+    });
+
+    it("rejects source key replacement", () => {
+      db = new Datastore(crypto, new Storage());
+
+      db.updateSources({ [sourceUuid]: sourceMetadata() });
+
+      expect(() =>
+        db.updateSources({
+          [sourceUuid]: sourceMetadata({ publicKey: "source-public-key-b" }),
+        }),
+      ).toThrow("source immutable field 'public_key' cannot be changed");
+      expect(db.getSource(sourceUuid)?.data.public_key).toBe(
+        "source-public-key-a",
+      );
+    });
+  });
+
+  describe("item immutable metadata", () => {
+    const itemUuid = "22222222-2222-4222-8222-222222222222";
+    const sourceUuid = "11111111-1111-4111-8111-111111111111";
+    const otherSourceUuid = "33333333-3333-4333-8333-333333333333";
+
+    function itemMetadata({
+      kind = "message" as "file" | "message",
+      source = sourceUuid,
+      interactionCount = 1,
+      isRead = false,
+      size = 100,
+    } = {}): SubmissionMetadata {
+      return {
+        kind,
+        uuid: itemUuid,
+        source,
+        size,
+        is_read: isRead,
+        seen_by: [],
+        interaction_count: interactionCount,
+      };
+    }
+
+    it("can update mutable item fields", () => {
+      db = new Datastore(crypto, new Storage());
+
+      db.updateItems({ [itemUuid]: itemMetadata() });
+      db.updateItems({ [itemUuid]: itemMetadata({ isRead: true, size: 250 }) });
+
+      const stored = db.getItem(itemUuid)?.data as SubmissionMetadata;
+      expect(stored.is_read).toBe(true);
+      expect(stored.size).toBe(250);
+      expect(stored.kind).toBe("message");
+      expect(stored.source).toBe(sourceUuid);
+      expect(stored.interaction_count).toBe(1);
+    });
+
+    it("rejects item kind changes", () => {
+      db = new Datastore(crypto, new Storage());
+
+      db.updateItems({ [itemUuid]: itemMetadata() });
+
+      expect(() =>
+        db.updateItems({ [itemUuid]: itemMetadata({ kind: "file" }) }),
+      ).toThrow("item immutable field 'kind' cannot be changed");
+      expect((db.getItem(itemUuid)?.data as SubmissionMetadata).kind).toBe(
+        "message",
+      );
+    });
+
+    it("rejects moving an item to another source", () => {
+      db = new Datastore(crypto, new Storage());
+
+      db.updateItems({ [itemUuid]: itemMetadata() });
+
+      expect(() =>
+        db.updateItems({
+          [itemUuid]: itemMetadata({ source: otherSourceUuid }),
+        }),
+      ).toThrow("item immutable field 'source' cannot be changed");
+      expect((db.getItem(itemUuid)?.data as SubmissionMetadata).source).toBe(
+        sourceUuid,
+      );
+    });
+
+    it("rejects item interaction count changes", () => {
+      db = new Datastore(crypto, new Storage());
+
+      db.updateItems({ [itemUuid]: itemMetadata() });
+
+      expect(() =>
+        db.updateItems({ [itemUuid]: itemMetadata({ interactionCount: 5 }) }),
+      ).toThrow("item immutable field 'interaction_count' cannot be changed");
+    });
+  });
 });
 
 describe("Datastore Method Tests", () => {
@@ -1320,12 +1487,11 @@ describe("Datastore Method Tests", () => {
     expect(sourceWithItems.items[0].plaintext).toBe("plaintext");
     expect(sourceWithItems.items[0].fetch_status).toBe(FetchStatus.Complete);
 
-    // Upsert with same uuid but different data
+    // Upsert with same uuid but different data.
     db.updateItems({
       item1: {
         ...mockItemMetadata("item1", "source1"),
         size: 99,
-        interaction_count: 42,
       },
     });
 
@@ -1333,7 +1499,7 @@ describe("Datastore Method Tests", () => {
     expect(sourceWithItems.items.length).toBe(1);
     expect(sourceWithItems.items[0].uuid).toBe("item1");
     expect(sourceWithItems.items[0].data.size).toBe(99);
-    expect(sourceWithItems.items[0].data.interaction_count).toBe(42);
+    expect(sourceWithItems.items[0].data.interaction_count).toBe(1);
     expect(sourceWithItems.items[0].plaintext).toBe("plaintext");
     expect(sourceWithItems.items[0].fetch_status).toBe(FetchStatus.Complete);
   });
@@ -1352,7 +1518,7 @@ describe("Datastore Method Tests", () => {
       db.updateItems({
         item1: mockItemMetadata("item1", "source2", "message"),
       }),
-    ).toThrow("items.source is immutable");
+    ).toThrow("item immutable field 'source' cannot be changed");
 
     const source1 = db.getSourceWithItems("source1");
     const source2 = db.getSourceWithItems("source2");

--- a/app/src/schemas.ts
+++ b/app/src/schemas.ts
@@ -53,6 +53,13 @@ export const SourceMetadataSchema = z.object({
   fingerprint: z.string(),
 });
 
+// Source metadata fields that cannot be changed on update.
+export const SOURCE_IMMUTABLE_FIELDS = [
+  "journalist_designation",
+  "public_key",
+  "fingerprint",
+] as const satisfies readonly (keyof SourceMetadata)[];
+
 export const ReplyMetadataSchema = z.object({
   kind: z.literal("reply"),
   uuid: UUIDSchema,
@@ -79,6 +86,13 @@ export const ItemMetadataSchema = z.union([
   ReplyMetadataSchema,
   SubmissionMetadataSchema,
 ]);
+
+// Metadata fields that cannot be updated for items.
+export const ITEM_IMMUTABLE_FIELDS = [
+  "kind",
+  "source",
+  "interaction_count",
+] as const satisfies readonly (keyof ItemMetadata)[];
 
 export const JournalistMetadataSchema = z.object({
   uuid: UUIDSchema,


### PR DESCRIPTION
Fixes #3563 

A number of issues were flagged surrounding the core issue that certain fields in the source and item metadata should be immutable: after initial write, these values should never be changed. In our current implementation, because we directly passthrough the metadata blob from a server's batch response to the DB, it's possible for writes to happen on what should be immutable data.

Currently, we have some DB/schema-level SQL triggers to catch and prevent these actions. However, this is really more of an application-level concern than a database-level concern, so I'd like to move the check up into the datastore code so that our database handlers can reject any writes with invalid changes to immutable metadata fields.

This change defines `SOURCE_IMMUTABLE_FIELDS` and `ITEM_IMMUTABLE_FIELDS`, and throws if there is ever a server batch response that attempts to mutate these fields. This should never happen, and in that case I think we want to throw an error to surface some incorrect server behavior.

I am not sure if we also want to make some of the journalist metadata immutable: currently, it is just `uuid` (immutable by definition), `username`, and then `first_name`/`last_name`. All of these seem perhaps reasonable to change, but we can add similar reinforcements if that seems useful.

## Test plan
Ensure that CI accurately covers the test cases that we aim to prevent.

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
