### PR TITLE
guarddog: Normalize version from git-pkgs

### DIFF
--- a/.github/scripts/guarddog_scan_matrix.py
+++ b/.github/scripts/guarddog_scan_matrix.py
@@ -19,6 +19,7 @@ See: https://developers.securedrop.org/en/latest/dependency_updates.html
 
 import json
 import os
+import re
 import sys
 
 # git-pkgs ecosystem name -> GuardDog scan subcommand. Note the strings differ
@@ -26,6 +27,8 @@ import sys
 # subcommand is "github_action". Ecosystems GuardDog can't scan (cargo, ...)
 # aren't in this map and are reported as skipped.
 ECOSYSTEMS = {"npm": "npm", "pypi": "pypi", "github-actions": "github_action"}
+# Strip various constraints from before a version
+LEADING_CONSTRAINT = re.compile(r"^[~^=<>!]*\s*")
 
 
 def step_summary(line: str = "") -> None:
@@ -56,6 +59,10 @@ def normalize_github_action(name: str) -> str | None:
     return "/".join(parts[:2])
 
 
+def normalize_version(version: str) -> str:
+    return LEADING_CONSTRAINT.sub("", version)
+
+
 def collect_packages(diff: dict) -> list[dict]:
     """Pull added + modified entries from a git-pkgs diff, deduped."""
     seen: set[tuple[str, str, str]] = set()
@@ -66,7 +73,7 @@ def collect_packages(diff: dict) -> list[dict]:
             name = entry.get("name", "")
             # to_requirement is the *new* resolved version for both added and
             # modified entries; that is what we want to scan.
-            version = entry.get("to_requirement", "")
+            version = normalize_version(entry.get("to_requirement", ""))
             if ecosystem == "github-actions":
                 # Collapse subpaths to owner/repo (and drop local/docker
                 # actions) so GuardDog can scan them and so two actions from the


### PR DESCRIPTION
git-pkgs returns changes to package.json + pnpm-lock.yml as two separate things, the former with the corresponding version constraint (e.g. `^0.0.0`), which guarddog can't handle since it's not a real version.

Strip the version constraint, so the two will get de-duped.

Fixes #3631.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] check out https://github.com/freedomofpress/securedrop-client/pull/3630 locally
* [ ] download git-pkgs locally (from e.g. https://github.com/git-pkgs/git-pkgs/releases/tag/v0.18.1)
* [ ] run `./git-pkgs diff --from 55ababc23194fa911156606899342080601c9f71 --to 81fbc63b74d74e26c0406c090d564c5bffc5acb3 -f json | python .github/scripts/guarddog_scan_matrix.py` -> should show 2 separate jobs spawned
* [ ] check out this PR
* [ ] re-run `./git-pkgs diff --from 55ababc23194fa911156606899342080601c9f71 --to 81fbc63b74d74e26c0406c090d564c5bffc5acb3 -f json | python .github/scripts/guarddog_scan_matrix.py` -> should only show 1 job being spawned
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
