### PR TITLE
Remove now-unused requestStream IPC

### DIFF
--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -2,7 +2,6 @@
 // https://www.electronjs.org/docs/latest/tutorial/process-model#preload-scripts
 import { contextBridge, ipcRenderer } from "electron";
 import {
-  type ProxyResponse,
   type Source,
   type SourceWithItems,
   type SourceItemCounts,
@@ -17,7 +16,6 @@ import {
   SyncStatus,
   DeviceStatus,
   PendingEventData,
-  ProxyRequest,
 } from "../types";
 
 // Log the performance of IPC calls
@@ -48,11 +46,6 @@ const electronAPI = {
   quitApp: logIpcCall<string>("quitApp", () => ipcRenderer.invoke("quitApp")),
   login: logIpcCall<LoginResult>("login", (credentials: LoginCredentials) =>
     ipcRenderer.invoke("login", credentials),
-  ),
-  requestStream: logIpcCall<ProxyResponse>(
-    "requestStream",
-    (request: ProxyRequest, downloadPath: string) =>
-      ipcRenderer.invoke("requestStream", request, downloadPath),
   ),
   syncMetadata: logIpcCall<SyncStatus>("syncMetadata", (request: SyncRequest) =>
     ipcRenderer.invoke("syncMetadata", request),

--- a/app/src/renderer/test-component-setup.tsx
+++ b/app/src/renderer/test-component-setup.tsx
@@ -104,7 +104,6 @@ beforeEach(() => {
   // Mock the electronAPI before each test
   (window as any).electronAPI = {
     login: vi.fn().mockRejectedValue(new Error("mock not implemented")),
-    requestStream: vi.fn().mockResolvedValue({ sha256sum: "abc" }),
     getSystemLanguage: vi.fn().mockResolvedValue("en"),
     getCSPNonce: vi.fn().mockResolvedValue("nonce"),
     // TODO: we may want a real mock here


### PR DESCRIPTION


## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] CI passes, grep that nothing still uses it
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
