### PR TITLE
Remove translation keys the English source no longer has

### DIFF
--- a/app/src/renderer/locales/de.json
+++ b/app/src/renderer/locales/de.json
@@ -114,7 +114,6 @@
     },
     "helpModals": {
       "aboutRepoTitle": "Quellcode",
-      "aboutLicence": "SecureDrop ist Open Source und wird unter der GNU Affero General Public License v3 veröffentlicht.",
       "keyboardTitle": "Tastenkombinationen",
       "aboutCopyright": "© 2013–2026 Aaron Swartz, James Dolan, Freedom of the Press Foundation, und SecureDrop Mitwirkende.",
       "aboutAppDesc": "Sichere Kommunikation für Journalisten und Informationsquellen",
@@ -237,7 +236,6 @@
     "resume": "Wiederaufnahme"
   },
   "QuitModal": {
-    "cancel": "Abbrechen",
     "withDrafts": "Entwürfe von Antworten werden gelöscht.",
     "Quit": "Beenden",
     "discardAndQuit": "Verwerfen und beenden",

--- a/app/src/renderer/locales/en-XA.json
+++ b/app/src/renderer/locales/en-XA.json
@@ -88,7 +88,6 @@
     },
     "helpModals": {
       "aboutRepoTitle": "[!Source code!]",
-      "aboutLicence": "[!!!!!!!!SecureDrop is open source and released under the GNU Affero General Public License v3.!!!!!!!!]",
       "keyboardTitle": "[!Keyboard shortcuts!]",
       "aboutCopyright": "[!!!!!!!!!!!!© 2013–2026 Aaron Swartz, James Dolan, Freedom of the Press Foundation, and SecureDrop contributors. Released under the AGPL-3.0.!!!!!!!!!!!!]",
       "aboutAppDesc": "[!!!!Secure communications for journalists and sources!!!!]",
@@ -213,7 +212,6 @@
     }
   },
   "QuitModal": {
-    "cancel": "[Cancel]",
     "withDrafts": "[!!!Draft replies will be discarded.!!!]",
     "Quit": "[Quit]",
     "discardAndQuit": "[!Discard and Quit!]",

--- a/app/src/renderer/locales/es.json
+++ b/app/src/renderer/locales/es.json
@@ -119,7 +119,6 @@
     },
     "helpModals": {
       "aboutRepoTitle": "Código fuente",
-      "aboutLicence": "",
       "keyboardTitle": "Atajos del teclado",
       "aboutCopyright": "© 2013–2026 Aaron Swartz, James Dolan, Freedom of the Press Foundation, y colaboradores de SecureDrop. Lanzada bajo licencia AGPL-3.0.",
       "aboutAppDesc": "Comunicación segura para periodistas y fuentes",
@@ -243,7 +242,6 @@
     "exportToWhistleflow": "Exportar a Whistleflow"
   },
   "QuitModal": {
-    "cancel": "",
     "withDrafts": "Los borradores de respuestas serán descartados.",
     "Quit": "Salir",
     "discardAndQuit": "Descartar y Salir",

--- a/app/src/renderer/locales/fr.json
+++ b/app/src/renderer/locales/fr.json
@@ -126,8 +126,7 @@
       "aboutMoreTitle": "Plus de renseignements",
       "aboutRepoTitle": "Code source",
       "aboutRepoContent": "https://github.com/freedomofpress/securedrop-client",
-      "aboutCopyright": "© 2013 à 2026 Aaron Swartz, James Dolan, Fondation « Freedom of the Press » et les contributeurs de SecureDrop. Publié sous licence AGPL-3.0.",
-      "aboutLicence": "SecureDrop est un logiciel à code source ouvert distribué sous licence GNU Licence générale publique Affero v3."
+      "aboutCopyright": "© 2013 à 2026 Aaron Swartz, James Dolan, Fondation « Freedom of the Press » et les contributeurs de SecureDrop. Publié sous licence AGPL-3.0."
     },
     "syncStatus": {
       "notloggedin": "Synchronisation : Vous n’êtes pas connecté",
@@ -251,8 +250,6 @@
   "QuitModal": {
     "title": "Fermer la boîte de réception SecureDrop ?",
     "withDrafts": "Les brouillons de réponse seront supprimés.",
-    "cancel": "Annuler",
-    "ok": "Oui, quitter",
     "goBack": "Retour",
     "Quit": "Fermer",
     "discardAndQuit": "Abandonner et fermer"

--- a/app/src/renderer/locales/nb-NO.json
+++ b/app/src/renderer/locales/nb-NO.json
@@ -88,7 +88,6 @@
     },
     "helpModals": {
       "aboutRepoTitle": "",
-      "aboutLicence": "",
       "keyboardTitle": "",
       "aboutCopyright": "",
       "aboutAppDesc": "",
@@ -211,7 +210,6 @@
     }
   },
   "QuitModal": {
-    "cancel": "",
     "withDrafts": "",
     "Quit": "",
     "discardAndQuit": "",


### PR DESCRIPTION
Removes stale strings from translations that are removed from the English source.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
