### PR TITLE
Force CI builds to use docker to work around a GHA bug

### DIFF
--- a/scripts/build-debs.sh
+++ b/scripts/build-debs.sh
@@ -15,7 +15,11 @@ set -euxo pipefail
 OCI_RUN_ARGUMENTS="--user=root -v $(pwd):/src:Z"
 
 # Default to podman if available
-if which podman > /dev/null 2>&1; then
+# HACK: Force usage of docker on CI while podman is broken:
+# <https://github.com/actions/runner-images/issues/14473>.
+if [[ "${CI:-}" == "true" ]]; then
+    OCI_BIN="docker"
+elif which podman > /dev/null 2>&1; then
     OCI_BIN="podman"
     # Make sure host UID/GID are mapped into container,
     # see podman-run(1) manual.


### PR DESCRIPTION
Works around <https://github.com/actions/runner-images/issues/14473>, which has temporarily broken podman in GitHub Actions.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [x] CI passes
* [x] `FAST=1 make build-debs` works fine locally
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
