### PR TITLE
[inbox] add setupStore utility for renderer tests

### DIFF
--- a/app/src/renderer/features/conversation/conversationSlice.test.ts
+++ b/app/src/renderer/features/conversation/conversationSlice.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { configureStore } from "@reduxjs/toolkit";
 import { FetchStatus, type SourceWithItems } from "../../../types";
 import conversationSlice, {
   fetchConversation,
@@ -11,6 +10,7 @@ import conversationSlice, {
   type ConversationState,
 } from "./conversationSlice";
 import { SessionStatus } from "../session/sessionSlice";
+import { defaultSliceState, setupStore } from "../../store";
 
 // Mock conversation data
 const mockSourceWithItems: SourceWithItems = {
@@ -103,17 +103,12 @@ const mockSourceWithItems2: SourceWithItems = {
 };
 
 describe("conversationSlice", () => {
-  let store: ReturnType<typeof configureStore>;
+  let store: ReturnType<typeof setupStore>;
   const mockGetSourceWithItems = vi.fn();
   const mockAddPendingSourceConversationSeen = vi.fn();
 
   beforeEach(() => {
-    // Create a test store with conversations slice
-    store = configureStore({
-      reducer: {
-        conversation: conversationSlice,
-      },
-    });
+    store = setupStore();
 
     // Reset mocks
     vi.clearAllMocks();
@@ -136,28 +131,16 @@ describe("conversationSlice", () => {
   describe("initial state", () => {
     it("has correct initial state", () => {
       const state = (store.getState() as any).conversation;
-      expect(state).toEqual({
-        conversation: null,
-        loading: false,
-        error: null,
-        lastFetchTime: null,
-        hasMoreHistoricalItems: false,
-        olderItemsLoading: false,
-      });
+      expect(state).toEqual(defaultSliceState(conversationSlice));
     });
   });
 
   describe("clearError action", () => {
     it("clears the error state", () => {
       // First, set an error state
-      const initialState: ConversationState = {
-        conversation: null,
-        loading: false,
+      const initialState = defaultSliceState(conversationSlice, {
         error: "Some error message",
-        lastFetchTime: null,
-        hasMoreHistoricalItems: false,
-        olderItemsLoading: false,
-      };
+      });
 
       const action = clearError();
       const newState = conversationSlice(initialState, action);
@@ -171,14 +154,10 @@ describe("conversationSlice", () => {
 
   describe("clearConversation action", () => {
     it("clears the current conversation", () => {
-      const initialState: ConversationState = {
+      const initialState = defaultSliceState(conversationSlice, {
         conversation: mockSourceWithItems,
-        loading: false,
-        error: null,
         lastFetchTime: 123456789,
-        hasMoreHistoricalItems: false,
-        olderItemsLoading: false,
-      };
+      });
 
       const action = clearConversation();
       const newState = conversationSlice(initialState, action);
@@ -267,14 +246,11 @@ describe("conversationSlice", () => {
         loading: false,
         error: null,
       },
-      conversation: {
+      conversation: defaultSliceState(conversationSlice, {
         conversation: mockSourceWithItems,
-        loading: false,
         error: "Test error",
         lastFetchTime: 123456789,
-        hasMoreHistoricalItems: false,
-        olderItemsLoading: false,
-      },
+      }),
       sync: {
         error: null,
         lastSyncStarted: null,
@@ -401,14 +377,9 @@ describe("conversationSlice", () => {
       items: [fileItem],
     };
 
-    const stateWithFile: ConversationState = {
+    const stateWithFile = defaultSliceState(conversationSlice, {
       conversation: sourceWithFile,
-      loading: false,
-      error: null,
-      lastFetchTime: null,
-      hasMoreHistoricalItems: false,
-      olderItemsLoading: false,
-    };
+    });
 
     it("does not resurrect a Cancelled item", () => {
       const canceledState: ConversationState = {

--- a/app/src/renderer/features/journalists/journalistsSlice.test.ts
+++ b/app/src/renderer/features/journalists/journalistsSlice.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { configureStore, type EnhancedStore } from "@reduxjs/toolkit";
 import type { Journalist } from "../../../types";
 import journalistsReducer, {
   fetchJournalists,
@@ -8,9 +7,8 @@ import journalistsReducer, {
   getJournalists,
   getJournalistsLoading,
   getJournalistsError,
-  type JournalistsState,
 } from "./journalistsSlice";
-import type { RootState } from "../../store";
+import { defaultSliceState, makeRootState, setupStore } from "../../store";
 
 // Mock electronAPI
 const mockElectronAPI = {
@@ -54,29 +52,16 @@ describe("journalistsSlice", () => {
     },
   ];
 
-  const initialState: JournalistsState = {
-    journalists: [],
-    loading: false,
-    error: null,
-  };
-
-  const loadingState: JournalistsState = {
-    journalists: [],
+  const initialState = defaultSliceState(journalistsReducer);
+  const loadingState = defaultSliceState(journalistsReducer, {
     loading: true,
-    error: null,
-  };
-
-  const loadedState: JournalistsState = {
+  });
+  const loadedState = defaultSliceState(journalistsReducer, {
     journalists: mockJournalists,
-    loading: false,
-    error: null,
-  };
-
-  const errorState: JournalistsState = {
-    journalists: [],
-    loading: false,
+  });
+  const errorState = defaultSliceState(journalistsReducer, {
     error: "Failed to fetch journalists",
-  };
+  });
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -103,16 +88,10 @@ describe("journalistsSlice", () => {
   });
 
   describe("fetchJournalists async thunk", () => {
-    let store: EnhancedStore<{
-      journalists: JournalistsState;
-    }>;
+    let store: ReturnType<typeof setupStore>;
 
     beforeEach(() => {
-      store = configureStore({
-        reducer: {
-          journalists: journalistsReducer,
-        },
-      });
+      store = setupStore();
     });
 
     it("should handle pending state", () => {
@@ -196,32 +175,7 @@ describe("journalistsSlice", () => {
   });
 
   describe("selectors", () => {
-    const mockRootState: RootState = {
-      journalists: loadedState,
-      session: {} as any, // Mock other state slices
-      sources: {
-        sources: {},
-        activeSourceUuid: null,
-        loading: false,
-        error: null,
-        conversationIndicators: {},
-      },
-      conversation: {
-        conversation: null,
-        loading: false,
-        error: null,
-        lastFetchTime: null,
-        hasMoreHistoricalItems: false,
-        olderItemsLoading: false,
-      },
-      sync: {
-        error: null,
-        lastSyncStarted: null,
-        lastSyncFinished: null,
-        status: null,
-      },
-      drafts: { drafts: {} },
-    };
+    const mockRootState = makeRootState({ journalists: loadedState });
 
     it("getJournalistsState should return the entire journalists state", () => {
       const result = getJournalistsState(mockRootState);

--- a/app/src/renderer/features/sources/sourcesSlice.test.ts
+++ b/app/src/renderer/features/sources/sourcesSlice.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { configureStore } from "@reduxjs/toolkit";
 import type { Source as SourceType } from "../../../types";
 import sourcesSlice, {
   fetchSources,
@@ -12,15 +11,10 @@ import sourcesSlice, {
   selectConversationLastSeen,
   initializeConversationIndicator,
   markConversationLastSeen,
-  type SourcesState,
 } from "./sourcesSlice";
-import sessionSlice, {
-  SessionStatus,
-  type SessionState,
-} from "../session/sessionSlice";
-import conversationSlice, {
-  ConversationState,
-} from "../conversation/conversationSlice";
+import { SessionStatus, type SessionState } from "../session/sessionSlice";
+import { ConversationState } from "../conversation/conversationSlice";
+import { defaultSliceState, setupStore } from "../../store";
 
 // Mock data matching the structure from test-component-setup.tsx
 const mockSources: SourceType[] = [
@@ -68,18 +62,11 @@ const mockSourcesRecord: Record<string, SourceType> = Object.fromEntries(
 );
 
 describe("sourcesSlice", () => {
-  let store: ReturnType<typeof configureStore>;
+  let store: ReturnType<typeof setupStore>;
   const mockGetSources = vi.fn();
 
   beforeEach(() => {
-    // Create a test store with sources, session, and conversations slices for proper typing
-    store = configureStore({
-      reducer: {
-        sources: sourcesSlice,
-        session: sessionSlice,
-        conversation: conversationSlice,
-      },
-    });
+    store = setupStore();
 
     // Reset mocks
     vi.clearAllMocks();
@@ -105,26 +92,16 @@ describe("sourcesSlice", () => {
   describe("initial state", () => {
     it("has correct initial state", () => {
       const state = (store.getState() as any).sources;
-      expect(state).toEqual({
-        sources: {},
-        activeSourceUuid: null,
-        loading: false,
-        error: null,
-        conversationIndicators: {},
-      });
+      expect(state).toEqual(defaultSliceState(sourcesSlice));
     });
   });
 
   describe("clearError action", () => {
     it("clears the error state", () => {
       // First, set an error state
-      const initialState: SourcesState = {
-        sources: {},
-        activeSourceUuid: null,
-        loading: false,
+      const initialState = defaultSliceState(sourcesSlice, {
         error: "Some error message",
-        conversationIndicators: {},
-      };
+      });
 
       const action = clearError();
       const newState = sourcesSlice(initialState, action);
@@ -138,13 +115,7 @@ describe("sourcesSlice", () => {
 
   describe("setActiveSource action", () => {
     it("sets the active source UUID", () => {
-      const initialState: SourcesState = {
-        sources: {},
-        activeSourceUuid: null,
-        loading: false,
-        error: null,
-        conversationIndicators: {},
-      };
+      const initialState = defaultSliceState(sourcesSlice);
 
       const action = setActiveSource("source-1");
       const newState = sourcesSlice(initialState, action);
@@ -155,13 +126,9 @@ describe("sourcesSlice", () => {
 
   describe("clearActiveSource action", () => {
     it("clears the active source UUID", () => {
-      const initialState: SourcesState = {
-        sources: {},
+      const initialState = defaultSliceState(sourcesSlice, {
         activeSourceUuid: "source-1",
-        loading: false,
-        error: null,
-        conversationIndicators: {},
-      };
+      });
 
       const action = clearActiveSource();
       const newState = sourcesSlice(initialState, action);
@@ -172,13 +139,7 @@ describe("sourcesSlice", () => {
 
   describe("conversation indicator actions", () => {
     it("initializes indicator once per source", () => {
-      const initialState: SourcesState = {
-        sources: {},
-        activeSourceUuid: null,
-        loading: false,
-        error: null,
-        conversationIndicators: {},
-      };
+      const initialState = defaultSliceState(sourcesSlice);
 
       const initAction = initializeConversationIndicator({
         sourceUuid: "source-1",
@@ -204,13 +165,7 @@ describe("sourcesSlice", () => {
     });
 
     it("marks conversation last seen with latest count", () => {
-      const initialState: SourcesState = {
-        sources: {},
-        activeSourceUuid: null,
-        loading: false,
-        error: null,
-        conversationIndicators: {},
-      };
+      const initialState = defaultSliceState(sourcesSlice);
 
       const markedState = sourcesSlice(
         initialState,
@@ -364,13 +319,9 @@ describe("sourcesSlice", () => {
     it("selectSourcesLoading returns loading state", () => {
       const state = {
         session: mockSessionState,
-        sources: {
-          sources: {},
-          activeSourceUuid: null,
+        sources: defaultSliceState(sourcesSlice, {
           loading: true,
-          error: null,
-          conversationIndicators: {},
-        },
+        }),
         journalists: {
           journalists: [],
           loading: false,

--- a/app/src/renderer/features/sync/syncSlice.test.ts
+++ b/app/src/renderer/features/sync/syncSlice.test.ts
@@ -1,10 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { configureStore } from "@reduxjs/toolkit";
+import { setupStore } from "../../store";
 import { Source as SourceType, SyncStatus } from "../../../types";
-import syncSlice, { syncMetadata } from "./syncSlice";
-import sourcesSlice from "../sources/sourcesSlice";
-import sessionSlice, { type AuthData } from "../session/sessionSlice";
-import conversationSlice from "../conversation/conversationSlice";
+import { syncMetadata } from "./syncSlice";
+import { type AuthData } from "../session/sessionSlice";
 
 function mockAuthData(): AuthData {
   return {
@@ -61,20 +59,12 @@ const mockSourcesRecord: Record<string, SourceType> = Object.fromEntries(
 );
 
 describe("syncSlice", () => {
-  let store: ReturnType<typeof configureStore>;
+  let store: ReturnType<typeof setupStore>;
   const mockGetSources = vi.fn();
   const mockSyncMetadata = vi.fn();
 
   beforeEach(() => {
-    // Create a test store with sources, session, conversations, and sync slices for proper typing
-    store = configureStore({
-      reducer: {
-        sources: sourcesSlice,
-        session: sessionSlice,
-        conversation: conversationSlice,
-        sync: syncSlice,
-      },
-    });
+    store = setupStore();
 
     // Reset mocks
     vi.clearAllMocks();
@@ -172,31 +162,7 @@ describe("syncSlice", () => {
     it("fetches conversation for active source during sync", async () => {
       const activeSourceUuid = "source-1";
 
-      // Set up store with active source
-      store = configureStore({
-        reducer: {
-          sources: sourcesSlice,
-          session: sessionSlice,
-          conversation: conversationSlice,
-          sync: syncSlice,
-        },
-        preloadedState: {
-          sources: {
-            sources: {},
-            activeSourceUuid: activeSourceUuid,
-            error: null,
-            lastFetchTime: null,
-            loading: false,
-            conversationIndicators: {},
-          },
-          sync: {
-            error: null,
-            lastSyncStarted: null,
-            lastSyncFinished: null,
-            status: null,
-          },
-        },
-      });
+      store = setupStore({ sources: { activeSourceUuid } });
 
       // Mock getSourceWithItems for the active conversation
       const mockGetSourceWithItems = vi.fn();

--- a/app/src/renderer/store.ts
+++ b/app/src/renderer/store.ts
@@ -1,4 +1,8 @@
-import { combineReducers, configureStore } from "@reduxjs/toolkit";
+import {
+  combineReducers,
+  configureStore,
+  type Reducer,
+} from "@reduxjs/toolkit";
 import sessionSlice from "./features/session/sessionSlice";
 import journalistsSlice from "./features/journalists/journalistsSlice";
 import sourcesSlice from "./features/sources/sourcesSlice";
@@ -6,7 +10,7 @@ import conversationSlice from "./features/conversation/conversationSlice";
 import syncSlice from "./features/sync/syncSlice";
 import draftsSlice from "./features/drafts/draftsSlice";
 
-const rootReducer = combineReducers({
+export const rootReducer = combineReducers({
   session: sessionSlice,
   journalists: journalistsSlice,
   sources: sourcesSlice,
@@ -15,10 +19,38 @@ const rootReducer = combineReducers({
   drafts: draftsSlice,
 });
 
-export const setupStore = (preloadedState?: Partial<RootState>) => {
+export type PreloadedRootState = {
+  [K in keyof RootState]?: Partial<RootState[K]>;
+};
+
+// Not a real action type: reducers answer an unrecognized action with their own
+// initial state, which is how the defaults are read back out of them here.
+const PROBE = { type: "@@store/probe" };
+
+export const defaultRootState = (): RootState => rootReducer(undefined, PROBE);
+
+export const defaultSliceState = <S extends object>(
+  reducer: Reducer<S>,
+  overrides: Partial<S> = {},
+): S => ({ ...reducer(undefined, PROBE), ...overrides });
+
+// Fills a partial state out to a complete `RootState`, slice by slice.
+export const makeRootState = (
+  overrides: PreloadedRootState = {},
+): RootState => {
+  const base = defaultRootState();
+  const merged = { ...base };
+  for (const slice of Object.keys(overrides) as (keyof RootState)[]) {
+    // Sound by construction: each override is a `Partial` of that slice.
+    Object.assign(merged, { [slice]: { ...base[slice], ...overrides[slice] } });
+  }
+  return merged;
+};
+
+export const setupStore = (preloadedState?: PreloadedRootState) => {
   return configureStore({
     reducer: rootReducer,
-    preloadedState,
+    preloadedState: preloadedState && makeRootState(preloadedState),
   });
 };
 

--- a/app/src/renderer/test-component-setup.tsx
+++ b/app/src/renderer/test-component-setup.tsx
@@ -9,7 +9,7 @@ import { MemoryRouter, useLocation } from "react-router";
 import { Provider } from "react-redux";
 import React, { memo } from "react";
 
-import { setupStore, type RootState } from "./store";
+import { setupStore, type PreloadedRootState } from "./store";
 import "./i18n";
 import type { ElectronAPI } from "../preload/index";
 import { ExportStatus, PrintStatus } from "../types";
@@ -353,7 +353,7 @@ export const TestWrapper = ({
   children: React.ReactNode;
   initialEntries?: string[];
   onLocationChange?: (location: any) => void;
-  preloadedState?: Partial<RootState>;
+  preloadedState?: PreloadedRootState;
   store?: ReturnType<typeof setupStore>;
 }) => {
   const store = providedStore || setupStore(preloadedState);
@@ -375,7 +375,7 @@ export const renderWithProviders = (
   options?: {
     initialEntries?: string[];
     onLocationChange?: (location: any) => void;
-    preloadedState?: Partial<RootState>;
+    preloadedState?: PreloadedRootState;
   },
 ): RenderResult & { store: ReturnType<typeof setupStore> } => {
   recordRenderedComponents(ui);


### PR DESCRIPTION
Adds a `setupStore` utility to create default store state for renderer tests. It automatically prefills with empty state for slices. 

This means that changes to the overall shape of the store data no longer have to change every single renderer test file.

## Test plan
All unit tests pass

