### PR TITLE
inbox: make sidebar width adjustable

### DIFF
--- a/app/src/renderer/a11y.test.tsx
+++ b/app/src/renderer/a11y.test.tsx
@@ -33,6 +33,7 @@ import { PrintWizard } from "./views/Inbox/MainContent/Conversation/Item/Print";
 import File from "./views/Inbox/MainContent/Conversation/Item/File";
 import Message from "./views/Inbox/MainContent/Conversation/Item/Message";
 import SourceList from "./views/Inbox/Sidebar/SourceList";
+import SidebarResizer from "./views/Inbox/SidebarResizer";
 import Source from "./views/Inbox/Sidebar/SourceList/Source";
 import MainMenu from "./views/Inbox/Sidebar/Account/MainMenu";
 import KeyboardHelp from "./views/Inbox/Sidebar/Account/KeyboardHelp";
@@ -251,6 +252,14 @@ describe.sequential("accessibility (axe)", () => {
   describe("Inbox", () => {
     it("has no axe violations on initial render", async () => {
       await renderAndCheckA11y(<InboxView />);
+    });
+  });
+
+  describe("SidebarResizer", () => {
+    it("has no axe violations", async () => {
+      await renderAndCheckA11y(
+        <SidebarResizer width={384} onWidthChange={vi.fn()} />,
+      );
     });
   });
 

--- a/app/src/renderer/components/Avatar.tsx
+++ b/app/src/renderer/components/Avatar.tsx
@@ -4,9 +4,14 @@ import { getInitials } from "../utils";
 interface AvatarProps {
   designation: string;
   isActive?: boolean;
+  className?: string;
 }
 
-const Avatar = memo(function Avatar({ designation, isActive }: AvatarProps) {
+const Avatar = memo(function Avatar({
+  designation,
+  isActive,
+  className = "",
+}: AvatarProps) {
   const initials = useMemo(() => getInitials(designation), [designation]);
 
   return (
@@ -15,7 +20,7 @@ const Avatar = memo(function Avatar({ designation, isActive }: AvatarProps) {
         isActive
           ? "bg-blue-700 border-blue-700 text-white"
           : "bg-gray-100 border-gray-300 text-gray-600"
-      }`}
+      } ${className}`}
     >
       {initials}
     </div>

--- a/app/src/renderer/locales/en.json
+++ b/app/src/renderer/locales/en.json
@@ -63,6 +63,10 @@
     }
   },
   "Sidebar": {
+    "resizer": {
+      "label": "Resize sidebar",
+      "hint": "Drag to resize the sidebar"
+    },
     "account": {
       "signOut": "Sign out",
       "offlineMode": "Offline Mode",

--- a/app/src/renderer/views/Inbox.test.tsx
+++ b/app/src/renderer/views/Inbox.test.tsx
@@ -1,11 +1,62 @@
-import { screen } from "@testing-library/react";
-import { expect } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import { expect, describe, it } from "vitest";
 import InboxView from "./Inbox";
 import { renderWithProviders } from "../test-component-setup";
+import {
+  SIDEBAR_DEFAULT_WIDTH,
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_MIN_WIDTH,
+  SIDEBAR_RESIZE_STEP,
+} from "./Inbox/SidebarResizer";
+
+const sidebarWidth = () =>
+  screen.getByTestId("sidebar-panel").style.getPropertyValue("width");
+
+// Drag the resize handle by `delta` pixels, starting from an arbitrary but
+// consistent pointer position.
+const dragBy = (delta: number) => {
+  const separator = screen.getByTestId("sidebar-resizer");
+  fireEvent.mouseDown(separator, { button: 0, clientX: 500 });
+  fireEvent.mouseMove(window, { clientX: 500 + delta });
+  fireEvent.mouseUp(window);
+};
 
 describe("InboxView Component", () => {
   it('says the string "Select a source"', () => {
     renderWithProviders(<InboxView />);
     expect(screen.getByText("Select a source")).toBeInTheDocument();
+  });
+
+  describe("resizable sidebar", () => {
+    it("starts at the default width", () => {
+      renderWithProviders(<InboxView />);
+      expect(sidebarWidth()).toBe(`${SIDEBAR_DEFAULT_WIDTH}px`);
+    });
+
+    it("widens and narrows when the handle is dragged", () => {
+      renderWithProviders(<InboxView />);
+
+      dragBy(60);
+      expect(sidebarWidth()).toBe(`${SIDEBAR_DEFAULT_WIDTH + 60}px`);
+
+      dragBy(-100);
+      expect(sidebarWidth()).toBe(`${SIDEBAR_DEFAULT_WIDTH - 40}px`);
+    });
+
+    it("resizes with the keyboard and stays within its bounds", () => {
+      renderWithProviders(<InboxView />);
+      const separator = screen.getByTestId("sidebar-resizer");
+
+      fireEvent.keyDown(separator, { key: "ArrowRight" });
+      expect(sidebarWidth()).toBe(
+        `${SIDEBAR_DEFAULT_WIDTH + SIDEBAR_RESIZE_STEP}px`,
+      );
+
+      fireEvent.keyDown(separator, { key: "Home" });
+      expect(sidebarWidth()).toBe(`${SIDEBAR_MIN_WIDTH}px`);
+
+      fireEvent.keyDown(separator, { key: "End" });
+      expect(sidebarWidth()).toBe(`${SIDEBAR_MAX_WIDTH}px`);
+    });
   });
 });

--- a/app/src/renderer/views/Inbox.tsx
+++ b/app/src/renderer/views/Inbox.tsx
@@ -21,6 +21,7 @@ import { useGlobalShortcuts } from "../shortcuts";
 import { requestQuit } from "../components/quitRequester";
 import { requestHelp } from "../components/helpRequester";
 import KeyboardHelpModal from "../components/KeyboardHelpModal";
+import SidebarResizer, { SIDEBAR_DEFAULT_WIDTH } from "./Inbox/SidebarResizer";
 
 export type FocusedPanel = "sidebar" | "mainContent";
 
@@ -34,6 +35,7 @@ function InboxView() {
   const sidebarRef = useRef<HTMLDivElement>(null);
   const mainContentRef = useRef<HTMLDivElement>(null);
   const [focusedPanel, setFocusedPanel] = useState<FocusedPanel>("sidebar");
+  const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_DEFAULT_WIDTH);
 
   const sync = useCallback(() => {
     if (session.authData && import.meta.env.MODE != "test") {
@@ -121,11 +123,13 @@ function InboxView() {
       <div
         ref={sidebarRef}
         tabIndex={-1}
-        className="h-full outline-0 focus:outline-2 focus:outline-blue-300 focus:-outline-offset-2"
+        style={{ width: sidebarWidth }}
+        className="h-full flex-shrink-0 outline-0 focus:outline-2 focus:outline-blue-300 focus:-outline-offset-2"
         data-testid="sidebar-panel"
       >
         <Sidebar focusedPanel={focusedPanel} />
       </div>
+      <SidebarResizer width={sidebarWidth} onWidthChange={setSidebarWidth} />
       <div
         ref={mainContentRef}
         tabIndex={-1}

--- a/app/src/renderer/views/Inbox/Sidebar.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar.tsx
@@ -9,7 +9,7 @@ interface SidebarProps {
 
 const Sidebar = memo(function Sidebar({ focusedPanel }: SidebarProps) {
   return (
-    <div className="sd-border-secondary w-96 flex flex-col h-full min-h-0 border-r">
+    <div className="sd-border-secondary @container w-full flex flex-col h-full min-h-0 border-r">
       <Account />
       <SourceList focusedPanel={focusedPanel} />
     </div>

--- a/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.tsx
+++ b/app/src/renderer/views/Inbox/Sidebar/SourceList/Source.tsx
@@ -156,8 +156,12 @@ const Source = memo(function Source({
         />
       </Tooltip>
 
-      {/* Avatar with initials */}
-      <Avatar designation={designation} isActive={isActive} />
+      {/* Avatar with initials: hidden in the compact sidebar layout*/}
+      <Avatar
+        designation={designation}
+        isActive={isActive}
+        className="@max-[340px]:hidden"
+      />
 
       {/* Source info */}
       <div className="flex-1 min-w-0 py-2 pl-3">

--- a/app/src/renderer/views/Inbox/SidebarResizer.test.tsx
+++ b/app/src/renderer/views/Inbox/SidebarResizer.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+
+import { renderWithProviders } from "../../test-component-setup";
+import SidebarResizer, {
+  SIDEBAR_DEFAULT_WIDTH,
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_MIN_WIDTH,
+  SIDEBAR_RESIZE_STEP,
+} from "./SidebarResizer";
+
+// Stateful harness so a drag reports cumulative movement the way the real
+// layout does, rather than replaying against a frozen starting width.
+function Harness({
+  initialWidth = SIDEBAR_DEFAULT_WIDTH,
+  onWidthChange,
+}: {
+  initialWidth?: number;
+  onWidthChange?: (width: number) => void;
+}) {
+  const [width, setWidth] = useState(initialWidth);
+  return (
+    <>
+      <SidebarResizer
+        width={width}
+        onWidthChange={(next) => {
+          onWidthChange?.(next);
+          setWidth(next);
+        }}
+      />
+      <span data-testid="current-width">{width}</span>
+    </>
+  );
+}
+
+const currentWidth = () =>
+  Number(screen.getByTestId("current-width").textContent);
+
+describe("SidebarResizer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("accessibility", () => {
+    it("exposes the splitter as a separator reporting the current width", () => {
+      renderWithProviders(<Harness />);
+
+      const separator = screen.getByTestId("sidebar-resizer");
+      expect(separator).toHaveAttribute("role", "separator");
+      expect(separator).toHaveAttribute("aria-orientation", "vertical");
+      expect(separator).toHaveAttribute(
+        "aria-valuenow",
+        String(SIDEBAR_DEFAULT_WIDTH),
+      );
+      expect(separator).toHaveAttribute(
+        "aria-valuemin",
+        String(SIDEBAR_MIN_WIDTH),
+      );
+      expect(separator).toHaveAttribute(
+        "aria-valuemax",
+        String(SIDEBAR_MAX_WIDTH),
+      );
+      expect(separator).toHaveAccessibleName("Resize sidebar");
+    });
+
+    it("is reachable by keyboard", async () => {
+      renderWithProviders(<Harness />);
+
+      await userEvent.tab();
+      expect(screen.getByTestId("sidebar-resizer")).toHaveFocus();
+    });
+  });
+
+  describe("keyboard resizing", () => {
+    it("narrows and widens by a fixed step with the arrow keys", () => {
+      renderWithProviders(<Harness />);
+      const separator = screen.getByTestId("sidebar-resizer");
+
+      fireEvent.keyDown(separator, { key: "ArrowLeft" });
+      expect(currentWidth()).toBe(SIDEBAR_DEFAULT_WIDTH - SIDEBAR_RESIZE_STEP);
+
+      fireEvent.keyDown(separator, { key: "ArrowRight" });
+      expect(currentWidth()).toBe(SIDEBAR_DEFAULT_WIDTH);
+    });
+
+    it("jumps to the bounds with Home and End", () => {
+      renderWithProviders(<Harness />);
+      const separator = screen.getByTestId("sidebar-resizer");
+
+      fireEvent.keyDown(separator, { key: "Home" });
+      expect(currentWidth()).toBe(SIDEBAR_MIN_WIDTH);
+
+      fireEvent.keyDown(separator, { key: "End" });
+      expect(currentWidth()).toBe(SIDEBAR_MAX_WIDTH);
+    });
+
+    it("ignores keys it does not handle, leaving them to other handlers", () => {
+      const onWidthChange = vi.fn();
+      renderWithProviders(<Harness onWidthChange={onWidthChange} />);
+
+      fireEvent.keyDown(screen.getByTestId("sidebar-resizer"), { key: "a" });
+      expect(onWidthChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("mouse resizing", () => {
+    it("tracks pointer movement from where the drag started", () => {
+      renderWithProviders(<Harness />);
+      const separator = screen.getByTestId("sidebar-resizer");
+
+      fireEvent.mouseDown(separator, { button: 0, clientX: 400 });
+      expect(separator).toHaveAttribute("data-dragging", "true");
+
+      fireEvent.mouseMove(window, { clientX: 450 });
+      expect(currentWidth()).toBe(SIDEBAR_DEFAULT_WIDTH + 50);
+
+      // Cumulative, not incremental: total delta is measured from mousedown.
+      fireEvent.mouseMove(window, { clientX: 430 });
+      expect(currentWidth()).toBe(SIDEBAR_DEFAULT_WIDTH + 30);
+
+      fireEvent.mouseUp(window);
+      expect(separator).toHaveAttribute("data-dragging", "false");
+    });
+
+    it("stops tracking once the drag ends", () => {
+      renderWithProviders(<Harness />);
+      const separator = screen.getByTestId("sidebar-resizer");
+
+      fireEvent.mouseDown(separator, { button: 0, clientX: 400 });
+      fireEvent.mouseUp(window);
+
+      fireEvent.mouseMove(window, { clientX: 600 });
+      expect(currentWidth()).toBe(SIDEBAR_DEFAULT_WIDTH);
+    });
+
+    it("clamps to the minimum and maximum width", () => {
+      renderWithProviders(<Harness />);
+      const separator = screen.getByTestId("sidebar-resizer");
+
+      fireEvent.mouseDown(separator, { button: 0, clientX: 400 });
+      fireEvent.mouseMove(window, { clientX: -1000 });
+      expect(currentWidth()).toBe(SIDEBAR_MIN_WIDTH);
+
+      fireEvent.mouseMove(window, { clientX: 5000 });
+      expect(currentWidth()).toBe(SIDEBAR_MAX_WIDTH);
+    });
+
+    it("ignores non-primary buttons", () => {
+      const onWidthChange = vi.fn();
+      renderWithProviders(<Harness onWidthChange={onWidthChange} />);
+      const separator = screen.getByTestId("sidebar-resizer");
+
+      fireEvent.mouseDown(separator, { button: 2, clientX: 400 });
+      expect(separator).toHaveAttribute("data-dragging", "false");
+
+      fireEvent.mouseMove(window, { clientX: 600 });
+      expect(onWidthChange).not.toHaveBeenCalled();
+    });
+
+    it("suppresses text selection while dragging and restores it after", () => {
+      renderWithProviders(<Harness />);
+      const separator = screen.getByTestId("sidebar-resizer");
+
+      fireEvent.mouseDown(separator, { button: 0, clientX: 400 });
+      expect(document.body.style.userSelect).toBe("none");
+      expect(document.body.style.cursor).toBe("col-resize");
+
+      fireEvent.mouseUp(window);
+      expect(document.body.style.userSelect).toBe("");
+      expect(document.body.style.cursor).toBe("");
+    });
+  });
+});

--- a/app/src/renderer/views/Inbox/SidebarResizer.tsx
+++ b/app/src/renderer/views/Inbox/SidebarResizer.tsx
@@ -1,0 +1,125 @@
+/*
+ * Sidebar resizing is implemented with a focusable `separator` per the ARIA
+ * window splitter pattern. The role is interactive because it is focusable,
+ * and adjustable via both mouse and keyboard handlers.
+ */
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+/* eslint-disable jsx-a11y/no-noninteractive-tabindex */
+/* eslint-disable react-refresh/only-export-components */
+import { memo, useEffect, useState } from "react";
+import type { KeyboardEvent, MouseEvent } from "react";
+import { useTranslation } from "react-i18next";
+
+export const SIDEBAR_DEFAULT_WIDTH = 384;
+
+export const SIDEBAR_MIN_WIDTH = 260;
+
+export const SIDEBAR_MAX_WIDTH = 640;
+
+// Pixels per arrow-key press when the resize handle has keyboard focus.
+export const SIDEBAR_RESIZE_STEP = 16;
+
+const clamp = (width: number) =>
+  Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, width));
+
+interface SidebarResizerProps {
+  width: number;
+  onWidthChange: (width: number) => void;
+}
+
+/**
+ * Drag handle between the sidebar and the main content.
+ *
+ * Implements the ARIA window splitter pattern: a focusable `role="separator"`
+ * that reports the current width, so the sidebar can be resized with the arrow
+ * keys as well as the mouse.
+ */
+const SidebarResizer = memo(function SidebarResizer({
+  width,
+  onWidthChange,
+}: SidebarResizerProps) {
+  const { t } = useTranslation("Sidebar");
+
+  // Pointer position and sidebar width at mousedown; null when not dragging.
+  // Tracking the delta rather than the absolute pointer position keeps the
+  // handle from jumping when the grab point isn't exactly on the divider.
+  const [drag, setDrag] = useState<{ x: number; width: number } | null>(null);
+
+  useEffect(() => {
+    if (!drag) {
+      return;
+    }
+
+    // Listen on the window, not the handle: the pointer routinely outruns a
+    // few-pixel-wide divider mid-drag, and the drag must continue anyway.
+    const handleMouseMove = (e: globalThis.MouseEvent) =>
+      onWidthChange(clamp(drag.width + (e.clientX - drag.x)));
+    const handleMouseUp = () => setDrag(null);
+
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+
+    // Keep the resize cursor and suppress selection across the whole window
+    // for the duration of the drag, wherever the pointer ends up.
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "col-resize";
+
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+      document.body.style.userSelect = "";
+      document.body.style.cursor = "";
+    };
+  }, [drag, onWidthChange]);
+
+  const handleMouseDown = (e: MouseEvent<HTMLDivElement>) => {
+    // Primary button only; ignore middle/right clicks and context menus.
+    if (e.button !== 0) {
+      return;
+    }
+    // Suppress the text selection that a drag across the panels would start.
+    e.preventDefault();
+    setDrag({ x: e.clientX, width });
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    const next = {
+      ArrowLeft: width - SIDEBAR_RESIZE_STEP,
+      ArrowRight: width + SIDEBAR_RESIZE_STEP,
+      Home: SIDEBAR_MIN_WIDTH,
+      End: SIDEBAR_MAX_WIDTH,
+    }[e.key];
+    // Only swallow the keys we actually handled, so the sidebar's own
+    // shortcuts keep working when the handle happens to hold focus.
+    if (next === undefined) {
+      return;
+    }
+    onWidthChange(clamp(next));
+    e.preventDefault();
+  };
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={t("resizer.label")}
+      aria-valuenow={width}
+      aria-valuemin={SIDEBAR_MIN_WIDTH}
+      aria-valuemax={SIDEBAR_MAX_WIDTH}
+      tabIndex={0}
+      title={t("resizer.hint")}
+      data-testid="sidebar-resizer"
+      data-dragging={drag !== null}
+      onMouseDown={handleMouseDown}
+      onKeyDown={handleKeyDown}
+      // The `after` pseudo-element widens the grab area past the visible
+      // divider without taking up any layout space, so the handle is
+      // comfortable to hit with a mouse.
+      className={`relative w-1 flex-shrink-0 cursor-col-resize outline-0 transition-colors duration-150 after:absolute after:inset-y-0 after:-inset-x-1 after:content-[''] focus-visible:outline-2 focus-visible:outline-blue-300 focus-visible:-outline-offset-2 ${
+        drag ? "bg-blue-400" : "bg-transparent hover:bg-blue-200"
+      }`}
+    />
+  );
+});
+
+export default SidebarResizer;


### PR DESCRIPTION
Fixes #3455

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

- [ ] Run Inbox locally 
- [ ] Increase the sidebar width, see that the sidebar resizes as expected + more preview text is shown
- [ ] Decrease the sidebar width, see that the avatar disappears when shrunk past a certain point 
- [ ] Closing + reopening the app should restore the original default sidebar width

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
