### PR TITLE
Stop building snap and AppImage in CI

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -65,7 +65,7 @@ jobs:
         run: pnpm test
       - name: Build
         working-directory: app
-        run: pnpm build:linux
+        run: pnpm build:unpack
 
   translator-screenshots:
     strategy:

--- a/app/README.md
+++ b/app/README.md
@@ -94,7 +94,7 @@ You can then access the [Demo Source Interface](https://demo-source.securedrop.o
 - `pnpm test` - Run unit tests with coverage
 - `pnpm integration-test` - Run integration tests
 - `pnpm build` - Build for production
-- `pnpm build:linux` - Build Linux distribution package
+- `pnpm build:unpack` - Build an unpacked application directory
 - `pnpm lint` - Check code style and linting
 - `pnpm fix` - Auto-fix linting and formatting issues
 - `pnpm typecheck` - Run TypeScript type checking

--- a/app/package.json
+++ b/app/package.json
@@ -27,7 +27,6 @@
     "build": "electron-vite build",
     "postinstall": "./scripts/download-sqlite-binaries.py",
     "build:unpack": "pnpm run build && electron-builder --dir",
-    "build:linux": "pnpm run build && electron-builder --linux",
     "build:mac-demo": "cargo build --release --manifest-path ../proxy/Cargo.toml && PROXY_ORIGIN=https://demo-journalist.securedrop.org electron-vite build --mode mac-demo && electron-builder --mac",
     "dbmate": "sh -c 'dbmate --url sqlite:$HOME/.config/SecureDrop/db.sqlite --migrations-dir ./src/main/database/migrations --schema-file ./src/main/database/schema.sql \"$@\"' _",
     "dbmate:check": "pnpm run dbmate up && pnpm run dbmate dump && git diff --exit-code ./src/main/database/schema.sql",


### PR DESCRIPTION
These were the default "build:linux" targets that we never overrode, but we don't need nor want them. Drop that command entirely since it's misleading as to what it builds.

`pnpm build:unpack` is what we actually want, and what `make build-debs` uses.

----

I only noticed this when another PR was failing on spurious AppImage failures and got confused as to why we were doing that. Roughly cuts down ~30s from the CI job.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] visual review
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
