### PR TITLE
Have dependabot propose electron minor/patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    ignore:
+      # electron major bumps are done manually
+      - dependency-name: "electron"
+        update-types: ["version-update:semver-major"]
     groups:
       frontend:
         patterns:
@@ -22,10 +26,18 @@ updates:
           - "@ant-design*"
       electron:
         patterns:
-          - "*electron*"
-          # better-sqlite3/node-abi need to upgrade with electron
-          - "node-abi"
+          - "electron"
+        update-types:
+          - "minor"
+          - "patch"
+      better-sqlite3:
+        patterns:
           - "better-sqlite3"
+          - "node-abi"
+      electron-support:
+        patterns:
+          - "electron-*"
+          - "@electron-toolkit/*"
       eslint:
         patterns: ["*eslint*"]
       vite:


### PR DESCRIPTION
So we are better at staying up to date because it can be reviewed and tested individually. Major updates need to be done by hand but honestly that was already the case.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* visual review
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
