### PR TITLE
fix(`ProxyStreamRequestInner`): peek at the first byte of a response before buffering it to parse as JSON

### DIFF
--- a/app/src/main/proxy.test.ts
+++ b/app/src/main/proxy.test.ts
@@ -6,6 +6,7 @@ import { Readable, Writable } from "stream";
 import type {
   ProxyRequest,
   ProxyCommand,
+  ProxyJSONResponse,
   ProxyStreamResponse,
   ms,
 } from "../types";
@@ -446,7 +447,7 @@ describe("Test executing proxy with streaming requests", () => {
   it("proxy should return ProxyStreamResponse with data on successful response", async () => {
     const respData = "Hello, world";
     const respSHA256 = "12345";
-    process.stdout = Readable.from(respData);
+    process.stdout = Readable.from(Buffer.from(respData));
 
     let data = "";
 
@@ -475,6 +476,75 @@ describe("Test executing proxy with streaming requests", () => {
 
     expect(data.toString()).toEqual(respData);
     expect(sha256sum).toEqual(respSHA256);
+  });
+
+  it("proxy should return ProxyJSONResponse when the stream body is a proxy JSON response", async () => {
+    // A stream request can still come back as a JSON response, e.g. when the
+    // server rejects the download rather than sending file data.
+    const respStatus = 400;
+    process.stdout = Readable.from(
+      Buffer.from(
+        JSON.stringify({
+          status: respStatus,
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ message: "Bad request" }),
+        }),
+      ),
+    );
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const proxyExec = proxyStreamRequest({} as ProxyRequest, writeStream);
+
+    if (process.stderr) {
+      process.stderr.emit("data", JSON.stringify({ headers: { etag: "x" } }));
+    }
+
+    setTimeout(() => {
+      process.emit("close", 0);
+    }, 10);
+
+    const { status, error } = (await proxyExec) as ProxyJSONResponse;
+
+    expect(status).toEqual(respStatus);
+    expect(error).toBe(true);
+
+    // Having resolved as JSON, we must not fall through and also handle this
+    // as a completed stream.
+    expect(logSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("stream complete"),
+    );
+  });
+
+  it("proxy should reject a JSON-shaped body that is not a proxy response", async () => {
+    // Downloads are OpenPGP-encrypted, so a body starting with "{" is neither
+    // a JSON response nor streamable data: fail rather than record a corrupt
+    // download as complete.
+    process.stdout = Readable.from(
+      Buffer.from(JSON.stringify({ not: "a proxy response" })),
+    );
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const proxyExec = proxyStreamRequest({} as ProxyRequest, writeStream);
+
+    if (process.stderr) {
+      process.stderr.emit("data", JSON.stringify({ headers: { etag: "x" } }));
+    }
+
+    setTimeout(() => {
+      process.emit("close", 0);
+    }, 10);
+
+    await expect(proxyExec).rejects.toThrowError(
+      /Response was neither JSON nor streamed data/,
+    );
+
+    // Having rejected, we must not fall through and log the failed download as
+    // a completed stream.
+    expect(logSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("stream complete"),
+    );
   });
 
   it("proxy should return on proxy-command exit error code", async () => {

--- a/app/src/main/proxy.test.ts
+++ b/app/src/main/proxy.test.ts
@@ -478,6 +478,73 @@ describe("Test executing proxy with streaming requests", () => {
     expect(sha256sum).toEqual(respSHA256);
   });
 
+  it("proxy should stream a body whose later chunks start with a JSON byte", async () => {
+    // Chunk boundaries fall wherever the pipe puts them, so an encrypted body
+    // can easily begin a later chunk with "{". Only the first byte of the
+    // response decides, and nothing after it may be retained.
+    const respSHA256 = "12345";
+    process.stdout = Readable.from([
+      Buffer.from("encrypted"),
+      Buffer.from('{"status": 200}'),
+    ]);
+
+    let data = "";
+
+    writeStream.on("data", (chunk) => {
+      data += chunk;
+    });
+
+    const proxyExec = proxyStreamRequest({} as ProxyRequest, writeStream);
+
+    if (process.stderr) {
+      process.stderr.emit(
+        "data",
+        JSON.stringify({ headers: { etag: respSHA256 } }),
+      );
+    }
+
+    setTimeout(() => {
+      process.emit("close", 0);
+    }, 10);
+
+    const { complete, sha256sum, bytesWritten } =
+      (await proxyExec) as ProxyStreamResponse;
+
+    expect(complete).toBe(true);
+    expect(sha256sum).toEqual(respSHA256);
+    expect(bytesWritten).toEqual(24);
+    expect(data).toEqual('encrypted{"status": 200}');
+  });
+
+  it("proxy should parse a JSON response split across chunks", async () => {
+    // A JSON response is retained in full, however many chunks it arrives in.
+    const respStatus = 403;
+    const body = JSON.stringify({
+      status: respStatus,
+      headers: {},
+      body: "Forbidden",
+    });
+    process.stdout = Readable.from([
+      Buffer.from(body.slice(0, 5)),
+      Buffer.from(body.slice(5)),
+    ]);
+
+    const proxyExec = proxyStreamRequest({} as ProxyRequest, writeStream);
+
+    if (process.stderr) {
+      process.stderr.emit("data", JSON.stringify({ headers: { etag: "x" } }));
+    }
+
+    setTimeout(() => {
+      process.emit("close", 0);
+    }, 10);
+
+    const { status, error } = (await proxyExec) as ProxyJSONResponse;
+
+    expect(status).toEqual(respStatus);
+    expect(error).toBe(true);
+  });
+
   it("proxy should return ProxyJSONResponse when the stream body is a proxy JSON response", async () => {
     // A stream request can still come back as a JSON response, e.g. when the
     // server rejects the download rather than sending file data.

--- a/app/src/main/proxy.ts
+++ b/app/src/main/proxy.ts
@@ -280,32 +280,52 @@ export async function proxyStreamRequestInner(
         });
         return;
       }
-      try {
-        // If we receive JSON data, parse and return
-        // Convert buffer chunks to string only when needed for JSON parsing
-        const stdout = Buffer.concat(stdoutChunks).toString("utf8");
-        const response = parseJSONResponse(stdout);
-        logJSONResponse(requestID, response, Buffer.byteLength(stdout, "utf8"));
-        resolve(response);
-      } catch {
+
+      // If the first byte is "{", is it a JSON response?
+      if (stdoutChunks[0]?.[0] === 0x7b /* "{" */) {
         try {
-          const header = JSON.parse(stderr);
-          const headers: Map<string, string> = new Map(
-            Object.entries(header["headers"]),
+          // To find out, convert the buffer chunks to string, then try to parse and return.
+          const stdout = Buffer.concat(stdoutChunks).toString("utf8");
+          const response = parseJSONResponse(stdout);
+          logJSONResponse(
+            requestID,
+            response,
+            Buffer.byteLength(stdout, "utf8"),
           );
-          console.log(
-            `[proxy] ${requestID} stream complete: bytesWritten=${bytesWritten}`,
-          );
-          resolve({
-            complete: true,
-            sha256sum: getHeader(headers, "etag") || "",
-            bytesWritten: bytesWritten,
-          });
+          resolve(response);
+          return;
         } catch (err) {
           reject(
-            `${requestID}: Error reading headers from proxy stderr: ${err}`,
+            new Error(
+              `${requestID}: Response was neither JSON nor streamed data`,
+              { cause: err },
+            ),
           );
+          return;
         }
+      }
+
+      // Otherwise, handle it as a stream response instead.
+      try {
+        const header = JSON.parse(stderr);
+        const headers: Map<string, string> = new Map(
+          Object.entries(header["headers"]),
+        );
+        console.log(
+          `[proxy] ${requestID} stream complete: bytesWritten=${bytesWritten}`,
+        );
+        resolve({
+          complete: true,
+          sha256sum: getHeader(headers, "etag") || "",
+          bytesWritten: bytesWritten,
+        });
+      } catch (err) {
+        reject(
+          new Error(
+            `${requestID}: Error reading headers from proxy stderr: ${err}`,
+            { cause: err },
+          ),
+        );
       }
     });
 

--- a/app/src/main/proxy.ts
+++ b/app/src/main/proxy.ts
@@ -221,13 +221,20 @@ export async function proxyStreamRequestInner(
     // contents directly to the `writeStream`.
     process.stdout.pipe(writeStream);
 
-    // Store stdout as buffer array to avoid binary data corruption, and track bytes written
+    // Peek at the first byte of the first chunk of the returned stdout.  If it
+    // begins with "{", buffer it as JSON to be parsed on close; otherwise
+    // stream the response without retaining the chunks in memory.  Store stdout
+    // as buffer array to avoid binary data corruption, and track bytes written
     // to allow resuming incremental progress.
     const stdoutChunks: Buffer[] = [];
     let bytesWritten = 0;
+    let looksLikeJSON: boolean | undefined;
     process.stdout.on("data", (data) => {
       bytesWritten += data.length;
-      stdoutChunks.push(data);
+      looksLikeJSON ??= data[0] === 0x7b; /* "{" */
+      if (looksLikeJSON) {
+        stdoutChunks.push(data);
+      }
       // Report progress to caller if callback is provided
       if (onProgress) {
         try {
@@ -281,8 +288,8 @@ export async function proxyStreamRequestInner(
         return;
       }
 
-      // If the first byte is "{", is it a JSON response?
-      if (stdoutChunks[0]?.[0] === 0x7b /* "{" */) {
+      // If the first byte was "{", is it actually a JSON response?
+      if (looksLikeJSON) {
         try {
           // To find out, convert the buffer chunks to string, then try to parse and return.
           const stdout = Buffer.concat(stdoutChunks).toString("utf8");


### PR DESCRIPTION
Fixes #3569 by peeking at the first byte (of the first chunk) of a given response before (1) buffering the rest of the response and then (2) attempting to parse it as JSON.

As Copilot has pointed out quite insistently, this doesn't eliminate the possibility of an over-large response being buffered into memory; it just isolates it to probable JSON responses.  I don't think the full solution is worth the extra logic it would require here.  Instead, this approach is a compromise to eliminate the performance hit from a large streaming response, until #3660 can split these paths fully.


## Test plan

- [ ] Smoke-test sync (JSON responses).
- [ ] Smoke-test downloading a file (stream response).