### PR TITLE
Explicitly invoke `install-electron` to ensure it's present

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -12,10 +12,11 @@
   "engines": {
     "node": ">=24"
   },
+  "//": "explicit install-electron is needed until https://github.com/alex8088/electron-vite/issues/904 is fixed",
   "scripts": {
-    "start": "electron-vite preview",
-    "dev": "electron-vite dev",
-    "dev-demo": "PROXY_ORIGIN=https://demo-journalist.securedrop.org electron-vite dev -- --login",
+    "start": "install-electron && electron-vite preview",
+    "dev": "install-electron && electron-vite dev",
+    "dev-demo": "install-electron && PROXY_ORIGIN=https://demo-journalist.securedrop.org electron-vite dev -- --login",
     "test": "vitest run --config vitest.config.ts --project=unit --project=component --coverage",
     "integration-test": "vitest run --config vitest.config.ts --project=integration --coverage",
     "server-test": "electron-vite build --mode test && vitest run --config vitest.config.ts --project=server --coverage --no-file-parallelism",


### PR DESCRIPTION
Electron 42 now lazy-loads the electron binary as part of the ecosystem-wide move away from postinstall scripts. However, electron-vite has not yet been updated for that and it fails with an error that electron isn't installed
(https://github.com/alex8088/electron-vite/issues/904).

Workaround it for adding explicit `install-electron` invocations for the targets that need it. In other places it explicitly downloads electron (build:unpack) or triggers the lazy-load behavior (server-test), so we don't need the workaround.

Fixes #3735.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->
* [ ] check out this branch
* [ ] `cd app && rm -rf node_modules && pnpm i`
* [ ] `pnpm dev` should work just fine
## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/proxy/usr.bin.securedrop-proxy
[self-contained]: https://github.com/freedomofpress/securedrop-client/blob/main/app/README.md#database
