### PR TITLE
Have db.getSourceWithItems() require passing in a limit

### DIFF
--- a/app/server_tests/helper.ts
+++ b/app/server_tests/helper.ts
@@ -319,7 +319,9 @@ export class TestHelpers {
   async getSourceItemCount(sourceUuid: string): Promise<number> {
     return this.dbHelper.withDb(async (db) => {
       try {
-        const sourceWithItems = db.getSourceWithItems(sourceUuid);
+        const sourceWithItems = db.getSourceWithItems(sourceUuid, {
+          limit: "all",
+        });
         return sourceWithItems.items.length;
       } catch {
         return 0;

--- a/app/server_tests/replies.test.ts
+++ b/app/server_tests/replies.test.ts
@@ -50,7 +50,9 @@ describe.sequential("sending replies", () => {
 
   async function getItemCount(): Promise<number> {
     return withDb(async (db) => {
-      const sourceWithItems = db.getSourceWithItems(TARGET_SOURCE.uuid);
+      const sourceWithItems = db.getSourceWithItems(TARGET_SOURCE.uuid, {
+        limit: "all",
+      });
       return sourceWithItems.items.length;
     });
   }

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -32,6 +32,7 @@ import {
   FirstRunStatus,
   PendingEventData,
   SourceItemCounts,
+  SourceItemsQuery,
 } from "../../types";
 import { Crypto } from "../crypto";
 import { Search } from "./search";
@@ -39,7 +40,6 @@ import { Search } from "./search";
 // Truncate message previews to 200 Unicode code points
 // at the database layer; CSS will handle the rest
 export const MESSAGE_PREVIEW_LENGTH = 200;
-const DEFAULT_ITEM_LIMIT = 100;
 export const DEFAULT_PENDING_EVENTS_LIMIT = 20;
 
 interface KeyObject {
@@ -827,11 +827,7 @@ export class DB {
 
   getSourceWithItems(
     sourceUuid: string,
-    options?: {
-      limit?: number;
-      beforeInteractionCount?: number;
-      journalistUuid?: string;
-    },
+    options: SourceItemsQuery,
   ): SourceWithItems {
     if (!this.db) {
       throw new Error("Database is not open");
@@ -847,14 +843,12 @@ export class DB {
 
     const sourceData = JSON.parse(sourceRow.data);
 
-    let limit = DEFAULT_ITEM_LIMIT;
-    if (options?.limit) {
-      limit = options?.limit;
-    }
-    // Fetch limit+1 rows to detect if there are more historical items
-    const fetchLimit = limit + 1;
+    const fetchAll = options.limit === "all";
+    // A negative LIMIT means "no upper bound" in SQLite. Otherwise fetch
+    // limit+1 rows to detect if there are more historical items.
+    const fetchLimit = fetchAll ? -1 : (options.limit as number) + 1;
     let rows: ItemRow[];
-    if (options?.beforeInteractionCount) {
+    if (options.beforeInteractionCount) {
       rows = this.selectItemsBySourceIdBefore.all(
         sourceUuid,
         options.beforeInteractionCount,
@@ -863,9 +857,13 @@ export class DB {
     } else {
       rows = this.selectItemsBySourceId.all(sourceUuid, fetchLimit);
     }
-    const hasMoreHistoricalItems = rows.length > limit;
+    const hasMoreHistoricalItems = fetchAll
+      ? false
+      : rows.length > (options.limit as number);
     // Take at most `limit` rows (DESC order), then reverse to ASC for display
-    const itemRows = rows.slice(0, limit).reverse();
+    const itemRows = (
+      fetchAll ? rows : rows.slice(0, options.limit as number)
+    ).reverse();
 
     const items = itemRows.map((row) => {
       const data = JSON.parse(row.data) as ItemMetadata;

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -344,6 +344,50 @@ describe("Datastore Method Tests", () => {
     expect([...sources.keys()]).toEqual(["source1", "source2"]);
   });
 
+  it('getSourceWithItems with limit "all" should return conversations longer than one page', () => {
+    db = new Datastore(crypto, new Storage());
+    db.updateSources({ source1: mockSourceMetadata("source1") });
+
+    const items: Record<string, ItemMetadata> = {};
+    for (let i = 1; i <= 150; i++) {
+      items[`item${i}`] = mockItemMetadata(`item${i}`, "source1", "message", i);
+    }
+    db.updateItems(items);
+
+    const all = db.getSourceWithItems("source1", { limit: "all" });
+    expect(all.items.length).toEqual(150);
+    expect(all.hasMoreHistoricalItems).toBe(false);
+    // Items are returned oldest-first, so the whole history must be present
+    expect(all.items[0].uuid).toEqual("item1");
+    expect(all.items[149].uuid).toEqual("item150");
+  });
+
+  it("getSourceWithItems with a numeric limit should return only the newest page", () => {
+    db = new Datastore(crypto, new Storage());
+    db.updateSources({ source1: mockSourceMetadata("source1") });
+
+    const items: Record<string, ItemMetadata> = {};
+    for (let i = 1; i <= 150; i++) {
+      items[`item${i}`] = mockItemMetadata(`item${i}`, "source1", "message", i);
+    }
+    db.updateItems(items);
+
+    const page = db.getSourceWithItems("source1", { limit: 100 });
+    expect(page.items.length).toEqual(100);
+    expect(page.hasMoreHistoricalItems).toBe(true);
+    expect(page.items[0].uuid).toEqual("item51");
+    expect(page.items.map((i) => i.uuid)).not.toContain("item1");
+
+    // The remaining history is reachable via beforeInteractionCount
+    const rest = db.getSourceWithItems("source1", {
+      limit: "all",
+      beforeInteractionCount: page.items[0].data.interaction_count,
+    });
+    expect(rest.items.length).toEqual(50);
+    expect(rest.items[0].uuid).toEqual("item1");
+    expect(rest.hasMoreHistoricalItems).toBe(false);
+  });
+
   it("pending SourceConversationTruncated should remove items up to and including upper_bound", () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),
@@ -355,7 +399,7 @@ describe("Datastore Method Tests", () => {
       item3: mockItemMetadata("item3", "source1", "message", 3),
     });
 
-    let sourceWithItems = db.getSourceWithItems("source1");
+    let sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     expect(sourceWithItems.items.length).toEqual(3);
 
     db.addPendingSourceEvent(
@@ -363,7 +407,7 @@ describe("Datastore Method Tests", () => {
       PendingEventType.SourceConversationTruncated,
       { upper_bound: 2 },
     );
-    sourceWithItems = db.getSourceWithItems("source1");
+    sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     expect(sourceWithItems.items.length).toEqual(1);
   });
 
@@ -378,7 +422,7 @@ describe("Datastore Method Tests", () => {
       item3: mockItemMetadata("item3", "source1", "message", 3),
     });
 
-    let sourceWithItems = db.getSourceWithItems("source1");
+    let sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     expect(sourceWithItems.items.length).toEqual(3);
 
     db.addPendingSourceEvent(
@@ -386,7 +430,7 @@ describe("Datastore Method Tests", () => {
       PendingEventType.SourceConversationTruncated,
       { upper_bound: 3 },
     );
-    sourceWithItems = db.getSourceWithItems("source1");
+    sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     expect(sourceWithItems.items.length).toEqual(0);
 
     // Add source2 with 3 items
@@ -399,7 +443,7 @@ describe("Datastore Method Tests", () => {
       item5: mockItemMetadata("item5", "source2", "message", 2),
       item6: mockItemMetadata("item6", "source2", "message", 3),
     });
-    sourceWithItems = db.getSourceWithItems("source2");
+    sourceWithItems = db.getSourceWithItems("source2", { limit: "all" });
     expect(sourceWithItems.items.length).toEqual(3);
   });
 
@@ -697,11 +741,11 @@ describe("Datastore Method Tests", () => {
       item3: mockItemMetadata("item3", "source1"),
     });
 
-    let sourceWithItems = db.getSourceWithItems("source1");
+    let sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     expect(sourceWithItems.items.length).toEqual(3);
 
     await db.addPendingReplySentEvent("here is a reply", "source1", 4);
-    sourceWithItems = db.getSourceWithItems("source1");
+    sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     expect(sourceWithItems.items.length).toEqual(4);
     const reply = sourceWithItems.items[3];
     expect(reply?.plaintext).toBe("here is a reply");
@@ -735,7 +779,7 @@ describe("Datastore Method Tests", () => {
       },
     });
 
-    const sourceWithItems = db.getSourceWithItems("source1");
+    const sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     const items = sourceWithItems.items;
 
     // Clone and sort by interaction_count
@@ -758,12 +802,12 @@ describe("Datastore Method Tests", () => {
       item3: mockItemMetadata("item3", "source1"),
     });
 
-    let sourceWithItems = db.getSourceWithItems("source1");
+    let sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     expect(sourceWithItems.items.length).toEqual(3);
 
     db.addPendingItemEvent("item1", PendingEventType.ItemDeleted);
 
-    sourceWithItems = db.getSourceWithItems("source1");
+    sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     expect(sourceWithItems.items.length).toEqual(2);
   });
 
@@ -794,7 +838,7 @@ describe("Datastore Method Tests", () => {
     });
 
     await db.addPendingReplySentEvent("reply text", "source1", 3);
-    let sourceWithItems = db.getSourceWithItems("source1");
+    let sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     expect(sourceWithItems.items.length).toEqual(3);
 
     db.addPendingSourceEvent(
@@ -802,7 +846,7 @@ describe("Datastore Method Tests", () => {
       PendingEventType.SourceConversationTruncated,
       { upper_bound: 3 },
     );
-    sourceWithItems = db.getSourceWithItems("source1");
+    sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     expect(sourceWithItems.items.length).toEqual(0);
   });
 
@@ -821,7 +865,7 @@ describe("Datastore Method Tests", () => {
       PendingEventType.SourceConversationTruncated,
       { upper_bound: 2 },
     )!;
-    let sourceWithItems = db.getSourceWithItems("source1");
+    let sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     expect(sourceWithItems.items.length).toEqual(0);
 
     const snowflake2 = await db.addPendingReplySentEvent(
@@ -830,7 +874,7 @@ describe("Datastore Method Tests", () => {
       3,
     );
     expect(snowflake2 > snowflake1);
-    sourceWithItems = db.getSourceWithItems("source1");
+    sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     expect(sourceWithItems.items.length).toEqual(1);
     expect(sourceWithItems.items[0].uuid).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
@@ -866,7 +910,7 @@ describe("Datastore Method Tests", () => {
     });
 
     await db.addPendingReplySentEvent("reply text", "source1", 2);
-    let sourceWithItems = db.getSourceWithItems("source1");
+    let sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     expect(sourceWithItems.items.length).toEqual(2);
     const pendingReplyUuid = sourceWithItems.items[1].uuid;
 
@@ -882,7 +926,7 @@ describe("Datastore Method Tests", () => {
     });
 
     db.addPendingItemEvent(pendingReplyUuid, PendingEventType.ItemDeleted);
-    sourceWithItems = db.getSourceWithItems("source1");
+    sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     expect(sourceWithItems.items.length).toEqual(1);
     expect(
       sourceWithItems.items.find((i) => i.uuid === pendingReplyUuid),
@@ -903,7 +947,7 @@ describe("Datastore Method Tests", () => {
     db.addPendingItemEvent("item1", PendingEventType.ItemDeleted);
     db.addPendingItemEvent("item3", PendingEventType.ItemDeleted);
 
-    const sourceWithItems = db.getSourceWithItems("source1");
+    const sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     expect(sourceWithItems.items.length).toEqual(1);
     expect(sourceWithItems.items[0].uuid).toBe("item2");
   });
@@ -1019,7 +1063,7 @@ describe("Datastore Method Tests", () => {
     // Mark up to interaction_count=5 as seen
     db.addPendingSourceConversationSeen("source1", 5);
 
-    const sourceWithItems = db.getSourceWithItems("source1");
+    const sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     const byUuid = Object.fromEntries(
       sourceWithItems.items.map((i) => [i.uuid, i]),
     );
@@ -1210,7 +1254,7 @@ describe("Datastore Method Tests", () => {
     });
 
     // Verify source and item exist
-    const sourceWithItems = db.getSourceWithItems("source1");
+    const sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     expect(sourceWithItems).toBeDefined();
     expect(sourceWithItems.uuid).toEqual("source1");
     expect(sourceWithItems.items.length).toBe(1);
@@ -1364,7 +1408,7 @@ describe("Datastore Method Tests", () => {
       },
     });
 
-    let sourceWithItems = db.getSourceWithItems("source1");
+    let sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     expect(sourceWithItems.items.length).toBe(1);
     expect(sourceWithItems.items[0].uuid).toBe("item1");
     expect(sourceWithItems.items[0].data.size).toBe(50);
@@ -1372,7 +1416,7 @@ describe("Datastore Method Tests", () => {
     expect(sourceWithItems.items[0].fetch_status).toBe(FetchStatus.Initial);
 
     db.completePlaintextItem("item1", "plaintext", null);
-    sourceWithItems = db.getSourceWithItems("source1");
+    sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     expect(sourceWithItems.items.length).toBe(1);
     expect(sourceWithItems.items[0].uuid).toBe("item1");
     expect(sourceWithItems.items[0].plaintext).toBe("plaintext");
@@ -1387,7 +1431,7 @@ describe("Datastore Method Tests", () => {
       },
     });
 
-    sourceWithItems = db.getSourceWithItems("source1");
+    sourceWithItems = db.getSourceWithItems("source1", { limit: "all" });
     expect(sourceWithItems.items.length).toBe(1);
     expect(sourceWithItems.items[0].uuid).toBe("item1");
     expect(sourceWithItems.items[0].data.size).toBe(99);
@@ -1412,8 +1456,8 @@ describe("Datastore Method Tests", () => {
       }),
     ).toThrow("items.source is immutable");
 
-    const source1 = db.getSourceWithItems("source1");
-    const source2 = db.getSourceWithItems("source2");
+    const source1 = db.getSourceWithItems("source1", { limit: "all" });
+    const source2 = db.getSourceWithItems("source2", { limit: "all" });
     expect(source1.items).toHaveLength(1);
     expect(source1.items[0].plaintext).toBe("plaintext");
     expect(source2.items).toHaveLength(0);

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -696,8 +696,8 @@ if (!gotTheLock) {
             if (!fs.existsSync(filePath)) {
               throw new Error(`Transcript file not found: ${filePath}`);
             }
-            const sourceWithItems = db.getSourceWithItems(sourceUuid);
-            const sourceName = sourceWithItems.data.journalist_designation;
+            const sourceName =
+              db.getSource(sourceUuid)?.data.journalist_designation;
             return await exporter.export(
               [filePath],
               passphrase,
@@ -738,8 +738,8 @@ if (!gotTheLock) {
             }
             filenames.push(item.filename);
             if (!sourceName) {
-              const source = db.getSourceWithItems(item.data.source);
-              sourceName = source.data.journalist_designation;
+              sourceName = db.getSource(item.data.source)?.data
+                .journalist_designation;
             }
           }
           return await exporter.export(

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -23,6 +23,7 @@ import {
   type Source,
   type SourceWithItems,
   type SourceItemCounts,
+  type SourceItemsQuery,
   type Journalist,
   type AuthedRequest,
   type SyncRequest,
@@ -429,11 +430,7 @@ if (!gotTheLock) {
         async (
           _event,
           sourceUuid: string,
-          options?: {
-            limit?: number;
-            beforeInteractionCount?: number;
-            journalistUuid?: string;
-          },
+          options: SourceItemsQuery,
         ): Promise<SourceWithItems> => {
           const sourceWithItems = db.getSourceWithItems(sourceUuid, options);
           return sourceWithItems;
@@ -531,6 +528,7 @@ if (!gotTheLock) {
           }
           if (data?.upper_bound) {
             const items = db.getSourceWithItems(sourceUuid, {
+              limit: "all",
               beforeInteractionCount: data?.upper_bound + 1,
             }).items;
             const DELETE_BATCH_SIZE = 8;
@@ -769,7 +767,9 @@ if (!gotTheLock) {
               throw new Error(`Transcript file not found: ${transcriptPath}`);
             }
 
-            const sourceWithItems = db.getSourceWithItems(sourceUuid);
+            const sourceWithItems = db.getSourceWithItems(sourceUuid, {
+              limit: "all",
+            });
             const filenames: string[] = [transcriptPath];
             for (const item of sourceWithItems.items) {
               if (

--- a/app/src/main/transcriber.test.ts
+++ b/app/src/main/transcriber.test.ts
@@ -265,6 +265,11 @@ Interesting message there
 `;
 
     const output: string = await writeTranscript(mockSourceWithItems.uuid, db);
+    // A transcript must cover the whole conversation, not one page of it
+    expect(db.getSourceWithItems).toHaveBeenCalledWith(
+      mockSourceWithItems.uuid,
+      { limit: "all" },
+    );
     expect(output).toContain("transcript.txt");
     expect(fs.existsSync(output)).toBe(true);
     console.log(`BANANA: ${output}`);

--- a/app/src/main/transcriber.ts
+++ b/app/src/main/transcriber.ts
@@ -63,7 +63,7 @@ export async function writeTranscript(
   const storage = new Storage();
 
   try {
-    const sourceWithItems = db.getSourceWithItems(sourceUuid);
+    const sourceWithItems = db.getSourceWithItems(sourceUuid, { limit: "all" });
     const filePath: string = join(
       storage.sourceDirectory(sourceUuid).path,
       "transcript.txt",

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -6,6 +6,7 @@ import {
   type Source,
   type SourceWithItems,
   type SourceItemCounts,
+  type SourceItemsQuery,
   type Journalist,
   type SyncRequest,
   type LoginCredentials,
@@ -68,14 +69,8 @@ const electronAPI = {
   ),
   getSourceWithItems: logIpcCall<SourceWithItems>(
     "getSourceWithItems",
-    (
-      sourceUuid: string,
-      options?: {
-        limit?: number;
-        beforeInteractionCount?: number;
-        journalistUuid?: string;
-      },
-    ) => ipcRenderer.invoke("getSourceWithItems", sourceUuid, options),
+    (sourceUuid: string, options: SourceItemsQuery) =>
+      ipcRenderer.invoke("getSourceWithItems", sourceUuid, options),
   ),
   getSourceItemCounts: logIpcCall<SourceItemCounts>(
     "getSourceItemCounts",

--- a/app/src/renderer/features/conversation/conversationSlice.ts
+++ b/app/src/renderer/features/conversation/conversationSlice.ts
@@ -120,8 +120,10 @@ export const deleteItem = createAsyncThunk(
       itemUuid,
       PendingEventType.ItemDeleted,
     );
-    const sourceWithItems =
-      await window.electronAPI.getSourceWithItems(sourceUuid);
+    const sourceWithItems = await window.electronAPI.getSourceWithItems(
+      sourceUuid,
+      { limit: CONVERSATION_PAGE_SIZE },
+    );
     return { sourceWithItems };
   },
 );

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -188,6 +188,15 @@ export type SourceWithItems = {
   lastSeenInteractionCount?: number | null;
 };
 
+// Options for fetching a source's conversation items. `limit` is mandatory so
+// that every caller has to decide explicitly between a page ("N") and a
+// complete conversation ("all").
+export type SourceItemsQuery = {
+  limit: number | "all";
+  beforeInteractionCount?: number;
+  journalistUuid?: string;
+};
+
 export type SourceItemCounts = {
   messages: number;
   files: number;


### PR DESCRIPTION
We've seen that in some cases, the default limit of 100 is unexpected or wrong behavior; fix that by requiring callers to explicitly specify the limit they want.

Fixes #3580.
Fixes #3581.

I also added a commit to switch some callers away from getSourceWithItems because they didn't actually need the items.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] review limits are appropriate
* [ ] tests pass and cover what's necessary
* [ ] bonus: create a conversation w/ 100+ messages, export the transcript, verify they're all included.
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
