### PR TITLE
[sync] resubmit AlreadyReported events until complete

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -193,11 +193,8 @@ export class DB {
     { snowflake_id: string; status: number },
     void
   >;
-  private setPendingEventStatus: Statement<
-    { snowflake_id: string; status: number },
-    void
-  >;
   private selectPendingEvents: Statement<[{ limit: number }], PendingEventRow>;
+  private selectFreshPendingEventsCount: Statement<[], { count: number }>;
   private deletePendingEventsBySourceScope: Statement<
     { source_uuid: string },
     void
@@ -432,17 +429,15 @@ export class DB {
       SET retry_attempts = retry_attempts + 1, last_event_status = @status
       WHERE snowflake_id = @snowflake_id
     `);
-    this.setPendingEventStatus = this.db.prepare(`
-      UPDATE pending_events
-      SET last_event_status = @status
-      WHERE snowflake_id = @snowflake_id
-    `);
-    // Schedule previously-failed events later, and exclude events already reported
-    // and accepted on the server that are just awaiting completion.
+    // Schedule new events first, and retries for events later.
+    // All pending events are resubmitted until the server reports completion.
     this.selectPendingEvents = this.db.prepare(`
       SELECT snowflake_id, source_uuid, item_uuid, type, data FROM pending_events
-      WHERE last_event_status IS NOT ${EventStatus.AlreadyReported}
       ORDER BY retry_attempts ASC, snowflake_id ASC LIMIT @limit
+    `);
+    // Events that have never been submitted or that were rejected due to conflict.
+    this.selectFreshPendingEventsCount = this.db.prepare(`
+      SELECT COUNT(*) AS count FROM pending_events WHERE retry_attempts = 0
     `);
     this.deletePendingEventsBySourceScope = this.db.prepare(`
       DELETE FROM pending_events
@@ -1343,6 +1338,12 @@ export class DB {
     return pendingEvents;
   }
 
+  // Number of pending events that have never been submitted to the server,
+  // i.e. excluding events awaiting resubmission.
+  countFreshPendingEvents(): number {
+    return this.selectFreshPendingEventsCount.get()!.count;
+  }
+
   // Takes pending events and their statuses from the server and applies
   // pending event updates as needed.
   // Should be run within a transaction that also updates index version.
@@ -1361,13 +1362,8 @@ export class DB {
       } else if (result === EventStatus.Gone) {
         // Target no longer exists on the server: remove pending_event.
         eventIDsToRemove.push(snowflake_id);
-      } else if (result === EventStatus.AlreadyReported) {
-        // Already reported to the server but awaiting completion.
-        // Retain the event but record the status so it's excluded from future
-        // sync batches and not re-sent.
-        this.setPendingEventStatus.run({ snowflake_id, status: result });
       } else {
-        // All other statuses indicate event was submitted but not accepted
+        // All other statuses indicate event was submitted but not yet complete.
         // Retain and bump the retry counter, recording the status.
         // This event will be re-scheduled in subsequent batches.
         this.incrementPendingEventRetry.run({ snowflake_id, status: result });

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -1441,9 +1441,9 @@ describe("Datastore Method Tests", () => {
     let events = db.getPendingEvents();
     expect(events.map((e) => e.id)).toEqual([snowflakeSource, snowflakeItem]);
 
-    // The earlier (source) event fails to be accepted, bumping its retry count.
+    // The earlier (source) event is in-progress but not complete, bumping its retry count.
     db.updatePendingEvents({
-      [snowflakeSource.toString()]: [500, "error"],
+      [snowflakeSource.toString()]: [208, "AlreadyReported"],
     });
 
     // Should now be scheduled after the never-failed item event.
@@ -1457,46 +1457,99 @@ describe("Datastore Method Tests", () => {
       )
       .get(snowflakeSource.toString());
     expect(row.retry_attempts).toBe(1);
-    expect(row.last_event_status).toBe(500);
+    expect(row.last_event_status).toBe(208);
   });
 
-  it("updatePendingEvents should retain but exclude AlreadyReported events", () => {
+  it("updatePendingEvents should resubmit AlreadyReported events until the server completes them", () => {
     db.updateSources({
       source1: mockSourceMetadata("source1"),
-    });
-    db.updateItems({
-      item1: mockItemMetadata("item1", "source1"),
     });
 
     const snowflakeSource = db.addPendingSourceEvent(
       "source1",
       PendingEventType.Starred,
     )!;
-    const snowflakeItem = db.addPendingItemEvent(
-      "item1",
-      PendingEventType.ItemDeleted,
-    )!;
 
-    // The server reports the source event as already reported + accepted (208),
-    // and the item event as not yet accepted (500).
+    const pendingEventRow = () =>
+      (db as any).db
+        .prepare(
+          "SELECT retry_attempts, last_event_status FROM pending_events WHERE snowflake_id = ?",
+        )
+        .get(snowflakeSource.toString());
+
+    // Event is queued for its first submission.
+    expect(db.getPendingEvents().map((e) => e.id)).toEqual([snowflakeSource]);
+
+    // Round 1: server reports event as AlreadyReported
     db.updatePendingEvents({
-      [snowflakeSource.toString()]: [208, null],
-      [snowflakeItem.toString()]: [500, "error"],
+      [snowflakeSource.toString()]: [208, "AlreadyReported"],
+    });
+    expect(db.getPendingEvents().map((e) => e.id)).toEqual([snowflakeSource]);
+    expect(pendingEventRow().retry_attempts).toBe(1);
+
+    // Round 2: the server dropped the event.
+    // The inbox should keep the event in its batch to resubmit
+    db.updatePendingEvents({});
+    expect(db.getPendingEvents().map((e) => e.id)).toEqual([snowflakeSource]);
+    expect(pendingEventRow().retry_attempts).toBe(1);
+
+    // Round 3: the server marks event as complete.
+    db.updatePendingEvents({
+      [snowflakeSource.toString()]: [200, ""],
+    });
+    expect(db.getPendingEvents()).toEqual([]);
+  });
+
+  it("countFreshPendingEvents should exclude events awaiting resubmission", () => {
+    db.updateSources({
+      source1: mockSourceMetadata("source1"),
+      source2: mockSourceMetadata("source2"),
     });
 
-    // The AlreadyReported event must be excluded from future sync batches
-    const events = db.getPendingEvents();
-    expect(events.map((e) => e.id)).toEqual([snowflakeItem]);
+    expect(db.countFreshPendingEvents()).toBe(0);
 
-    // but event should be retained in the table to preserve projection state
-    // with the status recorded
+    const snowflake1 = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.Starred,
+    )!;
+    db.addPendingSourceEvent("source2", PendingEventType.Starred);
+    expect(db.countFreshPendingEvents()).toBe(2);
+
+    // Once the server reports a status, the event is a retry, not a fresh event
+    db.updatePendingEvents({
+      [snowflake1.toString()]: [208, "AlreadyReported"],
+    });
+    expect(db.getPendingEvents().length).toBe(2);
+    expect(db.countFreshPendingEvents()).toBe(1);
+  });
+
+  it("updatePendingEvents should stop resubmitting AlreadyReported events once the target is Gone", () => {
+    db.updateSources({
+      source1: mockSourceMetadata("source1"),
+    });
+
+    const snowflakeSource = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.Starred,
+    )!;
+
+    // The server reports the event as already reported but awaiting completion.
+    db.updatePendingEvents({
+      [snowflakeSource.toString()]: [208, "AlreadyReported"],
+    });
+    expect(db.getPendingEvents().map((e) => e.id)).toEqual([snowflakeSource]);
+
+    // The target is subsequently removed on the server (410 Gone): the event is
+    // a terminal no-op and must be dropped rather than resubmitted forever.
+    db.updatePendingEvents({
+      [snowflakeSource.toString()]: [410, "Gone"],
+    });
+    expect(db.getPendingEvents()).toEqual([]);
+
     const row = (db as any).db
-      .prepare(
-        "SELECT last_event_status FROM pending_events WHERE snowflake_id = ?",
-      )
+      .prepare("SELECT snowflake_id FROM pending_events WHERE snowflake_id = ?")
       .get(snowflakeSource.toString());
-    expect(row).toBeDefined();
-    expect(row.last_event_status).toBe(208);
+    expect(row).toBeUndefined();
   });
 
   it("updateItems should upsert items with conflicting uuid", () => {

--- a/app/src/main/index.test.ts
+++ b/app/src/main/index.test.ts
@@ -132,6 +132,7 @@ vi.mock("./crypto", () => ({
 vi.mock("./datastore", () => ({
   Datastore: class {
     getPendingEvents = vi.fn(() => []);
+    countFreshPendingEvents = vi.fn(() => 0);
     close = testState.datastoreClose;
   },
 }));

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -905,8 +905,9 @@ if (!gotTheLock) {
             }
             wakeFetchWorkerIfNeeded();
           } while (
+            // While there are fresh pending events (not retries), continue syncing
             syncStatus === SyncStatus.UPDATED &&
-            db.getPendingEvents().length > 0
+            db.countFreshPendingEvents() > 0
           );
           // If we receive an auth error from sync, reset the auth token
           if (syncStatus === SyncStatus.FORBIDDEN) {

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -306,6 +306,7 @@ export enum EventStatus {
   AlreadyReported = 208,
   BadRequest = 400,
   NotFound = 404,
+  Conflict = 409,
   Gone = 410,
   NotImplemented = 501,
 }


### PR DESCRIPTION
Fixes #3568 

Currently, the Inbox excludes events with status `208: AlreadyReported` from new batches submitted to server sync, but retains the event in the `pending_events` table to preserve the projected state until the server successfully notifies of completion in a sync response. This behavior assumes that the server will eventually successfully complete the in-progress event and report success back to the Inbox, where we can then remove the pending event.

As noted in #3568, there is an edge case possible where the server drops an event, leaving it orphaned on the client and never resubmitted for eventual resolution.

Status quo:
- Sync cycle 1: Client submits `event_a` in a sync batch to the server
- Sync cycle 1: Server accepts `event_a` and begins processing, but it is long-running
- Sync cycle 2: Client submits `event_a` again, having not received a response
- Sync cycle 2: Server sends back `{'event_a': [208, 'AlreadyReported']}` since it has begun but not completed processing
- Sync cycle 3: Client omits `event_a` from the batch since its last status is `208` 
- Sync cycle 3: Server fails + drops `event_a` from its table. Processing stops or fails.
- At this point, the client will never resubmit `event_a` and the server has dropped processing of `event_a`. It is now effectively orphaned and the client/server state is inconsistent.

Instead, we should always resubmit pending events, but just increment our `retry_attempts` to deprioritize long-running pending events in the batch if there are many fresher updates to sync. This way, we avoid orphaning events and rely on request idempotency to achieve eventual consistency between the client and server.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

Unit tests added should verify the correct behavior.

Can run through the source resurrection test plan to ensure there are no regressions:

Simulate "bad" SecureDrop server conditions:

- Run local development SecureDrop server from `2.15.1` (or any pre-2.16.0 version with synchronous deletion)
- Manually add a 120s sleep into the `handle_source_deleted` function
```python
 @staticmethod
  def handle_source_deleted(event: Event, minor: int) -> EventResult:
      # tktk: just for testing 

      import time
      time.sleep(120)
 ```
Verify fix
- Run SecureDrop Inbox from branch, optionally nuke db state + apply client migrations
- Select a source account for deletion
- Delete the source account + confirm
- [x] Source should disappear from the source list
- Trigger manual sync or wait for the next re-sync 
- [x] Source should not reappear in the source list
- [x] Inspecting `pending_events` table should show a record for the still-pending deletion event with `last_event_status` of `208` 
- [x] Subsequent sync batches should re-send the already-accepted deletion event and increment `retry_attempts`

Eventual server/client consistency:

- [x] Server logs should eventually show the deletion occurring (after the 2min sleep) 
- [x] On the subsequent client sync, we should delete the underlying source
- [x] Inspect the client DB to see that the source has been deleted from the `sources` table, and that the `pending_event` for the deletion is also deleted
