### PR TITLE
Only expose __REDUX_STORE__ in test mode

### DIFF
--- a/app/src/renderer/index.tsx
+++ b/app/src/renderer/index.tsx
@@ -12,8 +12,8 @@ import { setupStore } from "./store";
 
 const store = setupStore();
 
-// Expose store to window for testing
-if (typeof window !== "undefined") {
+// Expose store to window for server tests
+if (import.meta.env.MODE === "test") {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (window as any).__REDUX_STORE__ = store;
 }


### PR DESCRIPTION
We only need it there, so this reduces our attack surface slightly. Flagged by Claude 5 Opus.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] visual review is sufficient, just grep that it's not used anywhere outside the server test
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
