### PR TITLE
Fix delete button on hover

### DIFF
--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.test.tsx
@@ -1,4 +1,4 @@
-import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { expect, describe, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import File from "./File";
@@ -387,14 +387,16 @@ describe("File Component", () => {
     ) as HTMLElement;
     expect(trashButton).not.toBeNull();
 
-    // Before focus the wrapper is opacity 0
+    // Hidden until the row is hovered or the button takes focus. jsdom does
+    // not evaluate :hover/:focus-within, so assert the classes that carry the
+    // behaviour rather than a computed opacity.
     const wrapper = trashButton.closest(".transition-opacity") as HTMLElement;
-    expect(wrapper.style.opacity).toBe("0");
+    expect(wrapper).toHaveClass("opacity-0");
+    expect(wrapper).toHaveClass("group-hover:opacity-100");
+    expect(wrapper).toHaveClass("focus-within:opacity-100");
 
-    // fireEvent.focus triggers the React onFocus handler and flushes state,
-    // which should make the button visible so keyboard users can see it.
-    fireEvent.focus(trashButton);
-    expect(wrapper.style.opacity).toBe("1");
+    trashButton.focus();
+    expect(trashButton).toHaveFocus();
   });
 
   it("shows the double-encryption badge on a downloaded double-encrypted file", () => {

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/File.tsx
@@ -214,8 +214,6 @@ const File = memo(function File({
   const titleCaseDesignation = toTitleCase(designation);
   const fetchStatus = item.fetch_status;
   const [isFileBoxHovered, setIsFileBoxHovered] = useState(false);
-  const [isDeleteFocused, setIsDeleteFocused] = useState(false);
-  const showDelete = isFileBoxHovered || isDeleteFocused;
 
   // Disable downloading of files in offline mode
   const session = useAppSelector(getSessionState);
@@ -347,10 +345,7 @@ const File = memo(function File({
             </div>
           </Tooltip>
           {!disableFetch && (
-            <div
-              className="flex-shrink-0 transition-opacity group-hover:opacity-100"
-              style={{ opacity: showDelete ? 1 : 0 }}
-            >
+            <div className="flex-shrink-0 transition-opacity opacity-0 group-hover:opacity-100 focus-within:opacity-100">
               <Button
                 type="text"
                 size="small"
@@ -358,8 +353,6 @@ const File = memo(function File({
                 icon={<Trash size={16} />}
                 onClick={onDelete}
                 aria-label={t("deleteFile")}
-                onFocus={() => setIsDeleteFocused(true)}
-                onBlur={() => setIsDeleteFocused(false)}
                 data-testid="file-delete-button"
               />
             </div>

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.test.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import userEvent from "@testing-library/user-event";
-import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import Message from "./Message";
 import {
   testMemoization,
@@ -1160,11 +1160,15 @@ describe("Message and Reply delete button keyboard accessibility", () => {
     const deleteBtn = screen.getByRole("button", { name: "Delete message" });
     const wrapper = deleteBtn.closest(".transition-opacity") as HTMLElement;
 
-    // Starts hidden
-    expect(wrapper.style.opacity).toBe("0");
+    // Hidden until the item is hovered or the button takes focus. jsdom does
+    // not evaluate :hover/:focus-within, so assert the classes that carry the
+    // behaviour rather than a computed opacity.
+    expect(wrapper).toHaveClass("opacity-0");
+    expect(wrapper).toHaveClass("focus-within:opacity-100");
+    expect(wrapper).toHaveClass("group-hover:opacity-100");
 
-    fireEvent.focus(deleteBtn);
-    expect(wrapper.style.opacity).toBe("1");
+    deleteBtn.focus();
+    expect(deleteBtn).toHaveFocus();
   });
 
   it("reply delete button is reachable by keyboard and becomes visible on focus", () => {
@@ -1176,10 +1180,12 @@ describe("Message and Reply delete button keyboard accessibility", () => {
     const deleteBtn = screen.getByRole("button", { name: "Delete reply" });
     const wrapper = deleteBtn.closest(".transition-opacity") as HTMLElement;
 
-    expect(wrapper.style.opacity).toBe("0");
+    expect(wrapper).toHaveClass("opacity-0");
+    expect(wrapper).toHaveClass("focus-within:opacity-100");
+    expect(wrapper).toHaveClass("group-hover:opacity-100");
 
-    fireEvent.focus(deleteBtn);
-    expect(wrapper.style.opacity).toBe("1");
+    deleteBtn.focus();
+    expect(deleteBtn).toHaveFocus();
   });
 
   it("message delete button calls onDelete when activated by keyboard", async () => {

--- a/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.tsx
+++ b/app/src/renderer/views/Inbox/MainContent/Conversation/Item/Message.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo } from "react";
 import {
   FetchStatus,
   ItemUpdateType,
@@ -60,9 +60,6 @@ const Message = memo(function Message(props: MessageProps) {
   const currentKeyFingerprint = useSubmissionKeyFingerprint(
     kind === "message" && item.doubleEncryptedKeyFingerprint !== null,
   );
-  const [isDeleteFocused, setIsDeleteFocused] = useState(false);
-  const showDelete = isDeleteFocused;
-
   const sessionState = useAppSelector(getSessionState);
   const disableDelete = sessionState.status !== SessionStatus.Auth;
 
@@ -250,10 +247,7 @@ const Message = memo(function Message(props: MessageProps) {
               {displayMessage()}
             </div>
             {!disableDelete && (
-              <div
-                className="flex-shrink-0 transition-opacity group-hover:opacity-100"
-                style={{ opacity: showDelete ? 1 : 0 }}
-              >
+              <div className="flex-shrink-0 transition-opacity opacity-0 group-hover:opacity-100 focus-within:opacity-100">
                 <Button
                   type="text"
                   size="small"
@@ -261,8 +255,6 @@ const Message = memo(function Message(props: MessageProps) {
                   icon={<Trash size={16} />}
                   onClick={onDelete}
                   aria-label={t("deleteMessage")}
-                  onFocus={() => setIsDeleteFocused(true)}
-                  onBlur={() => setIsDeleteFocused(false)}
                 />
               </div>
             )}
@@ -284,10 +276,7 @@ const Message = memo(function Message(props: MessageProps) {
         </div>
         <div className="flex items-center gap-1">
           {!disableDelete && (
-            <div
-              className="flex-shrink-0 transition-opacity group-hover:opacity-100"
-              style={{ opacity: showDelete ? 1 : 0 }}
-            >
+            <div className="flex-shrink-0 transition-opacity opacity-0 group-hover:opacity-100 focus-within:opacity-100">
               <Button
                 type="text"
                 size="small"
@@ -295,8 +284,6 @@ const Message = memo(function Message(props: MessageProps) {
                 icon={<Trash size={16} />}
                 onClick={onDelete}
                 aria-label={t("deleteReply")}
-                onFocus={() => setIsDeleteFocused(true)}
-                onBlur={() => setIsDeleteFocused(false)}
               />
             </div>
           )}


### PR DESCRIPTION
Fixes a bug in the delete button that led it to not appear on hover. Uses CSS to set the opacity on hover now.

## Test plan

- [ ] Run SecureDrop Inbox locally with test data 
- [ ] Hover over a message and see that the delete icon appears next to it
- [ ] Hover over a reply and see that delete icon successfully appears 
- [ ] Download a file, and then hover over the file box and see that delete icon successfully appears 
- [ ] Clicking the delete icon should show the delete modal and allow deletion
