### PR TITLE
Update empty conversation string to make deletion clear

### DIFF
--- a/app/src/renderer/locales/de.json
+++ b/app/src/renderer/locales/de.json
@@ -20,7 +20,7 @@
     "retryFetch": "Erneut versuchen",
     "itemEncrypted": "Die Nachricht ist verschlüsselt…",
     "lastSourceActivity": "Letzte Aktivität in der Quelle",
-    "emptyConversation": "In diesem Chat gibt es noch keine Nachrichten.",
+    "emptyConversation": "",
     "nonProduction": "WARNUNG: Nicht-Produktionsmodus",
     "you": "Du",
     "unknown": "Unbekannt"

--- a/app/src/renderer/locales/en-XA.json
+++ b/app/src/renderer/locales/en-XA.json
@@ -244,7 +244,7 @@
     "retryFetch": "[Retry]",
     "itemEncrypted": "[!!Message is encrypted...!!]",
     "lastSourceActivity": "[!!Last source activity!!]",
-    "emptyConversation": "[!!!This conversation has no messages yet.!!!]",
+    "emptyConversation": "",
     "nonProduction": "[!!WARNING: non-production mode!!]",
     "you": "[You]",
     "unknown": "[Unknown]"

--- a/app/src/renderer/locales/en.json
+++ b/app/src/renderer/locales/en.json
@@ -19,7 +19,7 @@
   "MainContent": {
     "nonProduction": "WARNING: non-production mode",
     "emptyState": "<bold>Select a source</bold> from the list to read messages, retrieve files, or send responses.",
-    "emptyConversation": "This conversation has no messages yet.",
+    "emptyConversation": "All files and messages have been deleted for this source.",
     "conversation": {
       "sendButton": "Send",
       "messagePlaceholder": "Message {{designation}}...",

--- a/app/src/renderer/locales/es.json
+++ b/app/src/renderer/locales/es.json
@@ -22,7 +22,7 @@
     "retryFetch": "Reintentar",
     "itemEncrypted": "El mensaje está cifrado...",
     "lastSourceActivity": "Última actividad de la fuente",
-    "emptyConversation": "Esta conversación aún no tiene mensajes.",
+    "emptyConversation": "",
     "nonProduction": "ADVERTENCIA: no está en modo producción",
     "you": "Tu",
     "unknown": "Desconocido"

--- a/app/src/renderer/locales/fr.json
+++ b/app/src/renderer/locales/fr.json
@@ -7,7 +7,7 @@
   },
   "MainContent": {
     "emptyState": "<bold>Choisissez une source</bold> dans la liste pour lire les messages, récupérer les fichiers ou envoyer des réponses.",
-    "emptyConversation": "Cette conversation n’a pas encore de messages.",
+    "emptyConversation": "",
     "conversation": {
       "sendButton": "Envoyer",
       "messagePlaceholder": "Message {{designation}}…",


### PR DESCRIPTION
Fixes #3496 

Updates the `emptyConversation` string to make explicit that all files and messages have been deleted, using the previous client's wording. This prevents potential confusion on the empty conversation state, which is only possible when a conversation (but not entire source account) has been deleted.

<img width="1195" height="697" alt="image" src="https://github.com/user-attachments/assets/08e59575-5a3e-4403-9fe7-5a210c729e67" />


## Test plan

- [ ] Delete a conversation for a source in the Inbox
- [ ] Verify that the conversation view shows "All files and messages have been deleted for this source."

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
