### PR TITLE
Allow dependabot to open all our JavaScript PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    open-pull-requests-limit: 10
     ignore:
       # electron major bumps are done manually
       - dependency-name: "electron"


### PR DESCRIPTION
Right now the electron minor bump PR is stick behind the limit, which is probably the one we want the most.

