### PR TITLE
[proposal] docs: disambiguate streamed stdout

### DIFF
--- a/proxy/README.md
+++ b/proxy/README.md
@@ -58,9 +58,9 @@ deactivate s
 alt stream: false, status: any
 p ->> c: stdout: {status, headers, body}<br>stderr: ∅<br>rc = 0
 else stream: true, status: 2xx/3xx
-p ->> c: stdout: HTTP response body<br>stderr: {headers}<br>rc = 0
+p ->> c: stdout: HTTP response body<br>stderr: {status, headers}<br>rc = 0
 else stream: true, status: 4xx/5xx
-p ->> c: stdout: {status, headers, body}<br>stderr: ∅<br>rc = 0
+p ->> c: stdout: ∅<br>stderr: {status, headers, body} [2]<br>rc = 0
 else proxy failure
 p ->> c: stdout: ∅ or partial HTTP response body<br>stderr: {error}<br>rc ≠ 0
 else killed by Inbox
@@ -74,6 +74,8 @@ deactivate p
 
 1. The request on the standard input MUST be a single-line JSON object, at most
    [`STDIN_LIMIT`] long.
+
+2. `body` MUST be capped at some length (TBD).
 
 ## Quick Start
 


### PR DESCRIPTION
#3569 concerns some compounding inefficiencies in the proxy's return path. In the worst case, for an $n$-byte stream response up to the 500 MiB maximum, the Inbox holds $4n$ in memory before it can parse the response's standard output to check for errors.

#3591 attempts to fix this inefficiency by _bounding_ the buffering of the response, at the cost of significantly complicating both the proxy- and the Inbox-side implementations (and their test suites). But we could make this inefficiency go away altogether by addressing the root cause, which is that the standard output is ambiguous for stream responses:

https://github.com/freedomofpress/securedrop-client/blob/471ee387236a65eace5d5a095ace3455b8f8b9df/proxy/README.md?plain=1#L60-L63

This diff is a proposal, for now just at the specification level, to disambiguate it, so that the standard output is _always_ the HTTP response body (or empty), and the Inbox can check by looking only at the standard error:

https://github.com/freedomofpress/securedrop-client/blob/49c14759d7e191d77f15373aaf28617eac38c8e1/proxy/README.md?plain=1#L60-L63

This change could be implemented on this branch to complete this pull request. It would unblock the following further changes in the spirit of #3591:

1. Set limits on the standard output and error sizes, for downloads based directly on the `size` attribute we already have.

2. When partial downloads fail, resume from the known-good offset (in the database) rather than the new partial size of the file, and delete the file when we fail it terminally.

There are some concrete bugs this approach would let us fix too. Claude found an edge case something like: (a) we manage to write part of a file, (b) a subsequent retry errors out (including just by HTTP `403` when a journalist's API token times out), (c) we write the _error_ to the end of the file, (d) we resume downloading it, (e) when we're done, the `ETag` doesn't match, so (f) we mark the download _terminally_ failed and never retry it. This diff (here) would fix step (c), and then part (2) would let us recover from it.
