### PR TITLE
Have eslint ban usage of shell.openExternal()

### DIFF
--- a/app/eslint.config.ts
+++ b/app/eslint.config.ts
@@ -58,6 +58,10 @@ const a11yChecks = {
 
 // ---------------------------------------------------------------------------
 
+const openExternalMessage =
+  "shell.openExternal() is banned: it launches a URL in the host desktop's " +
+  "default handler.";
+
 export default tseslint.config(
   {
     ignores: [
@@ -90,6 +94,27 @@ export default tseslint.config(
     },
     rules: {
       curly: ["error", "all"],
+      // Forbid electron's shell.openExternal()
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "MemberExpression[property.name='openExternal']",
+          message: openExternalMessage,
+        },
+        {
+          selector: "ImportSpecifier[imported.name='openExternal']",
+          message: openExternalMessage,
+        },
+        {
+          selector:
+            "ObjectPattern > Property[key.name='openExternal'][computed=false]",
+          message: openExternalMessage,
+        },
+        {
+          selector: "MemberExpression[property.value='openExternal']",
+          message: openExternalMessage,
+        },
+      ],
       "@typescript-eslint/no-unused-vars": [
         "error",
         {


### PR DESCRIPTION
Per <https://www.electronjs.org/blog/electron-42-0#electron-no-longer-downloads-itself-via-postinstall-script>, this is dangerous and we don't need it at all.

Refs #2521.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] introduce a call to shell.openExternal(), see eslint fail
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
