### PR TITLE
fix: returned events must be a subset of submitted events

### DIFF
--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -190,7 +190,7 @@ export class DB {
   >;
   private deletePendingEvent: Statement<{ snowflake_id: string }, void>;
   private incrementPendingEventRetry: Statement<
-    { snowflake_id: string; status: number },
+    { snowflake_id: string; status: number | null },
     void
   >;
   private selectPendingEvents: Statement<[{ limit: number }], PendingEventRow>;
@@ -636,12 +636,15 @@ export class DB {
     })(journalists);
   }
 
-  protected updateBatch(batchResponse: BatchResponse): {
+  protected updateBatch(
+    batchResponse: BatchResponse,
+    submittedEventIDs?: string[],
+  ): {
     deleted_items: Item[];
     deleted_sources: string[];
   } {
     return this.db!.transaction((batch: BatchResponse) => {
-      this.updatePendingEvents(batch.events);
+      this.updatePendingEvents(batch.events, submittedEventIDs);
       const deleted_items = this.updateItems(batch.items);
       const deleted_sources = this.updateSources(batch.sources);
       this.updateJournalists(batch.journalists);
@@ -1347,15 +1350,25 @@ export class DB {
   // Takes pending events and their statuses from the server and applies
   // pending event updates as needed.
   // Should be run within a transaction that also updates index version.
-  updatePendingEvents(events: {
-    [snowflake_id: string]: [number, string | null];
-  }) {
+  updatePendingEvents(
+    events: {
+      [snowflake_id: string]: [number, string | null];
+    },
+    submitted: string[] = Object.keys(events),
+  ) {
+    // Only update the statuses for events we submitted in this batch.
+    const submittedIDs = new Set(submitted);
+    for (const id of Object.keys(events)) {
+      if (!submittedIDs.has(id)) {
+        console.warn(`[sync] ignoring status for unsubmitted event ${id}`);
+      }
+    }
     // Remove successfully applied pending events. On failure, retain them in the
     // pending events table for resubmission on next sync
     const appliedEventIDs: string[] = [];
     const eventIDsToRemove: string[] = [];
-    Object.keys(events).forEach((snowflake_id: string) => {
-      const result = events[snowflake_id][0];
+    submitted.forEach((snowflake_id: string) => {
+      const result = events[snowflake_id]?.[0] ?? null;
       if (result === EventStatus.OK) {
         // Event has been accepted by the server: apply + remove from pending_events
         appliedEventIDs.push(snowflake_id);
@@ -1363,7 +1376,8 @@ export class DB {
         // Target no longer exists on the server: remove pending_event.
         eventIDsToRemove.push(snowflake_id);
       } else {
-        // All other statuses indicate event was submitted but not yet complete.
+        // All other statuses, or the absence of a returned status for an event
+        // we submitted, indicate the event is not complete.
         // Retain and bump the retry counter, recording the status.
         // This event will be re-scheduled in subsequent batches.
         this.incrementPendingEventRetry.run({ snowflake_id, status: result });

--- a/app/src/main/datastore.test.ts
+++ b/app/src/main/datastore.test.ts
@@ -1481,23 +1481,49 @@ describe("Datastore Method Tests", () => {
     expect(db.getPendingEvents().map((e) => e.id)).toEqual([snowflakeSource]);
 
     // Round 1: server reports event as AlreadyReported
-    db.updatePendingEvents({
-      [snowflakeSource.toString()]: [208, "AlreadyReported"],
-    });
+    db.updatePendingEvents(
+      {
+        [snowflakeSource.toString()]: [208, "AlreadyReported"],
+      },
+      [snowflakeSource.toString()],
+    );
     expect(db.getPendingEvents().map((e) => e.id)).toEqual([snowflakeSource]);
     expect(pendingEventRow().retry_attempts).toBe(1);
 
-    // Round 2: the server dropped the event.
-    // The inbox should keep the event in its batch to resubmit
-    db.updatePendingEvents({});
+    // Round 2: the server dropped the event from its response.  We did submit
+    // it, so that's a failure: keep it in the batch to resubmit, but bump the
+    // counter so it stops counting as fresh and can't spin the flush loop.
+    db.updatePendingEvents({}, [snowflakeSource.toString()]);
     expect(db.getPendingEvents().map((e) => e.id)).toEqual([snowflakeSource]);
-    expect(pendingEventRow().retry_attempts).toBe(1);
+    expect(pendingEventRow().retry_attempts).toBe(2);
+    expect(pendingEventRow().last_event_status).toBe(null);
 
     // Round 3: the server marks event as complete.
-    db.updatePendingEvents({
-      [snowflakeSource.toString()]: [200, ""],
-    });
+    db.updatePendingEvents(
+      {
+        [snowflakeSource.toString()]: [200, ""],
+      },
+      [snowflakeSource.toString()],
+    );
     expect(db.getPendingEvents()).toEqual([]);
+  });
+
+  it("updatePendingEvents should ignore statuses for events it did not submit", () => {
+    db.updateSources({
+      source1: mockSourceMetadata("source1"),
+    });
+
+    const snowflakeSource = db.addPendingSourceEvent(
+      "source1",
+      PendingEventType.Starred,
+    )!;
+
+    // The server reports success for an event we never submitted, e.g. one
+    // deferred past this batch's limit.  It must not be applied or removed.
+    db.updatePendingEvents({ [snowflakeSource.toString()]: [200, ""] }, []);
+
+    expect(db.getPendingEvents().map((e) => e.id)).toEqual([snowflakeSource]);
+    expect(db.countFreshPendingEvents()).toBe(1);
   });
 
   it("countFreshPendingEvents should exclude events awaiting resubmission", () => {

--- a/app/src/main/datastore.ts
+++ b/app/src/main/datastore.ts
@@ -71,12 +71,15 @@ export class Datastore extends DB {
     super.updateJournalists(journalists);
   }
 
-  override updateBatch(batchResponse: BatchResponse): {
+  override updateBatch(
+    batchResponse: BatchResponse,
+    submittedEventIDs?: string[],
+  ): {
     deleted_items: Item[];
     deleted_sources: string[];
   } {
     // Perform all DB updates
-    const result = super.updateBatch(batchResponse);
+    const result = super.updateBatch(batchResponse, submittedEventIDs);
     // Perform all filesystem cleanups as necessary
     for (const item of result.deleted_items) {
       void this.storage.deleteItemFs(item);

--- a/app/src/main/sync/index.test.ts
+++ b/app/src/main/sync/index.test.ts
@@ -203,7 +203,7 @@ describe("syncMetadata", () => {
 
     expect(proxyMock).toHaveBeenCalledTimes(2);
     // Should update sources and items with new data
-    expect(db.updateBatch).toHaveBeenCalledWith(batch);
+    expect(db.updateBatch).toHaveBeenCalledWith(batch, []);
   });
 
   it("rejects a batch item whose map key differs from its metadata UUID", async () => {
@@ -549,7 +549,7 @@ describe("syncMetadata", () => {
 
     expect(proxyMock).toHaveBeenCalledTimes(2);
     expect(db.deleteItemsAsync).toHaveBeenCalledWith([ITEM_UUID_2]);
-    expect(db.updateBatch).toHaveBeenCalledWith(metadata);
+    expect(db.updateBatch).toHaveBeenCalledWith(metadata, []);
     expect(fs.promises.rm).toHaveBeenCalledTimes(1);
     expect(fs.promises.rm).toHaveBeenCalledWith(
       `/mock-home/.config/SecureDrop/files/${SOURCE_UUID_1}/${ITEM_UUID_2}/`,
@@ -631,7 +631,7 @@ describe("syncMetadata", () => {
     await syncModule.syncMetadata(db, "");
 
     expect(proxyMock).toHaveBeenCalledTimes(2);
-    expect(db.updateBatch).toHaveBeenCalledWith(metadata);
+    expect(db.updateBatch).toHaveBeenCalledWith(metadata, []);
   });
 
   it("deletes sources on sync + updates source delta", async () => {
@@ -677,12 +677,15 @@ describe("syncMetadata", () => {
 
     expect(proxyMock).toHaveBeenCalledTimes(2);
     expect(db.deleteSourcesAsync).toHaveBeenCalledWith([SOURCE_UUID_2]);
-    expect(db.updateBatch).toHaveBeenCalledWith({
-      items: {},
-      sources: {},
-      journalists: {},
-      events: {},
-    });
+    expect(db.updateBatch).toHaveBeenCalledWith(
+      {
+        items: {},
+        sources: {},
+        journalists: {},
+        events: {},
+      },
+      [],
+    );
   });
 
   it("deletes source directory from filesystem when source is deleted on server", async () => {
@@ -779,7 +782,7 @@ describe("syncMetadata", () => {
     // The batch request should include the pending events
     const batchRequestArg = proxyMock.mock.calls[1][0];
     expect(JSON.parse(batchRequestArg.body!).events).toEqual(pendingEvents);
-    expect(db.updateBatch).toHaveBeenCalledWith(batch);
+    expect(db.updateBatch).toHaveBeenCalledWith(batch, ["1", "2"]);
     expect(status).toBe(SyncStatus.UPDATED);
   });
 
@@ -861,7 +864,7 @@ describe("syncMetadata", () => {
     const status = await syncModule.syncMetadata(db, "");
 
     expect(proxyMock).toHaveBeenCalledTimes(2);
-    expect(db.updateBatch).toHaveBeenCalledWith(batch);
+    expect(db.updateBatch).toHaveBeenCalledWith(batch, ["1"]);
     expect(status).toBe(SyncStatus.UPDATED);
   });
 });

--- a/app/src/main/sync/index.ts
+++ b/app/src/main/sync/index.ts
@@ -287,7 +287,7 @@ export async function syncMetadata(
     return SyncStatus.FORBIDDEN;
   }
 
-  db.updateBatch(batchResponse.data);
+  db.updateBatch(batchResponse.data, request.events?.map((e) => e.id) ?? []);
 
   syncStatus = SyncStatus.UPDATED;
   console.log("[sync] updates complete");


### PR DESCRIPTION
I recommended closing #3590 because its back-off logic was too complex. I missed this simpler and more-useful property it also proposed. "Returned must be a subset of submitted" means, as re-proposed here:

1. If the server omits a status for an event the client submitted, the client must consider it to have failed.

2. The client must not accept a new status for an event it didn't submit in this batch.

This change should be a no-op against a well-behaved server but could help diagnose a buggy one.  It's a low priority if we don't want to alter this logic right now.

Thanks to @wizardengineer for originally proposing this in #3590.


## Test plan

Visual review and smoke-testing.